### PR TITLE
feat(generator): support parameters named "options"

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -25,12 +25,12 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options options) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(options), golden_internal::GoldenKitchenSinkDefaultOptions(connection_->options()))) {}
+GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options opts) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(opts), golden_internal::GoldenKitchenSinkDefaultOptions(connection_->options()))) {}
 GoldenKitchenSinkClient::~GoldenKitchenSinkClient() = default;
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::GenerateAccessTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -40,14 +40,14 @@ GoldenKitchenSinkClient::GenerateAccessToken(std::string const& name, std::vecto
 }
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateAccessToken(request);
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::GenerateIdTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -57,14 +57,14 @@ GoldenKitchenSinkClient::GenerateIdToken(std::string const& name, std::vector<st
 }
 
 StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateIdToken(request);
 }
 
 StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::WriteLogEntriesRequest request;
   request.set_log_name(log_name);
   *request.mutable_labels() = {labels.begin(), labels.end()};
@@ -72,42 +72,42 @@ GoldenKitchenSinkClient::WriteLogEntries(std::string const& log_name, std::map<s
 }
 
 StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->WriteLogEntries(request);
 }
 
 StreamRange<std::string>
-GoldenKitchenSinkClient::ListLogs(std::string const& parent, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::ListLogs(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
 }
 
 StreamRange<std::string>
-GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListLogs(std::move(request));
 }
 
 StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource_names, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::TailLogEntries(std::vector<std::string> const& resource_names, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::TailLogEntriesRequest request;
   *request.mutable_resource_names() = {resource_names.begin(), resource_names.end()};
   return connection_->TailLogEntries(request);
 }
 
 StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TailLogEntries(request);
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::ListServiceAccountKeysRequest request;
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
@@ -115,30 +115,30 @@ GoldenKitchenSinkClient::ListServiceAccountKeys(std::string const& name, std::ve
 }
 
 StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServiceAccountKeys(request);
 }
 
 Status
-GoldenKitchenSinkClient::DoNothing(Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::DoNothing(Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::protobuf::Empty request;
   return connection_->DoNothing(request);
 }
 
 Status
-GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DoNothing(request);
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::test::admin::database::v1::AppendRowsRequest,
     google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkClient::AsyncAppendRows(Options options) {
+GoldenKitchenSinkClient::AsyncAppendRows(Options opts) {
   internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+      internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncAppendRows();
 }
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class GoldenKitchenSinkClient {
  public:
-  explicit GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options options = {});
+  explicit GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options opts = {});
   ~GoldenKitchenSinkClient();
 
   //@{
@@ -107,27 +107,29 @@ class GoldenKitchenSinkClient {
   ///  Must be set to a value less than or equal to 3600 (1 hour). If a value is
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L905}
   ///
   /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L865}
   /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L905}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options options = {});
+  GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
 
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L865}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L905}
   ///
   /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L865}
   /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L905}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
-  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options options = {});
+  GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
@@ -149,27 +151,29 @@ class GoldenKitchenSinkClient {
   ///  grants access to.
   /// @param include_email  Include the service account email in the token. If set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L947}
   ///
   /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
   /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options options = {});
+  GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L914}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L947}
   ///
   /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
   /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
-  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options options = {});
+  GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -197,14 +201,15 @@ class GoldenKitchenSinkClient {
   ///  entries in `entries`. If a log entry already has a label with the same key
   ///  as a label in this parameter, then the log entry's label is not changed.
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L986}
   ///
   /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
   /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L986}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options options = {});
+  WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -216,14 +221,15 @@ class GoldenKitchenSinkClient {
   /// folders)
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L953}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L986}
   ///
   /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
   /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L986}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
-  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options options = {});
+  WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -234,26 +240,28 @@ class GoldenKitchenSinkClient {
   ///      "organizations/[ORGANIZATION_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
   ///      "folders/[FOLDER_ID]"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L989}
   ///
   StreamRange<std::string>
-  ListLogs(std::string const& parent, Options options = {});
+  ListLogs(std::string const& parent, Options opts = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L989}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L989}
   ///
   StreamRange<std::string>
-  ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options options = {});
+  ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
 
   ///
   /// Streaming read of log entries as they are ingested. Until the stream is
@@ -269,28 +277,30 @@ class GoldenKitchenSinkClient {
   ///      "organization/[ORGANIZATION_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1247}
   ///
   /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1215}
   /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1247}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(std::vector<std::string> const& resource_names, Options options = {});
+  TailLogEntries(std::vector<std::string> const& resource_names, Options opts = {});
 
   ///
   /// Streaming read of log entries as they are ingested. Until the stream is
   /// terminated, it will continue reading logs.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1215}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1247}
   ///
   /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1215}
   /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1247}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
-  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options options = {});
+  TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options opts = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
@@ -303,53 +313,57 @@ class GoldenKitchenSinkClient {
   /// @param key_types  Filters the types of keys the user wants to include in the list
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1319}
   ///
   /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1287}
   /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1319}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options options = {});
+  ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1287}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1319}
   ///
   /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1287}
   /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1319}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
-  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options options = {});
+  ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
 
   ///
   /// Does Nothing.
   ///
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
   ///
   Status
-  DoNothing(Options options = {});
+  DoNothing(Options opts = {});
 
   ///
   /// Does Nothing.
   ///
   /// @param request @googleapis_link{google::protobuf::Empty,google/protobuf/empty.proto#L52}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.protobuf.Empty]: @googleapis_reference_link{google/protobuf/empty.proto#L52}
   ///
   Status
-  DoNothing(google::protobuf::Empty const& request, Options options = {});
+  DoNothing(google::protobuf::Empty const& request, Options opts = {});
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(Options options = {});
+  AsyncAppendRows(Options opts = {});
 
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -27,26 +27,26 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options options) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(options), golden_internal::GoldenThingAdminDefaultOptions(connection_->options()))) {}
+GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options opts) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(opts), golden_internal::GoldenThingAdminDefaultOptions(connection_->options()))) {}
 GoldenThingAdminClient::~GoldenThingAdminClient() = default;
 
 StreamRange<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::ListDatabases(std::string const& parent, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListDatabases(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::ListDatabasesRequest request;
   request.set_parent(parent);
   return connection_->ListDatabases(request);
 }
 
 StreamRange<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDatabases(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string const& create_statement, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(parent);
   request.set_create_statement(create_statement);
@@ -54,28 +54,28 @@ GoldenThingAdminClient::CreateDatabase(std::string const& parent, std::string co
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDatabase(request);
 }
 
 StatusOr<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::GetDatabase(std::string const& name, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetDatabase(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->GetDatabase(request);
 }
 
 StatusOr<google::test::admin::database::v1::Database>
-GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDatabase(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(database);
   *request.mutable_statements() = {statements.begin(), statements.end()};
@@ -83,42 +83,42 @@ GoldenThingAdminClient::UpdateDatabaseDdl(std::string const& database, std::vect
 }
 
 future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDatabaseDdl(request);
 }
 
 Status
-GoldenThingAdminClient::DropDatabase(std::string const& database, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::DropDatabase(std::string const& database, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->DropDatabase(request);
 }
 
 Status
-GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DropDatabase(request);
 }
 
 StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-GoldenThingAdminClient::GetDatabaseDdl(std::string const& database, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetDatabaseDdl(std::string const& database, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -126,9 +126,9 @@ GoldenThingAdminClient::SetIamPolicy(std::string const& resource, google::iam::v
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<GoldenThingAdminBackoffPolicyOption>(options, __func__);
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<GoldenThingAdminBackoffPolicyOption>(opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -153,28 +153,28 @@ GoldenThingAdminClient::SetIamPolicy(std::string const& resource, IamUpdater con
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::GetIamPolicy(std::string const& resource, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetIamPolicy(std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy>
-GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
-GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -182,14 +182,14 @@ GoldenThingAdminClient::TestIamPermissions(std::string const& resource, std::vec
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
-GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::CreateBackupRequest request;
   request.set_parent(parent);
   *request.mutable_backup() = backup;
@@ -198,28 +198,28 @@ GoldenThingAdminClient::CreateBackup(std::string const& parent, google::test::ad
 }
 
 future<StatusOr<google::test::admin::database::v1::Backup>>
-GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::GetBackup(std::string const& name, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetBackup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
@@ -227,42 +227,42 @@ GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::Backup c
 }
 
 StatusOr<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBackup(request);
 }
 
 Status
-GoldenThingAdminClient::DeleteBackup(std::string const& name, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::DeleteBackup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
 }
 
 Status
-GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::ListBackups(std::string const& parent, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListBackups(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
 }
 
 StreamRange<google::test::admin::database::v1::Backup>
-GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent(parent);
   request.set_database_id(database_id);
@@ -271,70 +271,70 @@ GoldenThingAdminClient::RestoreDatabase(std::string const& parent, std::string c
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreDatabase(request);
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListDatabaseOperations(std::string const& parent, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListDatabaseOperations(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListDatabaseOperations(request);
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDatabaseOperations(std::move(request));
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListBackupOperations(std::string const& parent, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListBackupOperations(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListBackupOperations(request);
 }
 
 StreamRange<google::longrunning::Operation>
-GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackupOperations(std::move(request));
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->LongRunningWithoutRouting(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::AsyncGetDatabase(std::string const& name, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::AsyncGetDatabase(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->AsyncGetDatabase(request);
 }
 
 future<StatusOr<google::test::admin::database::v1::Database>>
-GoldenThingAdminClient::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncGetDatabase(request);
 }
 
 future<Status>
-GoldenThingAdminClient::AsyncDropDatabase(std::string const& database, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::AsyncDropDatabase(std::string const& database, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::test::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->AsyncDropDatabase(request);
 }
 
 future<Status>
-GoldenThingAdminClient::AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options) {
-  internal::OptionsSpan span(internal::MergeOptions(std::move(options), options_));
+GoldenThingAdminClient::AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncDropDatabase(request);
 }
 

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -67,7 +67,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ///
 class GoldenThingAdminClient {
  public:
-  explicit GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options options = {});
+  explicit GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options opts = {});
   ~GoldenThingAdminClient();
 
   //@{
@@ -93,27 +93,29 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance whose databases should be listed.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StreamRange<google::test::admin::database::v1::Database>
-  ListDatabases(std::string const& parent, Options options = {});
+  ListDatabases(std::string const& parent, Options opts = {});
 
   ///
   /// Lists Cloud Test databases.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L385}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StreamRange<google::test::admin::database::v1::Database>
-  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options options = {});
+  ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options opts = {});
 
   ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
@@ -132,14 +134,15 @@ class GoldenThingAdminClient {
   ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
   ///  If the database ID is a reserved word or if it contains a hyphen, the
   ///  database ID must be enclosed in backticks (`` ` ``).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  CreateDatabase(std::string const& parent, std::string const& create_statement, Options options = {});
+  CreateDatabase(std::string const& parent, std::string const& create_statement, Options opts = {});
 
   ///
   /// Creates a new Cloud Test database and starts to prepare it for serving.
@@ -152,41 +155,44 @@ class GoldenThingAdminClient {
   /// [Database][google.test.admin.database.v1.Database], if successful.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L417}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options options = {});
+  CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options opts = {});
 
   ///
   /// Gets the state of a Cloud Test database.
   ///
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StatusOr<google::test::admin::database::v1::Database>
-  GetDatabase(std::string const& name, Options options = {});
+  GetDatabase(std::string const& name, Options opts = {});
 
   ///
   /// Gets the state of a Cloud Test database.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   StatusOr<google::test::admin::database::v1::Database>
-  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
+  GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts = {});
 
   ///
   /// Updates the schema of a Cloud Test database by
@@ -199,14 +205,15 @@ class GoldenThingAdminClient {
   ///
   /// @param database  Required. The database to update.
   /// @param statements  Required. DDL statements to be applied to the database.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
   ///
   /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
   /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options options = {});
+  UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options opts = {});
 
   ///
   /// Updates the schema of a Cloud Test database by
@@ -218,14 +225,15 @@ class GoldenThingAdminClient {
   /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L478}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
   ///
   /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
   /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
-  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options options = {});
+  UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options opts = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -233,12 +241,13 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param database  Required. The database to be dropped.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   Status
-  DropDatabase(std::string const& database, Options options = {});
+  DropDatabase(std::string const& database, Options opts = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -246,12 +255,13 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   Status
-  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
+  DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts = {});
 
   ///
   /// Returns the schema of a Cloud Test database as a list of formatted
@@ -259,14 +269,15 @@ class GoldenThingAdminClient {
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
   /// @param database  Required. The database whose schema we wish to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
   ///
   /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
   /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(std::string const& database, Options options = {});
+  GetDatabaseDdl(std::string const& database, Options opts = {});
 
   ///
   /// Returns the schema of a Cloud Test database as a list of formatted
@@ -274,14 +285,15 @@ class GoldenThingAdminClient {
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L542}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
   ///
   /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
   /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options options = {});
+  GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -298,14 +310,15 @@ class GoldenThingAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy, Options options = {});
+  SetIamPolicy(std::string const& resource, google::iam::v1::Policy const& policy, Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -323,13 +336,12 @@ class GoldenThingAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `GoldenThingAdminBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy>
-  SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options options = {});
+  SetIamPolicy(std::string const& resource, IamUpdater const& updater, Options opts = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -341,14 +353,15 @@ class GoldenThingAdminClient {
   /// permission on [resource][google.iam.v1.SetIamPolicyRequest.resource].
   ///
   /// @param request @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.SetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L98}
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options options = {});
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for a database or backup resource.
@@ -362,14 +375,15 @@ class GoldenThingAdminClient {
   ///
   /// @param resource  REQUIRED: The resource for which the policy is being requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  GetIamPolicy(std::string const& resource, Options options = {});
+  GetIamPolicy(std::string const& resource, Options opts = {});
 
   ///
   /// Gets the access control policy for a database or backup resource.
@@ -382,14 +396,15 @@ class GoldenThingAdminClient {
   /// permission on [resource][google.iam.v1.GetIamPolicyRequest.resource].
   ///
   /// @param request @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
   /// [google.iam.v1.GetIamPolicyRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L113}
   /// [google.iam.v1.Policy]: @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy>
-  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options options = {});
+  GetIamPolicy(google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or backup
@@ -409,14 +424,15 @@ class GoldenThingAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options options = {});
+  TestIamPermissions(std::string const& resource, std::vector<std::string> const& permissions, Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or backup
@@ -431,14 +447,15 @@ class GoldenThingAdminClient {
   /// `test.backups.list` permission on the containing instance.
   ///
   /// @param request @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
   /// [google.iam.v1.TestIamPermissionsRequest]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L126}
   /// [google.iam.v1.TestIamPermissionsResponse]: @googleapis_reference_link{google/iam/v1/iam_policy.proto#L141}
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse>
-  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options options = {});
+  TestIamPermissions(google::iam::v1::TestIamPermissionsRequest const& request, Options opts = {});
 
   ///
   /// Starts creating a new Cloud Test Backup.
@@ -464,14 +481,15 @@ class GoldenThingAdminClient {
   /// @param backup_id  Required. The id of the backup to be created. The `backup_id` appended to
   ///  `parent` forms the full backup name of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
-  CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options options = {});
+  CreateBackup(std::string const& parent, google::test::admin::database::v1::Backup const& backup, std::string const& backup_id, Options opts = {});
 
   ///
   /// Starts creating a new Cloud Test Backup.
@@ -488,14 +506,15 @@ class GoldenThingAdminClient {
   /// of different databases can run concurrently.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::CreateBackupRequest,generator/integration_tests/backup.proto#L110}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.CreateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L110}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   future<StatusOr<google::test::admin::database::v1::Backup>>
-  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options options = {});
+  CreateBackup(google::test::admin::database::v1::CreateBackupRequest const& request, Options opts = {});
 
   ///
   /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -503,27 +522,29 @@ class GoldenThingAdminClient {
   /// @param name  Required. Name of the backup.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  GetBackup(std::string const& name, Options options = {});
+  GetBackup(std::string const& name, Options opts = {});
 
   ///
   /// Gets metadata on a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetBackupRequest,generator/integration_tests/backup.proto#L177}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.GetBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L177}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options options = {});
+  GetBackup(google::test::admin::database::v1::GetBackupRequest const& request, Options opts = {});
 
   ///
   /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -537,27 +558,29 @@ class GoldenThingAdminClient {
   ///  resource, not to the request message. The field mask must always be
   ///  specified; this prevents any future fields from being erased accidentally
   ///  by clients that do not know about them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options options = {});
+  UpdateBackup(google::test::admin::database::v1::Backup const& backup, google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::UpdateBackupRequest,generator/integration_tests/backup.proto#L161}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.UpdateBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L161}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StatusOr<google::test::admin::database::v1::Backup>
-  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options options = {});
+  UpdateBackup(google::test::admin::database::v1::UpdateBackupRequest const& request, Options opts = {});
 
   ///
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
@@ -565,23 +588,25 @@ class GoldenThingAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
   Status
-  DeleteBackup(std::string const& name, Options options = {});
+  DeleteBackup(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a pending or completed [Backup][google.test.admin.database.v1.Backup].
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DeleteBackupRequest,generator/integration_tests/backup.proto#L190}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.test.admin.database.v1.DeleteBackupRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L190}
   ///
   Status
-  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options options = {});
+  DeleteBackup(google::test::admin::database::v1::DeleteBackupRequest const& request, Options opts = {});
 
   ///
   /// Lists completed and pending backups.
@@ -590,14 +615,15 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance to list backups from.  Values are of the
   ///  form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
-  ListBackups(std::string const& parent, Options options = {});
+  ListBackups(std::string const& parent, Options opts = {});
 
   ///
   /// Lists completed and pending backups.
@@ -605,14 +631,15 @@ class GoldenThingAdminClient {
   /// starting from the most recent `create_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupsRequest,generator/integration_tests/backup.proto#L203}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Backup,generator/integration_tests/backup.proto#L36}
   ///
   /// [google.test.admin.database.v1.ListBackupsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L203}
   /// [google.test.admin.database.v1.Backup]: @googleapis_reference_link{generator/integration_tests/backup.proto#L36}
   ///
   StreamRange<google::test::admin::database::v1::Backup>
-  ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options options = {});
+  ListBackups(google::test::admin::database::v1::ListBackupsRequest request, Options opts = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -644,14 +671,15 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database_id>`.
   /// @param backup  Name of the backup from which to restore.  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options options = {});
+  RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options opts = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -673,14 +701,15 @@ class GoldenThingAdminClient {
   /// first restore to complete.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L642}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options = {});
+  RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -694,14 +723,15 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance of the database operations.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListDatabaseOperations(std::string const& parent, Options options = {});
+  ListDatabaseOperations(std::string const& parent, Options opts = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -714,14 +744,15 @@ class GoldenThingAdminClient {
   /// and pending operations.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L561}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options options = {});
+  ListDatabaseOperations(google::test::admin::database::v1::ListDatabaseOperationsRequest request, Options opts = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -737,14 +768,15 @@ class GoldenThingAdminClient {
   ///
   /// @param parent  Required. The instance of the backup operations. Values are of
   ///  the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListBackupOperations(std::string const& parent, Options options = {});
+  ListBackupOperations(std::string const& parent, Options opts = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation] in
@@ -759,54 +791,58 @@ class GoldenThingAdminClient {
   /// from the most recently started operation.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::ListBackupOperationsRequest,generator/integration_tests/backup.proto#L274}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
   /// [google.test.admin.database.v1.ListBackupOperationsRequest]: @googleapis_reference_link{generator/integration_tests/backup.proto#L274}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
-  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options options = {});
+  ListBackupOperations(google::test::admin::database::v1::ListBackupOperationsRequest request, Options opts = {});
 
   ///
   /// Tests longrunning operations without routing headers
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L642}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options options = {});
+  LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts = {});
 
   ///
   /// Gets the state of a Cloud Test database.
   ///
   /// @param name  Required. The name of the requested database. Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  AsyncGetDatabase(std::string const& name, Options options = {});
+  AsyncGetDatabase(std::string const& name, Options opts = {});
 
   ///
   /// Gets the state of a Cloud Test database.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
   ///
   /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
   /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
-  AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options options = {});
+  AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -814,12 +850,13 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param database  Required. The database to be dropped.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   future<Status>
-  AsyncDropDatabase(std::string const& database, Options options = {});
+  AsyncDropDatabase(std::string const& database, Options opts = {});
 
   ///
   /// Drops (aka deletes) a Cloud Test database.
@@ -827,12 +864,13 @@ class GoldenThingAdminClient {
   /// `expire_time`.
   ///
   /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
   ///
   future<Status>
-  AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options options = {});
+  AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts = {});
 
  private:
   std::shared_ptr<GoldenThingAdminConnection> connection_;

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -336,8 +336,8 @@ class GoldenThingAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy>

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -197,8 +197,8 @@ Status ClientGenerator::GenerateHeader() {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
 )"""},
             {"   * @return " + response_type + "\n"},
             {"   */\n"},

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -92,7 +92,7 @@ Status ClientGenerator::GenerateHeader() {
     "$class_comment_block$\n"
     "class $client_class_name$ {\n"
     " public:\n"
-    "  explicit $client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options options = {});\n"
+    "  explicit $client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options opts = {});\n"
     "  ~$client_class_name$();\n"
     "\n"
     "  //@{\n"
@@ -121,7 +121,7 @@ Status ClientGenerator::GenerateHeader() {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       $request_type$,
       $response_type$>>
-  Async$method_name$(Options options = {});
+  Async$method_name$(Options opts = {});
 )""");
       continue;
     }
@@ -130,7 +130,7 @@ Status ClientGenerator::GenerateHeader() {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       if (IsDeprecatedMethodSignature(method, i)) continue;
       std::string const method_string = absl::StrCat(
-          "  $method_name$($method_signature", i, "$Options options = {});\n");
+          "  $method_name$($method_signature", i, "$Options opts = {});\n");
       std::string const signature = method_signature_extension[i];
       HeaderPrintMethod(
           method,
@@ -197,9 +197,8 @@ Status ClientGenerator::GenerateHeader() {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `$service_name$BackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
 )"""},
             {"   * @return " + response_type + "\n"},
             {"   */\n"},
@@ -207,7 +206,7 @@ Status ClientGenerator::GenerateHeader() {
             {"  " + set_method_name},
             {"(std::string const& resource,"
              " IamUpdater const& updater,"
-             " Options options = {});\n"},
+             " Options opts = {});\n"},
         });
       }
     }
@@ -221,7 +220,7 @@ Status ClientGenerator::GenerateHeader() {
                   // clang-format off
     "  Status\n",
     "  StatusOr<$response_type$>\n"},
-   {"  $method_name$($request_type$ const& request, Options options = {});\n"}
+   {"  $method_name$($request_type$ const& request, Options opts = {});\n"}
                  // clang-format on
              },
              All(IsNonStreaming, Not(IsLongrunningOperation),
@@ -234,7 +233,7 @@ Status ClientGenerator::GenerateHeader() {
                   // clang-format off
     "  future<Status>\n",
     "  future<StatusOr<$longrunning_deduced_response_type$>>\n"},
-   {"  $method_name$($request_type$ const& request, Options options = {});\n"}
+   {"  $method_name$($request_type$ const& request, Options opts = {});\n"}
                  // clang-format on
              },
              All(IsNonStreaming, IsLongrunningOperation, Not(IsPaginated))),
@@ -244,7 +243,7 @@ Status ClientGenerator::GenerateHeader() {
                  {FormatMethodCommentsProtobufRequest(method)},
                  // clang-format off
    {"  StreamRange<$range_output_type$>\n"
-    "  $method_name$($request_type$ request, Options options = {});\n"},
+    "  $method_name$($request_type$ request, Options opts = {});\n"},
                  // clang-format on
              },
              All(IsNonStreaming, Not(IsLongrunningOperation), IsPaginated)),
@@ -254,7 +253,7 @@ Status ClientGenerator::GenerateHeader() {
                  {FormatMethodCommentsProtobufRequest(method)},
                  // clang-format off
    {"  StreamRange<$response_type$>\n"
-    "  $method_name$($request_type$ const& request, Options options = {});\n"},
+    "  $method_name$($request_type$ const& request, Options opts = {});\n"},
                  // clang-format on
              },
              IsStreamingRead)},
@@ -267,7 +266,7 @@ Status ClientGenerator::GenerateHeader() {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       std::string const method_string =
           absl::StrCat("  Async$method_name$($method_signature", i,
-                       "$Options options = {});\n");
+                       "$Options opts = {});\n");
       std::string const signature = method_signature_extension[i];
       HeaderPrintMethod(
           method,
@@ -294,7 +293,7 @@ Status ClientGenerator::GenerateHeader() {
                  // clang-format off
     "  future<Status>\n",
     "  future<StatusOr<$response_type$>>\n"},
-   {"  Async$method_name$($request_type$ const& request, Options options = {});\n"}
+   {"  Async$method_name$($request_type$ const& request, Options opts = {});\n"}
                 // clang-format on
             },
             All(IsNonStreaming, Not(IsLongrunningOperation),
@@ -342,9 +341,9 @@ Status ClientGenerator::GenerateCc() {
 
   CcPrint(  // clang-format off
     "\n"
-    "$client_class_name$::$client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options options)"
+    "$client_class_name$::$client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options opts)"
     " : connection_(std::move(connection)),"
-    " options_(internal::MergeOptions(std::move(options),"
+    " options_(internal::MergeOptions(std::move(opts),"
     " $product_internal_namespace$::$service_name$DefaultOptions(connection_->options()))) {}\n");
   // clang-format on
 
@@ -359,9 +358,9 @@ Status ClientGenerator::GenerateCc() {
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     $request_type$,
     $response_type$>>
-$client_class_name$::Async$method_name$(Options options) {
+$client_class_name$::Async$method_name$(Options opts) {
   internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+      internal::MergeOptions(std::move(opts), options_));
   return connection_->Async$method_name$();
 }
 )""");
@@ -373,7 +372,7 @@ $client_class_name$::Async$method_name$(Options options) {
       if (IsDeprecatedMethodSignature(method, i)) continue;
       std::string method_string =
           absl::StrCat("$client_class_name$::$method_name$($method_signature",
-                       i, "$Options options) {\n");
+                       i, "$Options opts) {\n");
       std::string method_request_string =
           absl::StrCat("$method_request_setters", i, "$");
       CcPrintMethod(
@@ -386,7 +385,7 @@ $client_class_name$::Async$method_name$(Options options) {
                    "\nStatusOr<$response_type$>\n"},
                   {method_string},
                   {"  internal::OptionsSpan span(internal::MergeOptions("
-                   "std::move(options), options_));\n"},
+                   "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
                   {"  return connection_->$method_name$(request);\n"
@@ -403,7 +402,7 @@ $client_class_name$::Async$method_name$(Options options) {
                     "\nfuture<StatusOr<$longrunning_deduced_response_type$>>\n"},
                   {method_string},
                   {"  internal::OptionsSpan span(internal::MergeOptions("
-                   "std::move(options), options_));\n"},
+                   "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
                   {"  return connection_->$method_name$(request);\n"
@@ -417,7 +416,7 @@ $client_class_name$::Async$method_name$(Options options) {
                    {"\nStreamRange<$range_output_type$>\n"},
                   {method_string},
                   {"  internal::OptionsSpan span(internal::MergeOptions("
-                   "std::move(options), options_));\n"},
+                   "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
                   {"  return connection_->$method_name$(request);\n"
@@ -431,7 +430,7 @@ $client_class_name$::Async$method_name$(Options options) {
                    {"\nStreamRange<$response_type$>\n"},
                   {method_string},
                   {"  internal::OptionsSpan span(internal::MergeOptions("
-                   "std::move(options), options_));\n"},
+                   "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
                   {"  return connection_->$method_name$(request);\n"
@@ -452,11 +451,11 @@ $client_class_name$::Async$method_name$(Options options) {
             {"$client_class_name$::" + set_method_name},
             {"(std::string const& resource,"
              " IamUpdater const& updater,"
-             " Options options) {\n"
+             " Options opts) {\n"
              "  internal::CheckExpectedOptions<$service_name$"
-             "BackoffPolicyOption>(options, __func__);\n"
+             "BackoffPolicyOption>(opts, __func__);\n"
              "  internal::OptionsSpan span(internal::MergeOptions("
-             "std::move(options), options_));\n"},
+             "std::move(opts), options_));\n"},
             {"  "},
             {ProtoNameToCppName(
                 get_iam_policy_extension_->input_type()->full_name())},
@@ -503,9 +502,9 @@ $client_class_name$::Async$method_name$(Options options) {
     "\nStatus\n",
     "\nStatusOr<$response_type$>\n"},
    {"$client_class_name$::$method_name$($request_type$ const& request"
-    ", Options options) {\n"
+    ", Options opts) {\n"
     "  internal::OptionsSpan span(internal::MergeOptions("
-    "std::move(options), options_));\n"
+    "std::move(opts), options_));\n"
     "  return connection_->$method_name$(request);\n"
     "}\n"}
                  // clang-format on
@@ -519,9 +518,9 @@ $client_class_name$::Async$method_name$(Options options) {
     "\nfuture<Status>\n",
     "\nfuture<StatusOr<$longrunning_deduced_response_type$>>\n"},
    {"$client_class_name$::$method_name$($request_type$ const& request"
-    ", Options options) {\n"
+    ", Options opts) {\n"
     "  internal::OptionsSpan span(internal::MergeOptions("
-    "std::move(options), options_));\n"
+    "std::move(opts), options_));\n"
     "  return connection_->$method_name$(request);\n"
     "}\n"}
                  // clang-format on
@@ -532,9 +531,9 @@ $client_class_name$::Async$method_name$(Options options) {
                  // clang-format off
    {"\nStreamRange<$range_output_type$>\n"
     "$client_class_name$::$method_name$($request_type$ request"
-    ", Options options) {\n"
+    ", Options opts) {\n"
     "  internal::OptionsSpan span(internal::MergeOptions("
-    "std::move(options), options_));\n"
+    "std::move(opts), options_));\n"
     "  return connection_->$method_name$(std::move(request));\n"
     "}\n"}
                  // clang-format on
@@ -545,9 +544,9 @@ $client_class_name$::Async$method_name$(Options options) {
                  // clang-format off
    {"\nStreamRange<$response_type$>\n"
     "$client_class_name$::$method_name$($request_type$ const& request"
-    ", Options options) {\n"
+    ", Options opts) {\n"
     "  internal::OptionsSpan span(internal::MergeOptions("
-    "std::move(options), options_));\n"
+    "std::move(opts), options_));\n"
     "  return connection_->$method_name$(request);\n"
     "}\n"}
                  // clang-format on
@@ -562,7 +561,7 @@ $client_class_name$::Async$method_name$(Options options) {
     for (int i = 0; i < method_signature_extension.size(); ++i) {
       std::string method_string = absl::StrCat(
           "$client_class_name$::Async$method_name$($method_signature", i,
-          "$Options options) {\n");
+          "$Options opts) {\n");
       std::string method_request_string =
           absl::StrCat("$method_request_setters", i, "$");
       CcPrintMethod(
@@ -575,7 +574,7 @@ $client_class_name$::Async$method_name$(Options options) {
                    "\nfuture<StatusOr<$response_type$>>\n"},
                   {method_string},
                   {"  internal::OptionsSpan span(internal::MergeOptions("
-                   "std::move(options), options_));\n"},
+                   "std::move(opts), options_));\n"},
                   {"  $request_type$ request;\n"},
                    {method_request_string},
                   {"  return connection_->Async$method_name$(request);\n"
@@ -595,9 +594,9 @@ $client_class_name$::Async$method_name$(Options options) {
     "\nfuture<Status>\n",
     "\nfuture<StatusOr<$response_type$>>\n"},
    {"$client_class_name$::Async$method_name$($request_type$ const& request"
-    ", Options options) {\n"
+    ", Options opts) {\n"
     "  internal::OptionsSpan span(internal::MergeOptions("
-    "std::move(options), options_));\n"
+    "std::move(opts), options_));\n"
     "  return connection_->Async$method_name$(request);\n"
     "}\n"}
                 // clang-format on

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -449,8 +449,10 @@ std::string FormatMethodComments(
       EscapePrinterDelimiter(method_source_location.leading_comments),
       {{"\n", "\n  ///"}});
 
-  std::string options_comment =
-      absl::StrFormat("  /// @param options  Optional. Operation options.\n");
+  auto const options_comment = std::string{
+      R"""(  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+)"""};
 
   std::string return_comment_string;
   if (IsLongrunningOperation(method)) {

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -541,7 +541,8 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsProtobufRequest) {
   /// Leading comments about rpc Method0$$.
   ///
   /// @param request @googleapis_link{google::protobuf::Bar,google/foo/v1/service.proto#L16}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
 )"""));
 }
@@ -555,7 +556,8 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsMethodSignature) {
   /// Leading comments about rpc $$Method6.
   ///
   /// @param labels  labels $$field comment.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
 )"""));
   EXPECT_THAT(
@@ -566,7 +568,8 @@ TEST_F(CreateMethodVarsTest, FormatMethodCommentsMethodSignature) {
   ///
   /// @param name  name field$$ comment.
   /// @param labels  labels $$field comment.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
 )"""));
 }

--- a/google/cloud/accessapproval/access_approval_client.cc
+++ b/google/cloud/accessapproval/access_approval_client.cc
@@ -26,19 +26,18 @@ namespace accessapproval {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AccessApprovalClient::AccessApprovalClient(
-    std::shared_ptr<AccessApprovalConnection> connection, Options options)
+    std::shared_ptr<AccessApprovalConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           accessapproval_internal::AccessApprovalDefaultOptions(
               connection_->options()))) {}
 AccessApprovalClient::~AccessApprovalClient() = default;
 
 StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalClient::ListApprovalRequests(std::string const& parent,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::accessapproval::v1::ListApprovalRequestsMessage request;
   request.set_parent(parent);
   return connection_->ListApprovalRequests(request);
@@ -47,17 +46,15 @@ AccessApprovalClient::ListApprovalRequests(std::string const& parent,
 StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalClient::ListApprovalRequests(
     google::cloud::accessapproval::v1::ListApprovalRequestsMessage request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListApprovalRequests(std::move(request));
 }
 
 StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalClient::GetApprovalRequest(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::accessapproval::v1::GetApprovalRequestMessage request;
   request.set_name(name);
   return connection_->GetApprovalRequest(request);
@@ -66,9 +63,8 @@ AccessApprovalClient::GetApprovalRequest(std::string const& name,
 StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalClient::GetApprovalRequest(
     google::cloud::accessapproval::v1::GetApprovalRequestMessage const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetApprovalRequest(request);
 }
 
@@ -76,9 +72,8 @@ StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalClient::ApproveApprovalRequest(
     google::cloud::accessapproval::v1::ApproveApprovalRequestMessage const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ApproveApprovalRequest(request);
 }
 
@@ -86,17 +81,15 @@ StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalClient::DismissApprovalRequest(
     google::cloud::accessapproval::v1::DismissApprovalRequestMessage const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DismissApprovalRequest(request);
 }
 
 StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>
 AccessApprovalClient::GetAccessApprovalSettings(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::accessapproval::v1::GetAccessApprovalSettingsMessage request;
   request.set_name(name);
   return connection_->GetAccessApprovalSettings(request);
@@ -106,18 +99,16 @@ StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>
 AccessApprovalClient::GetAccessApprovalSettings(
     google::cloud::accessapproval::v1::GetAccessApprovalSettingsMessage const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAccessApprovalSettings(request);
 }
 
 StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>
 AccessApprovalClient::UpdateAccessApprovalSettings(
     google::cloud::accessapproval::v1::AccessApprovalSettings const& settings,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::accessapproval::v1::UpdateAccessApprovalSettingsMessage
       request;
   *request.mutable_settings() = settings;
@@ -129,16 +120,14 @@ StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>
 AccessApprovalClient::UpdateAccessApprovalSettings(
     google::cloud::accessapproval::v1::
         UpdateAccessApprovalSettingsMessage const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAccessApprovalSettings(request);
 }
 
 Status AccessApprovalClient::DeleteAccessApprovalSettings(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::accessapproval::v1::DeleteAccessApprovalSettingsMessage
       request;
   request.set_name(name);
@@ -148,9 +137,8 @@ Status AccessApprovalClient::DeleteAccessApprovalSettings(
 Status AccessApprovalClient::DeleteAccessApprovalSettings(
     google::cloud::accessapproval::v1::
         DeleteAccessApprovalSettingsMessage const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAccessApprovalSettings(request);
 }
 

--- a/google/cloud/accessapproval/access_approval_client.h
+++ b/google/cloud/accessapproval/access_approval_client.h
@@ -93,8 +93,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AccessApprovalClient {
  public:
   explicit AccessApprovalClient(
-      std::shared_ptr<AccessApprovalConnection> connection,
-      Options options = {});
+      std::shared_ptr<AccessApprovalConnection> connection, Options opts = {});
   ~AccessApprovalClient();
 
   //@{
@@ -124,7 +123,8 @@ class AccessApprovalClient {
   ///
   /// @param parent  The parent resource. This may be "projects/{project_id}",
   ///  "folders/{folder_id}", or "organizations/{organization_id}".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::ApprovalRequest,google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
@@ -134,7 +134,7 @@ class AccessApprovalClient {
   /// @googleapis_reference_link{google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
   StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>
-  ListApprovalRequests(std::string const& parent, Options options = {});
+  ListApprovalRequests(std::string const& parent, Options opts = {});
 
   ///
   /// Lists approval requests associated with a project, folder, or
@@ -143,7 +143,8 @@ class AccessApprovalClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::ListApprovalRequestsMessage,google/cloud/accessapproval/v1/accessapproval.proto#L402}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::ApprovalRequest,google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
@@ -155,13 +156,14 @@ class AccessApprovalClient {
   StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>
   ListApprovalRequests(
       google::cloud::accessapproval::v1::ListApprovalRequestsMessage request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an approval request. Returns NOT_FOUND if the request does not exist.
   ///
   /// @param name  Name of the approval request to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::ApprovalRequest,google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
@@ -171,14 +173,15 @@ class AccessApprovalClient {
   /// @googleapis_reference_link{google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
   StatusOr<google::cloud::accessapproval::v1::ApprovalRequest>
-  GetApprovalRequest(std::string const& name, Options options = {});
+  GetApprovalRequest(std::string const& name, Options opts = {});
 
   ///
   /// Gets an approval request. Returns NOT_FOUND if the request does not exist.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::GetApprovalRequestMessage,google/cloud/accessapproval/v1/accessapproval.proto#L435}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::ApprovalRequest,google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
@@ -191,7 +194,7 @@ class AccessApprovalClient {
   GetApprovalRequest(
       google::cloud::accessapproval::v1::GetApprovalRequestMessage const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Approves a request and returns the updated ApprovalRequest.
@@ -201,7 +204,8 @@ class AccessApprovalClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::ApproveApprovalRequestMessage,google/cloud/accessapproval/v1/accessapproval.proto#L441}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::ApprovalRequest,google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
@@ -214,7 +218,7 @@ class AccessApprovalClient {
   ApproveApprovalRequest(
       google::cloud::accessapproval::v1::ApproveApprovalRequestMessage const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Dismisses a request. Returns the updated ApprovalRequest.
@@ -230,7 +234,8 @@ class AccessApprovalClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::DismissApprovalRequestMessage,google/cloud/accessapproval/v1/accessapproval.proto#L450}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::ApprovalRequest,google/cloud/accessapproval/v1/accessapproval.proto#L293}
   ///
@@ -243,13 +248,14 @@ class AccessApprovalClient {
   DismissApprovalRequest(
       google::cloud::accessapproval::v1::DismissApprovalRequestMessage const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the settings associated with a project, folder, or organization.
   ///
   /// @param name  Name of the AccessApprovalSettings to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::AccessApprovalSettings,google/cloud/accessapproval/v1/accessapproval.proto#L365}
   ///
@@ -259,14 +265,15 @@ class AccessApprovalClient {
   /// @googleapis_reference_link{google/cloud/accessapproval/v1/accessapproval.proto#L365}
   ///
   StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>
-  GetAccessApprovalSettings(std::string const& name, Options options = {});
+  GetAccessApprovalSettings(std::string const& name, Options opts = {});
 
   ///
   /// Gets the settings associated with a project, folder, or organization.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::GetAccessApprovalSettingsMessage,google/cloud/accessapproval/v1/accessapproval.proto#L456}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::AccessApprovalSettings,google/cloud/accessapproval/v1/accessapproval.proto#L365}
   ///
@@ -279,7 +286,7 @@ class AccessApprovalClient {
   GetAccessApprovalSettings(
       google::cloud::accessapproval::v1::GetAccessApprovalSettingsMessage const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the settings associated with a project, folder, or organization.
@@ -296,7 +303,8 @@ class AccessApprovalClient {
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
   ///  If this field is left unset, only the notification_emails field will be
   ///  updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::AccessApprovalSettings,google/cloud/accessapproval/v1/accessapproval.proto#L365}
   ///
@@ -308,7 +316,7 @@ class AccessApprovalClient {
   StatusOr<google::cloud::accessapproval::v1::AccessApprovalSettings>
   UpdateAccessApprovalSettings(
       google::cloud::accessapproval::v1::AccessApprovalSettings const& settings,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the settings associated with a project, folder, or organization.
@@ -316,7 +324,8 @@ class AccessApprovalClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::UpdateAccessApprovalSettingsMessage,google/cloud/accessapproval/v1/accessapproval.proto#L462}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::accessapproval::v1::AccessApprovalSettings,google/cloud/accessapproval/v1/accessapproval.proto#L365}
   ///
@@ -329,7 +338,7 @@ class AccessApprovalClient {
   UpdateAccessApprovalSettings(
       google::cloud::accessapproval::v1::
           UpdateAccessApprovalSettingsMessage const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the settings associated with a project, folder, or organization.
@@ -340,13 +349,14 @@ class AccessApprovalClient {
   /// the settings are inherited.
   ///
   /// @param name  Name of the AccessApprovalSettings to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.accessapproval.v1.DeleteAccessApprovalSettingsMessage]:
   /// @googleapis_reference_link{google/cloud/accessapproval/v1/accessapproval.proto#L480}
   ///
   Status DeleteAccessApprovalSettings(std::string const& name,
-                                      Options options = {});
+                                      Options opts = {});
 
   ///
   /// Deletes the settings associated with a project, folder, or organization.
@@ -358,7 +368,8 @@ class AccessApprovalClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::accessapproval::v1::DeleteAccessApprovalSettingsMessage,google/cloud/accessapproval/v1/accessapproval.proto#L480}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.accessapproval.v1.DeleteAccessApprovalSettingsMessage]:
   /// @googleapis_reference_link{google/cloud/accessapproval/v1/accessapproval.proto#L480}
@@ -366,7 +377,7 @@ class AccessApprovalClient {
   Status DeleteAccessApprovalSettings(
       google::cloud::accessapproval::v1::
           DeleteAccessApprovalSettingsMessage const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AccessApprovalConnection> connection_;

--- a/google/cloud/accesscontextmanager/access_context_manager_client.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_client.cc
@@ -26,10 +26,10 @@ namespace accesscontextmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AccessContextManagerClient::AccessContextManagerClient(
-    std::shared_ptr<AccessContextManagerConnection> connection, Options options)
+    std::shared_ptr<AccessContextManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           accesscontextmanager_internal::AccessContextManagerDefaultOptions(
               connection_->options()))) {}
 AccessContextManagerClient::~AccessContextManagerClient() = default;
@@ -38,17 +38,15 @@ StreamRange<google::identity::accesscontextmanager::v1::AccessPolicy>
 AccessContextManagerClient::ListAccessPolicies(
     google::identity::accesscontextmanager::v1::ListAccessPoliciesRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAccessPolicies(std::move(request));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>
 AccessContextManagerClient::GetAccessPolicy(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::GetAccessPolicyRequest request;
   request.set_name(name);
   return connection_->GetAccessPolicy(request);
@@ -58,27 +56,24 @@ StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>
 AccessContextManagerClient::GetAccessPolicy(
     google::identity::accesscontextmanager::v1::GetAccessPolicyRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAccessPolicy(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
 AccessContextManagerClient::CreateAccessPolicy(
     google::identity::accesscontextmanager::v1::AccessPolicy const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAccessPolicy(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
 AccessContextManagerClient::UpdateAccessPolicy(
     google::identity::accesscontextmanager::v1::AccessPolicy const& policy,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::UpdateAccessPolicyRequest request;
   *request.mutable_policy() = policy;
   *request.mutable_update_mask() = update_mask;
@@ -89,18 +84,16 @@ future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
 AccessContextManagerClient::UpdateAccessPolicy(
     google::identity::accesscontextmanager::v1::UpdateAccessPolicyRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAccessPolicy(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::
                     AccessContextManagerOperationMetadata>>
 AccessContextManagerClient::DeleteAccessPolicy(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::DeleteAccessPolicyRequest request;
   request.set_name(name);
   return connection_->DeleteAccessPolicy(request);
@@ -111,17 +104,15 @@ future<StatusOr<google::identity::accesscontextmanager::v1::
 AccessContextManagerClient::DeleteAccessPolicy(
     google::identity::accesscontextmanager::v1::DeleteAccessPolicyRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAccessPolicy(request);
 }
 
 StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>
 AccessContextManagerClient::ListAccessLevels(std::string const& parent,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::ListAccessLevelsRequest request;
   request.set_parent(parent);
   return connection_->ListAccessLevels(request);
@@ -130,17 +121,15 @@ AccessContextManagerClient::ListAccessLevels(std::string const& parent,
 StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>
 AccessContextManagerClient::ListAccessLevels(
     google::identity::accesscontextmanager::v1::ListAccessLevelsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAccessLevels(std::move(request));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>
 AccessContextManagerClient::GetAccessLevel(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::GetAccessLevelRequest request;
   request.set_name(name);
   return connection_->GetAccessLevel(request);
@@ -150,9 +139,8 @@ StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>
 AccessContextManagerClient::GetAccessLevel(
     google::identity::accesscontextmanager::v1::GetAccessLevelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAccessLevel(request);
 }
 
@@ -160,9 +148,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
 AccessContextManagerClient::CreateAccessLevel(
     std::string const& parent,
     google::identity::accesscontextmanager::v1::AccessLevel const& access_level,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::CreateAccessLevelRequest request;
   request.set_parent(parent);
   *request.mutable_access_level() = access_level;
@@ -173,18 +160,16 @@ future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
 AccessContextManagerClient::CreateAccessLevel(
     google::identity::accesscontextmanager::v1::CreateAccessLevelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAccessLevel(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
 AccessContextManagerClient::UpdateAccessLevel(
     google::identity::accesscontextmanager::v1::AccessLevel const& access_level,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::UpdateAccessLevelRequest request;
   *request.mutable_access_level() = access_level;
   *request.mutable_update_mask() = update_mask;
@@ -195,18 +180,16 @@ future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
 AccessContextManagerClient::UpdateAccessLevel(
     google::identity::accesscontextmanager::v1::UpdateAccessLevelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAccessLevel(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::
                     AccessContextManagerOperationMetadata>>
 AccessContextManagerClient::DeleteAccessLevel(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::DeleteAccessLevelRequest request;
   request.set_name(name);
   return connection_->DeleteAccessLevel(request);
@@ -217,9 +200,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::
 AccessContextManagerClient::DeleteAccessLevel(
     google::identity::accesscontextmanager::v1::DeleteAccessLevelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAccessLevel(request);
 }
 
@@ -228,17 +210,15 @@ future<StatusOr<
 AccessContextManagerClient::ReplaceAccessLevels(
     google::identity::accesscontextmanager::v1::
         ReplaceAccessLevelsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReplaceAccessLevels(request);
 }
 
 StreamRange<google::identity::accesscontextmanager::v1::ServicePerimeter>
 AccessContextManagerClient::ListServicePerimeters(std::string const& parent,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::ListServicePerimetersRequest
       request;
   request.set_parent(parent);
@@ -249,17 +229,15 @@ StreamRange<google::identity::accesscontextmanager::v1::ServicePerimeter>
 AccessContextManagerClient::ListServicePerimeters(
     google::identity::accesscontextmanager::v1::ListServicePerimetersRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServicePerimeters(std::move(request));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>
 AccessContextManagerClient::GetServicePerimeter(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::GetServicePerimeterRequest
       request;
   request.set_name(name);
@@ -270,9 +248,8 @@ StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>
 AccessContextManagerClient::GetServicePerimeter(
     google::identity::accesscontextmanager::v1::
         GetServicePerimeterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServicePerimeter(request);
 }
 
@@ -281,9 +258,8 @@ AccessContextManagerClient::CreateServicePerimeter(
     std::string const& parent,
     google::identity::accesscontextmanager::v1::ServicePerimeter const&
         service_perimeter,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::CreateServicePerimeterRequest
       request;
   request.set_parent(parent);
@@ -295,9 +271,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>>
 AccessContextManagerClient::CreateServicePerimeter(
     google::identity::accesscontextmanager::v1::
         CreateServicePerimeterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServicePerimeter(request);
 }
 
@@ -305,9 +280,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>>
 AccessContextManagerClient::UpdateServicePerimeter(
     google::identity::accesscontextmanager::v1::ServicePerimeter const&
         service_perimeter,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::UpdateServicePerimeterRequest
       request;
   *request.mutable_service_perimeter() = service_perimeter;
@@ -319,18 +293,16 @@ future<StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>>
 AccessContextManagerClient::UpdateServicePerimeter(
     google::identity::accesscontextmanager::v1::
         UpdateServicePerimeterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateServicePerimeter(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::
                     AccessContextManagerOperationMetadata>>
 AccessContextManagerClient::DeleteServicePerimeter(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::DeleteServicePerimeterRequest
       request;
   request.set_name(name);
@@ -342,9 +314,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::
 AccessContextManagerClient::DeleteServicePerimeter(
     google::identity::accesscontextmanager::v1::
         DeleteServicePerimeterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteServicePerimeter(request);
 }
 
@@ -353,9 +324,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::
 AccessContextManagerClient::ReplaceServicePerimeters(
     google::identity::accesscontextmanager::v1::
         ReplaceServicePerimetersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReplaceServicePerimeters(request);
 }
 
@@ -364,17 +334,15 @@ future<StatusOr<google::identity::accesscontextmanager::v1::
 AccessContextManagerClient::CommitServicePerimeters(
     google::identity::accesscontextmanager::v1::
         CommitServicePerimetersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CommitServicePerimeters(request);
 }
 
 StreamRange<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
 AccessContextManagerClient::ListGcpUserAccessBindings(std::string const& parent,
-                                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                      Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::ListGcpUserAccessBindingsRequest
       request;
   request.set_parent(parent);
@@ -385,17 +353,15 @@ StreamRange<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
 AccessContextManagerClient::ListGcpUserAccessBindings(
     google::identity::accesscontextmanager::v1::ListGcpUserAccessBindingsRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGcpUserAccessBindings(std::move(request));
 }
 
 StatusOr<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
 AccessContextManagerClient::GetGcpUserAccessBinding(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::GetGcpUserAccessBindingRequest
       request;
   request.set_name(name);
@@ -406,9 +372,8 @@ StatusOr<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
 AccessContextManagerClient::GetGcpUserAccessBinding(
     google::identity::accesscontextmanager::v1::
         GetGcpUserAccessBindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGcpUserAccessBinding(request);
 }
 
@@ -418,9 +383,8 @@ AccessContextManagerClient::CreateGcpUserAccessBinding(
     std::string const& parent,
     google::identity::accesscontextmanager::v1::GcpUserAccessBinding const&
         gcp_user_access_binding,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::CreateGcpUserAccessBindingRequest
       request;
   request.set_parent(parent);
@@ -433,9 +397,8 @@ future<
 AccessContextManagerClient::CreateGcpUserAccessBinding(
     google::identity::accesscontextmanager::v1::
         CreateGcpUserAccessBindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGcpUserAccessBinding(request);
 }
 
@@ -444,9 +407,8 @@ future<
 AccessContextManagerClient::UpdateGcpUserAccessBinding(
     google::identity::accesscontextmanager::v1::GcpUserAccessBinding const&
         gcp_user_access_binding,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::UpdateGcpUserAccessBindingRequest
       request;
   *request.mutable_gcp_user_access_binding() = gcp_user_access_binding;
@@ -459,18 +421,16 @@ future<
 AccessContextManagerClient::UpdateGcpUserAccessBinding(
     google::identity::accesscontextmanager::v1::
         UpdateGcpUserAccessBindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGcpUserAccessBinding(request);
 }
 
 future<StatusOr<google::identity::accesscontextmanager::v1::
                     GcpUserAccessBindingOperationMetadata>>
 AccessContextManagerClient::DeleteGcpUserAccessBinding(std::string const& name,
-                                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::identity::accesscontextmanager::v1::DeleteGcpUserAccessBindingRequest
       request;
   request.set_name(name);
@@ -482,9 +442,8 @@ future<StatusOr<google::identity::accesscontextmanager::v1::
 AccessContextManagerClient::DeleteGcpUserAccessBinding(
     google::identity::accesscontextmanager::v1::
         DeleteGcpUserAccessBindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGcpUserAccessBinding(request);
 }
 

--- a/google/cloud/accesscontextmanager/access_context_manager_client.h
+++ b/google/cloud/accesscontextmanager/access_context_manager_client.h
@@ -73,7 +73,7 @@ class AccessContextManagerClient {
  public:
   explicit AccessContextManagerClient(
       std::shared_ptr<AccessContextManagerConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AccessContextManagerClient();
 
   //@{
@@ -104,7 +104,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ListAccessPoliciesRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L431}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
@@ -117,7 +118,7 @@ class AccessContextManagerClient {
   ListAccessPolicies(
       google::identity::accesscontextmanager::v1::ListAccessPoliciesRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get an [AccessPolicy]
@@ -125,7 +126,8 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Resource name for the access policy to get.
   ///  Format `accessPolicies/{policy_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
@@ -135,7 +137,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
   StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>
-  GetAccessPolicy(std::string const& name, Options options = {});
+  GetAccessPolicy(std::string const& name, Options opts = {});
 
   ///
   /// Get an [AccessPolicy]
@@ -143,7 +145,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GetAccessPolicyRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L463}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
@@ -156,7 +159,7 @@ class AccessContextManagerClient {
   GetAccessPolicy(
       google::identity::accesscontextmanager::v1::GetAccessPolicyRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create an `AccessPolicy`. Fails if this organization already has a
@@ -167,7 +170,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
@@ -179,7 +183,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
   CreateAccessPolicy(
       google::identity::accesscontextmanager::v1::AccessPolicy const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update an [AccessPolicy]
@@ -193,7 +197,8 @@ class AccessContextManagerClient {
   /// @param policy  Required. The updated AccessPolicy.
   /// @param update_mask  Required. Mask to control which fields get updated.
   /// Must be non-empty.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
@@ -205,7 +210,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
   UpdateAccessPolicy(
       google::identity::accesscontextmanager::v1::AccessPolicy const& policy,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update an [AccessPolicy]
@@ -218,7 +223,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::UpdateAccessPolicyRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L476}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessPolicy,google/identity/accesscontextmanager/v1/access_policy.proto#L37}
   ///
@@ -230,7 +236,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessPolicy>>
   UpdateAccessPolicy(google::identity::accesscontextmanager::v1::
                          UpdateAccessPolicyRequest const& request,
-                     Options options = {});
+                     Options opts = {});
 
   ///
   /// Delete an [AccessPolicy]
@@ -241,7 +247,8 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Resource name for the access policy to delete.
   ///  Format `accessPolicies/{policy_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessContextManagerOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L940}
   ///
@@ -252,7 +259,7 @@ class AccessContextManagerClient {
   ///
   future<StatusOr<google::identity::accesscontextmanager::v1::
                       AccessContextManagerOperationMetadata>>
-  DeleteAccessPolicy(std::string const& name, Options options = {});
+  DeleteAccessPolicy(std::string const& name, Options opts = {});
 
   ///
   /// Delete an [AccessPolicy]
@@ -263,7 +270,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::DeleteAccessPolicyRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L485}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessContextManagerOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L940}
   ///
@@ -276,7 +284,7 @@ class AccessContextManagerClient {
                       AccessContextManagerOperationMetadata>>
   DeleteAccessPolicy(google::identity::accesscontextmanager::v1::
                          DeleteAccessPolicyRequest const& request,
-                     Options options = {});
+                     Options opts = {});
 
   ///
   /// List all [Access Levels]
@@ -288,7 +296,8 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.AccessLevel] from.
   ///  Format:
   ///  `accessPolicies/{policy_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -298,7 +307,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
   StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>
-  ListAccessLevels(std::string const& parent, Options options = {});
+  ListAccessLevels(std::string const& parent, Options opts = {});
 
   ///
   /// List all [Access Levels]
@@ -307,7 +316,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ListAccessLevelsRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L498}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -320,7 +330,7 @@ class AccessContextManagerClient {
   ListAccessLevels(
       google::identity::accesscontextmanager::v1::ListAccessLevelsRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get an [Access Level]
@@ -331,7 +341,8 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.AccessLevel].
   ///  Format:
   ///  `accessPolicies/{policy_id}/accessLevels/{access_level_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -341,7 +352,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
   StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>
-  GetAccessLevel(std::string const& name, Options options = {});
+  GetAccessLevel(std::string const& name, Options opts = {});
 
   ///
   /// Get an [Access Level]
@@ -350,7 +361,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GetAccessLevelRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L539}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -363,7 +375,7 @@ class AccessContextManagerClient {
   GetAccessLevel(
       google::identity::accesscontextmanager::v1::GetAccessLevelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create an [Access Level]
@@ -383,7 +395,8 @@ class AccessContextManagerClient {
   ///  Syntactic correctness of the [Access Level]
   ///  [google.identity.accesscontextmanager.v1.AccessLevel] is a
   ///  precondition for creation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -397,7 +410,7 @@ class AccessContextManagerClient {
       std::string const& parent,
       google::identity::accesscontextmanager::v1::AccessLevel const&
           access_level,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create an [Access Level]
@@ -410,7 +423,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::CreateAccessLevelRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L564}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -422,7 +436,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
   CreateAccessLevel(google::identity::accesscontextmanager::v1::
                         CreateAccessLevelRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Update an [Access Level]
@@ -441,7 +455,8 @@ class AccessContextManagerClient {
   ///  precondition for creation.
   /// @param update_mask  Required. Mask to control which fields get updated.
   /// Must be non-empty.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -454,7 +469,7 @@ class AccessContextManagerClient {
   UpdateAccessLevel(
       google::identity::accesscontextmanager::v1::AccessLevel const&
           access_level,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update an [Access Level]
@@ -468,7 +483,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::UpdateAccessLevelRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L585}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessLevel,google/identity/accesscontextmanager/v1/access_level.proto#L37}
   ///
@@ -480,7 +496,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::AccessLevel>>
   UpdateAccessLevel(google::identity::accesscontextmanager::v1::
                         UpdateAccessLevelRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Delete an [Access Level]
@@ -494,7 +510,8 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.AccessLevel].
   ///  Format:
   ///  `accessPolicies/{policy_id}/accessLevels/{access_level_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessContextManagerOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L940}
   ///
@@ -505,7 +522,7 @@ class AccessContextManagerClient {
   ///
   future<StatusOr<google::identity::accesscontextmanager::v1::
                       AccessContextManagerOperationMetadata>>
-  DeleteAccessLevel(std::string const& name, Options options = {});
+  DeleteAccessLevel(std::string const& name, Options opts = {});
 
   ///
   /// Delete an [Access Level]
@@ -517,7 +534,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::DeleteAccessLevelRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L598}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessContextManagerOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L940}
   ///
@@ -530,7 +548,7 @@ class AccessContextManagerClient {
                       AccessContextManagerOperationMetadata>>
   DeleteAccessLevel(google::identity::accesscontextmanager::v1::
                         DeleteAccessLevelRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Replace all existing [Access Levels]
@@ -553,7 +571,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ReplaceAccessLevelsRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L614}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ReplaceAccessLevelsResponse,google/identity/accesscontextmanager/v1/access_context_manager.proto#L647}
   ///
@@ -566,7 +585,7 @@ class AccessContextManagerClient {
       google::identity::accesscontextmanager::v1::ReplaceAccessLevelsResponse>>
   ReplaceAccessLevels(google::identity::accesscontextmanager::v1::
                           ReplaceAccessLevelsRequest const& request,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// List all [Service Perimeters]
@@ -578,7 +597,8 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter] from.
   ///  Format:
   ///  `accessPolicies/{policy_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -588,7 +608,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
   StreamRange<google::identity::accesscontextmanager::v1::ServicePerimeter>
-  ListServicePerimeters(std::string const& parent, Options options = {});
+  ListServicePerimeters(std::string const& parent, Options opts = {});
 
   ///
   /// List all [Service Perimeters]
@@ -597,7 +617,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ListServicePerimetersRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L654}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -610,7 +631,7 @@ class AccessContextManagerClient {
   ListServicePerimeters(
       google::identity::accesscontextmanager::v1::ListServicePerimetersRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get a [Service Perimeter]
@@ -621,7 +642,8 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter].
   ///  Format:
   ///  `accessPolicies/{policy_id}/servicePerimeters/{service_perimeters_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -631,7 +653,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
   StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>
-  GetServicePerimeter(std::string const& name, Options options = {});
+  GetServicePerimeter(std::string const& name, Options opts = {});
 
   ///
   /// Get a [Service Perimeter]
@@ -640,7 +662,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GetServicePerimeterRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L690}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -652,7 +675,7 @@ class AccessContextManagerClient {
   StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>
   GetServicePerimeter(google::identity::accesscontextmanager::v1::
                           GetServicePerimeterRequest const& request,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Create a [Service Perimeter]
@@ -673,7 +696,8 @@ class AccessContextManagerClient {
   ///  Syntactic correctness of the [Service Perimeter]
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter] is a
   ///  precondition for creation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -687,7 +711,7 @@ class AccessContextManagerClient {
       std::string const& parent,
       google::identity::accesscontextmanager::v1::ServicePerimeter const&
           service_perimeter,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a [Service Perimeter]
@@ -701,7 +725,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::CreateServicePerimeterRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L705}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -713,7 +738,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>>
   CreateServicePerimeter(google::identity::accesscontextmanager::v1::
                              CreateServicePerimeterRequest const& request,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Update a [Service Perimeter]
@@ -730,7 +755,8 @@ class AccessContextManagerClient {
   ///  `ServicePerimeter` is a precondition for creation.
   /// @param update_mask  Required. Mask to control which fields get updated.
   /// Must be non-empty.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -743,7 +769,7 @@ class AccessContextManagerClient {
   UpdateServicePerimeter(
       google::identity::accesscontextmanager::v1::ServicePerimeter const&
           service_perimeter,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a [Service Perimeter]
@@ -757,7 +783,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::UpdateServicePerimeterRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L726}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ServicePerimeter,google/identity/accesscontextmanager/v1/service_perimeter.proto#L42}
   ///
@@ -769,7 +796,7 @@ class AccessContextManagerClient {
   future<StatusOr<google::identity::accesscontextmanager::v1::ServicePerimeter>>
   UpdateServicePerimeter(google::identity::accesscontextmanager::v1::
                              UpdateServicePerimeterRequest const& request,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Delete a [Service Perimeter]
@@ -783,7 +810,8 @@ class AccessContextManagerClient {
   ///  [google.identity.accesscontextmanager.v1.ServicePerimeter].
   ///  Format:
   ///  `accessPolicies/{policy_id}/servicePerimeters/{service_perimeter_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessContextManagerOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L940}
   ///
@@ -794,7 +822,7 @@ class AccessContextManagerClient {
   ///
   future<StatusOr<google::identity::accesscontextmanager::v1::
                       AccessContextManagerOperationMetadata>>
-  DeleteServicePerimeter(std::string const& name, Options options = {});
+  DeleteServicePerimeter(std::string const& name, Options opts = {});
 
   ///
   /// Delete a [Service Perimeter]
@@ -806,7 +834,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::DeleteServicePerimeterRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L736}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::AccessContextManagerOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L940}
   ///
@@ -819,7 +848,7 @@ class AccessContextManagerClient {
                       AccessContextManagerOperationMetadata>>
   DeleteServicePerimeter(google::identity::accesscontextmanager::v1::
                              DeleteServicePerimeterRequest const& request,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Replace all existing [Service Perimeters]
@@ -838,7 +867,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ReplaceServicePerimetersRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L752}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ReplaceServicePerimetersResponse,google/identity/accesscontextmanager/v1/access_context_manager.proto#L785}
   ///
@@ -851,7 +881,7 @@ class AccessContextManagerClient {
                       ReplaceServicePerimetersResponse>>
   ReplaceServicePerimeters(google::identity::accesscontextmanager::v1::
                                ReplaceServicePerimetersRequest const& request,
-                           Options options = {});
+                           Options opts = {});
 
   ///
   /// Commit the dry-run spec for all the [Service Perimeters]
@@ -872,7 +902,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::CommitServicePerimetersRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L794}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::CommitServicePerimetersResponse,google/identity/accesscontextmanager/v1/access_context_manager.proto#L821}
   ///
@@ -885,7 +916,7 @@ class AccessContextManagerClient {
                       CommitServicePerimetersResponse>>
   CommitServicePerimeters(google::identity::accesscontextmanager::v1::
                               CommitServicePerimetersRequest const& request,
-                          Options options = {});
+                          Options opts = {});
 
   ///
   /// Lists all [GcpUserAccessBindings]
@@ -893,7 +924,8 @@ class AccessContextManagerClient {
   /// Google Cloud organization.
   ///
   /// @param parent  Required. Example: "organizations/256"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -903,7 +935,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
   StreamRange<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
-  ListGcpUserAccessBindings(std::string const& parent, Options options = {});
+  ListGcpUserAccessBindings(std::string const& parent, Options opts = {});
 
   ///
   /// Lists all [GcpUserAccessBindings]
@@ -912,7 +944,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::ListGcpUserAccessBindingsRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L831}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -924,7 +957,7 @@ class AccessContextManagerClient {
   StreamRange<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
   ListGcpUserAccessBindings(google::identity::accesscontextmanager::v1::
                                 ListGcpUserAccessBindingsRequest request,
-                            Options options = {});
+                            Options opts = {});
 
   ///
   /// Gets the [GcpUserAccessBinding]
@@ -933,7 +966,8 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Example:
   /// "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -943,7 +977,7 @@ class AccessContextManagerClient {
   /// @googleapis_reference_link{google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
   StatusOr<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
-  GetGcpUserAccessBinding(std::string const& name, Options options = {});
+  GetGcpUserAccessBinding(std::string const& name, Options opts = {});
 
   ///
   /// Gets the [GcpUserAccessBinding]
@@ -952,7 +986,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GetGcpUserAccessBindingRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L878}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -964,7 +999,7 @@ class AccessContextManagerClient {
   StatusOr<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
   GetGcpUserAccessBinding(google::identity::accesscontextmanager::v1::
                               GetGcpUserAccessBindingRequest const& request,
-                          Options options = {});
+                          Options opts = {});
 
   ///
   /// Creates a [GcpUserAccessBinding]
@@ -981,7 +1016,8 @@ class AccessContextManagerClient {
   /// @param parent  Required. Example: "organizations/256"
   /// @param gcp_user_access_binding  Required. [GcpUserAccessBinding]
   ///  [google.identity.accesscontextmanager.v1.GcpUserAccessBinding]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -996,7 +1032,7 @@ class AccessContextManagerClient {
       std::string const& parent,
       google::identity::accesscontextmanager::v1::GcpUserAccessBinding const&
           gcp_user_access_binding,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a [GcpUserAccessBinding]
@@ -1012,7 +1048,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::CreateGcpUserAccessBindingRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L890}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -1026,7 +1063,7 @@ class AccessContextManagerClient {
   CreateGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           CreateGcpUserAccessBindingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a [GcpUserAccessBinding]
@@ -1043,7 +1080,8 @@ class AccessContextManagerClient {
   ///  update_mask {
   ///  paths: "access_levels"
   ///  }
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -1057,7 +1095,7 @@ class AccessContextManagerClient {
   UpdateGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::GcpUserAccessBinding const&
           gcp_user_access_binding,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a [GcpUserAccessBinding]
@@ -1068,7 +1106,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::UpdateGcpUserAccessBindingRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L906}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBinding,google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto#L34}
   ///
@@ -1082,7 +1121,7 @@ class AccessContextManagerClient {
   UpdateGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           UpdateGcpUserAccessBindingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a [GcpUserAccessBinding]
@@ -1093,7 +1132,8 @@ class AccessContextManagerClient {
   ///
   /// @param name  Required. Example:
   /// "organizations/256/gcpUserAccessBindings/b3-BhcX_Ud5N"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBindingOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L935}
   ///
@@ -1104,7 +1144,7 @@ class AccessContextManagerClient {
   ///
   future<StatusOr<google::identity::accesscontextmanager::v1::
                       GcpUserAccessBindingOperationMetadata>>
-  DeleteGcpUserAccessBinding(std::string const& name, Options options = {});
+  DeleteGcpUserAccessBinding(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a [GcpUserAccessBinding]
@@ -1115,7 +1155,8 @@ class AccessContextManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::identity::accesscontextmanager::v1::DeleteGcpUserAccessBindingRequest,google/identity/accesscontextmanager/v1/access_context_manager.proto#L922}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::identity::accesscontextmanager::v1::GcpUserAccessBindingOperationMetadata,google/identity/accesscontextmanager/v1/access_context_manager.proto#L935}
   ///
@@ -1129,7 +1170,7 @@ class AccessContextManagerClient {
   DeleteGcpUserAccessBinding(
       google::identity::accesscontextmanager::v1::
           DeleteGcpUserAccessBindingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AccessContextManagerConnection> connection_;

--- a/google/cloud/apigateway/api_gateway_client.cc
+++ b/google/cloud/apigateway/api_gateway_client.cc
@@ -26,19 +26,16 @@ namespace apigateway {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ApiGatewayServiceClient::ApiGatewayServiceClient(
-    std::shared_ptr<ApiGatewayServiceConnection> connection, Options options)
+    std::shared_ptr<ApiGatewayServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          apigateway_internal::ApiGatewayServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), apigateway_internal::ApiGatewayServiceDefaultOptions(
+                               connection_->options()))) {}
 ApiGatewayServiceClient::~ApiGatewayServiceClient() = default;
 
 StreamRange<google::cloud::apigateway::v1::Gateway>
-ApiGatewayServiceClient::ListGateways(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ApiGatewayServiceClient::ListGateways(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::ListGatewaysRequest request;
   request.set_parent(parent);
   return connection_->ListGateways(request);
@@ -46,17 +43,14 @@ ApiGatewayServiceClient::ListGateways(std::string const& parent,
 
 StreamRange<google::cloud::apigateway::v1::Gateway>
 ApiGatewayServiceClient::ListGateways(
-    google::cloud::apigateway::v1::ListGatewaysRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::apigateway::v1::ListGatewaysRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGateways(std::move(request));
 }
 
 StatusOr<google::cloud::apigateway::v1::Gateway>
-ApiGatewayServiceClient::GetGateway(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ApiGatewayServiceClient::GetGateway(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::GetGatewayRequest request;
   request.set_name(name);
   return connection_->GetGateway(request);
@@ -65,9 +59,8 @@ ApiGatewayServiceClient::GetGateway(std::string const& name, Options options) {
 StatusOr<google::cloud::apigateway::v1::Gateway>
 ApiGatewayServiceClient::GetGateway(
     google::cloud::apigateway::v1::GetGatewayRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGateway(request);
 }
 
@@ -75,9 +68,8 @@ future<StatusOr<google::cloud::apigateway::v1::Gateway>>
 ApiGatewayServiceClient::CreateGateway(
     std::string const& parent,
     google::cloud::apigateway::v1::Gateway const& gateway,
-    std::string const& gateway_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& gateway_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::CreateGatewayRequest request;
   request.set_parent(parent);
   *request.mutable_gateway() = gateway;
@@ -88,18 +80,16 @@ ApiGatewayServiceClient::CreateGateway(
 future<StatusOr<google::cloud::apigateway::v1::Gateway>>
 ApiGatewayServiceClient::CreateGateway(
     google::cloud::apigateway::v1::CreateGatewayRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGateway(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::Gateway>>
 ApiGatewayServiceClient::UpdateGateway(
     google::cloud::apigateway::v1::Gateway const& gateway,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::UpdateGatewayRequest request;
   *request.mutable_gateway() = gateway;
   *request.mutable_update_mask() = update_mask;
@@ -109,17 +99,14 @@ ApiGatewayServiceClient::UpdateGateway(
 future<StatusOr<google::cloud::apigateway::v1::Gateway>>
 ApiGatewayServiceClient::UpdateGateway(
     google::cloud::apigateway::v1::UpdateGatewayRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGateway(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
-ApiGatewayServiceClient::DeleteGateway(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ApiGatewayServiceClient::DeleteGateway(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::DeleteGatewayRequest request;
   request.set_name(name);
   return connection_->DeleteGateway(request);
@@ -128,16 +115,14 @@ ApiGatewayServiceClient::DeleteGateway(std::string const& name,
 future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
 ApiGatewayServiceClient::DeleteGateway(
     google::cloud::apigateway::v1::DeleteGatewayRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGateway(request);
 }
 
 StreamRange<google::cloud::apigateway::v1::Api>
-ApiGatewayServiceClient::ListApis(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ApiGatewayServiceClient::ListApis(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::ListApisRequest request;
   request.set_parent(parent);
   return connection_->ListApis(request);
@@ -145,35 +130,30 @@ ApiGatewayServiceClient::ListApis(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::apigateway::v1::Api>
 ApiGatewayServiceClient::ListApis(
-    google::cloud::apigateway::v1::ListApisRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::apigateway::v1::ListApisRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListApis(std::move(request));
 }
 
 StatusOr<google::cloud::apigateway::v1::Api> ApiGatewayServiceClient::GetApi(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::GetApiRequest request;
   request.set_name(name);
   return connection_->GetApi(request);
 }
 
 StatusOr<google::cloud::apigateway::v1::Api> ApiGatewayServiceClient::GetApi(
-    google::cloud::apigateway::v1::GetApiRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::apigateway::v1::GetApiRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetApi(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::Api>>
 ApiGatewayServiceClient::CreateApi(
     std::string const& parent, google::cloud::apigateway::v1::Api const& api,
-    std::string const& api_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& api_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::CreateApiRequest request;
   request.set_parent(parent);
   *request.mutable_api() = api;
@@ -184,18 +164,16 @@ ApiGatewayServiceClient::CreateApi(
 future<StatusOr<google::cloud::apigateway::v1::Api>>
 ApiGatewayServiceClient::CreateApi(
     google::cloud::apigateway::v1::CreateApiRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateApi(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::Api>>
 ApiGatewayServiceClient::UpdateApi(
     google::cloud::apigateway::v1::Api const& api,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::UpdateApiRequest request;
   *request.mutable_api() = api;
   *request.mutable_update_mask() = update_mask;
@@ -205,16 +183,14 @@ ApiGatewayServiceClient::UpdateApi(
 future<StatusOr<google::cloud::apigateway::v1::Api>>
 ApiGatewayServiceClient::UpdateApi(
     google::cloud::apigateway::v1::UpdateApiRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateApi(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
-ApiGatewayServiceClient::DeleteApi(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ApiGatewayServiceClient::DeleteApi(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::DeleteApiRequest request;
   request.set_name(name);
   return connection_->DeleteApi(request);
@@ -223,17 +199,15 @@ ApiGatewayServiceClient::DeleteApi(std::string const& name, Options options) {
 future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
 ApiGatewayServiceClient::DeleteApi(
     google::cloud::apigateway::v1::DeleteApiRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteApi(request);
 }
 
 StreamRange<google::cloud::apigateway::v1::ApiConfig>
 ApiGatewayServiceClient::ListApiConfigs(std::string const& parent,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::ListApiConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListApiConfigs(request);
@@ -242,17 +216,14 @@ ApiGatewayServiceClient::ListApiConfigs(std::string const& parent,
 StreamRange<google::cloud::apigateway::v1::ApiConfig>
 ApiGatewayServiceClient::ListApiConfigs(
     google::cloud::apigateway::v1::ListApiConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListApiConfigs(std::move(request));
 }
 
 StatusOr<google::cloud::apigateway::v1::ApiConfig>
-ApiGatewayServiceClient::GetApiConfig(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ApiGatewayServiceClient::GetApiConfig(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::GetApiConfigRequest request;
   request.set_name(name);
   return connection_->GetApiConfig(request);
@@ -261,9 +232,8 @@ ApiGatewayServiceClient::GetApiConfig(std::string const& name,
 StatusOr<google::cloud::apigateway::v1::ApiConfig>
 ApiGatewayServiceClient::GetApiConfig(
     google::cloud::apigateway::v1::GetApiConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetApiConfig(request);
 }
 
@@ -271,9 +241,8 @@ future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>
 ApiGatewayServiceClient::CreateApiConfig(
     std::string const& parent,
     google::cloud::apigateway::v1::ApiConfig const& api_config,
-    std::string const& api_config_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& api_config_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::CreateApiConfigRequest request;
   request.set_parent(parent);
   *request.mutable_api_config() = api_config;
@@ -284,18 +253,16 @@ ApiGatewayServiceClient::CreateApiConfig(
 future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>
 ApiGatewayServiceClient::CreateApiConfig(
     google::cloud::apigateway::v1::CreateApiConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateApiConfig(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>
 ApiGatewayServiceClient::UpdateApiConfig(
     google::cloud::apigateway::v1::ApiConfig const& api_config,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::UpdateApiConfigRequest request;
   *request.mutable_api_config() = api_config;
   *request.mutable_update_mask() = update_mask;
@@ -305,17 +272,15 @@ ApiGatewayServiceClient::UpdateApiConfig(
 future<StatusOr<google::cloud::apigateway::v1::ApiConfig>>
 ApiGatewayServiceClient::UpdateApiConfig(
     google::cloud::apigateway::v1::UpdateApiConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateApiConfig(request);
 }
 
 future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
 ApiGatewayServiceClient::DeleteApiConfig(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigateway::v1::DeleteApiConfigRequest request;
   request.set_name(name);
   return connection_->DeleteApiConfig(request);
@@ -324,9 +289,8 @@ ApiGatewayServiceClient::DeleteApiConfig(std::string const& name,
 future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
 ApiGatewayServiceClient::DeleteApiConfig(
     google::cloud::apigateway::v1::DeleteApiConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteApiConfig(request);
 }
 

--- a/google/cloud/apigateway/api_gateway_client.h
+++ b/google/cloud/apigateway/api_gateway_client.h
@@ -64,7 +64,7 @@ class ApiGatewayServiceClient {
  public:
   explicit ApiGatewayServiceClient(
       std::shared_ptr<ApiGatewayServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ApiGatewayServiceClient();
 
   //@{
@@ -92,7 +92,8 @@ class ApiGatewayServiceClient {
   ///
   /// @param parent  Required. Parent resource of the Gateway, of the form:
   ///  `projects/*/locations/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -102,14 +103,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
   StreamRange<google::cloud::apigateway::v1::Gateway> ListGateways(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Gateways in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::ListGatewaysRequest,google/cloud/apigateway/v1/apigateway.proto#L306}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -120,14 +122,15 @@ class ApiGatewayServiceClient {
   ///
   StreamRange<google::cloud::apigateway::v1::Gateway> ListGateways(
       google::cloud::apigateway::v1::ListGatewaysRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Gateway.
   ///
   /// @param name  Required. Resource name of the form:
   ///  `projects/*/locations/*/gateways/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -137,14 +140,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
   StatusOr<google::cloud::apigateway::v1::Gateway> GetGateway(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Gateway.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::GetGatewayRequest,google/cloud/apigateway/v1/apigateway.proto#L342}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -155,7 +159,7 @@ class ApiGatewayServiceClient {
   ///
   StatusOr<google::cloud::apigateway::v1::Gateway> GetGateway(
       google::cloud::apigateway::v1::GetGatewayRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Gateway in a given project and location.
@@ -166,7 +170,8 @@ class ApiGatewayServiceClient {
   /// @param gateway_id  Required. Identifier to assign to the Gateway. Must be
   /// unique within scope of
   ///  the parent resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -178,14 +183,15 @@ class ApiGatewayServiceClient {
   future<StatusOr<google::cloud::apigateway::v1::Gateway>> CreateGateway(
       std::string const& parent,
       google::cloud::apigateway::v1::Gateway const& gateway,
-      std::string const& gateway_id, Options options = {});
+      std::string const& gateway_id, Options opts = {});
 
   ///
   /// Creates a new Gateway in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::CreateGatewayRequest,google/cloud/apigateway/v1/apigateway.proto#L354}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -196,7 +202,7 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Gateway>> CreateGateway(
       google::cloud::apigateway::v1::CreateGatewayRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single Gateway.
@@ -208,7 +214,8 @@ class ApiGatewayServiceClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -219,14 +226,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Gateway>> UpdateGateway(
       google::cloud::apigateway::v1::Gateway const& gateway,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single Gateway.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::UpdateGatewayRequest,google/cloud/apigateway/v1/apigateway.proto#L373}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Gateway,google/cloud/apigateway/v1/apigateway.proto#L243}
   ///
@@ -237,14 +245,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Gateway>> UpdateGateway(
       google::cloud::apigateway::v1::UpdateGatewayRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Gateway.
   ///
   /// @param name  Required. Resource name of the form:
   ///  `projects/*/locations/*/gateways/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::OperationMetadata,google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
@@ -254,14 +263,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
-  DeleteGateway(std::string const& name, Options options = {});
+  DeleteGateway(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Gateway.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::DeleteGatewayRequest,google/cloud/apigateway/v1/apigateway.proto#L386}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::OperationMetadata,google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
@@ -273,14 +283,15 @@ class ApiGatewayServiceClient {
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
   DeleteGateway(
       google::cloud::apigateway::v1::DeleteGatewayRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Apis in a given project and location.
   ///
   /// @param parent  Required. Parent resource of the API, of the form:
   ///  `projects/*/locations/global`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -290,14 +301,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
   StreamRange<google::cloud::apigateway::v1::Api> ListApis(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Apis in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::ListApisRequest,google/cloud/apigateway/v1/apigateway.proto#L398}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -308,14 +320,15 @@ class ApiGatewayServiceClient {
   ///
   StreamRange<google::cloud::apigateway::v1::Api> ListApis(
       google::cloud::apigateway::v1::ListApisRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Api.
   ///
   /// @param name  Required. Resource name of the form:
   ///  `projects/*/locations/global/apis/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -325,14 +338,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
   StatusOr<google::cloud::apigateway::v1::Api> GetApi(std::string const& name,
-                                                      Options options = {});
+                                                      Options opts = {});
 
   ///
   /// Gets details of a single Api.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::GetApiRequest,google/cloud/apigateway/v1/apigateway.proto#L434}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -343,7 +357,7 @@ class ApiGatewayServiceClient {
   ///
   StatusOr<google::cloud::apigateway::v1::Api> GetApi(
       google::cloud::apigateway::v1::GetApiRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Api in a given project and location.
@@ -354,7 +368,8 @@ class ApiGatewayServiceClient {
   /// @param api_id  Required. Identifier to assign to the API. Must be unique
   /// within scope of
   ///  the parent resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -365,14 +380,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Api>> CreateApi(
       std::string const& parent, google::cloud::apigateway::v1::Api const& api,
-      std::string const& api_id, Options options = {});
+      std::string const& api_id, Options opts = {});
 
   ///
   /// Creates a new Api in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::CreateApiRequest,google/cloud/apigateway/v1/apigateway.proto#L446}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -383,7 +399,7 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Api>> CreateApi(
       google::cloud::apigateway::v1::CreateApiRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single Api.
@@ -395,7 +411,8 @@ class ApiGatewayServiceClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -406,14 +423,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Api>> UpdateApi(
       google::cloud::apigateway::v1::Api const& api,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single Api.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::UpdateApiRequest,google/cloud/apigateway/v1/apigateway.proto#L465}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::Api,google/cloud/apigateway/v1/apigateway.proto#L45}
   ///
@@ -424,14 +442,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::Api>> UpdateApi(
       google::cloud::apigateway::v1::UpdateApiRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Api.
   ///
   /// @param name  Required. Resource name of the form:
   ///  `projects/*/locations/global/apis/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::OperationMetadata,google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
@@ -441,14 +460,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>> DeleteApi(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Api.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::DeleteApiRequest,google/cloud/apigateway/v1/apigateway.proto#L478}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::OperationMetadata,google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
@@ -459,14 +479,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>> DeleteApi(
       google::cloud::apigateway::v1::DeleteApiRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists ApiConfigs in a given project and location.
   ///
   /// @param parent  Required. Parent resource of the API Config, of the form:
   ///  `projects/*/locations/global/apis/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -476,14 +497,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
   StreamRange<google::cloud::apigateway::v1::ApiConfig> ListApiConfigs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists ApiConfigs in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::ListApiConfigsRequest,google/cloud/apigateway/v1/apigateway.proto#L490}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -494,14 +516,15 @@ class ApiGatewayServiceClient {
   ///
   StreamRange<google::cloud::apigateway::v1::ApiConfig> ListApiConfigs(
       google::cloud::apigateway::v1::ListApiConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single ApiConfig.
   ///
   /// @param name  Required. Resource name of the form:
   ///  `projects/*/locations/global/apis/*/configs/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -511,14 +534,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
   StatusOr<google::cloud::apigateway::v1::ApiConfig> GetApiConfig(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single ApiConfig.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::GetApiConfigRequest,google/cloud/apigateway/v1/apigateway.proto#L526}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -529,7 +553,7 @@ class ApiGatewayServiceClient {
   ///
   StatusOr<google::cloud::apigateway::v1::ApiConfig> GetApiConfig(
       google::cloud::apigateway::v1::GetApiConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new ApiConfig in a given project and location.
@@ -540,7 +564,8 @@ class ApiGatewayServiceClient {
   /// @param api_config_id  Required. Identifier to assign to the API Config.
   /// Must be unique within scope of
   ///  the parent resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -552,14 +577,15 @@ class ApiGatewayServiceClient {
   future<StatusOr<google::cloud::apigateway::v1::ApiConfig>> CreateApiConfig(
       std::string const& parent,
       google::cloud::apigateway::v1::ApiConfig const& api_config,
-      std::string const& api_config_id, Options options = {});
+      std::string const& api_config_id, Options opts = {});
 
   ///
   /// Creates a new ApiConfig in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::CreateApiConfigRequest,google/cloud/apigateway/v1/apigateway.proto#L553}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -570,7 +596,7 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::ApiConfig>> CreateApiConfig(
       google::cloud::apigateway::v1::CreateApiConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single ApiConfig.
@@ -582,7 +608,8 @@ class ApiGatewayServiceClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -593,14 +620,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::ApiConfig>> UpdateApiConfig(
       google::cloud::apigateway::v1::ApiConfig const& api_config,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single ApiConfig.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::UpdateApiConfigRequest,google/cloud/apigateway/v1/apigateway.proto#L572}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::ApiConfig,google/cloud/apigateway/v1/apigateway.proto#L108}
   ///
@@ -611,14 +639,15 @@ class ApiGatewayServiceClient {
   ///
   future<StatusOr<google::cloud::apigateway::v1::ApiConfig>> UpdateApiConfig(
       google::cloud::apigateway::v1::UpdateApiConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single ApiConfig.
   ///
   /// @param name  Required. Resource name of the form:
   ///  `projects/*/locations/global/apis/*/configs/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::OperationMetadata,google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
@@ -628,14 +657,15 @@ class ApiGatewayServiceClient {
   /// @googleapis_reference_link{google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
-  DeleteApiConfig(std::string const& name, Options options = {});
+  DeleteApiConfig(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single ApiConfig.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigateway::v1::DeleteApiConfigRequest,google/cloud/apigateway/v1/apigateway.proto#L585}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigateway::v1::OperationMetadata,google/cloud/apigateway/v1/apigateway.proto#L597}
   ///
@@ -647,7 +677,7 @@ class ApiGatewayServiceClient {
   future<StatusOr<google::cloud::apigateway::v1::OperationMetadata>>
   DeleteApiConfig(
       google::cloud::apigateway::v1::DeleteApiConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ApiGatewayServiceConnection> connection_;

--- a/google/cloud/apigeeconnect/connection_client.cc
+++ b/google/cloud/apigeeconnect/connection_client.cc
@@ -26,19 +26,18 @@ namespace apigeeconnect {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ConnectionServiceClient::ConnectionServiceClient(
-    std::shared_ptr<ConnectionServiceConnection> connection, Options options)
+    std::shared_ptr<ConnectionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           apigeeconnect_internal::ConnectionServiceDefaultOptions(
               connection_->options()))) {}
 ConnectionServiceClient::~ConnectionServiceClient() = default;
 
 StreamRange<google::cloud::apigeeconnect::v1::Connection>
 ConnectionServiceClient::ListConnections(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::apigeeconnect::v1::ListConnectionsRequest request;
   request.set_parent(parent);
   return connection_->ListConnections(request);
@@ -47,9 +46,8 @@ ConnectionServiceClient::ListConnections(std::string const& parent,
 StreamRange<google::cloud::apigeeconnect::v1::Connection>
 ConnectionServiceClient::ListConnections(
     google::cloud::apigeeconnect::v1::ListConnectionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListConnections(std::move(request));
 }
 

--- a/google/cloud/apigeeconnect/connection_client.h
+++ b/google/cloud/apigeeconnect/connection_client.h
@@ -62,7 +62,7 @@ class ConnectionServiceClient {
  public:
   explicit ConnectionServiceClient(
       std::shared_ptr<ConnectionServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ConnectionServiceClient();
 
   //@{
@@ -91,7 +91,8 @@ class ConnectionServiceClient {
   ///
   /// @param parent  Required. Parent name of the form:
   ///      `projects/{project_number or project_id}/endpoints/{endpoint}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigeeconnect::v1::Connection,google/cloud/apigeeconnect/v1/connection.proto#L86}
   ///
@@ -101,7 +102,7 @@ class ConnectionServiceClient {
   /// @googleapis_reference_link{google/cloud/apigeeconnect/v1/connection.proto#L86}
   ///
   StreamRange<google::cloud::apigeeconnect::v1::Connection> ListConnections(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists connections that are currently active for the given Apigee Connect
@@ -109,7 +110,8 @@ class ConnectionServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::apigeeconnect::v1::ListConnectionsRequest,google/cloud/apigeeconnect/v1/connection.proto#L52}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::apigeeconnect::v1::Connection,google/cloud/apigeeconnect/v1/connection.proto#L86}
   ///
@@ -120,7 +122,7 @@ class ConnectionServiceClient {
   ///
   StreamRange<google::cloud::apigeeconnect::v1::Connection> ListConnections(
       google::cloud::apigeeconnect::v1::ListConnectionsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ConnectionServiceConnection> connection_;

--- a/google/cloud/appengine/applications_client.cc
+++ b/google/cloud/appengine/applications_client.cc
@@ -26,45 +26,40 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ApplicationsClient::ApplicationsClient(
-    std::shared_ptr<ApplicationsConnection> connection, Options options)
+    std::shared_ptr<ApplicationsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), appengine_internal::ApplicationsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), appengine_internal::ApplicationsDefaultOptions(
+                               connection_->options()))) {}
 ApplicationsClient::~ApplicationsClient() = default;
 
 StatusOr<google::appengine::v1::Application> ApplicationsClient::GetApplication(
-    google::appengine::v1::GetApplicationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::GetApplicationRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetApplication(request);
 }
 
 future<StatusOr<google::appengine::v1::Application>>
 ApplicationsClient::CreateApplication(
     google::appengine::v1::CreateApplicationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateApplication(request);
 }
 
 future<StatusOr<google::appengine::v1::Application>>
 ApplicationsClient::UpdateApplication(
     google::appengine::v1::UpdateApplicationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateApplication(request);
 }
 
 future<StatusOr<google::appengine::v1::Application>>
 ApplicationsClient::RepairApplication(
     google::appengine::v1::RepairApplicationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RepairApplication(request);
 }
 

--- a/google/cloud/appengine/applications_client.h
+++ b/google/cloud/appengine/applications_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ApplicationsClient {
  public:
   explicit ApplicationsClient(
-      std::shared_ptr<ApplicationsConnection> connection, Options options = {});
+      std::shared_ptr<ApplicationsConnection> connection, Options opts = {});
   ~ApplicationsClient();
 
   //@{
@@ -90,7 +90,8 @@ class ApplicationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetApplicationRequest,google/appengine/v1/appengine.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Application,google/appengine/v1/application.proto#L32}
   ///
@@ -101,7 +102,7 @@ class ApplicationsClient {
   ///
   StatusOr<google::appengine::v1::Application> GetApplication(
       google::appengine::v1::GetApplicationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an App Engine application for a Google Cloud Platform project.
@@ -118,7 +119,8 @@ class ApplicationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::CreateApplicationRequest,google/appengine/v1/appengine.proto#L119}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Application,google/appengine/v1/application.proto#L32}
   ///
@@ -129,7 +131,7 @@ class ApplicationsClient {
   ///
   future<StatusOr<google::appengine::v1::Application>> CreateApplication(
       google::appengine::v1::CreateApplicationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the specified Application resource.
@@ -142,7 +144,8 @@ class ApplicationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::UpdateApplicationRequest,google/appengine/v1/appengine.proto#L125}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Application,google/appengine/v1/application.proto#L32}
   ///
@@ -153,7 +156,7 @@ class ApplicationsClient {
   ///
   future<StatusOr<google::appengine::v1::Application>> UpdateApplication(
       google::appengine::v1::UpdateApplicationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Recreates the required App Engine features for the specified App Engine
@@ -170,7 +173,8 @@ class ApplicationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::RepairApplicationRequest,google/appengine/v1/appengine.proto#L137}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Application,google/appengine/v1/application.proto#L32}
   ///
@@ -181,7 +185,7 @@ class ApplicationsClient {
   ///
   future<StatusOr<google::appengine::v1::Application>> RepairApplication(
       google::appengine::v1::RepairApplicationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ApplicationsConnection> connection_;

--- a/google/cloud/appengine/authorized_certificates_client.cc
+++ b/google/cloud/appengine/authorized_certificates_client.cc
@@ -26,11 +26,10 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AuthorizedCertificatesClient::AuthorizedCertificatesClient(
-    std::shared_ptr<AuthorizedCertificatesConnection> connection,
-    Options options)
+    std::shared_ptr<AuthorizedCertificatesConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           appengine_internal::AuthorizedCertificatesDefaultOptions(
               connection_->options()))) {}
 AuthorizedCertificatesClient::~AuthorizedCertificatesClient() = default;
@@ -38,44 +37,39 @@ AuthorizedCertificatesClient::~AuthorizedCertificatesClient() = default;
 StreamRange<google::appengine::v1::AuthorizedCertificate>
 AuthorizedCertificatesClient::ListAuthorizedCertificates(
     google::appengine::v1::ListAuthorizedCertificatesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAuthorizedCertificates(std::move(request));
 }
 
 StatusOr<google::appengine::v1::AuthorizedCertificate>
 AuthorizedCertificatesClient::GetAuthorizedCertificate(
     google::appengine::v1::GetAuthorizedCertificateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAuthorizedCertificate(request);
 }
 
 StatusOr<google::appengine::v1::AuthorizedCertificate>
 AuthorizedCertificatesClient::CreateAuthorizedCertificate(
     google::appengine::v1::CreateAuthorizedCertificateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAuthorizedCertificate(request);
 }
 
 StatusOr<google::appengine::v1::AuthorizedCertificate>
 AuthorizedCertificatesClient::UpdateAuthorizedCertificate(
     google::appengine::v1::UpdateAuthorizedCertificateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAuthorizedCertificate(request);
 }
 
 Status AuthorizedCertificatesClient::DeleteAuthorizedCertificate(
     google::appengine::v1::DeleteAuthorizedCertificateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAuthorizedCertificate(request);
 }
 

--- a/google/cloud/appengine/authorized_certificates_client.h
+++ b/google/cloud/appengine/authorized_certificates_client.h
@@ -63,7 +63,7 @@ class AuthorizedCertificatesClient {
  public:
   explicit AuthorizedCertificatesClient(
       std::shared_ptr<AuthorizedCertificatesConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AuthorizedCertificatesClient();
 
   //@{
@@ -93,7 +93,8 @@ class AuthorizedCertificatesClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListAuthorizedCertificatesRequest,google/appengine/v1/appengine.proto#L652}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::AuthorizedCertificate,google/appengine/v1/certificate.proto#L33}
   ///
@@ -105,14 +106,15 @@ class AuthorizedCertificatesClient {
   StreamRange<google::appengine::v1::AuthorizedCertificate>
   ListAuthorizedCertificates(
       google::appengine::v1::ListAuthorizedCertificatesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the specified SSL certificate.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetAuthorizedCertificateRequest,google/appengine/v1/appengine.proto#L743}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::AuthorizedCertificate,google/appengine/v1/certificate.proto#L33}
   ///
@@ -124,14 +126,15 @@ class AuthorizedCertificatesClient {
   StatusOr<google::appengine::v1::AuthorizedCertificate>
   GetAuthorizedCertificate(
       google::appengine::v1::GetAuthorizedCertificateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Uploads the specified SSL certificate.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::CreateAuthorizedCertificateRequest,google/appengine/v1/appengine.proto#L753}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::AuthorizedCertificate,google/appengine/v1/certificate.proto#L33}
   ///
@@ -143,7 +146,7 @@ class AuthorizedCertificatesClient {
   StatusOr<google::appengine::v1::AuthorizedCertificate>
   CreateAuthorizedCertificate(
       google::appengine::v1::CreateAuthorizedCertificateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the specified SSL certificate. To renew a certificate and maintain
@@ -154,7 +157,8 @@ class AuthorizedCertificatesClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::UpdateAuthorizedCertificateRequest,google/appengine/v1/appengine.proto#L762}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::AuthorizedCertificate,google/appengine/v1/certificate.proto#L33}
   ///
@@ -166,21 +170,22 @@ class AuthorizedCertificatesClient {
   StatusOr<google::appengine::v1::AuthorizedCertificate>
   UpdateAuthorizedCertificate(
       google::appengine::v1::UpdateAuthorizedCertificateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified SSL certificate.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DeleteAuthorizedCertificateRequest,google/appengine/v1/appengine.proto#L777}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.appengine.v1.DeleteAuthorizedCertificateRequest]:
   /// @googleapis_reference_link{google/appengine/v1/appengine.proto#L777}
   ///
   Status DeleteAuthorizedCertificate(
       google::appengine::v1::DeleteAuthorizedCertificateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AuthorizedCertificatesConnection> connection_;

--- a/google/cloud/appengine/authorized_domains_client.cc
+++ b/google/cloud/appengine/authorized_domains_client.cc
@@ -26,20 +26,17 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AuthorizedDomainsClient::AuthorizedDomainsClient(
-    std::shared_ptr<AuthorizedDomainsConnection> connection, Options options)
+    std::shared_ptr<AuthorizedDomainsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          appengine_internal::AuthorizedDomainsDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), appengine_internal::AuthorizedDomainsDefaultOptions(
+                               connection_->options()))) {}
 AuthorizedDomainsClient::~AuthorizedDomainsClient() = default;
 
 StreamRange<google::appengine::v1::AuthorizedDomain>
 AuthorizedDomainsClient::ListAuthorizedDomains(
-    google::appengine::v1::ListAuthorizedDomainsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::ListAuthorizedDomainsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAuthorizedDomains(std::move(request));
 }
 

--- a/google/cloud/appengine/authorized_domains_client.h
+++ b/google/cloud/appengine/authorized_domains_client.h
@@ -64,7 +64,7 @@ class AuthorizedDomainsClient {
  public:
   explicit AuthorizedDomainsClient(
       std::shared_ptr<AuthorizedDomainsConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AuthorizedDomainsClient();
 
   //@{
@@ -92,7 +92,8 @@ class AuthorizedDomainsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListAuthorizedDomainsRequest,google/appengine/v1/appengine.proto#L631}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::AuthorizedDomain,google/appengine/v1/domain.proto#L32}
   ///
@@ -103,7 +104,7 @@ class AuthorizedDomainsClient {
   ///
   StreamRange<google::appengine::v1::AuthorizedDomain> ListAuthorizedDomains(
       google::appengine::v1::ListAuthorizedDomainsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AuthorizedDomainsConnection> connection_;

--- a/google/cloud/appengine/domain_mappings_client.cc
+++ b/google/cloud/appengine/domain_mappings_client.cc
@@ -26,54 +26,49 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DomainMappingsClient::DomainMappingsClient(
-    std::shared_ptr<DomainMappingsConnection> connection, Options options)
+    std::shared_ptr<DomainMappingsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), appengine_internal::DomainMappingsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), appengine_internal::DomainMappingsDefaultOptions(
+                               connection_->options()))) {}
 DomainMappingsClient::~DomainMappingsClient() = default;
 
 StreamRange<google::appengine::v1::DomainMapping>
 DomainMappingsClient::ListDomainMappings(
-    google::appengine::v1::ListDomainMappingsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::ListDomainMappingsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDomainMappings(std::move(request));
 }
 
 StatusOr<google::appengine::v1::DomainMapping>
 DomainMappingsClient::GetDomainMapping(
     google::appengine::v1::GetDomainMappingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDomainMapping(request);
 }
 
 future<StatusOr<google::appengine::v1::DomainMapping>>
 DomainMappingsClient::CreateDomainMapping(
     google::appengine::v1::CreateDomainMappingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDomainMapping(request);
 }
 
 future<StatusOr<google::appengine::v1::DomainMapping>>
 DomainMappingsClient::UpdateDomainMapping(
     google::appengine::v1::UpdateDomainMappingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDomainMapping(request);
 }
 
 future<StatusOr<google::appengine::v1::OperationMetadataV1>>
 DomainMappingsClient::DeleteDomainMapping(
     google::appengine::v1::DeleteDomainMappingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDomainMapping(request);
 }
 

--- a/google/cloud/appengine/domain_mappings_client.h
+++ b/google/cloud/appengine/domain_mappings_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DomainMappingsClient {
  public:
   explicit DomainMappingsClient(
-      std::shared_ptr<DomainMappingsConnection> connection,
-      Options options = {});
+      std::shared_ptr<DomainMappingsConnection> connection, Options opts = {});
   ~DomainMappingsClient();
 
   //@{
@@ -91,7 +90,8 @@ class DomainMappingsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListDomainMappingsRequest,google/appengine/v1/appengine.proto#L784}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::DomainMapping,google/appengine/v1/domain_mapping.proto#L30}
   ///
@@ -102,14 +102,15 @@ class DomainMappingsClient {
   ///
   StreamRange<google::appengine::v1::DomainMapping> ListDomainMappings(
       google::appengine::v1::ListDomainMappingsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the specified domain mapping.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetDomainMappingRequest,google/appengine/v1/appengine.proto#L805}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::DomainMapping,google/appengine/v1/domain_mapping.proto#L30}
   ///
@@ -120,7 +121,7 @@ class DomainMappingsClient {
   ///
   StatusOr<google::appengine::v1::DomainMapping> GetDomainMapping(
       google::appengine::v1::GetDomainMappingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Maps a domain to an application. A user must be authorized to administer a
@@ -129,7 +130,8 @@ class DomainMappingsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::CreateDomainMappingRequest,google/appengine/v1/appengine.proto#L812}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::DomainMapping,google/appengine/v1/domain_mapping.proto#L30}
   ///
@@ -140,7 +142,7 @@ class DomainMappingsClient {
   ///
   future<StatusOr<google::appengine::v1::DomainMapping>> CreateDomainMapping(
       google::appengine::v1::CreateDomainMappingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the specified domain mapping. To map an SSL certificate to a
@@ -150,7 +152,8 @@ class DomainMappingsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::UpdateDomainMappingRequest,google/appengine/v1/appengine.proto#L843}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::DomainMapping,google/appengine/v1/domain_mapping.proto#L30}
   ///
@@ -161,7 +164,7 @@ class DomainMappingsClient {
   ///
   future<StatusOr<google::appengine::v1::DomainMapping>> UpdateDomainMapping(
       google::appengine::v1::UpdateDomainMappingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified domain mapping. A user must be authorized to
@@ -170,7 +173,8 @@ class DomainMappingsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DeleteDomainMappingRequest,google/appengine/v1/appengine.proto#L857}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::OperationMetadataV1,google/appengine/v1/operation.proto#L32}
   ///
@@ -182,7 +186,7 @@ class DomainMappingsClient {
   future<StatusOr<google::appengine::v1::OperationMetadataV1>>
   DeleteDomainMapping(
       google::appengine::v1::DeleteDomainMappingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DomainMappingsConnection> connection_;

--- a/google/cloud/appengine/firewall_client.cc
+++ b/google/cloud/appengine/firewall_client.cc
@@ -26,60 +26,53 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 FirewallClient::FirewallClient(std::shared_ptr<FirewallConnection> connection,
-                               Options options)
+                               Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           appengine_internal::FirewallDefaultOptions(connection_->options()))) {
 }
 FirewallClient::~FirewallClient() = default;
 
 StreamRange<google::appengine::v1::FirewallRule>
 FirewallClient::ListIngressRules(
-    google::appengine::v1::ListIngressRulesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::ListIngressRulesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListIngressRules(std::move(request));
 }
 
 StatusOr<google::appengine::v1::BatchUpdateIngressRulesResponse>
 FirewallClient::BatchUpdateIngressRules(
     google::appengine::v1::BatchUpdateIngressRulesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchUpdateIngressRules(request);
 }
 
 StatusOr<google::appengine::v1::FirewallRule> FirewallClient::CreateIngressRule(
     google::appengine::v1::CreateIngressRuleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateIngressRule(request);
 }
 
 StatusOr<google::appengine::v1::FirewallRule> FirewallClient::GetIngressRule(
-    google::appengine::v1::GetIngressRuleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::GetIngressRuleRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIngressRule(request);
 }
 
 StatusOr<google::appengine::v1::FirewallRule> FirewallClient::UpdateIngressRule(
     google::appengine::v1::UpdateIngressRuleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateIngressRule(request);
 }
 
 Status FirewallClient::DeleteIngressRule(
     google::appengine::v1::DeleteIngressRuleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteIngressRule(request);
 }
 

--- a/google/cloud/appengine/firewall_client.h
+++ b/google/cloud/appengine/firewall_client.h
@@ -70,7 +70,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FirewallClient {
  public:
   explicit FirewallClient(std::shared_ptr<FirewallConnection> connection,
-                          Options options = {});
+                          Options opts = {});
   ~FirewallClient();
 
   //@{
@@ -96,7 +96,8 @@ class FirewallClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListIngressRulesRequest,google/appengine/v1/appengine.proto#L475}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::FirewallRule,google/appengine/v1/firewall.proto#L31}
   ///
@@ -107,7 +108,7 @@ class FirewallClient {
   ///
   StreamRange<google::appengine::v1::FirewallRule> ListIngressRules(
       google::appengine::v1::ListIngressRulesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Replaces the entire firewall ruleset in one bulk operation. This overrides
@@ -118,7 +119,8 @@ class FirewallClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::BatchUpdateIngressRulesRequest,google/appengine/v1/appengine.proto#L569}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::BatchUpdateIngressRulesResponse,google/appengine/v1/appengine.proto#L579}
   ///
@@ -130,14 +132,15 @@ class FirewallClient {
   StatusOr<google::appengine::v1::BatchUpdateIngressRulesResponse>
   BatchUpdateIngressRules(
       google::appengine::v1::BatchUpdateIngressRulesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a firewall rule for the application.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::CreateIngressRuleRequest,google/appengine/v1/appengine.proto#L585}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::FirewallRule,google/appengine/v1/firewall.proto#L31}
   ///
@@ -148,14 +151,15 @@ class FirewallClient {
   ///
   StatusOr<google::appengine::v1::FirewallRule> CreateIngressRule(
       google::appengine::v1::CreateIngressRuleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the specified firewall rule.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetIngressRuleRequest,google/appengine/v1/appengine.proto#L604}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::FirewallRule,google/appengine/v1/firewall.proto#L31}
   ///
@@ -166,14 +170,15 @@ class FirewallClient {
   ///
   StatusOr<google::appengine::v1::FirewallRule> GetIngressRule(
       google::appengine::v1::GetIngressRuleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the specified firewall rule.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::UpdateIngressRuleRequest,google/appengine/v1/appengine.proto#L611}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::FirewallRule,google/appengine/v1/firewall.proto#L31}
   ///
@@ -184,21 +189,22 @@ class FirewallClient {
   ///
   StatusOr<google::appengine::v1::FirewallRule> UpdateIngressRule(
       google::appengine::v1::UpdateIngressRuleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified firewall rule.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DeleteIngressRuleRequest,google/appengine/v1/appengine.proto#L624}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.appengine.v1.DeleteIngressRuleRequest]:
   /// @googleapis_reference_link{google/appengine/v1/appengine.proto#L624}
   ///
   Status DeleteIngressRule(
       google::appengine::v1::DeleteIngressRuleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<FirewallConnection> connection_;

--- a/google/cloud/appengine/instances_client.cc
+++ b/google/cloud/appengine/instances_client.cc
@@ -26,42 +26,36 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 InstancesClient::InstancesClient(
-    std::shared_ptr<InstancesConnection> connection, Options options)
+    std::shared_ptr<InstancesConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), appengine_internal::InstancesDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), appengine_internal::InstancesDefaultOptions(
+                               connection_->options()))) {}
 InstancesClient::~InstancesClient() = default;
 
 StreamRange<google::appengine::v1::Instance> InstancesClient::ListInstances(
-    google::appengine::v1::ListInstancesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::ListInstancesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::appengine::v1::Instance> InstancesClient::GetInstance(
-    google::appengine::v1::GetInstanceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::GetInstanceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
 future<StatusOr<google::appengine::v1::OperationMetadataV1>>
 InstancesClient::DeleteInstance(
-    google::appengine::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::DeleteInstanceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
 future<StatusOr<google::appengine::v1::Instance>>
 InstancesClient::DebugInstance(
-    google::appengine::v1::DebugInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::DebugInstanceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DebugInstance(request);
 }
 

--- a/google/cloud/appengine/instances_client.h
+++ b/google/cloud/appengine/instances_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstancesClient {
  public:
   explicit InstancesClient(std::shared_ptr<InstancesConnection> connection,
-                           Options options = {});
+                           Options opts = {});
   ~InstancesClient();
 
   //@{
@@ -92,7 +92,8 @@ class InstancesClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListInstancesRequest,google/appengine/v1/appengine.proto#L423}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Instance,google/appengine/v1/instance.proto#L34}
   ///
@@ -102,15 +103,15 @@ class InstancesClient {
   /// @googleapis_reference_link{google/appengine/v1/instance.proto#L34}
   ///
   StreamRange<google::appengine::v1::Instance> ListInstances(
-      google::appengine::v1::ListInstancesRequest request,
-      Options options = {});
+      google::appengine::v1::ListInstancesRequest request, Options opts = {});
 
   ///
   /// Gets instance information.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetInstanceRequest,google/appengine/v1/appengine.proto#L445}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Instance,google/appengine/v1/instance.proto#L34}
   ///
@@ -121,7 +122,7 @@ class InstancesClient {
   ///
   StatusOr<google::appengine::v1::Instance> GetInstance(
       google::appengine::v1::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a running instance.
@@ -142,7 +143,8 @@ class InstancesClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DeleteInstanceRequest,google/appengine/v1/appengine.proto#L452}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::OperationMetadataV1,google/appengine/v1/operation.proto#L32}
   ///
@@ -153,7 +155,7 @@ class InstancesClient {
   ///
   future<StatusOr<google::appengine::v1::OperationMetadataV1>> DeleteInstance(
       google::appengine::v1::DeleteInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables debugging on a VM instance. This allows you to use the SSH
@@ -167,7 +169,8 @@ class InstancesClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DebugInstanceRequest,google/appengine/v1/appengine.proto#L459}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Instance,google/appengine/v1/instance.proto#L34}
   ///
@@ -178,7 +181,7 @@ class InstancesClient {
   ///
   future<StatusOr<google::appengine::v1::Instance>> DebugInstance(
       google::appengine::v1::DebugInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<InstancesConnection> connection_;

--- a/google/cloud/appengine/services_client.cc
+++ b/google/cloud/appengine/services_client.cc
@@ -26,42 +26,36 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServicesClient::ServicesClient(std::shared_ptr<ServicesConnection> connection,
-                               Options options)
+                               Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           appengine_internal::ServicesDefaultOptions(connection_->options()))) {
 }
 ServicesClient::~ServicesClient() = default;
 
 StreamRange<google::appengine::v1::Service> ServicesClient::ListServices(
-    google::appengine::v1::ListServicesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::ListServicesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServices(std::move(request));
 }
 
 StatusOr<google::appengine::v1::Service> ServicesClient::GetService(
-    google::appengine::v1::GetServiceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::GetServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetService(request);
 }
 
 future<StatusOr<google::appengine::v1::Service>> ServicesClient::UpdateService(
-    google::appengine::v1::UpdateServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::UpdateServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateService(request);
 }
 
 future<StatusOr<google::appengine::v1::OperationMetadataV1>>
 ServicesClient::DeleteService(
-    google::appengine::v1::DeleteServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::DeleteServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteService(request);
 }
 

--- a/google/cloud/appengine/services_client.h
+++ b/google/cloud/appengine/services_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServicesClient {
  public:
   explicit ServicesClient(std::shared_ptr<ServicesConnection> connection,
-                          Options options = {});
+                          Options opts = {});
   ~ServicesClient();
 
   //@{
@@ -88,7 +88,8 @@ class ServicesClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListServicesRequest,google/appengine/v1/appengine.proto#L189}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Service,google/appengine/v1/service.proto#L37}
   ///
@@ -98,14 +99,15 @@ class ServicesClient {
   /// @googleapis_reference_link{google/appengine/v1/service.proto#L37}
   ///
   StreamRange<google::appengine::v1::Service> ListServices(
-      google::appengine::v1::ListServicesRequest request, Options options = {});
+      google::appengine::v1::ListServicesRequest request, Options opts = {});
 
   ///
   /// Gets the current configuration of the specified service.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetServiceRequest,google/appengine/v1/appengine.proto#L210}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Service,google/appengine/v1/service.proto#L37}
   ///
@@ -116,14 +118,15 @@ class ServicesClient {
   ///
   StatusOr<google::appengine::v1::Service> GetService(
       google::appengine::v1::GetServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the configuration of the specified service.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::UpdateServiceRequest,google/appengine/v1/appengine.proto#L216}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Service,google/appengine/v1/service.proto#L37}
   ///
@@ -134,14 +137,15 @@ class ServicesClient {
   ///
   future<StatusOr<google::appengine::v1::Service>> UpdateService(
       google::appengine::v1::UpdateServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified service and all enclosed versions.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DeleteServiceRequest,google/appengine/v1/appengine.proto#L243}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::OperationMetadataV1,google/appengine/v1/operation.proto#L32}
   ///
@@ -152,7 +156,7 @@ class ServicesClient {
   ///
   future<StatusOr<google::appengine::v1::OperationMetadataV1>> DeleteService(
       google::appengine::v1::DeleteServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ServicesConnection> connection_;

--- a/google/cloud/appengine/versions_client.cc
+++ b/google/cloud/appengine/versions_client.cc
@@ -26,50 +26,42 @@ namespace appengine {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VersionsClient::VersionsClient(std::shared_ptr<VersionsConnection> connection,
-                               Options options)
+                               Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           appengine_internal::VersionsDefaultOptions(connection_->options()))) {
 }
 VersionsClient::~VersionsClient() = default;
 
 StreamRange<google::appengine::v1::Version> VersionsClient::ListVersions(
-    google::appengine::v1::ListVersionsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::ListVersionsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListVersions(std::move(request));
 }
 
 StatusOr<google::appengine::v1::Version> VersionsClient::GetVersion(
-    google::appengine::v1::GetVersionRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::GetVersionRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetVersion(request);
 }
 
 future<StatusOr<google::appengine::v1::Version>> VersionsClient::CreateVersion(
-    google::appengine::v1::CreateVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::CreateVersionRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateVersion(request);
 }
 
 future<StatusOr<google::appengine::v1::Version>> VersionsClient::UpdateVersion(
-    google::appengine::v1::UpdateVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::UpdateVersionRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateVersion(request);
 }
 
 future<StatusOr<google::appengine::v1::OperationMetadataV1>>
 VersionsClient::DeleteVersion(
-    google::appengine::v1::DeleteVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::appengine::v1::DeleteVersionRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteVersion(request);
 }
 

--- a/google/cloud/appengine/versions_client.h
+++ b/google/cloud/appengine/versions_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VersionsClient {
  public:
   explicit VersionsClient(std::shared_ptr<VersionsConnection> connection,
-                          Options options = {});
+                          Options opts = {});
   ~VersionsClient();
 
   //@{
@@ -89,7 +89,8 @@ class VersionsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::ListVersionsRequest,google/appengine/v1/appengine.proto#L344}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Version,google/appengine/v1/version.proto#L36}
   ///
@@ -99,7 +100,7 @@ class VersionsClient {
   /// @googleapis_reference_link{google/appengine/v1/version.proto#L36}
   ///
   StreamRange<google::appengine::v1::Version> ListVersions(
-      google::appengine::v1::ListVersionsRequest request, Options options = {});
+      google::appengine::v1::ListVersionsRequest request, Options opts = {});
 
   ///
   /// Gets the specified Version resource.
@@ -108,7 +109,8 @@ class VersionsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::GetVersionRequest,google/appengine/v1/appengine.proto#L369}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Version,google/appengine/v1/version.proto#L36}
   ///
@@ -119,14 +121,15 @@ class VersionsClient {
   ///
   StatusOr<google::appengine::v1::Version> GetVersion(
       google::appengine::v1::GetVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deploys code and resource files to a new version.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::CreateVersionRequest,google/appengine/v1/appengine.proto#L379}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Version,google/appengine/v1/version.proto#L36}
   ///
@@ -137,7 +140,7 @@ class VersionsClient {
   ///
   future<StatusOr<google::appengine::v1::Version>> CreateVersion(
       google::appengine::v1::CreateVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the specified Version resource.
@@ -179,7 +182,8 @@ class VersionsClient {
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::UpdateVersionRequest,google/appengine/v1/appengine.proto#L389}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::Version,google/appengine/v1/version.proto#L36}
   ///
@@ -190,14 +194,15 @@ class VersionsClient {
   ///
   future<StatusOr<google::appengine::v1::Version>> UpdateVersion(
       google::appengine::v1::UpdateVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an existing Version resource.
   ///
   /// @param request
   /// @googleapis_link{google::appengine::v1::DeleteVersionRequest,google/appengine/v1/appengine.proto#L416}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::appengine::v1::OperationMetadataV1,google/appengine/v1/operation.proto#L32}
   ///
@@ -208,7 +213,7 @@ class VersionsClient {
   ///
   future<StatusOr<google::appengine::v1::OperationMetadataV1>> DeleteVersion(
       google::appengine::v1::DeleteVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<VersionsConnection> connection_;

--- a/google/cloud/artifactregistry/artifact_registry_client.cc
+++ b/google/cloud/artifactregistry/artifact_registry_client.cc
@@ -26,19 +26,18 @@ namespace artifactregistry {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ArtifactRegistryClient::ArtifactRegistryClient(
-    std::shared_ptr<ArtifactRegistryConnection> connection, Options options)
+    std::shared_ptr<ArtifactRegistryConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           artifactregistry_internal::ArtifactRegistryDefaultOptions(
               connection_->options()))) {}
 ArtifactRegistryClient::~ArtifactRegistryClient() = default;
 
 StreamRange<google::devtools::artifactregistry::v1::DockerImage>
 ArtifactRegistryClient::ListDockerImages(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::artifactregistry::v1::ListDockerImagesRequest request;
   request.set_parent(parent);
   return connection_->ListDockerImages(request);
@@ -47,17 +46,15 @@ ArtifactRegistryClient::ListDockerImages(std::string const& parent,
 StreamRange<google::devtools::artifactregistry::v1::DockerImage>
 ArtifactRegistryClient::ListDockerImages(
     google::devtools::artifactregistry::v1::ListDockerImagesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDockerImages(std::move(request));
 }
 
 StreamRange<google::devtools::artifactregistry::v1::Repository>
 ArtifactRegistryClient::ListRepositories(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::artifactregistry::v1::ListRepositoriesRequest request;
   request.set_parent(parent);
   return connection_->ListRepositories(request);
@@ -66,17 +63,14 @@ ArtifactRegistryClient::ListRepositories(std::string const& parent,
 StreamRange<google::devtools::artifactregistry::v1::Repository>
 ArtifactRegistryClient::ListRepositories(
     google::devtools::artifactregistry::v1::ListRepositoriesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListRepositories(std::move(request));
 }
 
 StatusOr<google::devtools::artifactregistry::v1::Repository>
-ArtifactRegistryClient::GetRepository(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ArtifactRegistryClient::GetRepository(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::artifactregistry::v1::GetRepositoryRequest request;
   request.set_name(name);
   return connection_->GetRepository(request);
@@ -85,9 +79,8 @@ ArtifactRegistryClient::GetRepository(std::string const& name,
 StatusOr<google::devtools::artifactregistry::v1::Repository>
 ArtifactRegistryClient::GetRepository(
     google::devtools::artifactregistry::v1::GetRepositoryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetRepository(request);
 }
 

--- a/google/cloud/artifactregistry/artifact_registry_client.h
+++ b/google/cloud/artifactregistry/artifact_registry_client.h
@@ -75,7 +75,7 @@ class ArtifactRegistryClient {
  public:
   explicit ArtifactRegistryClient(
       std::shared_ptr<ArtifactRegistryConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ArtifactRegistryClient();
 
   //@{
@@ -103,7 +103,8 @@ class ArtifactRegistryClient {
   ///
   /// @param parent  Required. The name of the parent resource whose docker
   /// images will be listed.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::artifactregistry::v1::DockerImage,google/devtools/artifactregistry/v1/artifact.proto#L38}
   ///
@@ -113,14 +114,15 @@ class ArtifactRegistryClient {
   /// @googleapis_reference_link{google/devtools/artifactregistry/v1/artifact.proto#L38}
   ///
   StreamRange<google::devtools::artifactregistry::v1::DockerImage>
-  ListDockerImages(std::string const& parent, Options options = {});
+  ListDockerImages(std::string const& parent, Options opts = {});
 
   ///
   /// Lists docker images.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::artifactregistry::v1::ListDockerImagesRequest,google/devtools/artifactregistry/v1/artifact.proto#L87}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::artifactregistry::v1::DockerImage,google/devtools/artifactregistry/v1/artifact.proto#L38}
   ///
@@ -132,14 +134,15 @@ class ArtifactRegistryClient {
   StreamRange<google::devtools::artifactregistry::v1::DockerImage>
   ListDockerImages(
       google::devtools::artifactregistry::v1::ListDockerImagesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists repositories.
   ///
   /// @param parent  Required. The name of the parent resource whose
   /// repositories will be listed.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::artifactregistry::v1::Repository,google/devtools/artifactregistry/v1/repository.proto#L33}
   ///
@@ -149,14 +152,15 @@ class ArtifactRegistryClient {
   /// @googleapis_reference_link{google/devtools/artifactregistry/v1/repository.proto#L33}
   ///
   StreamRange<google::devtools::artifactregistry::v1::Repository>
-  ListRepositories(std::string const& parent, Options options = {});
+  ListRepositories(std::string const& parent, Options opts = {});
 
   ///
   /// Lists repositories.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::artifactregistry::v1::ListRepositoriesRequest,google/devtools/artifactregistry/v1/repository.proto#L94}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::artifactregistry::v1::Repository,google/devtools/artifactregistry/v1/repository.proto#L33}
   ///
@@ -168,13 +172,14 @@ class ArtifactRegistryClient {
   StreamRange<google::devtools::artifactregistry::v1::Repository>
   ListRepositories(
       google::devtools::artifactregistry::v1::ListRepositoriesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a repository.
   ///
   /// @param name  Required. The name of the repository to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::artifactregistry::v1::Repository,google/devtools/artifactregistry/v1/repository.proto#L33}
   ///
@@ -184,14 +189,15 @@ class ArtifactRegistryClient {
   /// @googleapis_reference_link{google/devtools/artifactregistry/v1/repository.proto#L33}
   ///
   StatusOr<google::devtools::artifactregistry::v1::Repository> GetRepository(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a repository.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::artifactregistry::v1::GetRepositoryRequest,google/devtools/artifactregistry/v1/repository.proto#L121}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::artifactregistry::v1::Repository,google/devtools/artifactregistry/v1/repository.proto#L33}
   ///
@@ -203,7 +209,7 @@ class ArtifactRegistryClient {
   StatusOr<google::devtools::artifactregistry::v1::Repository> GetRepository(
       google::devtools::artifactregistry::v1::GetRepositoryRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ArtifactRegistryConnection> connection_;

--- a/google/cloud/asset/asset_client.cc
+++ b/google/cloud/asset/asset_client.cc
@@ -26,10 +26,10 @@ namespace asset {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AssetServiceClient::AssetServiceClient(
-    std::shared_ptr<AssetServiceConnection> connection, Options options)
+    std::shared_ptr<AssetServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           asset_internal::AssetServiceDefaultOptions(connection_->options()))) {
 }
 AssetServiceClient::~AssetServiceClient() = default;
@@ -37,74 +37,64 @@ AssetServiceClient::~AssetServiceClient() = default;
 future<StatusOr<google::cloud::asset::v1::ExportAssetsResponse>>
 AssetServiceClient::ExportAssets(
     google::cloud::asset::v1::ExportAssetsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExportAssets(request);
 }
 
 StreamRange<google::cloud::asset::v1::Asset> AssetServiceClient::ListAssets(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::ListAssetsRequest request;
   request.set_parent(parent);
   return connection_->ListAssets(request);
 }
 
 StreamRange<google::cloud::asset::v1::Asset> AssetServiceClient::ListAssets(
-    google::cloud::asset::v1::ListAssetsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::ListAssetsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAssets(std::move(request));
 }
 
 StatusOr<google::cloud::asset::v1::BatchGetAssetsHistoryResponse>
 AssetServiceClient::BatchGetAssetsHistory(
     google::cloud::asset::v1::BatchGetAssetsHistoryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchGetAssetsHistory(request);
 }
 
 StatusOr<google::cloud::asset::v1::Feed> AssetServiceClient::CreateFeed(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::CreateFeedRequest request;
   request.set_parent(parent);
   return connection_->CreateFeed(request);
 }
 
 StatusOr<google::cloud::asset::v1::Feed> AssetServiceClient::CreateFeed(
-    google::cloud::asset::v1::CreateFeedRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::CreateFeedRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateFeed(request);
 }
 
 StatusOr<google::cloud::asset::v1::Feed> AssetServiceClient::GetFeed(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::GetFeedRequest request;
   request.set_name(name);
   return connection_->GetFeed(request);
 }
 
 StatusOr<google::cloud::asset::v1::Feed> AssetServiceClient::GetFeed(
-    google::cloud::asset::v1::GetFeedRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::GetFeedRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetFeed(request);
 }
 
 StatusOr<google::cloud::asset::v1::ListFeedsResponse>
-AssetServiceClient::ListFeeds(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AssetServiceClient::ListFeeds(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::ListFeedsRequest request;
   request.set_parent(parent);
   return connection_->ListFeeds(request);
@@ -112,53 +102,43 @@ AssetServiceClient::ListFeeds(std::string const& parent, Options options) {
 
 StatusOr<google::cloud::asset::v1::ListFeedsResponse>
 AssetServiceClient::ListFeeds(
-    google::cloud::asset::v1::ListFeedsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::ListFeedsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFeeds(request);
 }
 
 StatusOr<google::cloud::asset::v1::Feed> AssetServiceClient::UpdateFeed(
-    google::cloud::asset::v1::Feed const& feed, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::Feed const& feed, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::UpdateFeedRequest request;
   *request.mutable_feed() = feed;
   return connection_->UpdateFeed(request);
 }
 
 StatusOr<google::cloud::asset::v1::Feed> AssetServiceClient::UpdateFeed(
-    google::cloud::asset::v1::UpdateFeedRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::UpdateFeedRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateFeed(request);
 }
 
-Status AssetServiceClient::DeleteFeed(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status AssetServiceClient::DeleteFeed(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::DeleteFeedRequest request;
   request.set_name(name);
   return connection_->DeleteFeed(request);
 }
 
 Status AssetServiceClient::DeleteFeed(
-    google::cloud::asset::v1::DeleteFeedRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::DeleteFeedRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteFeed(request);
 }
 
 StreamRange<google::cloud::asset::v1::ResourceSearchResult>
 AssetServiceClient::SearchAllResources(
     std::string const& scope, std::string const& query,
-    std::vector<std::string> const& asset_types, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<std::string> const& asset_types, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::SearchAllResourcesRequest request;
   request.set_scope(scope);
   request.set_query(query);
@@ -168,19 +148,16 @@ AssetServiceClient::SearchAllResources(
 
 StreamRange<google::cloud::asset::v1::ResourceSearchResult>
 AssetServiceClient::SearchAllResources(
-    google::cloud::asset::v1::SearchAllResourcesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::SearchAllResourcesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchAllResources(std::move(request));
 }
 
 StreamRange<google::cloud::asset::v1::IamPolicySearchResult>
 AssetServiceClient::SearchAllIamPolicies(std::string const& scope,
                                          std::string const& query,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::asset::v1::SearchAllIamPoliciesRequest request;
   request.set_scope(scope);
   request.set_query(query);
@@ -190,36 +167,31 @@ AssetServiceClient::SearchAllIamPolicies(std::string const& scope,
 StreamRange<google::cloud::asset::v1::IamPolicySearchResult>
 AssetServiceClient::SearchAllIamPolicies(
     google::cloud::asset::v1::SearchAllIamPoliciesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchAllIamPolicies(std::move(request));
 }
 
 StatusOr<google::cloud::asset::v1::AnalyzeIamPolicyResponse>
 AssetServiceClient::AnalyzeIamPolicy(
     google::cloud::asset::v1::AnalyzeIamPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeIamPolicy(request);
 }
 
 future<StatusOr<google::cloud::asset::v1::AnalyzeIamPolicyLongrunningResponse>>
 AssetServiceClient::AnalyzeIamPolicyLongrunning(
     google::cloud::asset::v1::AnalyzeIamPolicyLongrunningRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeIamPolicyLongrunning(request);
 }
 
 StatusOr<google::cloud::asset::v1::AnalyzeMoveResponse>
 AssetServiceClient::AnalyzeMove(
-    google::cloud::asset::v1::AnalyzeMoveRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::asset::v1::AnalyzeMoveRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeMove(request);
 }
 

--- a/google/cloud/asset/asset_client.h
+++ b/google/cloud/asset/asset_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AssetServiceClient {
  public:
   explicit AssetServiceClient(
-      std::shared_ptr<AssetServiceConnection> connection, Options options = {});
+      std::shared_ptr<AssetServiceConnection> connection, Options opts = {});
   ~AssetServiceClient();
 
   //@{
@@ -100,7 +100,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::ExportAssetsRequest,google/cloud/asset/v1/asset_service.proto#L201}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::ExportAssetsResponse,google/cloud/asset/v1/asset_service.proto#L268}
   ///
@@ -111,7 +112,7 @@ class AssetServiceClient {
   ///
   future<StatusOr<google::cloud::asset::v1::ExportAssetsResponse>> ExportAssets(
       google::cloud::asset::v1::ExportAssetsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists assets with time and resource types and returns paged results in
@@ -122,7 +123,8 @@ class AssetServiceClient {
   ///  "organizations/[organization-number]" (such as "organizations/123"),
   ///  "projects/[project-id]" (such as "projects/my-project-id"), or
   ///  "projects/[project-number]" (such as "projects/12345").
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Asset,google/cloud/asset/v1/assets.proto#L97}
   ///
@@ -132,7 +134,7 @@ class AssetServiceClient {
   /// @googleapis_reference_link{google/cloud/asset/v1/assets.proto#L97}
   ///
   StreamRange<google::cloud::asset::v1::Asset> ListAssets(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists assets with time and resource types and returns paged results in
@@ -140,7 +142,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::ListAssetsRequest,google/cloud/asset/v1/asset_service.proto#L284}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Asset,google/cloud/asset/v1/assets.proto#L97}
   ///
@@ -150,8 +153,7 @@ class AssetServiceClient {
   /// @googleapis_reference_link{google/cloud/asset/v1/assets.proto#L97}
   ///
   StreamRange<google::cloud::asset::v1::Asset> ListAssets(
-      google::cloud::asset::v1::ListAssetsRequest request,
-      Options options = {});
+      google::cloud::asset::v1::ListAssetsRequest request, Options opts = {});
 
   ///
   /// Batch gets the update history of assets that overlap a time window.
@@ -163,7 +165,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::BatchGetAssetsHistoryRequest,google/cloud/asset/v1/asset_service.proto#L369}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::BatchGetAssetsHistoryResponse,google/cloud/asset/v1/asset_service.proto#L421}
   ///
@@ -175,7 +178,7 @@ class AssetServiceClient {
   StatusOr<google::cloud::asset::v1::BatchGetAssetsHistoryResponse>
   BatchGetAssetsHistory(
       google::cloud::asset::v1::BatchGetAssetsHistoryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a feed in a parent project/folder/organization to listen to its
@@ -187,7 +190,8 @@ class AssetServiceClient {
   ///  "organizations/123"), a folder number (such as "folders/123"), a project
   ///  ID (such as "projects/my-project-id")", or a project number (such as
   ///  "projects/12345").
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Feed,google/cloud/asset/v1/asset_service.proto#L677}
   ///
@@ -197,7 +201,7 @@ class AssetServiceClient {
   /// @googleapis_reference_link{google/cloud/asset/v1/asset_service.proto#L677}
   ///
   StatusOr<google::cloud::asset::v1::Feed> CreateFeed(std::string const& parent,
-                                                      Options options = {});
+                                                      Options opts = {});
 
   ///
   /// Creates a feed in a parent project/folder/organization to listen to its
@@ -205,7 +209,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::CreateFeedRequest,google/cloud/asset/v1/asset_service.proto#L427}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Feed,google/cloud/asset/v1/asset_service.proto#L677}
   ///
@@ -216,7 +221,7 @@ class AssetServiceClient {
   ///
   StatusOr<google::cloud::asset::v1::Feed> CreateFeed(
       google::cloud::asset::v1::CreateFeedRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details about an asset feed.
@@ -226,7 +231,8 @@ class AssetServiceClient {
   ///  projects/project_number/feeds/feed_id
   ///  folders/folder_number/feeds/feed_id
   ///  organizations/organization_number/feeds/feed_id
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Feed,google/cloud/asset/v1/asset_service.proto#L677}
   ///
@@ -236,14 +242,15 @@ class AssetServiceClient {
   /// @googleapis_reference_link{google/cloud/asset/v1/asset_service.proto#L677}
   ///
   StatusOr<google::cloud::asset::v1::Feed> GetFeed(std::string const& name,
-                                                   Options options = {});
+                                                   Options opts = {});
 
   ///
   /// Gets details about an asset feed.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::GetFeedRequest,google/cloud/asset/v1/asset_service.proto#L448}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Feed,google/cloud/asset/v1/asset_service.proto#L677}
   ///
@@ -254,7 +261,7 @@ class AssetServiceClient {
   ///
   StatusOr<google::cloud::asset::v1::Feed> GetFeed(
       google::cloud::asset::v1::GetFeedRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all asset feeds in a parent project/folder/organization.
@@ -263,7 +270,8 @@ class AssetServiceClient {
   /// feeds are to be
   ///  listed. It can only be using project/folder/organization number (such as
   ///  "folders/12345")", or a project ID (such as "projects/my-project-id").
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::ListFeedsResponse,google/cloud/asset/v1/asset_service.proto#L469}
   ///
@@ -273,14 +281,15 @@ class AssetServiceClient {
   /// @googleapis_reference_link{google/cloud/asset/v1/asset_service.proto#L469}
   ///
   StatusOr<google::cloud::asset::v1::ListFeedsResponse> ListFeeds(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all asset feeds in a parent project/folder/organization.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::ListFeedsRequest,google/cloud/asset/v1/asset_service.proto#L462}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::ListFeedsResponse,google/cloud/asset/v1/asset_service.proto#L469}
   ///
@@ -291,7 +300,7 @@ class AssetServiceClient {
   ///
   StatusOr<google::cloud::asset::v1::ListFeedsResponse> ListFeeds(
       google::cloud::asset::v1::ListFeedsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an asset feed configuration.
@@ -302,7 +311,8 @@ class AssetServiceClient {
   ///  projects/project_number/feeds/feed_id or
   ///  folders/folder_number/feeds/feed_id or
   ///  organizations/organization_number/feeds/feed_id.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Feed,google/cloud/asset/v1/asset_service.proto#L677}
   ///
@@ -312,14 +322,15 @@ class AssetServiceClient {
   /// @googleapis_reference_link{google/cloud/asset/v1/asset_service.proto#L677}
   ///
   StatusOr<google::cloud::asset::v1::Feed> UpdateFeed(
-      google::cloud::asset::v1::Feed const& feed, Options options = {});
+      google::cloud::asset::v1::Feed const& feed, Options opts = {});
 
   ///
   /// Updates an asset feed configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::UpdateFeedRequest,google/cloud/asset/v1/asset_service.proto#L475}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::Feed,google/cloud/asset/v1/asset_service.proto#L677}
   ///
@@ -330,7 +341,7 @@ class AssetServiceClient {
   ///
   StatusOr<google::cloud::asset::v1::Feed> UpdateFeed(
       google::cloud::asset::v1::UpdateFeedRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an asset feed.
@@ -340,25 +351,27 @@ class AssetServiceClient {
   ///  projects/project_number/feeds/feed_id
   ///  folders/folder_number/feeds/feed_id
   ///  organizations/organization_number/feeds/feed_id
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.asset.v1.DeleteFeedRequest]:
   /// @googleapis_reference_link{google/cloud/asset/v1/asset_service.proto#L489}
   ///
-  Status DeleteFeed(std::string const& name, Options options = {});
+  Status DeleteFeed(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an asset feed.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::DeleteFeedRequest,google/cloud/asset/v1/asset_service.proto#L489}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.asset.v1.DeleteFeedRequest]:
   /// @googleapis_reference_link{google/cloud/asset/v1/asset_service.proto#L489}
   ///
   Status DeleteFeed(google::cloud::asset::v1::DeleteFeedRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Searches all Cloud resources within the specified scope, such as a
@@ -432,7 +445,8 @@ class AssetServiceClient {
   ///  supported regular expression syntax. If the regular expression does not
   ///  match any supported asset type, an INVALID_ARGUMENT error will be
   ///  returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::ResourceSearchResult,google/cloud/asset/v1/assets.proto#L290}
   ///
@@ -444,7 +458,7 @@ class AssetServiceClient {
   StreamRange<google::cloud::asset::v1::ResourceSearchResult>
   SearchAllResources(std::string const& scope, std::string const& query,
                      std::vector<std::string> const& asset_types,
-                     Options options = {});
+                     Options opts = {});
 
   ///
   /// Searches all Cloud resources within the specified scope, such as a
@@ -454,7 +468,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::SearchAllResourcesRequest,google/cloud/asset/v1/asset_service.proto#L757}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::ResourceSearchResult,google/cloud/asset/v1/assets.proto#L290}
   ///
@@ -466,7 +481,7 @@ class AssetServiceClient {
   StreamRange<google::cloud::asset::v1::ResourceSearchResult>
   SearchAllResources(
       google::cloud::asset::v1::SearchAllResourcesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Searches all IAM policies within the specified scope, such as a project,
@@ -527,7 +542,8 @@ class AssetServiceClient {
   ///    Compute Admin role.
   ///  * `memberTypes:user` to find IAM policy bindings that contain the "user"
   ///    member type.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::IamPolicySearchResult,google/cloud/asset/v1/assets.proto#L586}
   ///
@@ -538,7 +554,7 @@ class AssetServiceClient {
   ///
   StreamRange<google::cloud::asset::v1::IamPolicySearchResult>
   SearchAllIamPolicies(std::string const& scope, std::string const& query,
-                       Options options = {});
+                       Options opts = {});
 
   ///
   /// Searches all IAM policies within the specified scope, such as a project,
@@ -548,7 +564,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::SearchAllIamPoliciesRequest,google/cloud/asset/v1/asset_service.proto#L909}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::IamPolicySearchResult,google/cloud/asset/v1/assets.proto#L586}
   ///
@@ -560,7 +577,7 @@ class AssetServiceClient {
   StreamRange<google::cloud::asset::v1::IamPolicySearchResult>
   SearchAllIamPolicies(
       google::cloud::asset::v1::SearchAllIamPoliciesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Analyzes IAM policies to answer which identities have what accesses on
@@ -568,7 +585,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::AnalyzeIamPolicyRequest,google/cloud/asset/v1/asset_service.proto#L1191}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::AnalyzeIamPolicyResponse,google/cloud/asset/v1/asset_service.proto#L1209}
   ///
@@ -579,7 +597,7 @@ class AssetServiceClient {
   ///
   StatusOr<google::cloud::asset::v1::AnalyzeIamPolicyResponse> AnalyzeIamPolicy(
       google::cloud::asset::v1::AnalyzeIamPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Analyzes IAM policies asynchronously to answer which identities have what
@@ -595,7 +613,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::AnalyzeIamPolicyLongrunningRequest,google/cloud/asset/v1/asset_service.proto#L1318}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::AnalyzeIamPolicyLongrunningResponse,google/cloud/asset/v1/asset_service.proto#L1327}
   ///
@@ -609,7 +628,7 @@ class AssetServiceClient {
   AnalyzeIamPolicyLongrunning(
       google::cloud::asset::v1::AnalyzeIamPolicyLongrunningRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Analyze moving a resource to a specified destination without kicking off
@@ -620,7 +639,8 @@ class AssetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::asset::v1::AnalyzeMoveRequest,google/cloud/asset/v1/asset_service.proto#L1332}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::asset::v1::AnalyzeMoveResponse,google/cloud/asset/v1/asset_service.proto#L1367}
   ///
@@ -631,7 +651,7 @@ class AssetServiceClient {
   ///
   StatusOr<google::cloud::asset::v1::AnalyzeMoveResponse> AnalyzeMove(
       google::cloud::asset::v1::AnalyzeMoveRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AssetServiceConnection> connection_;

--- a/google/cloud/assuredworkloads/assured_workloads_client.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_client.cc
@@ -26,11 +26,10 @@ namespace assuredworkloads {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AssuredWorkloadsServiceClient::AssuredWorkloadsServiceClient(
-    std::shared_ptr<AssuredWorkloadsServiceConnection> connection,
-    Options options)
+    std::shared_ptr<AssuredWorkloadsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           assuredworkloads_internal::AssuredWorkloadsServiceDefaultOptions(
               connection_->options()))) {}
 AssuredWorkloadsServiceClient::~AssuredWorkloadsServiceClient() = default;
@@ -39,9 +38,8 @@ future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>
 AssuredWorkloadsServiceClient::CreateWorkload(
     std::string const& parent,
     google::cloud::assuredworkloads::v1::Workload const& workload,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::assuredworkloads::v1::CreateWorkloadRequest request;
   request.set_parent(parent);
   *request.mutable_workload() = workload;
@@ -51,18 +49,16 @@ AssuredWorkloadsServiceClient::CreateWorkload(
 future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>
 AssuredWorkloadsServiceClient::CreateWorkload(
     google::cloud::assuredworkloads::v1::CreateWorkloadRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateWorkload(request);
 }
 
 StatusOr<google::cloud::assuredworkloads::v1::Workload>
 AssuredWorkloadsServiceClient::UpdateWorkload(
     google::cloud::assuredworkloads::v1::Workload const& workload,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::assuredworkloads::v1::UpdateWorkloadRequest request;
   *request.mutable_workload() = workload;
   *request.mutable_update_mask() = update_mask;
@@ -72,16 +68,14 @@ AssuredWorkloadsServiceClient::UpdateWorkload(
 StatusOr<google::cloud::assuredworkloads::v1::Workload>
 AssuredWorkloadsServiceClient::UpdateWorkload(
     google::cloud::assuredworkloads::v1::UpdateWorkloadRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateWorkload(request);
 }
 
 Status AssuredWorkloadsServiceClient::DeleteWorkload(std::string const& name,
-                                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::assuredworkloads::v1::DeleteWorkloadRequest request;
   request.set_name(name);
   return connection_->DeleteWorkload(request);
@@ -89,17 +83,15 @@ Status AssuredWorkloadsServiceClient::DeleteWorkload(std::string const& name,
 
 Status AssuredWorkloadsServiceClient::DeleteWorkload(
     google::cloud::assuredworkloads::v1::DeleteWorkloadRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteWorkload(request);
 }
 
 StatusOr<google::cloud::assuredworkloads::v1::Workload>
 AssuredWorkloadsServiceClient::GetWorkload(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::assuredworkloads::v1::GetWorkloadRequest request;
   request.set_name(name);
   return connection_->GetWorkload(request);
@@ -108,17 +100,15 @@ AssuredWorkloadsServiceClient::GetWorkload(std::string const& name,
 StatusOr<google::cloud::assuredworkloads::v1::Workload>
 AssuredWorkloadsServiceClient::GetWorkload(
     google::cloud::assuredworkloads::v1::GetWorkloadRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetWorkload(request);
 }
 
 StreamRange<google::cloud::assuredworkloads::v1::Workload>
 AssuredWorkloadsServiceClient::ListWorkloads(std::string const& parent,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::assuredworkloads::v1::ListWorkloadsRequest request;
   request.set_parent(parent);
   return connection_->ListWorkloads(request);
@@ -127,9 +117,8 @@ AssuredWorkloadsServiceClient::ListWorkloads(std::string const& parent,
 StreamRange<google::cloud::assuredworkloads::v1::Workload>
 AssuredWorkloadsServiceClient::ListWorkloads(
     google::cloud::assuredworkloads::v1::ListWorkloadsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListWorkloads(std::move(request));
 }
 

--- a/google/cloud/assuredworkloads/assured_workloads_client.h
+++ b/google/cloud/assuredworkloads/assured_workloads_client.h
@@ -64,7 +64,7 @@ class AssuredWorkloadsServiceClient {
  public:
   explicit AssuredWorkloadsServiceClient(
       std::shared_ptr<AssuredWorkloadsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AssuredWorkloadsServiceClient();
 
   //@{
@@ -95,7 +95,8 @@ class AssuredWorkloadsServiceClient {
   /// @param parent  Required. The resource name of the new Workload's parent.
   ///  Must be of the form `organizations/{org_id}/locations/{location_id}`.
   /// @param workload  Required. Assured Workload to create
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -107,14 +108,15 @@ class AssuredWorkloadsServiceClient {
   future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>
   CreateWorkload(std::string const& parent,
                  google::cloud::assuredworkloads::v1::Workload const& workload,
-                 Options options = {});
+                 Options opts = {});
 
   ///
   /// Creates Assured Workload.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::assuredworkloads::v1::CreateWorkloadRequest,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L101}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -126,7 +128,7 @@ class AssuredWorkloadsServiceClient {
   future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>
   CreateWorkload(
       google::cloud::assuredworkloads::v1::CreateWorkloadRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing workload.
@@ -139,7 +141,8 @@ class AssuredWorkloadsServiceClient {
   ///  updated. Format:
   ///  organizations/{org_id}/locations/{location_id}/workloads/{workload_id}
   /// @param update_mask  Required. The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -150,7 +153,7 @@ class AssuredWorkloadsServiceClient {
   ///
   StatusOr<google::cloud::assuredworkloads::v1::Workload> UpdateWorkload(
       google::cloud::assuredworkloads::v1::Workload const& workload,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing workload.
@@ -160,7 +163,8 @@ class AssuredWorkloadsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::assuredworkloads::v1::UpdateWorkloadRequest,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L122}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -171,7 +175,7 @@ class AssuredWorkloadsServiceClient {
   ///
   StatusOr<google::cloud::assuredworkloads::v1::Workload> UpdateWorkload(
       google::cloud::assuredworkloads::v1::UpdateWorkloadRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the workload. Make sure that workload's direct children are
@@ -181,12 +185,13 @@ class AssuredWorkloadsServiceClient {
   /// @param name  Required. The `name` field is used to identify the workload.
   ///  Format:
   ///  organizations/{org_id}/locations/{location_id}/workloads/{workload_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.assuredworkloads.v1.DeleteWorkloadRequest]:
   /// @googleapis_reference_link{google/cloud/assuredworkloads/v1/assuredworkloads.proto#L135}
   ///
-  Status DeleteWorkload(std::string const& name, Options options = {});
+  Status DeleteWorkload(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the workload. Make sure that workload's direct children are
@@ -195,14 +200,15 @@ class AssuredWorkloadsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::assuredworkloads::v1::DeleteWorkloadRequest,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L135}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.assuredworkloads.v1.DeleteWorkloadRequest]:
   /// @googleapis_reference_link{google/cloud/assuredworkloads/v1/assuredworkloads.proto#L135}
   ///
   Status DeleteWorkload(
       google::cloud::assuredworkloads::v1::DeleteWorkloadRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets Assured Workload associated with a CRM Node
@@ -213,7 +219,8 @@ class AssuredWorkloadsServiceClient {
   ///  "organizations/{organization_id}/locations/{location_id}/workloads/{workload_id}".
   ///  For example,
   ///  "organizations/123/locations/us-east1/workloads/assured-workload-1".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -223,14 +230,15 @@ class AssuredWorkloadsServiceClient {
   /// @googleapis_reference_link{google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
   StatusOr<google::cloud::assuredworkloads::v1::Workload> GetWorkload(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets Assured Workload associated with a CRM Node
   ///
   /// @param request
   /// @googleapis_link{google::cloud::assuredworkloads::v1::GetWorkloadRequest,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L152}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -241,14 +249,15 @@ class AssuredWorkloadsServiceClient {
   ///
   StatusOr<google::cloud::assuredworkloads::v1::Workload> GetWorkload(
       google::cloud::assuredworkloads::v1::GetWorkloadRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Assured Workloads under a CRM Node.
   ///
   /// @param parent  Required. Parent Resource to list workloads from.
   ///  Must be of the form `organizations/{org_id}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -258,14 +267,15 @@ class AssuredWorkloadsServiceClient {
   /// @googleapis_reference_link{google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
   StreamRange<google::cloud::assuredworkloads::v1::Workload> ListWorkloads(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Assured Workloads under a CRM Node.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::assuredworkloads::v1::ListWorkloadsRequest,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L167}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::assuredworkloads::v1::Workload,google/cloud/assuredworkloads/v1/assuredworkloads.proto#L201}
   ///
@@ -276,7 +286,7 @@ class AssuredWorkloadsServiceClient {
   ///
   StreamRange<google::cloud::assuredworkloads::v1::Workload> ListWorkloads(
       google::cloud::assuredworkloads::v1::ListWorkloadsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AssuredWorkloadsServiceConnection> connection_;

--- a/google/cloud/automl/auto_ml_client.cc
+++ b/google/cloud/automl/auto_ml_client.cc
@@ -26,19 +26,18 @@ namespace automl {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AutoMlClient::AutoMlClient(std::shared_ptr<AutoMlConnection> connection,
-                           Options options)
+                           Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           automl_internal::AutoMlDefaultOptions(connection_->options()))) {}
 AutoMlClient::~AutoMlClient() = default;
 
 future<StatusOr<google::cloud::automl::v1::Dataset>>
 AutoMlClient::CreateDataset(std::string const& parent,
                             google::cloud::automl::v1::Dataset const& dataset,
-                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::CreateDatasetRequest request;
   request.set_parent(parent);
   *request.mutable_dataset() = dataset;
@@ -48,50 +47,43 @@ AutoMlClient::CreateDataset(std::string const& parent,
 future<StatusOr<google::cloud::automl::v1::Dataset>>
 AutoMlClient::CreateDataset(
     google::cloud::automl::v1::CreateDatasetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDataset(request);
 }
 
 StatusOr<google::cloud::automl::v1::Dataset> AutoMlClient::GetDataset(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::GetDatasetRequest request;
   request.set_name(name);
   return connection_->GetDataset(request);
 }
 
 StatusOr<google::cloud::automl::v1::Dataset> AutoMlClient::GetDataset(
-    google::cloud::automl::v1::GetDatasetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::GetDatasetRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDataset(request);
 }
 
 StreamRange<google::cloud::automl::v1::Dataset> AutoMlClient::ListDatasets(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::ListDatasetsRequest request;
   request.set_parent(parent);
   return connection_->ListDatasets(request);
 }
 
 StreamRange<google::cloud::automl::v1::Dataset> AutoMlClient::ListDatasets(
-    google::cloud::automl::v1::ListDatasetsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::ListDatasetsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDatasets(std::move(request));
 }
 
 StatusOr<google::cloud::automl::v1::Dataset> AutoMlClient::UpdateDataset(
     google::cloud::automl::v1::Dataset const& dataset,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::UpdateDatasetRequest request;
   *request.mutable_dataset() = dataset;
   *request.mutable_update_mask() = update_mask;
@@ -100,16 +92,14 @@ StatusOr<google::cloud::automl::v1::Dataset> AutoMlClient::UpdateDataset(
 
 StatusOr<google::cloud::automl::v1::Dataset> AutoMlClient::UpdateDataset(
     google::cloud::automl::v1::UpdateDatasetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDataset(request);
 }
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
-AutoMlClient::DeleteDataset(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AutoMlClient::DeleteDataset(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::DeleteDatasetRequest request;
   request.set_name(name);
   return connection_->DeleteDataset(request);
@@ -118,19 +108,16 @@ AutoMlClient::DeleteDataset(std::string const& name, Options options) {
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::DeleteDataset(
     google::cloud::automl::v1::DeleteDatasetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDataset(request);
 }
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::ImportData(
     std::string const& name,
-    google::cloud::automl::v1::InputConfig const& input_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::InputConfig const& input_config, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::ImportDataRequest request;
   request.set_name(name);
   *request.mutable_input_config() = input_config;
@@ -139,10 +126,8 @@ AutoMlClient::ImportData(
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::ImportData(
-    google::cloud::automl::v1::ImportDataRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::ImportDataRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportData(request);
 }
 
@@ -150,9 +135,8 @@ future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::ExportData(
     std::string const& name,
     google::cloud::automl::v1::OutputConfig const& output_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::ExportDataRequest request;
   request.set_name(name);
   *request.mutable_output_config() = output_config;
@@ -161,17 +145,14 @@ AutoMlClient::ExportData(
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::ExportData(
-    google::cloud::automl::v1::ExportDataRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::ExportDataRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExportData(request);
 }
 
 StatusOr<google::cloud::automl::v1::AnnotationSpec>
-AutoMlClient::GetAnnotationSpec(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AutoMlClient::GetAnnotationSpec(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::GetAnnotationSpecRequest request;
   request.set_name(name);
   return connection_->GetAnnotationSpec(request);
@@ -180,17 +161,15 @@ AutoMlClient::GetAnnotationSpec(std::string const& name, Options options) {
 StatusOr<google::cloud::automl::v1::AnnotationSpec>
 AutoMlClient::GetAnnotationSpec(
     google::cloud::automl::v1::GetAnnotationSpecRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAnnotationSpec(request);
 }
 
 future<StatusOr<google::cloud::automl::v1::Model>> AutoMlClient::CreateModel(
     std::string const& parent, google::cloud::automl::v1::Model const& model,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::CreateModelRequest request;
   request.set_parent(parent);
   *request.mutable_model() = model;
@@ -199,49 +178,42 @@ future<StatusOr<google::cloud::automl::v1::Model>> AutoMlClient::CreateModel(
 
 future<StatusOr<google::cloud::automl::v1::Model>> AutoMlClient::CreateModel(
     google::cloud::automl::v1::CreateModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateModel(request);
 }
 
 StatusOr<google::cloud::automl::v1::Model> AutoMlClient::GetModel(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::GetModelRequest request;
   request.set_name(name);
   return connection_->GetModel(request);
 }
 
 StatusOr<google::cloud::automl::v1::Model> AutoMlClient::GetModel(
-    google::cloud::automl::v1::GetModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::GetModelRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetModel(request);
 }
 
 StreamRange<google::cloud::automl::v1::Model> AutoMlClient::ListModels(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::ListModelsRequest request;
   request.set_parent(parent);
   return connection_->ListModels(request);
 }
 
 StreamRange<google::cloud::automl::v1::Model> AutoMlClient::ListModels(
-    google::cloud::automl::v1::ListModelsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::ListModelsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListModels(std::move(request));
 }
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
-AutoMlClient::DeleteModel(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AutoMlClient::DeleteModel(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::DeleteModelRequest request;
   request.set_name(name);
   return connection_->DeleteModel(request);
@@ -250,17 +222,15 @@ AutoMlClient::DeleteModel(std::string const& name, Options options) {
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::DeleteModel(
     google::cloud::automl::v1::DeleteModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteModel(request);
 }
 
 StatusOr<google::cloud::automl::v1::Model> AutoMlClient::UpdateModel(
     google::cloud::automl::v1::Model const& model,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::UpdateModelRequest request;
   *request.mutable_model() = model;
   *request.mutable_update_mask() = update_mask;
@@ -269,16 +239,14 @@ StatusOr<google::cloud::automl::v1::Model> AutoMlClient::UpdateModel(
 
 StatusOr<google::cloud::automl::v1::Model> AutoMlClient::UpdateModel(
     google::cloud::automl::v1::UpdateModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateModel(request);
 }
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
-AutoMlClient::DeployModel(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AutoMlClient::DeployModel(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::DeployModelRequest request;
   request.set_name(name);
   return connection_->DeployModel(request);
@@ -287,16 +255,14 @@ AutoMlClient::DeployModel(std::string const& name, Options options) {
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::DeployModel(
     google::cloud::automl::v1::DeployModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeployModel(request);
 }
 
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
-AutoMlClient::UndeployModel(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AutoMlClient::UndeployModel(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::UndeployModelRequest request;
   request.set_name(name);
   return connection_->UndeployModel(request);
@@ -305,9 +271,8 @@ AutoMlClient::UndeployModel(std::string const& name, Options options) {
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::UndeployModel(
     google::cloud::automl::v1::UndeployModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeployModel(request);
 }
 
@@ -315,9 +280,8 @@ future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::ExportModel(
     std::string const& name,
     google::cloud::automl::v1::ModelExportOutputConfig const& output_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::ExportModelRequest request;
   request.set_name(name);
   *request.mutable_output_config() = output_config;
@@ -327,16 +291,14 @@ AutoMlClient::ExportModel(
 future<StatusOr<google::cloud::automl::v1::OperationMetadata>>
 AutoMlClient::ExportModel(
     google::cloud::automl::v1::ExportModelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExportModel(request);
 }
 
 StatusOr<google::cloud::automl::v1::ModelEvaluation>
-AutoMlClient::GetModelEvaluation(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AutoMlClient::GetModelEvaluation(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::GetModelEvaluationRequest request;
   request.set_name(name);
   return connection_->GetModelEvaluation(request);
@@ -345,17 +307,15 @@ AutoMlClient::GetModelEvaluation(std::string const& name, Options options) {
 StatusOr<google::cloud::automl::v1::ModelEvaluation>
 AutoMlClient::GetModelEvaluation(
     google::cloud::automl::v1::GetModelEvaluationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetModelEvaluation(request);
 }
 
 StreamRange<google::cloud::automl::v1::ModelEvaluation>
 AutoMlClient::ListModelEvaluations(std::string const& parent,
-                                   std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                   std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::ListModelEvaluationsRequest request;
   request.set_parent(parent);
   request.set_filter(filter);
@@ -365,9 +325,8 @@ AutoMlClient::ListModelEvaluations(std::string const& parent,
 StreamRange<google::cloud::automl::v1::ModelEvaluation>
 AutoMlClient::ListModelEvaluations(
     google::cloud::automl::v1::ListModelEvaluationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListModelEvaluations(std::move(request));
 }
 

--- a/google/cloud/automl/auto_ml_client.h
+++ b/google/cloud/automl/auto_ml_client.h
@@ -76,7 +76,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AutoMlClient {
  public:
   explicit AutoMlClient(std::shared_ptr<AutoMlConnection> connection,
-                        Options options = {});
+                        Options opts = {});
   ~AutoMlClient();
 
   //@{
@@ -103,7 +103,8 @@ class AutoMlClient {
   /// @param parent  Required. The resource name of the project to create the
   /// dataset for.
   /// @param dataset  Required. The dataset to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -114,14 +115,15 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::Dataset>> CreateDataset(
       std::string const& parent,
-      google::cloud::automl::v1::Dataset const& dataset, Options options = {});
+      google::cloud::automl::v1::Dataset const& dataset, Options opts = {});
 
   ///
   /// Creates a dataset.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::CreateDatasetRequest,google/cloud/automl/v1/service.proto#L294}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -132,13 +134,14 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::Dataset>> CreateDataset(
       google::cloud::automl::v1::CreateDatasetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a dataset.
   ///
   /// @param name  Required. The resource name of the dataset to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -148,14 +151,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/dataset.proto#L35}
   ///
   StatusOr<google::cloud::automl::v1::Dataset> GetDataset(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a dataset.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::GetDatasetRequest,google/cloud/automl/v1/service.proto#L308}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -166,14 +170,15 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::Dataset> GetDataset(
       google::cloud::automl::v1::GetDatasetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists datasets in a project.
   ///
   /// @param parent  Required. The resource name of the project from which to
   /// list datasets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -183,14 +188,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/dataset.proto#L35}
   ///
   StreamRange<google::cloud::automl::v1::Dataset> ListDatasets(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists datasets in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::ListDatasetsRequest,google/cloud/automl/v1/service.proto#L319}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -201,7 +207,7 @@ class AutoMlClient {
   ///
   StreamRange<google::cloud::automl::v1::Dataset> ListDatasets(
       google::cloud::automl::v1::ListDatasetsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a dataset.
@@ -209,7 +215,8 @@ class AutoMlClient {
   /// @param dataset  Required. The dataset which replaces the resource on the
   /// server.
   /// @param update_mask  Required. The update mask applies to the resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -220,14 +227,15 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::Dataset> UpdateDataset(
       google::cloud::automl::v1::Dataset const& dataset,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a dataset.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::UpdateDatasetRequest,google/cloud/automl/v1/service.proto#L359}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Dataset,google/cloud/automl/v1/dataset.proto#L35}
   ///
@@ -238,7 +246,7 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::Dataset> UpdateDataset(
       google::cloud::automl::v1::UpdateDatasetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a dataset and all of its contents.
@@ -248,7 +256,8 @@ class AutoMlClient {
   /// [metadata][google.longrunning.Operation.metadata] field.
   ///
   /// @param name  Required. The resource name of the dataset to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -258,7 +267,7 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/operations.proto#L38}
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> DeleteDataset(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a dataset and all of its contents.
@@ -269,7 +278,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::DeleteDatasetRequest,google/cloud/automl/v1/service.proto#L368}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -280,7 +290,7 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> DeleteDataset(
       google::cloud::automl::v1::DeleteDatasetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Imports data into a dataset.
@@ -299,7 +309,8 @@ class AutoMlClient {
   /// @param input_config  Required. The desired input location and its domain
   /// specific semantics,
   ///  if any.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -311,7 +322,7 @@ class AutoMlClient {
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ImportData(
       std::string const& name,
       google::cloud::automl::v1::InputConfig const& input_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Imports data into a dataset.
@@ -326,7 +337,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::ImportDataRequest,google/cloud/automl/v1/service.proto#L379}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -337,7 +349,7 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ImportData(
       google::cloud::automl::v1::ImportDataRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Exports dataset's data to the provided output location.
@@ -346,7 +358,8 @@ class AutoMlClient {
   ///
   /// @param name  Required. The resource name of the dataset.
   /// @param output_config  Required. The desired output location.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -358,7 +371,7 @@ class AutoMlClient {
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ExportData(
       std::string const& name,
       google::cloud::automl::v1::OutputConfig const& output_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Exports dataset's data to the provided output location.
@@ -367,7 +380,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::ExportDataRequest,google/cloud/automl/v1/service.proto#L395}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -378,14 +392,15 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ExportData(
       google::cloud::automl::v1::ExportDataRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an annotation spec.
   ///
   /// @param name  Required. The resource name of the annotation spec to
   /// retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::AnnotationSpec,google/cloud/automl/v1/annotation_spec.proto#L30}
   ///
@@ -395,14 +410,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/annotation_spec.proto#L30}
   ///
   StatusOr<google::cloud::automl::v1::AnnotationSpec> GetAnnotationSpec(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an annotation spec.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::GetAnnotationSpecRequest,google/cloud/automl/v1/service.proto#L409}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::AnnotationSpec,google/cloud/automl/v1/annotation_spec.proto#L30}
   ///
@@ -413,7 +429,7 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::AnnotationSpec> GetAnnotationSpec(
       google::cloud::automl::v1::GetAnnotationSpecRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a model.
@@ -425,7 +441,8 @@ class AutoMlClient {
   /// @param parent  Required. Resource name of the parent project where the
   /// model is being created.
   /// @param model  Required. The model to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -436,7 +453,7 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::Model>> CreateModel(
       std::string const& parent, google::cloud::automl::v1::Model const& model,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a model.
@@ -447,7 +464,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::CreateModelRequest,google/cloud/automl/v1/service.proto#L420}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -458,13 +476,14 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::Model>> CreateModel(
       google::cloud::automl::v1::CreateModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a model.
   ///
   /// @param name  Required. Resource name of the model.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -474,14 +493,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/model.proto#L34}
   ///
   StatusOr<google::cloud::automl::v1::Model> GetModel(std::string const& name,
-                                                      Options options = {});
+                                                      Options opts = {});
 
   ///
   /// Gets a model.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::GetModelRequest,google/cloud/automl/v1/service.proto#L434}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -492,14 +512,15 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::Model> GetModel(
       google::cloud::automl::v1::GetModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists models.
   ///
   /// @param parent  Required. Resource name of the project, from which to list
   /// the models.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -509,14 +530,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/model.proto#L34}
   ///
   StreamRange<google::cloud::automl::v1::Model> ListModels(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists models.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::ListModelsRequest,google/cloud/automl/v1/service.proto#L445}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -526,8 +548,7 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/model.proto#L34}
   ///
   StreamRange<google::cloud::automl::v1::Model> ListModels(
-      google::cloud::automl::v1::ListModelsRequest request,
-      Options options = {});
+      google::cloud::automl::v1::ListModelsRequest request, Options opts = {});
 
   ///
   /// Deletes a model.
@@ -537,7 +558,8 @@ class AutoMlClient {
   /// [metadata][google.longrunning.Operation.metadata] field.
   ///
   /// @param name  Required. Resource name of the model being deleted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -547,7 +569,7 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/operations.proto#L38}
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> DeleteModel(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a model.
@@ -558,7 +580,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::DeleteModelRequest,google/cloud/automl/v1/service.proto#L486}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -569,7 +592,7 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> DeleteModel(
       google::cloud::automl::v1::DeleteModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a model.
@@ -577,7 +600,8 @@ class AutoMlClient {
   /// @param model  Required. The model which replaces the resource on the
   /// server.
   /// @param update_mask  Required. The update mask applies to the resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -588,14 +612,15 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::Model> UpdateModel(
       google::cloud::automl::v1::Model const& model,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a model.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::UpdateModelRequest,google/cloud/automl/v1/service.proto#L497}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::Model,google/cloud/automl/v1/model.proto#L34}
   ///
@@ -606,7 +631,7 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::Model> UpdateModel(
       google::cloud::automl::v1::UpdateModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deploys a model. If a model is already deployed, deploying it with the
@@ -622,7 +647,8 @@ class AutoMlClient {
   /// [response][google.longrunning.Operation.response] field when it completes.
   ///
   /// @param name  Required. Resource name of the model to deploy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -632,7 +658,7 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/operations.proto#L38}
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> DeployModel(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deploys a model. If a model is already deployed, deploying it with the
@@ -649,7 +675,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::DeployModelRequest,google/cloud/automl/v1/service.proto#L506}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -660,7 +687,7 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> DeployModel(
       google::cloud::automl::v1::DeployModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Undeploys a model. If the model is not deployed this method has no effect.
@@ -672,7 +699,8 @@ class AutoMlClient {
   /// [response][google.longrunning.Operation.response] field when it completes.
   ///
   /// @param name  Required. Resource name of the model to undeploy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -682,7 +710,7 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/operations.proto#L38}
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> UndeployModel(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Undeploys a model. If the model is not deployed this method has no effect.
@@ -695,7 +723,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::UndeployModelRequest,google/cloud/automl/v1/service.proto#L526}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -706,7 +735,7 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> UndeployModel(
       google::cloud::automl::v1::UndeployModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Exports a trained, "export-able", model to a user specified Google Cloud
@@ -720,7 +749,8 @@ class AutoMlClient {
   /// @param name  Required. The resource name of the model to export.
   /// @param output_config  Required. The desired output location and
   /// configuration.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -732,7 +762,7 @@ class AutoMlClient {
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ExportModel(
       std::string const& name,
       google::cloud::automl::v1::ModelExportOutputConfig const& output_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Exports a trained, "export-able", model to a user specified Google Cloud
@@ -745,7 +775,8 @@ class AutoMlClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::ExportModelRequest,google/cloud/automl/v1/service.proto#L539}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::OperationMetadata,google/cloud/automl/v1/operations.proto#L38}
   ///
@@ -756,13 +787,14 @@ class AutoMlClient {
   ///
   future<StatusOr<google::cloud::automl::v1::OperationMetadata>> ExportModel(
       google::cloud::automl::v1::ExportModelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a model evaluation.
   ///
   /// @param name  Required. Resource name for the model evaluation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::ModelEvaluation,google/cloud/automl/v1/model_evaluation.proto#L36}
   ///
@@ -772,14 +804,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/model_evaluation.proto#L36}
   ///
   StatusOr<google::cloud::automl::v1::ModelEvaluation> GetModelEvaluation(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a model evaluation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::GetModelEvaluationRequest,google/cloud/automl/v1/service.proto#L553}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::ModelEvaluation,google/cloud/automl/v1/model_evaluation.proto#L36}
   ///
@@ -790,7 +823,7 @@ class AutoMlClient {
   ///
   StatusOr<google::cloud::automl::v1::ModelEvaluation> GetModelEvaluation(
       google::cloud::automl::v1::GetModelEvaluationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists model evaluations.
@@ -808,7 +841,8 @@ class AutoMlClient {
   ///                              annotation spec with ID different than 4.
   ///    * `NOT annotation_spec_id:*` --> The model evaluation was done for
   ///                                 aggregate of all annotation specs.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::ModelEvaluation,google/cloud/automl/v1/model_evaluation.proto#L36}
   ///
@@ -818,15 +852,15 @@ class AutoMlClient {
   /// @googleapis_reference_link{google/cloud/automl/v1/model_evaluation.proto#L36}
   ///
   StreamRange<google::cloud::automl::v1::ModelEvaluation> ListModelEvaluations(
-      std::string const& parent, std::string const& filter,
-      Options options = {});
+      std::string const& parent, std::string const& filter, Options opts = {});
 
   ///
   /// Lists model evaluations.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::ListModelEvaluationsRequest,google/cloud/automl/v1/service.proto#L564}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::ModelEvaluation,google/cloud/automl/v1/model_evaluation.proto#L36}
   ///
@@ -837,7 +871,7 @@ class AutoMlClient {
   ///
   StreamRange<google::cloud::automl::v1::ModelEvaluation> ListModelEvaluations(
       google::cloud::automl::v1::ListModelEvaluationsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AutoMlConnection> connection_;

--- a/google/cloud/automl/prediction_client.cc
+++ b/google/cloud/automl/prediction_client.cc
@@ -26,20 +26,19 @@ namespace automl {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PredictionServiceClient::PredictionServiceClient(
-    std::shared_ptr<PredictionServiceConnection> connection, Options options)
+    std::shared_ptr<PredictionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), automl_internal::PredictionServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), automl_internal::PredictionServiceDefaultOptions(
+                               connection_->options()))) {}
 PredictionServiceClient::~PredictionServiceClient() = default;
 
 StatusOr<google::cloud::automl::v1::PredictResponse>
 PredictionServiceClient::Predict(
     std::string const& name,
     google::cloud::automl::v1::ExamplePayload const& payload,
-    std::map<std::string, std::string> const& params, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::map<std::string, std::string> const& params, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::PredictRequest request;
   request.set_name(name);
   *request.mutable_payload() = payload;
@@ -49,9 +48,8 @@ PredictionServiceClient::Predict(
 
 StatusOr<google::cloud::automl::v1::PredictResponse>
 PredictionServiceClient::Predict(
-    google::cloud::automl::v1::PredictRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::automl::v1::PredictRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Predict(request);
 }
 
@@ -60,9 +58,8 @@ PredictionServiceClient::BatchPredict(
     std::string const& name,
     google::cloud::automl::v1::BatchPredictInputConfig const& input_config,
     google::cloud::automl::v1::BatchPredictOutputConfig const& output_config,
-    std::map<std::string, std::string> const& params, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::map<std::string, std::string> const& params, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::automl::v1::BatchPredictRequest request;
   request.set_name(name);
   *request.mutable_input_config() = input_config;
@@ -74,9 +71,8 @@ PredictionServiceClient::BatchPredict(
 future<StatusOr<google::cloud::automl::v1::BatchPredictResult>>
 PredictionServiceClient::BatchPredict(
     google::cloud::automl::v1::BatchPredictRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchPredict(request);
 }
 

--- a/google/cloud/automl/prediction_client.h
+++ b/google/cloud/automl/prediction_client.h
@@ -67,7 +67,7 @@ class PredictionServiceClient {
  public:
   explicit PredictionServiceClient(
       std::shared_ptr<PredictionServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~PredictionServiceClient();
 
   //@{
@@ -157,7 +157,8 @@ class PredictionServiceClient {
   ///    is populated in the returned list of
   ///    [TablesAnnotation][google.cloud.automl.v1.TablesAnnotation]
   ///    objects. The default is false.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::PredictResponse,google/cloud/automl/v1/prediction_service.proto#L164}
   ///
@@ -169,7 +170,7 @@ class PredictionServiceClient {
   StatusOr<google::cloud::automl::v1::PredictResponse> Predict(
       std::string const& name,
       google::cloud::automl::v1::ExamplePayload const& payload,
-      std::map<std::string, std::string> const& params, Options options = {});
+      std::map<std::string, std::string> const& params, Options opts = {});
 
   ///
   /// Perform an online prediction. The prediction result is directly
@@ -211,7 +212,8 @@ class PredictionServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::PredictRequest,google/cloud/automl/v1/prediction_service.proto#L117}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::PredictResponse,google/cloud/automl/v1/prediction_service.proto#L164}
   ///
@@ -222,7 +224,7 @@ class PredictionServiceClient {
   ///
   StatusOr<google::cloud::automl::v1::PredictResponse> Predict(
       google::cloud::automl::v1::PredictRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Perform a batch prediction. Unlike the online
@@ -319,7 +321,8 @@ class PredictionServiceClient {
   ///    at least that long as a relative value of video frame size are
   ///    returned. Value in 0 to 1 range. Default is 0.
   ///
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::BatchPredictResult,google/cloud/automl/v1/prediction_service.proto#L308}
   ///
@@ -332,7 +335,7 @@ class PredictionServiceClient {
       std::string const& name,
       google::cloud::automl::v1::BatchPredictInputConfig const& input_config,
       google::cloud::automl::v1::BatchPredictOutputConfig const& output_config,
-      std::map<std::string, std::string> const& params, Options options = {});
+      std::map<std::string, std::string> const& params, Options opts = {});
 
   ///
   /// Perform a batch prediction. Unlike the online
@@ -356,7 +359,8 @@ class PredictionServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::automl::v1::BatchPredictRequest,google/cloud/automl/v1/prediction_service.proto#L202}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::automl::v1::BatchPredictResult,google/cloud/automl/v1/prediction_service.proto#L308}
   ///
@@ -367,7 +371,7 @@ class PredictionServiceClient {
   ///
   future<StatusOr<google::cloud::automl::v1::BatchPredictResult>> BatchPredict(
       google::cloud::automl::v1::BatchPredictRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<PredictionServiceConnection> connection_;

--- a/google/cloud/bigquery/bigquery_read_client.cc
+++ b/google/cloud/bigquery/bigquery_read_client.cc
@@ -26,20 +26,19 @@ namespace bigquery {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigQueryReadClient::BigQueryReadClient(
-    std::shared_ptr<BigQueryReadConnection> connection, Options options)
+    std::shared_ptr<BigQueryReadConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), bigquery_internal::BigQueryReadDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), bigquery_internal::BigQueryReadDefaultOptions(
+                               connection_->options()))) {}
 BigQueryReadClient::~BigQueryReadClient() = default;
 
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadClient::CreateReadSession(
     std::string const& parent,
     google::cloud::bigquery::storage::v1::ReadSession const& read_session,
-    std::int32_t max_stream_count, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::int32_t max_stream_count, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::bigquery::storage::v1::CreateReadSessionRequest request;
   request.set_parent(parent);
   *request.mutable_read_session() = read_session;
@@ -51,17 +50,15 @@ StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadClient::CreateReadSession(
     google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateReadSession(request);
 }
 
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(std::string const& read_stream,
-                             std::int64_t offset, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                             std::int64_t offset, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::bigquery::storage::v1::ReadRowsRequest request;
   request.set_read_stream(read_stream);
   request.set_offset(offset);
@@ -71,18 +68,16 @@ BigQueryReadClient::ReadRows(std::string const& read_stream,
 StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse>
 BigQueryReadClient::ReadRows(
     google::cloud::bigquery::storage::v1::ReadRowsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReadRows(request);
 }
 
 StatusOr<google::cloud::bigquery::storage::v1::SplitReadStreamResponse>
 BigQueryReadClient::SplitReadStream(
     google::cloud::bigquery::storage::v1::SplitReadStreamRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SplitReadStream(request);
 }
 

--- a/google/cloud/bigquery/bigquery_read_client.h
+++ b/google/cloud/bigquery/bigquery_read_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BigQueryReadClient {
  public:
   explicit BigQueryReadClient(
-      std::shared_ptr<BigQueryReadConnection> connection, Options options = {});
+      std::shared_ptr<BigQueryReadConnection> connection, Options opts = {});
   ~BigQueryReadClient();
 
   //@{
@@ -119,7 +119,8 @@ class BigQueryReadClient {
   ///  table. Error will be returned if the max count is greater than the
   ///  current system max limit of 1,000. Streams must be read starting from
   ///  offset 0.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
@@ -131,7 +132,7 @@ class BigQueryReadClient {
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       std::string const& parent,
       google::cloud::bigquery::storage::v1::ReadSession const& read_session,
-      std::int32_t max_stream_count, Options options = {});
+      std::int32_t max_stream_count, Options opts = {});
 
   ///
   /// Creates a new read session. A read session divides the contents of a
@@ -156,7 +157,8 @@ class BigQueryReadClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::CreateReadSessionRequest,google/cloud/bigquery/storage/v1/storage.proto#L229}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadSession,google/cloud/bigquery/storage/v1/stream.proto#L47}
   ///
@@ -168,7 +170,7 @@ class BigQueryReadClient {
   StatusOr<google::cloud::bigquery::storage::v1::ReadSession> CreateReadSession(
       google::cloud::bigquery::storage::v1::CreateReadSessionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Reads rows from the stream in the format prescribed by the ReadSession.
@@ -184,7 +186,8 @@ class BigQueryReadClient {
   /// from Read.
   ///  Requesting a larger offset is undefined. If not specified, start reading
   ///  from offset zero.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
@@ -194,8 +197,7 @@ class BigQueryReadClient {
   /// @googleapis_reference_link{google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
-      std::string const& read_stream, std::int64_t offset,
-      Options options = {});
+      std::string const& read_stream, std::int64_t offset, Options opts = {});
 
   ///
   /// Reads rows from the stream in the format prescribed by the ReadSession.
@@ -208,7 +210,8 @@ class BigQueryReadClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsRequest,google/cloud/bigquery/storage/v1/storage.proto#L254}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::ReadRowsResponse,google/cloud/bigquery/storage/v1/storage.proto#L304}
   ///
@@ -219,7 +222,7 @@ class BigQueryReadClient {
   ///
   StreamRange<google::cloud::bigquery::storage::v1::ReadRowsResponse> ReadRows(
       google::cloud::bigquery::storage::v1::ReadRowsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Splits a given `ReadStream` into two `ReadStream` objects. These
@@ -237,7 +240,8 @@ class BigQueryReadClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamRequest,google/cloud/bigquery/storage/v1/storage.proto#L339}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::bigquery::storage::v1::SplitReadStreamResponse,google/cloud/bigquery/storage/v1/storage.proto#L359}
   ///
@@ -250,7 +254,7 @@ class BigQueryReadClient {
   SplitReadStream(
       google::cloud::bigquery::storage::v1::SplitReadStreamRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<BigQueryReadConnection> connection_;

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
@@ -28,11 +28,10 @@ namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigtableInstanceAdminClient::BigtableInstanceAdminClient(
-    std::shared_ptr<BigtableInstanceAdminConnection> connection,
-    Options options)
+    std::shared_ptr<BigtableInstanceAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           bigtable_admin_internal::BigtableInstanceAdminDefaultOptions(
               connection_->options()))) {}
 BigtableInstanceAdminClient::~BigtableInstanceAdminClient() = default;
@@ -42,9 +41,8 @@ BigtableInstanceAdminClient::CreateInstance(
     std::string const& parent, std::string const& instance_id,
     google::bigtable::admin::v2::Instance const& instance,
     std::map<std::string, google::bigtable::admin::v2::Cluster> const& clusters,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateInstanceRequest request;
   request.set_parent(parent);
   request.set_instance_id(instance_id);
@@ -56,17 +54,15 @@ BigtableInstanceAdminClient::CreateInstance(
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::CreateInstance(
     google::bigtable::admin::v2::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::GetInstance(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -75,17 +71,15 @@ BigtableInstanceAdminClient::GetInstance(std::string const& name,
 StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::GetInstance(
     google::bigtable::admin::v2::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
 StatusOr<google::bigtable::admin::v2::ListInstancesResponse>
 BigtableInstanceAdminClient::ListInstances(std::string const& parent,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
@@ -94,26 +88,23 @@ BigtableInstanceAdminClient::ListInstances(std::string const& parent,
 StatusOr<google::bigtable::admin::v2::ListInstancesResponse>
 BigtableInstanceAdminClient::ListInstances(
     google::bigtable::admin::v2::ListInstancesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Instance>
 BigtableInstanceAdminClient::UpdateInstance(
-    google::bigtable::admin::v2::Instance const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::Instance const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstance(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::PartialUpdateInstance(
     google::bigtable::admin::v2::Instance const& instance,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::PartialUpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_update_mask() = update_mask;
@@ -123,16 +114,14 @@ BigtableInstanceAdminClient::PartialUpdateInstance(
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminClient::PartialUpdateInstance(
     google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateInstance(request);
 }
 
 Status BigtableInstanceAdminClient::DeleteInstance(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -140,18 +129,16 @@ Status BigtableInstanceAdminClient::DeleteInstance(std::string const& name,
 
 Status BigtableInstanceAdminClient::DeleteInstance(
     google::bigtable::admin::v2::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::CreateCluster(
     std::string const& parent, std::string const& cluster_id,
-    google::bigtable::admin::v2::Cluster const& cluster, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::Cluster const& cluster, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateClusterRequest request;
   request.set_parent(parent);
   request.set_cluster_id(cluster_id);
@@ -162,17 +149,14 @@ BigtableInstanceAdminClient::CreateCluster(
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::CreateCluster(
     google::bigtable::admin::v2::CreateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCluster(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Cluster>
-BigtableInstanceAdminClient::GetCluster(std::string const& name,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BigtableInstanceAdminClient::GetCluster(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetClusterRequest request;
   request.set_name(name);
   return connection_->GetCluster(request);
@@ -181,17 +165,15 @@ BigtableInstanceAdminClient::GetCluster(std::string const& name,
 StatusOr<google::bigtable::admin::v2::Cluster>
 BigtableInstanceAdminClient::GetCluster(
     google::bigtable::admin::v2::GetClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCluster(request);
 }
 
 StatusOr<google::bigtable::admin::v2::ListClustersResponse>
 BigtableInstanceAdminClient::ListClusters(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListClustersRequest request;
   request.set_parent(parent);
   return connection_->ListClusters(request);
@@ -200,26 +182,23 @@ BigtableInstanceAdminClient::ListClusters(std::string const& parent,
 StatusOr<google::bigtable::admin::v2::ListClustersResponse>
 BigtableInstanceAdminClient::ListClusters(
     google::bigtable::admin::v2::ListClustersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListClusters(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::UpdateCluster(
-    google::bigtable::admin::v2::Cluster const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::Cluster const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCluster(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::PartialUpdateCluster(
     google::bigtable::admin::v2::Cluster const& cluster,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::PartialUpdateClusterRequest request;
   *request.mutable_cluster() = cluster;
   *request.mutable_update_mask() = update_mask;
@@ -229,16 +208,14 @@ BigtableInstanceAdminClient::PartialUpdateCluster(
 future<StatusOr<google::bigtable::admin::v2::Cluster>>
 BigtableInstanceAdminClient::PartialUpdateCluster(
     google::bigtable::admin::v2::PartialUpdateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PartialUpdateCluster(request);
 }
 
 Status BigtableInstanceAdminClient::DeleteCluster(std::string const& name,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteClusterRequest request;
   request.set_name(name);
   return connection_->DeleteCluster(request);
@@ -246,19 +223,16 @@ Status BigtableInstanceAdminClient::DeleteCluster(std::string const& name,
 
 Status BigtableInstanceAdminClient::DeleteCluster(
     google::bigtable::admin::v2::DeleteClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCluster(request);
 }
 
 StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::CreateAppProfile(
     std::string const& parent, std::string const& app_profile_id,
-    google::bigtable::admin::v2::AppProfile const& app_profile,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::AppProfile const& app_profile, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateAppProfileRequest request;
   request.set_parent(parent);
   request.set_app_profile_id(app_profile_id);
@@ -269,17 +243,15 @@ BigtableInstanceAdminClient::CreateAppProfile(
 StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::CreateAppProfile(
     google::bigtable::admin::v2::CreateAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAppProfile(request);
 }
 
 StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::GetAppProfile(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetAppProfileRequest request;
   request.set_name(name);
   return connection_->GetAppProfile(request);
@@ -288,17 +260,15 @@ BigtableInstanceAdminClient::GetAppProfile(std::string const& name,
 StatusOr<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::GetAppProfile(
     google::bigtable::admin::v2::GetAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAppProfile(request);
 }
 
 StreamRange<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::ListAppProfiles(std::string const& parent,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListAppProfilesRequest request;
   request.set_parent(parent);
   return connection_->ListAppProfiles(request);
@@ -306,19 +276,16 @@ BigtableInstanceAdminClient::ListAppProfiles(std::string const& parent,
 
 StreamRange<google::bigtable::admin::v2::AppProfile>
 BigtableInstanceAdminClient::ListAppProfiles(
-    google::bigtable::admin::v2::ListAppProfilesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::ListAppProfilesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAppProfiles(std::move(request));
 }
 
 future<StatusOr<google::bigtable::admin::v2::AppProfile>>
 BigtableInstanceAdminClient::UpdateAppProfile(
     google::bigtable::admin::v2::AppProfile const& app_profile,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateAppProfileRequest request;
   *request.mutable_app_profile() = app_profile;
   *request.mutable_update_mask() = update_mask;
@@ -328,16 +295,14 @@ BigtableInstanceAdminClient::UpdateAppProfile(
 future<StatusOr<google::bigtable::admin::v2::AppProfile>>
 BigtableInstanceAdminClient::UpdateAppProfile(
     google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAppProfile(request);
 }
 
 Status BigtableInstanceAdminClient::DeleteAppProfile(std::string const& name,
-                                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteAppProfileRequest request;
   request.set_name(name);
   return connection_->DeleteAppProfile(request);
@@ -345,33 +310,29 @@ Status BigtableInstanceAdminClient::DeleteAppProfile(std::string const& name,
 
 Status BigtableInstanceAdminClient::DeleteAppProfile(
     google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAppProfile(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -379,11 +340,10 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
+    std::string const& resource, IamUpdater const& updater, Options opts) {
   internal::CheckExpectedOptions<BigtableInstanceAdminBackoffPolicyOption>(
-      options, __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+      opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -410,18 +370,16 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableInstanceAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -430,10 +388,8 @@ BigtableInstanceAdminClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableInstanceAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -852,8 +852,8 @@ class BigtableInstanceAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.h
@@ -67,7 +67,7 @@ class BigtableInstanceAdminClient {
  public:
   explicit BigtableInstanceAdminClient(
       std::shared_ptr<BigtableInstanceAdminConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~BigtableInstanceAdminClient();
 
   //@{
@@ -116,7 +116,8 @@ class BigtableInstanceAdminClient {
   ///  `projects/myproject/instances/myinstance/clusters/mycluster`.
   ///  Fields marked `OutputOnly` must be left blank.
   ///  Currently, at most four clusters can be specified.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -130,7 +131,7 @@ class BigtableInstanceAdminClient {
       google::bigtable::admin::v2::Instance const& instance,
       std::map<std::string, google::bigtable::admin::v2::Cluster> const&
           clusters,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create an instance within a project.
@@ -143,7 +144,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CreateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L280}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -154,7 +156,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> CreateInstance(
       google::bigtable::admin::v2::CreateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information about an instance.
@@ -162,7 +164,8 @@ class BigtableInstanceAdminClient {
   /// @param name  Required. The unique name of the requested instance. Values
   /// are of the form
   ///  `projects/{project}/instances/{instance}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -172,14 +175,15 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information about an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L308}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -190,7 +194,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Instance> GetInstance(
       google::bigtable::admin::v2::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists information about instances in a project.
@@ -198,7 +202,8 @@ class BigtableInstanceAdminClient {
   /// @param parent  Required. The unique name of the project for which a list
   /// of instances is requested.
   ///  Values are of the form `projects/{project}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
@@ -208,14 +213,15 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists information about instances in a project.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L320}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::ListInstancesResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L335}
   ///
@@ -226,7 +232,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::ListInstancesResponse> ListInstances(
       google::bigtable::admin::v2::ListInstancesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an instance within a project. This method updates only the display
@@ -235,7 +241,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -245,8 +252,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L41}
   ///
   StatusOr<google::bigtable::admin::v2::Instance> UpdateInstance(
-      google::bigtable::admin::v2::Instance const& request,
-      Options options = {});
+      google::bigtable::admin::v2::Instance const& request, Options opts = {});
 
   ///
   /// Partially updates an instance within a project. This method can modify all
@@ -257,7 +263,8 @@ class BigtableInstanceAdminClient {
   /// @param update_mask  Required. The subset of Instance fields which should
   /// be replaced.
   ///  Must be explicitly set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -268,7 +275,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::Instance const& instance,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Partially updates an instance within a project. This method can modify all
@@ -276,7 +283,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L352}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Instance,google/bigtable/admin/v2/instance.proto#L41}
   ///
@@ -287,33 +295,35 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Instance>> PartialUpdateInstance(
       google::bigtable::admin::v2::PartialUpdateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Delete an instance from a project.
   ///
   /// @param name  Required. The unique name of the instance to be deleted.
   ///  Values are of the form `projects/{project}/instances/{instance}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
-  Status DeleteInstance(std::string const& name, Options options = {});
+  Status DeleteInstance(std::string const& name, Options opts = {});
 
   ///
   /// Delete an instance from a project.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteInstanceRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L362}
   ///
   Status DeleteInstance(
       google::bigtable::admin::v2::DeleteInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a cluster within an instance.
@@ -334,7 +344,8 @@ class BigtableInstanceAdminClient {
   ///  `projects/myproject/instances/myinstance/clusters/mycluster`.
   /// @param cluster  Required. The cluster to be created.
   ///  Fields marked `OutputOnly` must be left blank.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -345,8 +356,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       std::string const& parent, std::string const& cluster_id,
-      google::bigtable::admin::v2::Cluster const& cluster,
-      Options options = {});
+      google::bigtable::admin::v2::Cluster const& cluster, Options opts = {});
 
   ///
   /// Creates a cluster within an instance.
@@ -359,7 +369,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CreateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L374}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -370,7 +381,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> CreateCluster(
       google::bigtable::admin::v2::CreateClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information about a cluster.
@@ -378,7 +389,8 @@ class BigtableInstanceAdminClient {
   /// @param name  Required. The unique name of the requested cluster. Values
   /// are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -388,14 +400,15 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information about a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L396}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -406,7 +419,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Cluster> GetCluster(
       google::bigtable::admin::v2::GetClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists information about clusters in an instance.
@@ -416,7 +429,8 @@ class BigtableInstanceAdminClient {
   ///  Values are of the form `projects/{project}/instances/{instance}`.
   ///  Use `{instance} = '-'` to list Clusters for all Instances in a project,
   ///  e.g., `projects/myproject/instances/-`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
@@ -426,14 +440,15 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists information about clusters in an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L408}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::ListClustersResponse,google/bigtable/admin/v2/bigtable_instance_admin.proto#L425}
   ///
@@ -444,7 +459,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::ListClustersResponse> ListClusters(
       google::bigtable::admin::v2::ListClustersRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a cluster within an instance.
@@ -455,7 +470,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -465,8 +481,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L137}
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> UpdateCluster(
-      google::bigtable::admin::v2::Cluster const& request,
-      Options options = {});
+      google::bigtable::admin::v2::Cluster const& request, Options opts = {});
 
   ///
   /// Partially updates a cluster within a project. This method is the preferred
@@ -487,7 +502,8 @@ class BigtableInstanceAdminClient {
   ///  the update_mask.
   /// @param update_mask  Required. The subset of Cluster fields which should be
   /// replaced.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -498,7 +514,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::Cluster const& cluster,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Partially updates a cluster within a project. This method is the preferred
@@ -516,7 +532,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::PartialUpdateClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L513}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Cluster,google/bigtable/admin/v2/instance.proto#L137}
   ///
@@ -527,7 +544,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Cluster>> PartialUpdateCluster(
       google::bigtable::admin::v2::PartialUpdateClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a cluster from an instance.
@@ -535,26 +552,28 @@ class BigtableInstanceAdminClient {
   /// @param name  Required. The unique name of the cluster to be deleted.
   /// Values are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteClusterRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
-  Status DeleteCluster(std::string const& name, Options options = {});
+  Status DeleteCluster(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a cluster from an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteClusterRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteClusterRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L441}
   ///
   Status DeleteCluster(
       google::bigtable::admin::v2::DeleteClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an app profile within an instance.
@@ -569,7 +588,8 @@ class BigtableInstanceAdminClient {
   ///  `projects/myproject/instances/myinstance/appProfiles/myprofile`.
   /// @param app_profile  Required. The app profile to be created.
   ///  Fields marked `OutputOnly` will be ignored.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -581,14 +601,15 @@ class BigtableInstanceAdminClient {
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       std::string const& parent, std::string const& app_profile_id,
       google::bigtable::admin::v2::AppProfile const& app_profile,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an app profile within an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CreateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L523}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -599,7 +620,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> CreateAppProfile(
       google::bigtable::admin::v2::CreateAppProfileRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information about an app profile.
@@ -607,7 +628,8 @@ class BigtableInstanceAdminClient {
   /// @param name  Required. The unique name of the requested app profile.
   /// Values are of the form
   ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -617,14 +639,15 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information about an app profile.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L548}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -635,7 +658,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::AppProfile> GetAppProfile(
       google::bigtable::admin::v2::GetAppProfileRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists information about app profiles in an instance.
@@ -646,7 +669,8 @@ class BigtableInstanceAdminClient {
   ///  `projects/{project}/instances/{instance}`.
   ///  Use `{instance} = '-'` to list AppProfiles for all Instances in a
   ///  project, e.g., `projects/myproject/instances/-`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -656,14 +680,15 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/instance.proto#L236}
   ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists information about app profiles in an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListAppProfilesRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L560}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -674,7 +699,7 @@ class BigtableInstanceAdminClient {
   ///
   StreamRange<google::bigtable::admin::v2::AppProfile> ListAppProfiles(
       google::bigtable::admin::v2::ListAppProfilesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an app profile within an instance.
@@ -684,7 +709,8 @@ class BigtableInstanceAdminClient {
   /// @param update_mask  Required. The subset of app profile fields which
   /// should be replaced.
   ///  If unset, all fields will be replaced.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -695,14 +721,15 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::AppProfile const& app_profile,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an app profile within an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::UpdateAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L606}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::AppProfile,google/bigtable/admin/v2/instance.proto#L236}
   ///
@@ -713,7 +740,7 @@ class BigtableInstanceAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::AppProfile>> UpdateAppProfile(
       google::bigtable::admin::v2::UpdateAppProfileRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an app profile from an instance.
@@ -721,26 +748,28 @@ class BigtableInstanceAdminClient {
   /// @param name  Required. The unique name of the app profile to be deleted.
   /// Values are of the form
   ///  `projects/{project}/instances/{instance}/appProfiles/{app_profile}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   ///
-  Status DeleteAppProfile(std::string const& name, Options options = {});
+  Status DeleteAppProfile(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an app profile from an instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteAppProfileRequest,google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteAppProfileRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_instance_admin.proto#L619}
   ///
   Status DeleteAppProfile(
       google::bigtable::admin::v2::DeleteAppProfileRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy for an instance resource. Returns an empty
@@ -749,7 +778,8 @@ class BigtableInstanceAdminClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -759,7 +789,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for an instance resource. Returns an empty
@@ -767,7 +797,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -777,8 +808,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy on an instance resource. Replaces any
@@ -792,7 +822,8 @@ class BigtableInstanceAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -803,7 +834,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -821,14 +852,13 @@ class BigtableInstanceAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `BigtableInstanceAdminBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on an instance resource. Replaces any
@@ -836,7 +866,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -846,8 +877,7 @@ class BigtableInstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified instance
@@ -861,7 +891,8 @@ class BigtableInstanceAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -872,7 +903,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified instance
@@ -880,7 +911,8 @@ class BigtableInstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -891,7 +923,7 @@ class BigtableInstanceAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<BigtableInstanceAdminConnection> connection_;

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
@@ -28,10 +28,10 @@ namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BigtableTableAdminClient::BigtableTableAdminClient(
-    std::shared_ptr<BigtableTableAdminConnection> connection, Options options)
+    std::shared_ptr<BigtableTableAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           bigtable_admin_internal::BigtableTableAdminDefaultOptions(
               connection_->options()))) {}
 BigtableTableAdminClient::~BigtableTableAdminClient() = default;
@@ -39,9 +39,8 @@ BigtableTableAdminClient::~BigtableTableAdminClient() = default;
 StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::CreateTable(
     std::string const& parent, std::string const& table_id,
-    google::bigtable::admin::v2::Table const& table, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::Table const& table, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateTableRequest request;
   request.set_parent(parent);
   request.set_table_id(table_id);
@@ -52,17 +51,14 @@ BigtableTableAdminClient::CreateTable(
 StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::CreateTable(
     google::bigtable::admin::v2::CreateTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTable(request);
 }
 
 StreamRange<google::bigtable::admin::v2::Table>
-BigtableTableAdminClient::ListTables(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BigtableTableAdminClient::ListTables(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListTablesRequest request;
   request.set_parent(parent);
   return connection_->ListTables(request);
@@ -70,33 +66,28 @@ BigtableTableAdminClient::ListTables(std::string const& parent,
 
 StreamRange<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::ListTables(
-    google::bigtable::admin::v2::ListTablesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::ListTablesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTables(std::move(request));
 }
 
 StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetTableRequest request;
   request.set_name(name);
   return connection_->GetTable(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Table> BigtableTableAdminClient::GetTable(
-    google::bigtable::admin::v2::GetTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::GetTableRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTable(request);
 }
 
 Status BigtableTableAdminClient::DeleteTable(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteTableRequest request;
   request.set_name(name);
   return connection_->DeleteTable(request);
@@ -104,9 +95,8 @@ Status BigtableTableAdminClient::DeleteTable(std::string const& name,
 
 Status BigtableTableAdminClient::DeleteTable(
     google::bigtable::admin::v2::DeleteTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTable(request);
 }
 
@@ -115,9 +105,8 @@ BigtableTableAdminClient::ModifyColumnFamilies(
     std::string const& name,
     std::vector<google::bigtable::admin::v2::ModifyColumnFamiliesRequest::
                     Modification> const& modifications,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ModifyColumnFamiliesRequest request;
   request.set_name(name);
   *request.mutable_modifications() = {modifications.begin(),
@@ -128,25 +117,22 @@ BigtableTableAdminClient::ModifyColumnFamilies(
 StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminClient::ModifyColumnFamilies(
     google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ModifyColumnFamilies(request);
 }
 
 Status BigtableTableAdminClient::DropRowRange(
     google::bigtable::admin::v2::DropRowRangeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DropRowRange(request);
 }
 
 StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
 BigtableTableAdminClient::GenerateConsistencyToken(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GenerateConsistencyTokenRequest request;
   request.set_name(name);
   return connection_->GenerateConsistencyToken(request);
@@ -155,18 +141,16 @@ BigtableTableAdminClient::GenerateConsistencyToken(std::string const& name,
 StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
 BigtableTableAdminClient::GenerateConsistencyToken(
     google::bigtable::admin::v2::GenerateConsistencyTokenRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateConsistencyToken(request);
 }
 
 StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
 BigtableTableAdminClient::CheckConsistency(std::string const& name,
                                            std::string const& consistency_token,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CheckConsistencyRequest request;
   request.set_name(name);
   request.set_consistency_token(consistency_token);
@@ -176,18 +160,16 @@ BigtableTableAdminClient::CheckConsistency(std::string const& name,
 StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
 BigtableTableAdminClient::CheckConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CheckConsistency(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CreateBackup(
     std::string const& parent, std::string const& backup_id,
-    google::bigtable::admin::v2::Backup const& backup, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::Backup const& backup, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CreateBackupRequest request;
   request.set_parent(parent);
   request.set_backup_id(backup_id);
@@ -198,16 +180,14 @@ BigtableTableAdminClient::CreateBackup(
 future<StatusOr<google::bigtable::admin::v2::Backup>>
 BigtableTableAdminClient::CreateBackup(
     google::bigtable::admin::v2::CreateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Backup>
-BigtableTableAdminClient::GetBackup(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BigtableTableAdminClient::GetBackup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
@@ -216,18 +196,16 @@ BigtableTableAdminClient::GetBackup(std::string const& name, Options options) {
 StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::GetBackup(
     google::bigtable::admin::v2::GetBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::UpdateBackup(
     google::bigtable::admin::v2::Backup const& backup,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
@@ -237,16 +215,14 @@ BigtableTableAdminClient::UpdateBackup(
 StatusOr<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::UpdateBackup(
     google::bigtable::admin::v2::UpdateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBackup(request);
 }
 
 Status BigtableTableAdminClient::DeleteBackup(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
@@ -254,17 +230,14 @@ Status BigtableTableAdminClient::DeleteBackup(std::string const& name,
 
 Status BigtableTableAdminClient::DeleteBackup(
     google::bigtable::admin::v2::DeleteBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::bigtable::admin::v2::Backup>
-BigtableTableAdminClient::ListBackups(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BigtableTableAdminClient::ListBackups(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
@@ -272,42 +245,37 @@ BigtableTableAdminClient::ListBackups(std::string const& parent,
 
 StreamRange<google::bigtable::admin::v2::Backup>
 BigtableTableAdminClient::ListBackups(
-    google::bigtable::admin::v2::ListBackupsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::bigtable::admin::v2::ListBackupsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::bigtable::admin::v2::Table>>
 BigtableTableAdminClient::RestoreTable(
     google::bigtable::admin::v2::RestoreTableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreTable(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -315,11 +283,10 @@ StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
+    std::string const& resource, IamUpdater const& updater, Options opts) {
   internal::CheckExpectedOptions<BigtableTableAdminBackoffPolicyOption>(
-      options, __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+      opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -346,18 +313,16 @@ StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> BigtableTableAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableTableAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -366,19 +331,16 @@ BigtableTableAdminClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 BigtableTableAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminClient::AsyncCheckConsistency(
     std::string const& name, std::string const& consistency_token,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::bigtable::admin::v2::CheckConsistencyRequest request;
   request.set_name(name);
   request.set_consistency_token(consistency_token);
@@ -388,9 +350,8 @@ BigtableTableAdminClient::AsyncCheckConsistency(
 future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminClient::AsyncCheckConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncCheckConsistency(request);
 }
 

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -69,7 +69,7 @@ class BigtableTableAdminClient {
  public:
   explicit BigtableTableAdminClient(
       std::shared_ptr<BigtableTableAdminConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~BigtableTableAdminClient();
 
   //@{
@@ -106,7 +106,8 @@ class BigtableTableAdminClient {
   ///  instance, e.g., `foobar` rather than `{parent}/tables/foobar`.
   ///  Maximum 50 characters.
   /// @param table  Required. The Table to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -117,7 +118,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       std::string const& parent, std::string const& table_id,
-      google::bigtable::admin::v2::Table const& table, Options options = {});
+      google::bigtable::admin::v2::Table const& table, Options opts = {});
 
   ///
   /// Creates a new table in the specified instance.
@@ -126,7 +127,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CreateTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L408}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -137,7 +139,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Table> CreateTable(
       google::bigtable::admin::v2::CreateTableRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all tables served from a specified instance.
@@ -145,7 +147,8 @@ class BigtableTableAdminClient {
   /// @param parent  Required. The unique name of the instance for which tables
   /// should be listed.
   ///  Values are of the form `projects/{project}/instances/{instance}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -155,14 +158,15 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all tables served from a specified instance.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListTablesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L510}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -173,7 +177,7 @@ class BigtableTableAdminClient {
   ///
   StreamRange<google::bigtable::admin::v2::Table> ListTables(
       google::bigtable::admin::v2::ListTablesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets metadata information about the specified table.
@@ -181,7 +185,8 @@ class BigtableTableAdminClient {
   /// @param name  Required. The unique name of the requested table.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -191,14 +196,15 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L61}
   ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Gets metadata information about the specified table.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L553}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -209,7 +215,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Table> GetTable(
       google::bigtable::admin::v2::GetTableRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Permanently deletes a specified table and all of its data.
@@ -217,26 +223,28 @@ class BigtableTableAdminClient {
   /// @param name  Required. The unique name of the table to be deleted.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteTableRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
-  Status DeleteTable(std::string const& name, Options options = {});
+  Status DeleteTable(std::string const& name, Options opts = {});
 
   ///
   /// Permanently deletes a specified table and all of its data.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteTableRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L571}
   ///
   Status DeleteTable(
       google::bigtable::admin::v2::DeleteTableRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Performs a series of column family modifications on the specified table.
@@ -253,7 +261,8 @@ class BigtableTableAdminClient {
   ///  Entries are applied in order, meaning that earlier modifications can be
   ///  masked by later ones (in the case of repeated updates to the same family,
   ///  for example).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -266,7 +275,7 @@ class BigtableTableAdminClient {
       std::string const& name,
       std::vector<google::bigtable::admin::v2::ModifyColumnFamiliesRequest::
                       Modification> const& modifications,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Performs a series of column family modifications on the specified table.
@@ -276,7 +285,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ModifyColumnFamiliesRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L585}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -287,7 +297,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Table> ModifyColumnFamilies(
       google::bigtable::admin::v2::ModifyColumnFamiliesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Permanently drop/delete a row range from a specified table. The request
@@ -296,14 +306,15 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DropRowRangeRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DropRowRangeRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L486}
   ///
   Status DropRowRange(
       google::bigtable::admin::v2::DropRowRangeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Generates a consistency token for a Table, which can be used in
@@ -315,7 +326,8 @@ class BigtableTableAdminClient {
   /// consistency token.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
@@ -325,7 +337,7 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
   StatusOr<google::bigtable::admin::v2::GenerateConsistencyTokenResponse>
-  GenerateConsistencyToken(std::string const& name, Options options = {});
+  GenerateConsistencyToken(std::string const& name, Options opts = {});
 
   ///
   /// Generates a consistency token for a Table, which can be used in
@@ -335,7 +347,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L626}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::GenerateConsistencyTokenResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L640}
   ///
@@ -348,7 +361,7 @@ class BigtableTableAdminClient {
   GenerateConsistencyToken(
       google::bigtable::admin::v2::GenerateConsistencyTokenRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Checks replication consistency based on a consistency token, that is, if
@@ -361,7 +374,8 @@ class BigtableTableAdminClient {
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
   /// @param consistency_token  Required. The token created using
   /// GenerateConsistencyToken for the Table.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
@@ -372,7 +386,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(std::string const& name,
-                   std::string const& consistency_token, Options options = {});
+                   std::string const& consistency_token, Options opts = {});
 
   ///
   /// Checks replication consistency based on a consistency token, that is, if
@@ -381,7 +395,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
@@ -393,7 +408,7 @@ class BigtableTableAdminClient {
   StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>
   CheckConsistency(
       google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts creating a new Cloud Bigtable Backup.  The returned backup
@@ -417,7 +432,8 @@ class BigtableTableAdminClient {
   ///  This string must be between 1 and 50 characters in length and match the
   ///  regex [_a-zA-Z0-9][-_.a-zA-Z0-9]*.
   /// @param backup  Required. The backup to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -428,7 +444,7 @@ class BigtableTableAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       std::string const& parent, std::string const& backup_id,
-      google::bigtable::admin::v2::Backup const& backup, Options options = {});
+      google::bigtable::admin::v2::Backup const& backup, Options opts = {});
 
   ///
   /// Starts creating a new Cloud Bigtable Backup.  The returned backup
@@ -442,7 +458,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CreateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L833}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -453,7 +470,7 @@ class BigtableTableAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Backup>> CreateBackup(
       google::bigtable::admin::v2::CreateBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets metadata on a pending or completed Cloud Bigtable Backup.
@@ -461,7 +478,8 @@ class BigtableTableAdminClient {
   /// @param name  Required. Name of the backup.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -471,14 +489,15 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets metadata on a pending or completed Cloud Bigtable Backup.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::GetBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L889}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -489,7 +508,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Backup> GetBackup(
       google::bigtable::admin::v2::GetBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a pending or completed Cloud Bigtable Backup.
@@ -505,7 +524,8 @@ class BigtableTableAdminClient {
   ///  resource, not to the request message. The field mask must always be
   ///  specified; this prevents any future fields from being erased accidentally
   ///  by clients that do not know about them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -516,14 +536,15 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::Backup const& backup,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a pending or completed Cloud Bigtable Backup.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::UpdateBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L873}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -534,7 +555,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::bigtable::admin::v2::Backup> UpdateBackup(
       google::bigtable::admin::v2::UpdateBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a pending or completed Cloud Bigtable backup.
@@ -542,26 +563,28 @@ class BigtableTableAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/{project}/instances/{instance}/clusters/{cluster}/backups/{backup}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
-  Status DeleteBackup(std::string const& name, Options options = {});
+  Status DeleteBackup(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a pending or completed Cloud Bigtable backup.
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::DeleteBackupRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.bigtable.admin.v2.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/bigtable/admin/v2/bigtable_table_admin.proto#L902}
   ///
   Status DeleteBackup(
       google::bigtable::admin::v2::DeleteBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Cloud Bigtable backups. Returns both completed and pending
@@ -572,7 +595,8 @@ class BigtableTableAdminClient {
   ///  form `projects/{project}/instances/{instance}/clusters/{cluster}`.
   ///  Use `{cluster} = '-'` to list backups for all clusters in an instance,
   ///  e.g., `projects/{project}/instances/{instance}/clusters/-`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -582,7 +606,7 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/bigtable/admin/v2/table.proto#L317}
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Cloud Bigtable backups. Returns both completed and pending
@@ -590,7 +614,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::ListBackupsRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L915}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Backup,google/bigtable/admin/v2/table.proto#L317}
   ///
@@ -601,7 +626,7 @@ class BigtableTableAdminClient {
   ///
   StreamRange<google::bigtable::admin::v2::Backup> ListBackups(
       google::bigtable::admin::v2::ListBackupsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new table by restoring from a completed backup. The new table
@@ -615,7 +640,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::RestoreTableRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L336}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::Table,google/bigtable/admin/v2/table.proto#L61}
   ///
@@ -626,7 +652,7 @@ class BigtableTableAdminClient {
   ///
   future<StatusOr<google::bigtable::admin::v2::Table>> RestoreTable(
       google::bigtable::admin::v2::RestoreTableRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy for a Table or Backup resource.
@@ -636,7 +662,8 @@ class BigtableTableAdminClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -646,7 +673,7 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a Table or Backup resource.
@@ -655,7 +682,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -665,8 +693,7 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy on a Table or Backup resource.
@@ -680,7 +707,8 @@ class BigtableTableAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -691,7 +719,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -709,14 +737,13 @@ class BigtableTableAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `BigtableTableAdminBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on a Table or Backup resource.
@@ -724,7 +751,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -734,8 +762,7 @@ class BigtableTableAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified Table or Backup
@@ -749,7 +776,8 @@ class BigtableTableAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -760,7 +788,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified Table or Backup
@@ -768,7 +796,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -779,7 +808,7 @@ class BigtableTableAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Checks replication consistency based on a consistency token, that is, if
@@ -792,7 +821,8 @@ class BigtableTableAdminClient {
   ///  `projects/{project}/instances/{instance}/tables/{table}`.
   /// @param consistency_token  Required. The token created using
   /// GenerateConsistencyToken for the Table.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
@@ -804,7 +834,7 @@ class BigtableTableAdminClient {
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(std::string const& name,
                         std::string const& consistency_token,
-                        Options options = {});
+                        Options opts = {});
 
   ///
   /// Checks replication consistency based on a consistency token, that is, if
@@ -813,7 +843,8 @@ class BigtableTableAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyRequest,google/bigtable/admin/v2/bigtable_table_admin.proto#L647}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::bigtable::admin::v2::CheckConsistencyResponse,google/bigtable/admin/v2/bigtable_table_admin.proto#L664}
   ///
@@ -825,7 +856,7 @@ class BigtableTableAdminClient {
   future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
   AsyncCheckConsistency(
       google::bigtable::admin::v2::CheckConsistencyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<BigtableTableAdminConnection> connection_;

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.h
@@ -737,8 +737,8 @@ class BigtableTableAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/billing/budget_client.cc
+++ b/google/cloud/billing/budget_client.cc
@@ -26,20 +26,18 @@ namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BudgetServiceClient::BudgetServiceClient(
-    std::shared_ptr<BudgetServiceConnection> connection, Options options)
+    std::shared_ptr<BudgetServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), billing_internal::BudgetServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), billing_internal::BudgetServiceDefaultOptions(
+                               connection_->options()))) {}
 BudgetServiceClient::~BudgetServiceClient() = default;
 
 StatusOr<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceClient::CreateBudget(
     std::string const& parent,
-    google::cloud::billing::budgets::v1::Budget const& budget,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::billing::budgets::v1::Budget const& budget, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::budgets::v1::CreateBudgetRequest request;
   request.set_parent(parent);
   *request.mutable_budget() = budget;
@@ -49,18 +47,16 @@ BudgetServiceClient::CreateBudget(
 StatusOr<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceClient::CreateBudget(
     google::cloud::billing::budgets::v1::CreateBudgetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBudget(request);
 }
 
 StatusOr<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceClient::UpdateBudget(
     google::cloud::billing::budgets::v1::Budget const& budget,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::budgets::v1::UpdateBudgetRequest request;
   *request.mutable_budget() = budget;
   *request.mutable_update_mask() = update_mask;
@@ -70,16 +66,14 @@ BudgetServiceClient::UpdateBudget(
 StatusOr<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceClient::UpdateBudget(
     google::cloud::billing::budgets::v1::UpdateBudgetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBudget(request);
 }
 
 StatusOr<google::cloud::billing::budgets::v1::Budget>
-BudgetServiceClient::GetBudget(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BudgetServiceClient::GetBudget(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::budgets::v1::GetBudgetRequest request;
   request.set_name(name);
   return connection_->GetBudget(request);
@@ -88,16 +82,14 @@ BudgetServiceClient::GetBudget(std::string const& name, Options options) {
 StatusOr<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceClient::GetBudget(
     google::cloud::billing::budgets::v1::GetBudgetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBudget(request);
 }
 
 StreamRange<google::cloud::billing::budgets::v1::Budget>
-BudgetServiceClient::ListBudgets(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BudgetServiceClient::ListBudgets(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::budgets::v1::ListBudgetsRequest request;
   request.set_parent(parent);
   return connection_->ListBudgets(request);
@@ -106,16 +98,14 @@ BudgetServiceClient::ListBudgets(std::string const& parent, Options options) {
 StreamRange<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceClient::ListBudgets(
     google::cloud::billing::budgets::v1::ListBudgetsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBudgets(std::move(request));
 }
 
 Status BudgetServiceClient::DeleteBudget(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::budgets::v1::DeleteBudgetRequest request;
   request.set_name(name);
   return connection_->DeleteBudget(request);
@@ -123,9 +113,8 @@ Status BudgetServiceClient::DeleteBudget(std::string const& name,
 
 Status BudgetServiceClient::DeleteBudget(
     google::cloud::billing::budgets::v1::DeleteBudgetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBudget(request);
 }
 

--- a/google/cloud/billing/budget_client.h
+++ b/google/cloud/billing/budget_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BudgetServiceClient {
  public:
   explicit BudgetServiceClient(
-      std::shared_ptr<BudgetServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<BudgetServiceConnection> connection, Options opts = {});
   ~BudgetServiceClient();
 
   //@{
@@ -96,7 +95,8 @@ class BudgetServiceClient {
   /// budget in. Values
   ///  are of the form `billingAccounts/{billingAccountId}`.
   /// @param budget  Required. Budget to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -108,7 +108,7 @@ class BudgetServiceClient {
   StatusOr<google::cloud::billing::budgets::v1::Budget> CreateBudget(
       std::string const& parent,
       google::cloud::billing::budgets::v1::Budget const& budget,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new budget. See
@@ -118,7 +118,8 @@ class BudgetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::budgets::v1::CreateBudgetRequest,google/cloud/billing/budgets/v1/budget_service.proto#L100}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -129,7 +130,7 @@ class BudgetServiceClient {
   ///
   StatusOr<google::cloud::billing::budgets::v1::Budget> CreateBudget(
       google::cloud::billing::budgets::v1::CreateBudgetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a budget and returns the updated budget.
@@ -147,7 +148,8 @@ class BudgetServiceClient {
   ///  updated. See
   ///  https://developers.google.com/protocol-buffers/docs/proto3#default for
   ///  more details about default values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -158,7 +160,7 @@ class BudgetServiceClient {
   ///
   StatusOr<google::cloud::billing::budgets::v1::Budget> UpdateBudget(
       google::cloud::billing::budgets::v1::Budget const& budget,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a budget and returns the updated budget.
@@ -169,7 +171,8 @@ class BudgetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::budgets::v1::UpdateBudgetRequest,google/cloud/billing/budgets/v1/budget_service.proto#L115}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -180,7 +183,7 @@ class BudgetServiceClient {
   ///
   StatusOr<google::cloud::billing::budgets::v1::Budget> UpdateBudget(
       google::cloud::billing::budgets::v1::UpdateBudgetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a budget.
@@ -192,7 +195,8 @@ class BudgetServiceClient {
   ///
   /// @param name  Required. Name of budget to get. Values are of the form
   ///  `billingAccounts/{billingAccountId}/budgets/{budgetId}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -202,7 +206,7 @@ class BudgetServiceClient {
   /// @googleapis_reference_link{google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
   StatusOr<google::cloud::billing::budgets::v1::Budget> GetBudget(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns a budget.
@@ -214,7 +218,8 @@ class BudgetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::budgets::v1::GetBudgetRequest,google/cloud/billing/budgets/v1/budget_service.proto#L131}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -225,7 +230,7 @@ class BudgetServiceClient {
   ///
   StatusOr<google::cloud::billing::budgets::v1::Budget> GetBudget(
       google::cloud::billing::budgets::v1::GetBudgetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a list of budgets for a billing account.
@@ -238,7 +243,8 @@ class BudgetServiceClient {
   /// @param parent  Required. Name of billing account to list budgets under.
   /// Values
   ///  are of the form `billingAccounts/{billingAccountId}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -248,7 +254,7 @@ class BudgetServiceClient {
   /// @googleapis_reference_link{google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
   StreamRange<google::cloud::billing::budgets::v1::Budget> ListBudgets(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Returns a list of budgets for a billing account.
@@ -260,7 +266,8 @@ class BudgetServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::budgets::v1::ListBudgetsRequest,google/cloud/billing/budgets/v1/budget_service.proto#L143}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::budgets::v1::Budget,google/cloud/billing/budgets/v1/budget_model.proto#L35}
   ///
@@ -271,7 +278,7 @@ class BudgetServiceClient {
   ///
   StreamRange<google::cloud::billing::budgets::v1::Budget> ListBudgets(
       google::cloud::billing::budgets::v1::ListBudgetsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a budget. Returns successfully if already deleted.
@@ -279,26 +286,28 @@ class BudgetServiceClient {
   /// @param name  Required. Name of the budget to delete. Values are of the
   /// form
   ///  `billingAccounts/{billingAccountId}/budgets/{budgetId}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.billing.budgets.v1.DeleteBudgetRequest]:
   /// @googleapis_reference_link{google/cloud/billing/budgets/v1/budget_service.proto#L174}
   ///
-  Status DeleteBudget(std::string const& name, Options options = {});
+  Status DeleteBudget(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a budget. Returns successfully if already deleted.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::budgets::v1::DeleteBudgetRequest,google/cloud/billing/budgets/v1/budget_service.proto#L174}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.billing.budgets.v1.DeleteBudgetRequest]:
   /// @googleapis_reference_link{google/cloud/billing/budgets/v1/budget_service.proto#L174}
   ///
   Status DeleteBudget(
       google::cloud::billing::budgets::v1::DeleteBudgetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<BudgetServiceConnection> connection_;

--- a/google/cloud/billing/cloud_billing_client.cc
+++ b/google/cloud/billing/cloud_billing_client.cc
@@ -28,18 +28,16 @@ namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudBillingClient::CloudBillingClient(
-    std::shared_ptr<CloudBillingConnection> connection, Options options)
+    std::shared_ptr<CloudBillingConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), billing_internal::CloudBillingDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), billing_internal::CloudBillingDefaultOptions(
+                               connection_->options()))) {}
 CloudBillingClient::~CloudBillingClient() = default;
 
 StatusOr<google::cloud::billing::v1::BillingAccount>
-CloudBillingClient::GetBillingAccount(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudBillingClient::GetBillingAccount(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::GetBillingAccountRequest request;
   request.set_name(name);
   return connection_->GetBillingAccount(request);
@@ -48,16 +46,14 @@ CloudBillingClient::GetBillingAccount(std::string const& name,
 StatusOr<google::cloud::billing::v1::BillingAccount>
 CloudBillingClient::GetBillingAccount(
     google::cloud::billing::v1::GetBillingAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBillingAccount(request);
 }
 
 StreamRange<google::cloud::billing::v1::BillingAccount>
-CloudBillingClient::ListBillingAccounts(Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudBillingClient::ListBillingAccounts(Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::ListBillingAccountsRequest request;
   return connection_->ListBillingAccounts(request);
 }
@@ -65,19 +61,16 @@ CloudBillingClient::ListBillingAccounts(Options options) {
 StreamRange<google::cloud::billing::v1::BillingAccount>
 CloudBillingClient::ListBillingAccounts(
     google::cloud::billing::v1::ListBillingAccountsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBillingAccounts(std::move(request));
 }
 
 StatusOr<google::cloud::billing::v1::BillingAccount>
 CloudBillingClient::UpdateBillingAccount(
     std::string const& name,
-    google::cloud::billing::v1::BillingAccount const& account,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::billing::v1::BillingAccount const& account, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::UpdateBillingAccountRequest request;
   request.set_name(name);
   *request.mutable_account() = account;
@@ -87,18 +80,16 @@ CloudBillingClient::UpdateBillingAccount(
 StatusOr<google::cloud::billing::v1::BillingAccount>
 CloudBillingClient::UpdateBillingAccount(
     google::cloud::billing::v1::UpdateBillingAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBillingAccount(request);
 }
 
 StatusOr<google::cloud::billing::v1::BillingAccount>
 CloudBillingClient::CreateBillingAccount(
     google::cloud::billing::v1::BillingAccount const& billing_account,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::CreateBillingAccountRequest request;
   *request.mutable_billing_account() = billing_account;
   return connection_->CreateBillingAccount(request);
@@ -107,17 +98,15 @@ CloudBillingClient::CreateBillingAccount(
 StatusOr<google::cloud::billing::v1::BillingAccount>
 CloudBillingClient::CreateBillingAccount(
     google::cloud::billing::v1::CreateBillingAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBillingAccount(request);
 }
 
 StreamRange<google::cloud::billing::v1::ProjectBillingInfo>
 CloudBillingClient::ListProjectBillingInfo(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::ListProjectBillingInfoRequest request;
   request.set_name(name);
   return connection_->ListProjectBillingInfo(request);
@@ -126,17 +115,15 @@ CloudBillingClient::ListProjectBillingInfo(std::string const& name,
 StreamRange<google::cloud::billing::v1::ProjectBillingInfo>
 CloudBillingClient::ListProjectBillingInfo(
     google::cloud::billing::v1::ListProjectBillingInfoRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProjectBillingInfo(std::move(request));
 }
 
 StatusOr<google::cloud::billing::v1::ProjectBillingInfo>
 CloudBillingClient::GetProjectBillingInfo(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::GetProjectBillingInfoRequest request;
   request.set_name(name);
   return connection_->GetProjectBillingInfo(request);
@@ -145,9 +132,8 @@ CloudBillingClient::GetProjectBillingInfo(std::string const& name,
 StatusOr<google::cloud::billing::v1::ProjectBillingInfo>
 CloudBillingClient::GetProjectBillingInfo(
     google::cloud::billing::v1::GetProjectBillingInfoRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetProjectBillingInfo(request);
 }
 
@@ -155,9 +141,8 @@ StatusOr<google::cloud::billing::v1::ProjectBillingInfo>
 CloudBillingClient::UpdateProjectBillingInfo(
     std::string const& name,
     google::cloud::billing::v1::ProjectBillingInfo const& project_billing_info,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::UpdateProjectBillingInfoRequest request;
   request.set_name(name);
   *request.mutable_project_billing_info() = project_billing_info;
@@ -167,33 +152,29 @@ CloudBillingClient::UpdateProjectBillingInfo(
 StatusOr<google::cloud::billing::v1::ProjectBillingInfo>
 CloudBillingClient::UpdateProjectBillingInfo(
     google::cloud::billing::v1::UpdateProjectBillingInfoRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateProjectBillingInfo(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudBillingClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudBillingClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -201,11 +182,10 @@ StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<CloudBillingBackoffPolicyOption>(options,
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<CloudBillingBackoffPolicyOption>(opts,
                                                                   __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -232,18 +212,16 @@ StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudBillingClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -252,10 +230,8 @@ CloudBillingClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudBillingClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/billing/cloud_billing_client.h
+++ b/google/cloud/billing/cloud_billing_client.h
@@ -558,8 +558,8 @@ class CloudBillingClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/billing/cloud_billing_client.h
+++ b/google/cloud/billing/cloud_billing_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudBillingClient {
  public:
   explicit CloudBillingClient(
-      std::shared_ptr<CloudBillingConnection> connection, Options options = {});
+      std::shared_ptr<CloudBillingConnection> connection, Options opts = {});
   ~CloudBillingClient();
 
   //@{
@@ -93,7 +93,8 @@ class CloudBillingClient {
   /// @param name  Required. The resource name of the billing account to
   /// retrieve. For example,
   ///  `billingAccounts/012345-567890-ABCDEF`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -103,7 +104,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
   StatusOr<google::cloud::billing::v1::BillingAccount> GetBillingAccount(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information about a billing account. The current authenticated user
@@ -112,7 +113,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::GetBillingAccountRequest,google/cloud/billing/v1/cloud_billing.proto#L242}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -123,14 +125,15 @@ class CloudBillingClient {
   ///
   StatusOr<google::cloud::billing::v1::BillingAccount> GetBillingAccount(
       google::cloud::billing::v1::GetBillingAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the billing accounts that the current authenticated user has
   /// permission to
   /// [view](https://cloud.google.com/billing/docs/how-to/billing-access).
   ///
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -140,7 +143,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
   StreamRange<google::cloud::billing::v1::BillingAccount> ListBillingAccounts(
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the billing accounts that the current authenticated user has
@@ -149,7 +152,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::ListBillingAccountsRequest,google/cloud/billing/v1/cloud_billing.proto#L254}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -160,7 +164,7 @@ class CloudBillingClient {
   ///
   StreamRange<google::cloud::billing::v1::BillingAccount> ListBillingAccounts(
       google::cloud::billing::v1::ListBillingAccountsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a billing account's fields.
@@ -174,7 +178,8 @@ class CloudBillingClient {
   /// updated.
   /// @param account  Required. The billing account resource to replace the
   /// resource on the server.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -186,7 +191,7 @@ class CloudBillingClient {
   StatusOr<google::cloud::billing::v1::BillingAccount> UpdateBillingAccount(
       std::string const& name,
       google::cloud::billing::v1::BillingAccount const& account,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a billing account's fields.
@@ -198,7 +203,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::UpdateBillingAccountRequest,google/cloud/billing/v1/cloud_billing.proto#L294}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -209,7 +215,7 @@ class CloudBillingClient {
   ///
   StatusOr<google::cloud::billing::v1::BillingAccount> UpdateBillingAccount(
       google::cloud::billing::v1::UpdateBillingAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a billing account.
@@ -227,7 +233,8 @@ class CloudBillingClient {
   ///  Currently CreateBillingAccount only supports subaccount creation, so
   ///  any created billing accounts must be under a provided master billing
   ///  account.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -238,7 +245,7 @@ class CloudBillingClient {
   ///
   StatusOr<google::cloud::billing::v1::BillingAccount> CreateBillingAccount(
       google::cloud::billing::v1::BillingAccount const& billing_account,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a billing account.
@@ -254,7 +261,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::CreateBillingAccountRequest,google/cloud/billing/v1/cloud_billing.proto#L285}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::BillingAccount,google/cloud/billing/v1/cloud_billing.proto#L189}
   ///
@@ -265,7 +273,7 @@ class CloudBillingClient {
   ///
   StatusOr<google::cloud::billing::v1::BillingAccount> CreateBillingAccount(
       google::cloud::billing::v1::CreateBillingAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the projects associated with a billing account. The current
@@ -276,7 +284,8 @@ class CloudBillingClient {
   /// @param name  Required. The resource name of the billing account associated
   /// with the projects that
   ///  you want to list. For example, `billingAccounts/012345-567890-ABCDEF`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::ProjectBillingInfo,google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
@@ -286,7 +295,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
   StreamRange<google::cloud::billing::v1::ProjectBillingInfo>
-  ListProjectBillingInfo(std::string const& name, Options options = {});
+  ListProjectBillingInfo(std::string const& name, Options opts = {});
 
   ///
   /// Lists the projects associated with a billing account. The current
@@ -296,7 +305,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::ListProjectBillingInfoRequest,google/cloud/billing/v1/cloud_billing.proto#L312}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::ProjectBillingInfo,google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
@@ -308,7 +318,7 @@ class CloudBillingClient {
   StreamRange<google::cloud::billing::v1::ProjectBillingInfo>
   ListProjectBillingInfo(
       google::cloud::billing::v1::ListProjectBillingInfoRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the billing information for a project. The current authenticated user
@@ -319,7 +329,8 @@ class CloudBillingClient {
   /// @param name  Required. The resource name of the project for which billing
   /// information is
   ///  retrieved. For example, `projects/tokyo-rain-123`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::ProjectBillingInfo,google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
@@ -329,7 +340,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
   StatusOr<google::cloud::billing::v1::ProjectBillingInfo>
-  GetProjectBillingInfo(std::string const& name, Options options = {});
+  GetProjectBillingInfo(std::string const& name, Options opts = {});
 
   ///
   /// Gets the billing information for a project. The current authenticated user
@@ -339,7 +350,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::GetProjectBillingInfoRequest,google/cloud/billing/v1/cloud_billing.proto#L345}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::ProjectBillingInfo,google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
@@ -351,7 +363,7 @@ class CloudBillingClient {
   StatusOr<google::cloud::billing::v1::ProjectBillingInfo>
   GetProjectBillingInfo(
       google::cloud::billing::v1::GetProjectBillingInfoRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets or updates the billing account associated with a project. You specify
@@ -392,7 +404,8 @@ class CloudBillingClient {
   /// @param project_billing_info  The new billing information for the project.
   /// Read-only fields are ignored;
   ///  thus, you can leave empty all fields except `billing_account_name`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::ProjectBillingInfo,google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
@@ -405,7 +418,7 @@ class CloudBillingClient {
   UpdateProjectBillingInfo(std::string const& name,
                            google::cloud::billing::v1::ProjectBillingInfo const&
                                project_billing_info,
-                           Options options = {});
+                           Options opts = {});
 
   ///
   /// Sets or updates the billing account associated with a project. You specify
@@ -442,7 +455,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::UpdateProjectBillingInfoRequest,google/cloud/billing/v1/cloud_billing.proto#L352}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::ProjectBillingInfo,google/cloud/billing/v1/cloud_billing.proto#L218}
   ///
@@ -455,7 +469,7 @@ class CloudBillingClient {
   UpdateProjectBillingInfo(
       google::cloud::billing::v1::UpdateProjectBillingInfoRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy for a billing account.
@@ -466,7 +480,8 @@ class CloudBillingClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -476,7 +491,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a billing account.
@@ -486,7 +501,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -496,8 +512,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy for a billing account. Replaces any
@@ -513,7 +528,8 @@ class CloudBillingClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -524,7 +540,7 @@ class CloudBillingClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -542,14 +558,13 @@ class CloudBillingClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `CloudBillingBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy for a billing account. Replaces any
@@ -559,7 +574,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -569,8 +585,7 @@ class CloudBillingClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Tests the access control policy for a billing account. This method takes
@@ -585,7 +600,8 @@ class CloudBillingClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -596,7 +612,7 @@ class CloudBillingClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Tests the access control policy for a billing account. This method takes
@@ -605,7 +621,8 @@ class CloudBillingClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -616,7 +633,7 @@ class CloudBillingClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudBillingConnection> connection_;

--- a/google/cloud/billing/cloud_catalog_client.cc
+++ b/google/cloud/billing/cloud_catalog_client.cc
@@ -26,42 +26,38 @@ namespace billing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudCatalogClient::CloudCatalogClient(
-    std::shared_ptr<CloudCatalogConnection> connection, Options options)
+    std::shared_ptr<CloudCatalogConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), billing_internal::CloudCatalogDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), billing_internal::CloudCatalogDefaultOptions(
+                               connection_->options()))) {}
 CloudCatalogClient::~CloudCatalogClient() = default;
 
 StreamRange<google::cloud::billing::v1::Service>
-CloudCatalogClient::ListServices(Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudCatalogClient::ListServices(Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::ListServicesRequest request;
   return connection_->ListServices(request);
 }
 
 StreamRange<google::cloud::billing::v1::Service>
 CloudCatalogClient::ListServices(
-    google::cloud::billing::v1::ListServicesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::billing::v1::ListServicesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServices(std::move(request));
 }
 
 StreamRange<google::cloud::billing::v1::Sku> CloudCatalogClient::ListSkus(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::billing::v1::ListSkusRequest request;
   request.set_parent(parent);
   return connection_->ListSkus(request);
 }
 
 StreamRange<google::cloud::billing::v1::Sku> CloudCatalogClient::ListSkus(
-    google::cloud::billing::v1::ListSkusRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::billing::v1::ListSkusRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSkus(std::move(request));
 }
 

--- a/google/cloud/billing/cloud_catalog_client.h
+++ b/google/cloud/billing/cloud_catalog_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudCatalogClient {
  public:
   explicit CloudCatalogClient(
-      std::shared_ptr<CloudCatalogConnection> connection, Options options = {});
+      std::shared_ptr<CloudCatalogConnection> connection, Options opts = {});
   ~CloudCatalogClient();
 
   //@{
@@ -89,7 +89,8 @@ class CloudCatalogClient {
   ///
   /// Lists all public cloud services.
   ///
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::Service,google/cloud/billing/v1/cloud_catalog.proto#L59}
   ///
@@ -99,14 +100,15 @@ class CloudCatalogClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_catalog.proto#L59}
   ///
   StreamRange<google::cloud::billing::v1::Service> ListServices(
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all public cloud services.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::ListServicesRequest,google/cloud/billing/v1/cloud_catalog.proto#L260}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::Service,google/cloud/billing/v1/cloud_catalog.proto#L59}
   ///
@@ -117,14 +119,15 @@ class CloudCatalogClient {
   ///
   StreamRange<google::cloud::billing::v1::Service> ListServices(
       google::cloud::billing::v1::ListServicesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all publicly available SKUs for a given cloud service.
   ///
   /// @param parent  Required. The name of the service.
   ///  Example: "services/DA34-426B-A397"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::Sku,google/cloud/billing/v1/cloud_catalog.proto#L82}
   ///
@@ -134,14 +137,15 @@ class CloudCatalogClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_catalog.proto#L82}
   ///
   StreamRange<google::cloud::billing::v1::Sku> ListSkus(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all publicly available SKUs for a given cloud service.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::billing::v1::ListSkusRequest,google/cloud/billing/v1/cloud_catalog.proto#L282}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::billing::v1::Sku,google/cloud/billing/v1/cloud_catalog.proto#L82}
   ///
@@ -151,8 +155,7 @@ class CloudCatalogClient {
   /// @googleapis_reference_link{google/cloud/billing/v1/cloud_catalog.proto#L82}
   ///
   StreamRange<google::cloud::billing::v1::Sku> ListSkus(
-      google::cloud::billing::v1::ListSkusRequest request,
-      Options options = {});
+      google::cloud::billing::v1::ListSkusRequest request, Options opts = {});
 
  private:
   std::shared_ptr<CloudCatalogConnection> connection_;

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_client.cc
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_client.cc
@@ -27,20 +27,19 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BinauthzManagementServiceV1Client::BinauthzManagementServiceV1Client(
     std::shared_ptr<BinauthzManagementServiceV1Connection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), binaryauthorization_internal::
-                                  BinauthzManagementServiceV1DefaultOptions(
-                                      connection_->options()))) {}
+          std::move(opts), binaryauthorization_internal::
+                               BinauthzManagementServiceV1DefaultOptions(
+                                   connection_->options()))) {}
 BinauthzManagementServiceV1Client::~BinauthzManagementServiceV1Client() =
     default;
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
 BinauthzManagementServiceV1Client::GetPolicy(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::GetPolicyRequest request;
   request.set_name(name);
   return connection_->GetPolicy(request);
@@ -49,18 +48,16 @@ BinauthzManagementServiceV1Client::GetPolicy(std::string const& name,
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
 BinauthzManagementServiceV1Client::GetPolicy(
     google::cloud::binaryauthorization::v1::GetPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPolicy(request);
 }
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
 BinauthzManagementServiceV1Client::UpdatePolicy(
     google::cloud::binaryauthorization::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::UpdatePolicyRequest request;
   *request.mutable_policy() = policy;
   return connection_->UpdatePolicy(request);
@@ -69,9 +66,8 @@ BinauthzManagementServiceV1Client::UpdatePolicy(
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
 BinauthzManagementServiceV1Client::UpdatePolicy(
     google::cloud::binaryauthorization::v1::UpdatePolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdatePolicy(request);
 }
 
@@ -79,9 +75,8 @@ StatusOr<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::CreateAttestor(
     std::string const& parent, std::string const& attestor_id,
     google::cloud::binaryauthorization::v1::Attestor const& attestor,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::CreateAttestorRequest request;
   request.set_parent(parent);
   request.set_attestor_id(attestor_id);
@@ -93,17 +88,15 @@ StatusOr<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::CreateAttestor(
     google::cloud::binaryauthorization::v1::CreateAttestorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAttestor(request);
 }
 
 StatusOr<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::GetAttestor(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::GetAttestorRequest request;
   request.set_name(name);
   return connection_->GetAttestor(request);
@@ -112,18 +105,16 @@ BinauthzManagementServiceV1Client::GetAttestor(std::string const& name,
 StatusOr<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::GetAttestor(
     google::cloud::binaryauthorization::v1::GetAttestorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAttestor(request);
 }
 
 StatusOr<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::UpdateAttestor(
     google::cloud::binaryauthorization::v1::Attestor const& attestor,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::UpdateAttestorRequest request;
   *request.mutable_attestor() = attestor;
   return connection_->UpdateAttestor(request);
@@ -133,17 +124,15 @@ StatusOr<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::UpdateAttestor(
     google::cloud::binaryauthorization::v1::UpdateAttestorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAttestor(request);
 }
 
 StreamRange<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::ListAttestors(std::string const& parent,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::ListAttestorsRequest request;
   request.set_parent(parent);
   return connection_->ListAttestors(request);
@@ -152,16 +141,14 @@ BinauthzManagementServiceV1Client::ListAttestors(std::string const& parent,
 StreamRange<google::cloud::binaryauthorization::v1::Attestor>
 BinauthzManagementServiceV1Client::ListAttestors(
     google::cloud::binaryauthorization::v1::ListAttestorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAttestors(std::move(request));
 }
 
 Status BinauthzManagementServiceV1Client::DeleteAttestor(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::DeleteAttestorRequest request;
   request.set_name(name);
   return connection_->DeleteAttestor(request);
@@ -170,9 +157,8 @@ Status BinauthzManagementServiceV1Client::DeleteAttestor(
 Status BinauthzManagementServiceV1Client::DeleteAttestor(
     google::cloud::binaryauthorization::v1::DeleteAttestorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAttestor(request);
 }
 

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_client.h
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_client.h
@@ -69,7 +69,7 @@ class BinauthzManagementServiceV1Client {
  public:
   explicit BinauthzManagementServiceV1Client(
       std::shared_ptr<BinauthzManagementServiceV1Connection> connection,
-      Options options = {});
+      Options opts = {});
   ~BinauthzManagementServiceV1Client();
 
   //@{
@@ -111,7 +111,8 @@ class BinauthzManagementServiceV1Client {
   /// @param name  Required. The resource name of the
   /// [policy][google.cloud.binaryauthorization.v1.Policy] to retrieve,
   ///  in the format `projects/*/policy`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Policy,google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
@@ -121,7 +122,7 @@ class BinauthzManagementServiceV1Client {
   /// @googleapis_reference_link{google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetPolicy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// A [policy][google.cloud.binaryauthorization.v1.Policy] specifies the
@@ -137,7 +138,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::GetPolicyRequest,google/cloud/binaryauthorization/v1/service.proto#L155}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Policy,google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
@@ -148,7 +150,7 @@ class BinauthzManagementServiceV1Client {
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetPolicy(
       google::cloud::binaryauthorization::v1::GetPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or updates a project's
@@ -164,7 +166,8 @@ class BinauthzManagementServiceV1Client {
   ///  overwrite the [policy
   ///  name][google.cloud.binaryauthorization.v1.Policy.name] field with the
   ///  resource name in the request URL, in the format `projects/*/policy`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Policy,google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
@@ -175,7 +178,7 @@ class BinauthzManagementServiceV1Client {
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Policy> UpdatePolicy(
       google::cloud::binaryauthorization::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or updates a project's
@@ -187,7 +190,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::UpdatePolicyRequest,google/cloud/binaryauthorization/v1/service.proto#L167}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Policy,google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
@@ -199,7 +203,7 @@ class BinauthzManagementServiceV1Client {
   StatusOr<google::cloud::binaryauthorization::v1::Policy> UpdatePolicy(
       google::cloud::binaryauthorization::v1::UpdatePolicyRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an [attestor][google.cloud.binaryauthorization.v1.Attestor], and
@@ -219,7 +223,8 @@ class BinauthzManagementServiceV1Client {
   ///  overwrite the [attestor
   ///  name][google.cloud.binaryauthorization.v1.Attestor.name] field with the
   ///  resource name, in the format `projects/*/attestors/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -231,7 +236,7 @@ class BinauthzManagementServiceV1Client {
   StatusOr<google::cloud::binaryauthorization::v1::Attestor> CreateAttestor(
       std::string const& parent, std::string const& attestor_id,
       google::cloud::binaryauthorization::v1::Attestor const& attestor,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an [attestor][google.cloud.binaryauthorization.v1.Attestor], and
@@ -243,7 +248,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::CreateAttestorRequest,google/cloud/binaryauthorization/v1/service.proto#L175}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -255,7 +261,7 @@ class BinauthzManagementServiceV1Client {
   StatusOr<google::cloud::binaryauthorization::v1::Attestor> CreateAttestor(
       google::cloud::binaryauthorization::v1::CreateAttestorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -266,7 +272,8 @@ class BinauthzManagementServiceV1Client {
   /// [attestor][google.cloud.binaryauthorization.v1.Attestor] to retrieve, in
   /// the format
   ///  `projects/*/attestors/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -276,7 +283,7 @@ class BinauthzManagementServiceV1Client {
   /// @googleapis_reference_link{google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Attestor> GetAttestor(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -285,7 +292,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::GetAttestorRequest,google/cloud/binaryauthorization/v1/service.proto#L194}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -296,7 +304,7 @@ class BinauthzManagementServiceV1Client {
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Attestor> GetAttestor(
       google::cloud::binaryauthorization::v1::GetAttestorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -309,7 +317,8 @@ class BinauthzManagementServiceV1Client {
   ///  overwrite the [attestor
   ///  name][google.cloud.binaryauthorization.v1.Attestor.name] field with the
   ///  resource name in the request URL, in the format `projects/*/attestors/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -320,7 +329,7 @@ class BinauthzManagementServiceV1Client {
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Attestor> UpdateAttestor(
       google::cloud::binaryauthorization::v1::Attestor const& attestor,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -329,7 +338,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::UpdateAttestorRequest,google/cloud/binaryauthorization/v1/service.proto#L206}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -341,7 +351,7 @@ class BinauthzManagementServiceV1Client {
   StatusOr<google::cloud::binaryauthorization::v1::Attestor> UpdateAttestor(
       google::cloud::binaryauthorization::v1::UpdateAttestorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists [attestors][google.cloud.binaryauthorization.v1.Attestor].
@@ -351,7 +361,8 @@ class BinauthzManagementServiceV1Client {
   /// the
   ///  [attestors][google.cloud.binaryauthorization.v1.Attestor], in the format
   ///  `projects/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -361,7 +372,7 @@ class BinauthzManagementServiceV1Client {
   /// @googleapis_reference_link{google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
   StreamRange<google::cloud::binaryauthorization::v1::Attestor> ListAttestors(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [attestors][google.cloud.binaryauthorization.v1.Attestor].
@@ -369,7 +380,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::ListAttestorsRequest,google/cloud/binaryauthorization/v1/service.proto#L214}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Attestor,google/cloud/binaryauthorization/v1/resources.proto#L169}
   ///
@@ -380,7 +392,7 @@ class BinauthzManagementServiceV1Client {
   ///
   StreamRange<google::cloud::binaryauthorization::v1::Attestor> ListAttestors(
       google::cloud::binaryauthorization::v1::ListAttestorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -391,12 +403,13 @@ class BinauthzManagementServiceV1Client {
   /// [attestors][google.cloud.binaryauthorization.v1.Attestor] to delete, in
   /// the format
   ///  `projects/*/attestors/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.binaryauthorization.v1.DeleteAttestorRequest]:
   /// @googleapis_reference_link{google/cloud/binaryauthorization/v1/service.proto#L246}
   ///
-  Status DeleteAttestor(std::string const& name, Options options = {});
+  Status DeleteAttestor(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an [attestor][google.cloud.binaryauthorization.v1.Attestor].
@@ -405,7 +418,8 @@ class BinauthzManagementServiceV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::DeleteAttestorRequest,google/cloud/binaryauthorization/v1/service.proto#L246}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.binaryauthorization.v1.DeleteAttestorRequest]:
   /// @googleapis_reference_link{google/cloud/binaryauthorization/v1/service.proto#L246}
@@ -413,7 +427,7 @@ class BinauthzManagementServiceV1Client {
   Status DeleteAttestor(
       google::cloud::binaryauthorization::v1::DeleteAttestorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<BinauthzManagementServiceV1Connection> connection_;

--- a/google/cloud/binaryauthorization/system_policy_v1_client.cc
+++ b/google/cloud/binaryauthorization/system_policy_v1_client.cc
@@ -26,19 +26,17 @@ namespace binaryauthorization {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SystemPolicyV1Client::SystemPolicyV1Client(
-    std::shared_ptr<SystemPolicyV1Connection> connection, Options options)
+    std::shared_ptr<SystemPolicyV1Connection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           binaryauthorization_internal::SystemPolicyV1DefaultOptions(
               connection_->options()))) {}
 SystemPolicyV1Client::~SystemPolicyV1Client() = default;
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
-SystemPolicyV1Client::GetSystemPolicy(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+SystemPolicyV1Client::GetSystemPolicy(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::binaryauthorization::v1::GetSystemPolicyRequest request;
   request.set_name(name);
   return connection_->GetSystemPolicy(request);
@@ -48,9 +46,8 @@ StatusOr<google::cloud::binaryauthorization::v1::Policy>
 SystemPolicyV1Client::GetSystemPolicy(
     google::cloud::binaryauthorization::v1::GetSystemPolicyRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSystemPolicy(request);
 }
 

--- a/google/cloud/binaryauthorization/system_policy_v1_client.h
+++ b/google/cloud/binaryauthorization/system_policy_v1_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SystemPolicyV1Client {
  public:
   explicit SystemPolicyV1Client(
-      std::shared_ptr<SystemPolicyV1Connection> connection,
-      Options options = {});
+      std::shared_ptr<SystemPolicyV1Connection> connection, Options opts = {});
   ~SystemPolicyV1Client();
 
   //@{
@@ -92,7 +91,8 @@ class SystemPolicyV1Client {
   /// @param name  Required. The resource name, in the format
   /// `locations/*/policy`.
   ///  Note that the system policy is not associated with a project.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Policy,google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
@@ -102,14 +102,15 @@ class SystemPolicyV1Client {
   /// @googleapis_reference_link{google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetSystemPolicy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the current system policy in the specified location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::GetSystemPolicyRequest,google/cloud/binaryauthorization/v1/service.proto#L258}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::Policy,google/cloud/binaryauthorization/v1/resources.proto#L33}
   ///
@@ -121,7 +122,7 @@ class SystemPolicyV1Client {
   StatusOr<google::cloud::binaryauthorization::v1::Policy> GetSystemPolicy(
       google::cloud::binaryauthorization::v1::GetSystemPolicyRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<SystemPolicyV1Connection> connection_;

--- a/google/cloud/binaryauthorization/validation_helper_v1_client.cc
+++ b/google/cloud/binaryauthorization/validation_helper_v1_client.cc
@@ -26,10 +26,10 @@ namespace binaryauthorization {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ValidationHelperV1Client::ValidationHelperV1Client(
-    std::shared_ptr<ValidationHelperV1Connection> connection, Options options)
+    std::shared_ptr<ValidationHelperV1Connection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           binaryauthorization_internal::ValidationHelperV1DefaultOptions(
               connection_->options()))) {}
 ValidationHelperV1Client::~ValidationHelperV1Client() = default;
@@ -39,9 +39,8 @@ StatusOr<google::cloud::binaryauthorization::v1::
 ValidationHelperV1Client::ValidateAttestationOccurrence(
     google::cloud::binaryauthorization::v1::
         ValidateAttestationOccurrenceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ValidateAttestationOccurrence(request);
 }
 

--- a/google/cloud/binaryauthorization/validation_helper_v1_client.h
+++ b/google/cloud/binaryauthorization/validation_helper_v1_client.h
@@ -62,7 +62,7 @@ class ValidationHelperV1Client {
  public:
   explicit ValidationHelperV1Client(
       std::shared_ptr<ValidationHelperV1Connection> connection,
-      Options options = {});
+      Options opts = {});
   ~ValidationHelperV1Client();
 
   //@{
@@ -92,7 +92,8 @@ class ValidationHelperV1Client {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::binaryauthorization::v1::ValidateAttestationOccurrenceRequest,google/cloud/binaryauthorization/v1/service.proto#L271}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::binaryauthorization::v1::ValidateAttestationOccurrenceResponse,google/cloud/binaryauthorization/v1/service.proto#L294}
   ///
@@ -106,7 +107,7 @@ class ValidationHelperV1Client {
   ValidateAttestationOccurrence(
       google::cloud::binaryauthorization::v1::
           ValidateAttestationOccurrenceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ValidationHelperV1Connection> connection_;

--- a/google/cloud/channel/cloud_channel_client.cc
+++ b/google/cloud/channel/cloud_channel_client.cc
@@ -26,27 +26,23 @@ namespace channel {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudChannelServiceClient::CloudChannelServiceClient(
-    std::shared_ptr<CloudChannelServiceConnection> connection, Options options)
+    std::shared_ptr<CloudChannelServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          channel_internal::CloudChannelServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), channel_internal::CloudChannelServiceDefaultOptions(
+                               connection_->options()))) {}
 CloudChannelServiceClient::~CloudChannelServiceClient() = default;
 
 StreamRange<google::cloud::channel::v1::Customer>
 CloudChannelServiceClient::ListCustomers(
-    google::cloud::channel::v1::ListCustomersRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::channel::v1::ListCustomersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCustomers(std::move(request));
 }
 
 StatusOr<google::cloud::channel::v1::Customer>
-CloudChannelServiceClient::GetCustomer(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudChannelServiceClient::GetCustomer(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::channel::v1::GetCustomerRequest request;
   request.set_name(name);
   return connection_->GetCustomer(request);
@@ -55,9 +51,8 @@ CloudChannelServiceClient::GetCustomer(std::string const& name,
 StatusOr<google::cloud::channel::v1::Customer>
 CloudChannelServiceClient::GetCustomer(
     google::cloud::channel::v1::GetCustomerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCustomer(request);
 }
 
@@ -65,34 +60,30 @@ StatusOr<google::cloud::channel::v1::CheckCloudIdentityAccountsExistResponse>
 CloudChannelServiceClient::CheckCloudIdentityAccountsExist(
     google::cloud::channel::v1::CheckCloudIdentityAccountsExistRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CheckCloudIdentityAccountsExist(request);
 }
 
 StatusOr<google::cloud::channel::v1::Customer>
 CloudChannelServiceClient::CreateCustomer(
     google::cloud::channel::v1::CreateCustomerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCustomer(request);
 }
 
 StatusOr<google::cloud::channel::v1::Customer>
 CloudChannelServiceClient::UpdateCustomer(
     google::cloud::channel::v1::UpdateCustomerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCustomer(request);
 }
 
 Status CloudChannelServiceClient::DeleteCustomer(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::channel::v1::DeleteCustomerRequest request;
   request.set_name(name);
   return connection_->DeleteCustomer(request);
@@ -100,144 +91,127 @@ Status CloudChannelServiceClient::DeleteCustomer(std::string const& name,
 
 Status CloudChannelServiceClient::DeleteCustomer(
     google::cloud::channel::v1::DeleteCustomerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCustomer(request);
 }
 
 StatusOr<google::cloud::channel::v1::Customer>
 CloudChannelServiceClient::ImportCustomer(
     google::cloud::channel::v1::ImportCustomerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportCustomer(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Customer>>
 CloudChannelServiceClient::ProvisionCloudIdentity(
     google::cloud::channel::v1::ProvisionCloudIdentityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ProvisionCloudIdentity(request);
 }
 
 StreamRange<google::cloud::channel::v1::Entitlement>
 CloudChannelServiceClient::ListEntitlements(
-    google::cloud::channel::v1::ListEntitlementsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::channel::v1::ListEntitlementsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEntitlements(std::move(request));
 }
 
 StreamRange<google::cloud::channel::v1::TransferableSku>
 CloudChannelServiceClient::ListTransferableSkus(
     google::cloud::channel::v1::ListTransferableSkusRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTransferableSkus(std::move(request));
 }
 
 StreamRange<google::cloud::channel::v1::TransferableOffer>
 CloudChannelServiceClient::ListTransferableOffers(
     google::cloud::channel::v1::ListTransferableOffersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTransferableOffers(std::move(request));
 }
 
 StatusOr<google::cloud::channel::v1::Entitlement>
 CloudChannelServiceClient::GetEntitlement(
     google::cloud::channel::v1::GetEntitlementRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEntitlement(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::CreateEntitlement(
     google::cloud::channel::v1::CreateEntitlementRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEntitlement(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::ChangeParameters(
     google::cloud::channel::v1::ChangeParametersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ChangeParameters(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::ChangeRenewalSettings(
     google::cloud::channel::v1::ChangeRenewalSettingsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ChangeRenewalSettings(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::ChangeOffer(
     google::cloud::channel::v1::ChangeOfferRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ChangeOffer(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::StartPaidService(
     google::cloud::channel::v1::StartPaidServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartPaidService(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::SuspendEntitlement(
     google::cloud::channel::v1::SuspendEntitlementRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SuspendEntitlement(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::OperationMetadata>>
 CloudChannelServiceClient::CancelEntitlement(
     google::cloud::channel::v1::CancelEntitlementRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelEntitlement(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::Entitlement>>
 CloudChannelServiceClient::ActivateEntitlement(
     google::cloud::channel::v1::ActivateEntitlementRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ActivateEntitlement(request);
 }
 
 future<StatusOr<google::cloud::channel::v1::TransferEntitlementsResponse>>
 CloudChannelServiceClient::TransferEntitlements(
     google::cloud::channel::v1::TransferEntitlementsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TransferEntitlements(request);
 }
 
@@ -245,122 +219,107 @@ future<StatusOr<google::cloud::channel::v1::OperationMetadata>>
 CloudChannelServiceClient::TransferEntitlementsToGoogle(
     google::cloud::channel::v1::TransferEntitlementsToGoogleRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TransferEntitlementsToGoogle(request);
 }
 
 StreamRange<google::cloud::channel::v1::ChannelPartnerLink>
 CloudChannelServiceClient::ListChannelPartnerLinks(
     google::cloud::channel::v1::ListChannelPartnerLinksRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListChannelPartnerLinks(std::move(request));
 }
 
 StatusOr<google::cloud::channel::v1::ChannelPartnerLink>
 CloudChannelServiceClient::GetChannelPartnerLink(
     google::cloud::channel::v1::GetChannelPartnerLinkRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetChannelPartnerLink(request);
 }
 
 StatusOr<google::cloud::channel::v1::ChannelPartnerLink>
 CloudChannelServiceClient::CreateChannelPartnerLink(
     google::cloud::channel::v1::CreateChannelPartnerLinkRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateChannelPartnerLink(request);
 }
 
 StatusOr<google::cloud::channel::v1::ChannelPartnerLink>
 CloudChannelServiceClient::UpdateChannelPartnerLink(
     google::cloud::channel::v1::UpdateChannelPartnerLinkRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateChannelPartnerLink(request);
 }
 
 StatusOr<google::cloud::channel::v1::Offer>
 CloudChannelServiceClient::LookupOffer(
     google::cloud::channel::v1::LookupOfferRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->LookupOffer(request);
 }
 
 StreamRange<google::cloud::channel::v1::Product>
 CloudChannelServiceClient::ListProducts(
-    google::cloud::channel::v1::ListProductsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::channel::v1::ListProductsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProducts(std::move(request));
 }
 
 StreamRange<google::cloud::channel::v1::Sku>
 CloudChannelServiceClient::ListSkus(
-    google::cloud::channel::v1::ListSkusRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::channel::v1::ListSkusRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSkus(std::move(request));
 }
 
 StreamRange<google::cloud::channel::v1::Offer>
 CloudChannelServiceClient::ListOffers(
-    google::cloud::channel::v1::ListOffersRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::channel::v1::ListOffersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListOffers(std::move(request));
 }
 
 StreamRange<google::cloud::channel::v1::PurchasableSku>
 CloudChannelServiceClient::ListPurchasableSkus(
     google::cloud::channel::v1::ListPurchasableSkusRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPurchasableSkus(std::move(request));
 }
 
 StreamRange<google::cloud::channel::v1::PurchasableOffer>
 CloudChannelServiceClient::ListPurchasableOffers(
     google::cloud::channel::v1::ListPurchasableOffersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPurchasableOffers(std::move(request));
 }
 
 StatusOr<google::cloud::channel::v1::RegisterSubscriberResponse>
 CloudChannelServiceClient::RegisterSubscriber(
     google::cloud::channel::v1::RegisterSubscriberRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RegisterSubscriber(request);
 }
 
 StatusOr<google::cloud::channel::v1::UnregisterSubscriberResponse>
 CloudChannelServiceClient::UnregisterSubscriber(
     google::cloud::channel::v1::UnregisterSubscriberRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UnregisterSubscriber(request);
 }
 
 StreamRange<std::string> CloudChannelServiceClient::ListSubscribers(
-    google::cloud::channel::v1::ListSubscribersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::channel::v1::ListSubscribersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSubscribers(std::move(request));
 }
 

--- a/google/cloud/channel/cloud_channel_client.h
+++ b/google/cloud/channel/cloud_channel_client.h
@@ -82,7 +82,7 @@ class CloudChannelServiceClient {
  public:
   explicit CloudChannelServiceClient(
       std::shared_ptr<CloudChannelServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~CloudChannelServiceClient();
 
   //@{
@@ -121,7 +121,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListCustomersRequest,google/cloud/channel/v1/service.proto#L987}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -132,7 +133,7 @@ class CloudChannelServiceClient {
   ///
   StreamRange<google::cloud::channel::v1::Customer> ListCustomers(
       google::cloud::channel::v1::ListCustomersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the requested [Customer][google.cloud.channel.v1.Customer]
@@ -151,7 +152,8 @@ class CloudChannelServiceClient {
   ///
   /// @param name  Required. The resource name of the customer to retrieve.
   ///  Name uses the format: accounts/{account_id}/customers/{customer_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -161,7 +163,7 @@ class CloudChannelServiceClient {
   /// @googleapis_reference_link{google/cloud/channel/v1/customers.proto#L32}
   ///
   StatusOr<google::cloud::channel::v1::Customer> GetCustomer(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns the requested [Customer][google.cloud.channel.v1.Customer]
@@ -180,7 +182,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::GetCustomerRequest,google/cloud/channel/v1/service.proto#L1015}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -191,7 +194,7 @@ class CloudChannelServiceClient {
   ///
   StatusOr<google::cloud::channel::v1::Customer> GetCustomer(
       google::cloud::channel::v1::GetCustomerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Confirms the existence of Cloud Identity accounts based on the domain and
@@ -216,7 +219,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::CheckCloudIdentityAccountsExistRequest,google/cloud/channel/v1/service.proto#L950}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::CheckCloudIdentityAccountsExistResponse,google/cloud/channel/v1/service.proto#L981}
   ///
@@ -229,7 +233,7 @@ class CloudChannelServiceClient {
   CheckCloudIdentityAccountsExist(
       google::cloud::channel::v1::CheckCloudIdentityAccountsExistRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new [Customer][google.cloud.channel.v1.Customer] resource under
@@ -248,7 +252,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::CreateCustomerRequest,google/cloud/channel/v1/service.proto#L1027}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -259,7 +264,7 @@ class CloudChannelServiceClient {
   ///
   StatusOr<google::cloud::channel::v1::Customer> CreateCustomer(
       google::cloud::channel::v1::CreateCustomerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing [Customer][google.cloud.channel.v1.Customer] resource
@@ -278,7 +283,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::UpdateCustomerRequest,google/cloud/channel/v1/service.proto#L1037}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -289,7 +295,7 @@ class CloudChannelServiceClient {
   ///
   StatusOr<google::cloud::channel::v1::Customer> UpdateCustomer(
       google::cloud::channel::v1::UpdateCustomerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the given [Customer][google.cloud.channel.v1.Customer]
@@ -305,12 +311,13 @@ class CloudChannelServiceClient {
   /// found for the name in the request.
   ///
   /// @param name  Required. The resource name of the customer to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.channel.v1.DeleteCustomerRequest]:
   /// @googleapis_reference_link{google/cloud/channel/v1/service.proto#L1047}
   ///
-  Status DeleteCustomer(std::string const& name, Options options = {});
+  Status DeleteCustomer(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the given [Customer][google.cloud.channel.v1.Customer]
@@ -327,14 +334,15 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::DeleteCustomerRequest,google/cloud/channel/v1/service.proto#L1047}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.channel.v1.DeleteCustomerRequest]:
   /// @googleapis_reference_link{google/cloud/channel/v1/service.proto#L1047}
   ///
   Status DeleteCustomer(
       google::cloud::channel::v1::DeleteCustomerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Imports a [Customer][google.cloud.channel.v1.Customer] from the Cloud
@@ -357,7 +365,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ImportCustomerRequest,google/cloud/channel/v1/service.proto#L1058}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -368,7 +377,7 @@ class CloudChannelServiceClient {
   ///
   StatusOr<google::cloud::channel::v1::Customer> ImportCustomer(
       google::cloud::channel::v1::ImportCustomerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Cloud Identity for the given customer using the customer's
@@ -396,7 +405,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ProvisionCloudIdentityRequest,google/cloud/channel/v1/service.proto#L1104}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Customer,google/cloud/channel/v1/customers.proto#L32}
   ///
@@ -407,7 +417,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Customer>> ProvisionCloudIdentity(
       google::cloud::channel::v1::ProvisionCloudIdentityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists [Entitlement][google.cloud.channel.v1.Entitlement]s belonging to a
@@ -424,7 +434,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListEntitlementsRequest,google/cloud/channel/v1/service.proto#L1125}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -435,7 +446,7 @@ class CloudChannelServiceClient {
   ///
   StreamRange<google::cloud::channel::v1::Entitlement> ListEntitlements(
       google::cloud::channel::v1::ListEntitlementsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List [TransferableSku][google.cloud.channel.v1.TransferableSku]s of a
@@ -460,7 +471,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListTransferableSkusRequest,google/cloud/channel/v1/service.proto#L1159}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::TransferableSku,google/cloud/channel/v1/entitlements.proto#L214}
   ///
@@ -471,7 +483,7 @@ class CloudChannelServiceClient {
   ///
   StreamRange<google::cloud::channel::v1::TransferableSku> ListTransferableSkus(
       google::cloud::channel::v1::ListTransferableSkusRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List [TransferableOffer][google.cloud.channel.v1.TransferableOffer]s of a
@@ -496,7 +508,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListTransferableOffersRequest,google/cloud/channel/v1/service.proto#L1216}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::TransferableOffer,google/cloud/channel/v1/service.proto#L1266}
   ///
@@ -508,7 +521,7 @@ class CloudChannelServiceClient {
   StreamRange<google::cloud::channel::v1::TransferableOffer>
   ListTransferableOffers(
       google::cloud::channel::v1::ListTransferableOffersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the requested [Entitlement][google.cloud.channel.v1.Entitlement]
@@ -525,7 +538,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::GetEntitlementRequest,google/cloud/channel/v1/service.proto#L1272}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -536,7 +550,7 @@ class CloudChannelServiceClient {
   ///
   StatusOr<google::cloud::channel::v1::Entitlement> GetEntitlement(
       google::cloud::channel::v1::GetEntitlementRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an entitlement for a customer.
@@ -579,7 +593,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::CreateEntitlementRequest,google/cloud/channel/v1/service.proto#L1358}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -590,7 +605,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Entitlement>> CreateEntitlement(
       google::cloud::channel::v1::CreateEntitlementRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Change parameters of the entitlement.
@@ -620,7 +635,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ChangeParametersRequest,google/cloud/channel/v1/service.proto#L1448}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -631,7 +647,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Entitlement>> ChangeParameters(
       google::cloud::channel::v1::ChangeParametersRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the renewal settings for an existing customer entitlement.
@@ -662,7 +678,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ChangeRenewalSettingsRequest,google/cloud/channel/v1/service.proto#L1478}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -674,7 +691,7 @@ class CloudChannelServiceClient {
   future<StatusOr<google::cloud::channel::v1::Entitlement>>
   ChangeRenewalSettings(
       google::cloud::channel::v1::ChangeRenewalSettingsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the Offer for an existing customer entitlement.
@@ -702,7 +719,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ChangeOfferRequest,google/cloud/channel/v1/service.proto#L1502}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -713,7 +731,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Entitlement>> ChangeOffer(
       google::cloud::channel::v1::ChangeOfferRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts paid service for a trial entitlement.
@@ -744,7 +762,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::StartPaidServiceRequest,google/cloud/channel/v1/service.proto#L1539}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -755,7 +774,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Entitlement>> StartPaidService(
       google::cloud::channel::v1::StartPaidServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Suspends a previously fulfilled entitlement.
@@ -783,7 +802,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::SuspendEntitlementRequest,google/cloud/channel/v1/service.proto#L1581}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -794,7 +814,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Entitlement>> SuspendEntitlement(
       google::cloud::channel::v1::SuspendEntitlementRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Cancels a previously fulfilled entitlement.
@@ -827,7 +847,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::CancelEntitlementRequest,google/cloud/channel/v1/service.proto#L1560}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::OperationMetadata,google/cloud/channel/v1/operations.proto#L27}
   ///
@@ -839,7 +860,7 @@ class CloudChannelServiceClient {
   future<StatusOr<google::cloud::channel::v1::OperationMetadata>>
   CancelEntitlement(
       google::cloud::channel::v1::CancelEntitlementRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Activates a previously suspended entitlement. Entitlements suspended for
@@ -873,7 +894,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ActivateEntitlementRequest,google/cloud/channel/v1/service.proto#L1602}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Entitlement,google/cloud/channel/v1/entitlements.proto#L34}
   ///
@@ -884,7 +906,7 @@ class CloudChannelServiceClient {
   ///
   future<StatusOr<google::cloud::channel::v1::Entitlement>> ActivateEntitlement(
       google::cloud::channel::v1::ActivateEntitlementRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Transfers customer entitlements to new reseller.
@@ -920,7 +942,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::TransferEntitlementsRequest,google/cloud/channel/v1/service.proto#L1387}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::TransferEntitlementsResponse,google/cloud/channel/v1/service.proto#L1418}
   ///
@@ -932,7 +955,7 @@ class CloudChannelServiceClient {
   future<StatusOr<google::cloud::channel::v1::TransferEntitlementsResponse>>
   TransferEntitlements(
       google::cloud::channel::v1::TransferEntitlementsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Transfers customer entitlements from their current reseller to Google.
@@ -968,7 +991,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::TransferEntitlementsToGoogleRequest,google/cloud/channel/v1/service.proto#L1424}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::OperationMetadata,google/cloud/channel/v1/operations.proto#L27}
   ///
@@ -981,7 +1005,7 @@ class CloudChannelServiceClient {
   TransferEntitlementsToGoogle(
       google::cloud::channel::v1::TransferEntitlementsToGoogleRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List [ChannelPartnerLink][google.cloud.channel.v1.ChannelPartnerLink]s
@@ -1000,7 +1024,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListChannelPartnerLinksRequest,google/cloud/channel/v1/service.proto#L1285}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::ChannelPartnerLink,google/cloud/channel/v1/channel_partner_links.proto#L65}
   ///
@@ -1012,7 +1037,7 @@ class CloudChannelServiceClient {
   StreamRange<google::cloud::channel::v1::ChannelPartnerLink>
   ListChannelPartnerLinks(
       google::cloud::channel::v1::ListChannelPartnerLinksRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the requested
@@ -1033,7 +1058,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::GetChannelPartnerLinkRequest,google/cloud/channel/v1/service.proto#L1317}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::ChannelPartnerLink,google/cloud/channel/v1/channel_partner_links.proto#L65}
   ///
@@ -1045,7 +1071,7 @@ class CloudChannelServiceClient {
   StatusOr<google::cloud::channel::v1::ChannelPartnerLink>
   GetChannelPartnerLink(
       google::cloud::channel::v1::GetChannelPartnerLinkRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates a channel partner link between a distributor and a reseller, or
@@ -1074,7 +1100,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::CreateChannelPartnerLinkRequest,google/cloud/channel/v1/service.proto#L1328}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::ChannelPartnerLink,google/cloud/channel/v1/channel_partner_links.proto#L65}
   ///
@@ -1087,7 +1114,7 @@ class CloudChannelServiceClient {
   CreateChannelPartnerLink(
       google::cloud::channel::v1::CreateChannelPartnerLinkRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a channel partner link. Distributors call this method to change a
@@ -1115,7 +1142,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::UpdateChannelPartnerLinkRequest,google/cloud/channel/v1/service.proto#L1341}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::ChannelPartnerLink,google/cloud/channel/v1/channel_partner_links.proto#L65}
   ///
@@ -1128,7 +1156,7 @@ class CloudChannelServiceClient {
   UpdateChannelPartnerLink(
       google::cloud::channel::v1::UpdateChannelPartnerLinkRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the requested [Offer][google.cloud.channel.v1.Offer] resource.
@@ -1144,7 +1172,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::LookupOfferRequest,google/cloud/channel/v1/service.proto#L1623}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Offer,google/cloud/channel/v1/offers.proto#L131}
   ///
@@ -1155,7 +1184,7 @@ class CloudChannelServiceClient {
   ///
   StatusOr<google::cloud::channel::v1::Offer> LookupOffer(
       google::cloud::channel::v1::LookupOfferRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the Products the reseller is authorized to sell.
@@ -1166,7 +1195,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListProductsRequest,google/cloud/channel/v1/service.proto#L1636}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Product,google/cloud/channel/v1/products.proto#L38}
   ///
@@ -1177,7 +1207,7 @@ class CloudChannelServiceClient {
   ///
   StreamRange<google::cloud::channel::v1::Product> ListProducts(
       google::cloud::channel::v1::ListProductsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the SKUs for a product the reseller is authorized to sell.
@@ -1188,7 +1218,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListSkusRequest,google/cloud/channel/v1/service.proto#L1665}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Sku,google/cloud/channel/v1/products.proto#L56}
   ///
@@ -1198,8 +1229,7 @@ class CloudChannelServiceClient {
   /// @googleapis_reference_link{google/cloud/channel/v1/products.proto#L56}
   ///
   StreamRange<google::cloud::channel::v1::Sku> ListSkus(
-      google::cloud::channel::v1::ListSkusRequest request,
-      Options options = {});
+      google::cloud::channel::v1::ListSkusRequest request, Options opts = {});
 
   ///
   /// Lists the Offers the reseller can sell.
@@ -1210,7 +1240,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListOffersRequest,google/cloud/channel/v1/service.proto#L1705}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::Offer,google/cloud/channel/v1/offers.proto#L131}
   ///
@@ -1220,8 +1251,7 @@ class CloudChannelServiceClient {
   /// @googleapis_reference_link{google/cloud/channel/v1/offers.proto#L131}
   ///
   StreamRange<google::cloud::channel::v1::Offer> ListOffers(
-      google::cloud::channel::v1::ListOffersRequest request,
-      Options options = {});
+      google::cloud::channel::v1::ListOffersRequest request, Options opts = {});
 
   ///
   /// Lists the following:
@@ -1236,7 +1266,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListPurchasableSkusRequest,google/cloud/channel/v1/service.proto#L1741}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::PurchasableSku,google/cloud/channel/v1/service.proto#L1818}
   ///
@@ -1247,7 +1278,7 @@ class CloudChannelServiceClient {
   ///
   StreamRange<google::cloud::channel::v1::PurchasableSku> ListPurchasableSkus(
       google::cloud::channel::v1::ListPurchasableSkusRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the following:
@@ -1262,7 +1293,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListPurchasableOffersRequest,google/cloud/channel/v1/service.proto#L1824}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::PurchasableOffer,google/cloud/channel/v1/service.proto#L1888}
   ///
@@ -1274,7 +1306,7 @@ class CloudChannelServiceClient {
   StreamRange<google::cloud::channel::v1::PurchasableOffer>
   ListPurchasableOffers(
       google::cloud::channel::v1::ListPurchasableOffersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Registers a service account with subscriber privileges on the Cloud
@@ -1298,7 +1330,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::RegisterSubscriberRequest,google/cloud/channel/v1/service.proto#L1894}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::RegisterSubscriberResponse,google/cloud/channel/v1/service.proto#L1903}
   ///
@@ -1310,7 +1343,7 @@ class CloudChannelServiceClient {
   StatusOr<google::cloud::channel::v1::RegisterSubscriberResponse>
   RegisterSubscriber(
       google::cloud::channel::v1::RegisterSubscriberRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Unregisters a service account with subscriber privileges on the Cloud
@@ -1337,7 +1370,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::UnregisterSubscriberRequest,google/cloud/channel/v1/service.proto#L1909}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::channel::v1::UnregisterSubscriberResponse,google/cloud/channel/v1/service.proto#L1918}
   ///
@@ -1349,7 +1383,7 @@ class CloudChannelServiceClient {
   StatusOr<google::cloud::channel::v1::UnregisterSubscriberResponse>
   UnregisterSubscriber(
       google::cloud::channel::v1::UnregisterSubscriberRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists service accounts with subscriber privileges on the Cloud Pub/Sub
@@ -1372,7 +1406,8 @@ class CloudChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::channel::v1::ListSubscribersRequest,google/cloud/channel/v1/service.proto#L1924}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.cloud.channel.v1.ListSubscribersRequest]:
@@ -1380,7 +1415,7 @@ class CloudChannelServiceClient {
   ///
   StreamRange<std::string> ListSubscribers(
       google::cloud::channel::v1::ListSubscribersRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudChannelServiceConnection> connection_;

--- a/google/cloud/cloudbuild/cloud_build_client.cc
+++ b/google/cloud/cloudbuild/cloud_build_client.cc
@@ -26,19 +26,18 @@ namespace cloudbuild {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudBuildClient::CloudBuildClient(
-    std::shared_ptr<CloudBuildConnection> connection, Options options)
+    std::shared_ptr<CloudBuildConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), cloudbuild_internal::CloudBuildDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), cloudbuild_internal::CloudBuildDefaultOptions(
+                               connection_->options()))) {}
 CloudBuildClient::~CloudBuildClient() = default;
 
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::CreateBuild(
     std::string const& project_id,
-    google::devtools::cloudbuild::v1::Build const& build, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::devtools::cloudbuild::v1::Build const& build, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::CreateBuildRequest request;
   request.set_project_id(project_id);
   *request.mutable_build() = build;
@@ -48,16 +47,14 @@ CloudBuildClient::CreateBuild(
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::CreateBuild(
     google::devtools::cloudbuild::v1::CreateBuildRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBuild(request);
 }
 
 StatusOr<google::devtools::cloudbuild::v1::Build> CloudBuildClient::GetBuild(
-    std::string const& project_id, std::string const& id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& project_id, std::string const& id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::GetBuildRequest request;
   request.set_project_id(project_id);
   request.set_id(id);
@@ -66,17 +63,15 @@ StatusOr<google::devtools::cloudbuild::v1::Build> CloudBuildClient::GetBuild(
 
 StatusOr<google::devtools::cloudbuild::v1::Build> CloudBuildClient::GetBuild(
     google::devtools::cloudbuild::v1::GetBuildRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBuild(request);
 }
 
 StreamRange<google::devtools::cloudbuild::v1::Build>
 CloudBuildClient::ListBuilds(std::string const& project_id,
-                             std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                             std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::ListBuildsRequest request;
   request.set_project_id(project_id);
   request.set_filter(filter);
@@ -85,17 +80,14 @@ CloudBuildClient::ListBuilds(std::string const& project_id,
 
 StreamRange<google::devtools::cloudbuild::v1::Build>
 CloudBuildClient::ListBuilds(
-    google::devtools::cloudbuild::v1::ListBuildsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::devtools::cloudbuild::v1::ListBuildsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBuilds(std::move(request));
 }
 
 StatusOr<google::devtools::cloudbuild::v1::Build> CloudBuildClient::CancelBuild(
-    std::string const& project_id, std::string const& id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& project_id, std::string const& id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::CancelBuildRequest request;
   request.set_project_id(project_id);
   request.set_id(id);
@@ -104,17 +96,15 @@ StatusOr<google::devtools::cloudbuild::v1::Build> CloudBuildClient::CancelBuild(
 
 StatusOr<google::devtools::cloudbuild::v1::Build> CloudBuildClient::CancelBuild(
     google::devtools::cloudbuild::v1::CancelBuildRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelBuild(request);
 }
 
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::RetryBuild(std::string const& project_id,
-                             std::string const& id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                             std::string const& id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::RetryBuildRequest request;
   request.set_project_id(project_id);
   request.set_id(id);
@@ -124,9 +114,8 @@ CloudBuildClient::RetryBuild(std::string const& project_id,
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::RetryBuild(
     google::devtools::cloudbuild::v1::RetryBuildRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RetryBuild(request);
 }
 
@@ -134,9 +123,8 @@ future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::ApproveBuild(
     std::string const& name,
     google::devtools::cloudbuild::v1::ApprovalResult const& approval_result,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::ApproveBuildRequest request;
   request.set_name(name);
   *request.mutable_approval_result() = approval_result;
@@ -146,9 +134,8 @@ CloudBuildClient::ApproveBuild(
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::ApproveBuild(
     google::devtools::cloudbuild::v1::ApproveBuildRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ApproveBuild(request);
 }
 
@@ -156,9 +143,8 @@ StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::CreateBuildTrigger(
     std::string const& project_id,
     google::devtools::cloudbuild::v1::BuildTrigger const& trigger,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::CreateBuildTriggerRequest request;
   request.set_project_id(project_id);
   *request.mutable_trigger() = trigger;
@@ -168,18 +154,15 @@ CloudBuildClient::CreateBuildTrigger(
 StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::CreateBuildTrigger(
     google::devtools::cloudbuild::v1::CreateBuildTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBuildTrigger(request);
 }
 
 StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::GetBuildTrigger(std::string const& project_id,
-                                  std::string const& trigger_id,
-                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                  std::string const& trigger_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::GetBuildTriggerRequest request;
   request.set_project_id(project_id);
   request.set_trigger_id(trigger_id);
@@ -189,17 +172,15 @@ CloudBuildClient::GetBuildTrigger(std::string const& project_id,
 StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::GetBuildTrigger(
     google::devtools::cloudbuild::v1::GetBuildTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBuildTrigger(request);
 }
 
 StreamRange<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::ListBuildTriggers(std::string const& project_id,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::ListBuildTriggersRequest request;
   request.set_project_id(project_id);
   return connection_->ListBuildTriggers(request);
@@ -208,17 +189,15 @@ CloudBuildClient::ListBuildTriggers(std::string const& project_id,
 StreamRange<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::ListBuildTriggers(
     google::devtools::cloudbuild::v1::ListBuildTriggersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBuildTriggers(std::move(request));
 }
 
 Status CloudBuildClient::DeleteBuildTrigger(std::string const& project_id,
                                             std::string const& trigger_id,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::DeleteBuildTriggerRequest request;
   request.set_project_id(project_id);
   request.set_trigger_id(trigger_id);
@@ -227,9 +206,8 @@ Status CloudBuildClient::DeleteBuildTrigger(std::string const& project_id,
 
 Status CloudBuildClient::DeleteBuildTrigger(
     google::devtools::cloudbuild::v1::DeleteBuildTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBuildTrigger(request);
 }
 
@@ -237,9 +215,8 @@ StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::UpdateBuildTrigger(
     std::string const& project_id, std::string const& trigger_id,
     google::devtools::cloudbuild::v1::BuildTrigger const& trigger,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::UpdateBuildTriggerRequest request;
   request.set_project_id(project_id);
   request.set_trigger_id(trigger_id);
@@ -250,19 +227,16 @@ CloudBuildClient::UpdateBuildTrigger(
 StatusOr<google::devtools::cloudbuild::v1::BuildTrigger>
 CloudBuildClient::UpdateBuildTrigger(
     google::devtools::cloudbuild::v1::UpdateBuildTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBuildTrigger(request);
 }
 
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::RunBuildTrigger(
     std::string const& project_id, std::string const& trigger_id,
-    google::devtools::cloudbuild::v1::RepoSource const& source,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::devtools::cloudbuild::v1::RepoSource const& source, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::RunBuildTriggerRequest request;
   request.set_project_id(project_id);
   request.set_trigger_id(trigger_id);
@@ -273,9 +247,8 @@ CloudBuildClient::RunBuildTrigger(
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildClient::RunBuildTrigger(
     google::devtools::cloudbuild::v1::RunBuildTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RunBuildTrigger(request);
 }
 
@@ -283,9 +256,8 @@ StatusOr<google::devtools::cloudbuild::v1::ReceiveTriggerWebhookResponse>
 CloudBuildClient::ReceiveTriggerWebhook(
     google::devtools::cloudbuild::v1::ReceiveTriggerWebhookRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReceiveTriggerWebhook(request);
 }
 
@@ -293,9 +265,8 @@ future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
 CloudBuildClient::CreateWorkerPool(
     std::string const& parent,
     google::devtools::cloudbuild::v1::WorkerPool const& worker_pool,
-    std::string const& worker_pool_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& worker_pool_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::CreateWorkerPoolRequest request;
   request.set_parent(parent);
   *request.mutable_worker_pool() = worker_pool;
@@ -306,16 +277,14 @@ CloudBuildClient::CreateWorkerPool(
 future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
 CloudBuildClient::CreateWorkerPool(
     google::devtools::cloudbuild::v1::CreateWorkerPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateWorkerPool(request);
 }
 
 StatusOr<google::devtools::cloudbuild::v1::WorkerPool>
-CloudBuildClient::GetWorkerPool(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudBuildClient::GetWorkerPool(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::GetWorkerPoolRequest request;
   request.set_name(name);
   return connection_->GetWorkerPool(request);
@@ -324,17 +293,15 @@ CloudBuildClient::GetWorkerPool(std::string const& name, Options options) {
 StatusOr<google::devtools::cloudbuild::v1::WorkerPool>
 CloudBuildClient::GetWorkerPool(
     google::devtools::cloudbuild::v1::GetWorkerPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetWorkerPool(request);
 }
 
 future<StatusOr<
     google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata>>
-CloudBuildClient::DeleteWorkerPool(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudBuildClient::DeleteWorkerPool(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest request;
   request.set_name(name);
   return connection_->DeleteWorkerPool(request);
@@ -344,18 +311,16 @@ future<StatusOr<
     google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata>>
 CloudBuildClient::DeleteWorkerPool(
     google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteWorkerPool(request);
 }
 
 future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
 CloudBuildClient::UpdateWorkerPool(
     google::devtools::cloudbuild::v1::WorkerPool const& worker_pool,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::UpdateWorkerPoolRequest request;
   *request.mutable_worker_pool() = worker_pool;
   *request.mutable_update_mask() = update_mask;
@@ -365,16 +330,14 @@ CloudBuildClient::UpdateWorkerPool(
 future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
 CloudBuildClient::UpdateWorkerPool(
     google::devtools::cloudbuild::v1::UpdateWorkerPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateWorkerPool(request);
 }
 
 StreamRange<google::devtools::cloudbuild::v1::WorkerPool>
-CloudBuildClient::ListWorkerPools(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudBuildClient::ListWorkerPools(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudbuild::v1::ListWorkerPoolsRequest request;
   request.set_parent(parent);
   return connection_->ListWorkerPools(request);
@@ -383,9 +346,8 @@ CloudBuildClient::ListWorkerPools(std::string const& parent, Options options) {
 StreamRange<google::devtools::cloudbuild::v1::WorkerPool>
 CloudBuildClient::ListWorkerPools(
     google::devtools::cloudbuild::v1::ListWorkerPoolsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListWorkerPools(std::move(request));
 }
 

--- a/google/cloud/cloudbuild/cloud_build_client.h
+++ b/google/cloud/cloudbuild/cloud_build_client.h
@@ -70,7 +70,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudBuildClient {
  public:
   explicit CloudBuildClient(std::shared_ptr<CloudBuildConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~CloudBuildClient();
 
   //@{
@@ -100,7 +100,8 @@ class CloudBuildClient {
   ///
   /// @param project_id  Required. ID of the project.
   /// @param build  Required. Build resource to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -111,8 +112,7 @@ class CloudBuildClient {
   ///
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> CreateBuild(
       std::string const& project_id,
-      google::devtools::cloudbuild::v1::Build const& build,
-      Options options = {});
+      google::devtools::cloudbuild::v1::Build const& build, Options opts = {});
 
   ///
   /// Starts a build with the specified configuration.
@@ -123,7 +123,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::CreateBuildRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1100}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -134,7 +135,7 @@ class CloudBuildClient {
   ///
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> CreateBuild(
       google::devtools::cloudbuild::v1::CreateBuildRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns information about a previously requested build.
@@ -144,7 +145,8 @@ class CloudBuildClient {
   ///
   /// @param project_id  Required. ID of the project.
   /// @param id  Required. ID of the build.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -154,8 +156,7 @@ class CloudBuildClient {
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
   StatusOr<google::devtools::cloudbuild::v1::Build> GetBuild(
-      std::string const& project_id, std::string const& id,
-      Options options = {});
+      std::string const& project_id, std::string const& id, Options opts = {});
 
   ///
   /// Returns information about a previously requested build.
@@ -165,7 +166,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::GetBuildRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1115}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -176,7 +178,7 @@ class CloudBuildClient {
   ///
   StatusOr<google::devtools::cloudbuild::v1::Build> GetBuild(
       google::devtools::cloudbuild::v1::GetBuildRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists previously requested builds.
@@ -186,7 +188,8 @@ class CloudBuildClient {
   ///
   /// @param project_id  Required. ID of the project.
   /// @param filter  The raw filter text to constrain the results.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -197,7 +200,7 @@ class CloudBuildClient {
   ///
   StreamRange<google::devtools::cloudbuild::v1::Build> ListBuilds(
       std::string const& project_id, std::string const& filter,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists previously requested builds.
@@ -207,7 +210,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::ListBuildsRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1130}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -218,14 +222,15 @@ class CloudBuildClient {
   ///
   StreamRange<google::devtools::cloudbuild::v1::Build> ListBuilds(
       google::devtools::cloudbuild::v1::ListBuildsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Cancels a build in progress.
   ///
   /// @param project_id  Required. ID of the project.
   /// @param id  Required. ID of the build.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -235,15 +240,15 @@ class CloudBuildClient {
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
   StatusOr<google::devtools::cloudbuild::v1::Build> CancelBuild(
-      std::string const& project_id, std::string const& id,
-      Options options = {});
+      std::string const& project_id, std::string const& id, Options opts = {});
 
   ///
   /// Cancels a build in progress.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::CancelBuildRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1169}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -254,7 +259,7 @@ class CloudBuildClient {
   ///
   StatusOr<google::devtools::cloudbuild::v1::Build> CancelBuild(
       google::devtools::cloudbuild::v1::CancelBuildRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new build based on the specified build.
@@ -287,7 +292,8 @@ class CloudBuildClient {
   ///
   /// @param project_id  Required. ID of the project.
   /// @param id  Required. Build ID of the original build.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -297,8 +303,7 @@ class CloudBuildClient {
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> RetryBuild(
-      std::string const& project_id, std::string const& id,
-      Options options = {});
+      std::string const& project_id, std::string const& id, Options opts = {});
 
   ///
   /// Creates a new build based on the specified build.
@@ -331,7 +336,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::RetryBuildRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L364}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -342,7 +348,7 @@ class CloudBuildClient {
   ///
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> RetryBuild(
       google::devtools::cloudbuild::v1::RetryBuildRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Approves or rejects a pending build.
@@ -355,7 +361,8 @@ class CloudBuildClient {
   /// @param name  Required. Name of the target build.
   ///  For example: "projects/{$project_id}/builds/{$build_id}"
   /// @param approval_result  Approval decision and metadata.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -367,7 +374,7 @@ class CloudBuildClient {
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> ApproveBuild(
       std::string const& name,
       google::devtools::cloudbuild::v1::ApprovalResult const& approval_result,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Approves or rejects a pending build.
@@ -379,7 +386,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::ApproveBuildRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1184}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -390,7 +398,7 @@ class CloudBuildClient {
   ///
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> ApproveBuild(
       google::devtools::cloudbuild::v1::ApproveBuildRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new `BuildTrigger`.
@@ -400,7 +408,8 @@ class CloudBuildClient {
   /// @param project_id  Required. ID of the project for which to configure
   /// automatic builds.
   /// @param trigger  Required. `BuildTrigger` to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -412,7 +421,7 @@ class CloudBuildClient {
   StatusOr<google::devtools::cloudbuild::v1::BuildTrigger> CreateBuildTrigger(
       std::string const& project_id,
       google::devtools::cloudbuild::v1::BuildTrigger const& trigger,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new `BuildTrigger`.
@@ -421,7 +430,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::CreateBuildTriggerRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1557}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -433,7 +443,7 @@ class CloudBuildClient {
   StatusOr<google::devtools::cloudbuild::v1::BuildTrigger> CreateBuildTrigger(
       google::devtools::cloudbuild::v1::CreateBuildTriggerRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns information about a `BuildTrigger`.
@@ -443,7 +453,8 @@ class CloudBuildClient {
   /// @param project_id  Required. ID of the project that owns the trigger.
   /// @param trigger_id  Required. Identifier (`id` or `name`) of the
   /// `BuildTrigger` to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -454,7 +465,7 @@ class CloudBuildClient {
   ///
   StatusOr<google::devtools::cloudbuild::v1::BuildTrigger> GetBuildTrigger(
       std::string const& project_id, std::string const& trigger_id,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns information about a `BuildTrigger`.
@@ -463,7 +474,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::GetBuildTriggerRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1572}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -474,7 +486,7 @@ class CloudBuildClient {
   ///
   StatusOr<google::devtools::cloudbuild::v1::BuildTrigger> GetBuildTrigger(
       google::devtools::cloudbuild::v1::GetBuildTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists existing `BuildTrigger`s.
@@ -483,7 +495,8 @@ class CloudBuildClient {
   ///
   /// @param project_id  Required. ID of the project for which to list
   /// BuildTriggers.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -493,7 +506,7 @@ class CloudBuildClient {
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
   StreamRange<google::devtools::cloudbuild::v1::BuildTrigger> ListBuildTriggers(
-      std::string const& project_id, Options options = {});
+      std::string const& project_id, Options opts = {});
 
   ///
   /// Lists existing `BuildTrigger`s.
@@ -502,7 +515,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::ListBuildTriggersRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1587}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -513,7 +527,7 @@ class CloudBuildClient {
   ///
   StreamRange<google::devtools::cloudbuild::v1::BuildTrigger> ListBuildTriggers(
       google::devtools::cloudbuild::v1::ListBuildTriggersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a `BuildTrigger` by its project ID and trigger ID.
@@ -522,14 +536,14 @@ class CloudBuildClient {
   ///
   /// @param project_id  Required. ID of the project that owns the trigger.
   /// @param trigger_id  Required. ID of the `BuildTrigger` to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.devtools.cloudbuild.v1.DeleteBuildTriggerRequest]:
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L1614}
   ///
   Status DeleteBuildTrigger(std::string const& project_id,
-                            std::string const& trigger_id,
-                            Options options = {});
+                            std::string const& trigger_id, Options opts = {});
 
   ///
   /// Deletes a `BuildTrigger` by its project ID and trigger ID.
@@ -538,7 +552,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::DeleteBuildTriggerRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1614}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.devtools.cloudbuild.v1.DeleteBuildTriggerRequest]:
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L1614}
@@ -546,7 +561,7 @@ class CloudBuildClient {
   Status DeleteBuildTrigger(
       google::devtools::cloudbuild::v1::DeleteBuildTriggerRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a `BuildTrigger` by its project ID and trigger ID.
@@ -556,7 +571,8 @@ class CloudBuildClient {
   /// @param project_id  Required. ID of the project that owns the trigger.
   /// @param trigger_id  Required. ID of the `BuildTrigger` to update.
   /// @param trigger  Required. `BuildTrigger` to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -568,7 +584,7 @@ class CloudBuildClient {
   StatusOr<google::devtools::cloudbuild::v1::BuildTrigger> UpdateBuildTrigger(
       std::string const& project_id, std::string const& trigger_id,
       google::devtools::cloudbuild::v1::BuildTrigger const& trigger,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a `BuildTrigger` by its project ID and trigger ID.
@@ -577,7 +593,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::UpdateBuildTriggerRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1629}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::BuildTrigger,google/devtools/cloudbuild/v1/cloudbuild.proto#L1271}
   ///
@@ -589,7 +606,7 @@ class CloudBuildClient {
   StatusOr<google::devtools::cloudbuild::v1::BuildTrigger> UpdateBuildTrigger(
       google::devtools::cloudbuild::v1::UpdateBuildTriggerRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Runs a `BuildTrigger` at a particular source revision.
@@ -597,7 +614,8 @@ class CloudBuildClient {
   /// @param project_id  Required. ID of the project.
   /// @param trigger_id  Required. ID of the trigger.
   /// @param source  Source to build against this trigger.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -609,14 +627,15 @@ class CloudBuildClient {
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> RunBuildTrigger(
       std::string const& project_id, std::string const& trigger_id,
       google::devtools::cloudbuild::v1::RepoSource const& source,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Runs a `BuildTrigger` at a particular source revision.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::RunBuildTriggerRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L379}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::Build,google/devtools/cloudbuild/v1/cloudbuild.proto#L680}
   ///
@@ -627,7 +646,7 @@ class CloudBuildClient {
   ///
   future<StatusOr<google::devtools::cloudbuild::v1::Build>> RunBuildTrigger(
       google::devtools::cloudbuild::v1::RunBuildTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// ReceiveTriggerWebhook [Experimental] is called when the API receives a
@@ -635,7 +654,8 @@ class CloudBuildClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::ReceiveTriggerWebhookRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1811}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::ReceiveTriggerWebhookResponse,google/devtools/cloudbuild/v1/cloudbuild.proto#L1831}
   ///
@@ -648,7 +668,7 @@ class CloudBuildClient {
   ReceiveTriggerWebhook(
       google::devtools::cloudbuild::v1::ReceiveTriggerWebhookRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a `WorkerPool`.
@@ -662,7 +682,8 @@ class CloudBuildClient {
   ///  the final component of the resource name.
   ///  This value should be 1-63 characters, and valid characters
   ///  are /[a-z][0-9]-/.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -675,14 +696,15 @@ class CloudBuildClient {
   CreateWorkerPool(
       std::string const& parent,
       google::devtools::cloudbuild::v1::WorkerPool const& worker_pool,
-      std::string const& worker_pool_id, Options options = {});
+      std::string const& worker_pool_id, Options opts = {});
 
   ///
   /// Creates a `WorkerPool`.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::CreateWorkerPoolRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L1984}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -694,7 +716,7 @@ class CloudBuildClient {
   future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
   CreateWorkerPool(
       google::devtools::cloudbuild::v1::CreateWorkerPoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns details of a `WorkerPool`.
@@ -702,7 +724,8 @@ class CloudBuildClient {
   /// @param name  Required. The name of the `WorkerPool` to retrieve.
   ///  Format:
   ///  `projects/{project}/locations/{location}/workerPools/{workerPool}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -712,14 +735,15 @@ class CloudBuildClient {
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
   StatusOr<google::devtools::cloudbuild::v1::WorkerPool> GetWorkerPool(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns details of a `WorkerPool`.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::GetWorkerPoolRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L2013}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -730,7 +754,7 @@ class CloudBuildClient {
   ///
   StatusOr<google::devtools::cloudbuild::v1::WorkerPool> GetWorkerPool(
       google::devtools::cloudbuild::v1::GetWorkerPoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a `WorkerPool`.
@@ -738,7 +762,8 @@ class CloudBuildClient {
   /// @param name  Required. The name of the `WorkerPool` to delete.
   ///  Format:
   ///  `projects/{project}/locations/{workerPool}/workerPools/{workerPool}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata,google/devtools/cloudbuild/v1/cloudbuild.proto#L2129}
   ///
@@ -749,14 +774,15 @@ class CloudBuildClient {
   ///
   future<StatusOr<
       google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata>>
-  DeleteWorkerPool(std::string const& name, Options options = {});
+  DeleteWorkerPool(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a `WorkerPool`.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L2025}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata,google/devtools/cloudbuild/v1/cloudbuild.proto#L2129}
   ///
@@ -769,7 +795,7 @@ class CloudBuildClient {
       google::devtools::cloudbuild::v1::DeleteWorkerPoolOperationMetadata>>
   DeleteWorkerPool(
       google::devtools::cloudbuild::v1::DeleteWorkerPoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a `WorkerPool`.
@@ -780,7 +806,8 @@ class CloudBuildClient {
   ///  `projects/{project}/locations/{location}/workerPools/{workerPool}`.
   /// @param update_mask  A mask specifying which fields in `worker_pool` to
   /// update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -792,14 +819,15 @@ class CloudBuildClient {
   future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
   UpdateWorkerPool(
       google::devtools::cloudbuild::v1::WorkerPool const& worker_pool,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a `WorkerPool`.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::UpdateWorkerPoolRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L2050}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -811,14 +839,15 @@ class CloudBuildClient {
   future<StatusOr<google::devtools::cloudbuild::v1::WorkerPool>>
   UpdateWorkerPool(
       google::devtools::cloudbuild::v1::UpdateWorkerPoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists `WorkerPool`s.
   ///
   /// @param parent  Required. The parent of the collection of `WorkerPools`.
   ///  Format: `projects/{project}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -828,14 +857,15 @@ class CloudBuildClient {
   /// @googleapis_reference_link{google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
   StreamRange<google::devtools::cloudbuild::v1::WorkerPool> ListWorkerPools(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists `WorkerPool`s.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudbuild::v1::ListWorkerPoolsRequest,google/devtools/cloudbuild/v1/cloudbuild.proto#L2066}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudbuild::v1::WorkerPool,google/devtools/cloudbuild/v1/cloudbuild.proto#L1846}
   ///
@@ -846,7 +876,7 @@ class CloudBuildClient {
   ///
   StreamRange<google::devtools::cloudbuild::v1::WorkerPool> ListWorkerPools(
       google::devtools::cloudbuild::v1::ListWorkerPoolsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudBuildConnection> connection_;

--- a/google/cloud/composer/environments_client.cc
+++ b/google/cloud/composer/environments_client.cc
@@ -26,11 +26,11 @@ namespace composer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EnvironmentsClient::EnvironmentsClient(
-    std::shared_ptr<EnvironmentsConnection> connection, Options options)
+    std::shared_ptr<EnvironmentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), composer_internal::EnvironmentsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), composer_internal::EnvironmentsDefaultOptions(
+                               connection_->options()))) {}
 EnvironmentsClient::~EnvironmentsClient() = default;
 
 future<
@@ -39,9 +39,8 @@ EnvironmentsClient::CreateEnvironment(
     std::string const& parent,
     google::cloud::orchestration::airflow::service::v1::Environment const&
         environment,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orchestration::airflow::service::v1::CreateEnvironmentRequest
       request;
   request.set_parent(parent);
@@ -54,16 +53,14 @@ future<
 EnvironmentsClient::CreateEnvironment(
     google::cloud::orchestration::airflow::service::v1::
         CreateEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEnvironment(request);
 }
 
 StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>
-EnvironmentsClient::GetEnvironment(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+EnvironmentsClient::GetEnvironment(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orchestration::airflow::service::v1::GetEnvironmentRequest
       request;
   request.set_name(name);
@@ -74,17 +71,14 @@ StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>
 EnvironmentsClient::GetEnvironment(
     google::cloud::orchestration::airflow::service::v1::
         GetEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEnvironment(request);
 }
 
 StreamRange<google::cloud::orchestration::airflow::service::v1::Environment>
-EnvironmentsClient::ListEnvironments(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+EnvironmentsClient::ListEnvironments(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orchestration::airflow::service::v1::ListEnvironmentsRequest
       request;
   request.set_parent(parent);
@@ -95,9 +89,8 @@ StreamRange<google::cloud::orchestration::airflow::service::v1::Environment>
 EnvironmentsClient::ListEnvironments(
     google::cloud::orchestration::airflow::service::v1::ListEnvironmentsRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEnvironments(std::move(request));
 }
 
@@ -107,9 +100,8 @@ EnvironmentsClient::UpdateEnvironment(
     std::string const& name,
     google::cloud::orchestration::airflow::service::v1::Environment const&
         environment,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orchestration::airflow::service::v1::UpdateEnvironmentRequest
       request;
   request.set_name(name);
@@ -123,18 +115,15 @@ future<
 EnvironmentsClient::UpdateEnvironment(
     google::cloud::orchestration::airflow::service::v1::
         UpdateEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateEnvironment(request);
 }
 
 future<StatusOr<
     google::cloud::orchestration::airflow::service::v1::OperationMetadata>>
-EnvironmentsClient::DeleteEnvironment(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+EnvironmentsClient::DeleteEnvironment(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orchestration::airflow::service::v1::DeleteEnvironmentRequest
       request;
   request.set_name(name);
@@ -146,9 +135,8 @@ future<StatusOr<
 EnvironmentsClient::DeleteEnvironment(
     google::cloud::orchestration::airflow::service::v1::
         DeleteEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteEnvironment(request);
 }
 

--- a/google/cloud/composer/environments_client.h
+++ b/google/cloud/composer/environments_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EnvironmentsClient {
  public:
   explicit EnvironmentsClient(
-      std::shared_ptr<EnvironmentsConnection> connection, Options options = {});
+      std::shared_ptr<EnvironmentsConnection> connection, Options opts = {});
   ~EnvironmentsClient();
 
   //@{
@@ -92,7 +92,8 @@ class EnvironmentsClient {
   /// @param parent  The parent must be of the form
   ///  "projects/{projectId}/locations/{locationId}".
   /// @param environment  The environment to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -107,14 +108,15 @@ class EnvironmentsClient {
       std::string const& parent,
       google::cloud::orchestration::airflow::service::v1::Environment const&
           environment,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::CreateEnvironmentRequest,google/cloud/orchestration/airflow/service/v1/environments.proto#L92}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -127,14 +129,15 @@ class EnvironmentsClient {
       StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>>
   CreateEnvironment(google::cloud::orchestration::airflow::service::v1::
                         CreateEnvironmentRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Get an existing environment.
   ///
   /// @param name  The resource name of the environment to get, in the form:
   ///  "projects/{projectId}/locations/{locationId}/environments/{environmentId}"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -144,14 +147,15 @@ class EnvironmentsClient {
   /// @googleapis_reference_link{google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
   StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>
-  GetEnvironment(std::string const& name, Options options = {});
+  GetEnvironment(std::string const& name, Options opts = {});
 
   ///
   /// Get an existing environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::GetEnvironmentRequest,google/cloud/orchestration/airflow/service/v1/environments.proto#L102}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -163,7 +167,7 @@ class EnvironmentsClient {
   StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>
   GetEnvironment(google::cloud::orchestration::airflow::service::v1::
                      GetEnvironmentRequest const& request,
-                 Options options = {});
+                 Options opts = {});
 
   ///
   /// List environments.
@@ -171,7 +175,8 @@ class EnvironmentsClient {
   /// @param parent  List environments in the given project and location, in the
   /// form:
   ///  "projects/{projectId}/locations/{locationId}"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -181,14 +186,15 @@ class EnvironmentsClient {
   /// @googleapis_reference_link{google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
   StreamRange<google::cloud::orchestration::airflow::service::v1::Environment>
-  ListEnvironments(std::string const& parent, Options options = {});
+  ListEnvironments(std::string const& parent, Options opts = {});
 
   ///
   /// List environments.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::ListEnvironmentsRequest,google/cloud/orchestration/airflow/service/v1/environments.proto#L109}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -200,7 +206,7 @@ class EnvironmentsClient {
   StreamRange<google::cloud::orchestration::airflow::service::v1::Environment>
   ListEnvironments(google::cloud::orchestration::airflow::service::v1::
                        ListEnvironmentsRequest request,
-                   Options options = {});
+                   Options opts = {});
 
   ///
   /// Update an environment.
@@ -317,7 +323,8 @@ class EnvironmentsClient {
   ///        environment variables  are cleared. It is an error to provide both
   ///        this mask and a mask specifying one or more individual environment
   ///        variables.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -332,14 +339,15 @@ class EnvironmentsClient {
       std::string const& name,
       google::cloud::orchestration::airflow::service::v1::Environment const&
           environment,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update an environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::UpdateEnvironmentRequest,google/cloud/orchestration/airflow/service/v1/environments.proto#L138}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::Environment,google/cloud/orchestration/airflow/service/v1/environments.proto#L637}
   ///
@@ -352,14 +360,15 @@ class EnvironmentsClient {
       StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>>
   UpdateEnvironment(google::cloud::orchestration::airflow::service::v1::
                         UpdateEnvironmentRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Delete an environment.
   ///
   /// @param name  The environment to delete, in the form:
   ///  "projects/{projectId}/locations/{locationId}/environments/{environmentId}"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::OperationMetadata,google/cloud/orchestration/airflow/service/v1/operations.proto#L28}
   ///
@@ -370,14 +379,15 @@ class EnvironmentsClient {
   ///
   future<StatusOr<
       google::cloud::orchestration::airflow::service::v1::OperationMetadata>>
-  DeleteEnvironment(std::string const& name, Options options = {});
+  DeleteEnvironment(std::string const& name, Options opts = {});
 
   ///
   /// Delete an environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::DeleteEnvironmentRequest,google/cloud/orchestration/airflow/service/v1/environments.proto#L131}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::OperationMetadata,google/cloud/orchestration/airflow/service/v1/operations.proto#L28}
   ///
@@ -390,7 +400,7 @@ class EnvironmentsClient {
       google::cloud::orchestration::airflow::service::v1::OperationMetadata>>
   DeleteEnvironment(google::cloud::orchestration::airflow::service::v1::
                         DeleteEnvironmentRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
  private:
   std::shared_ptr<EnvironmentsConnection> connection_;

--- a/google/cloud/composer/image_versions_client.cc
+++ b/google/cloud/composer/image_versions_client.cc
@@ -26,18 +26,17 @@ namespace composer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ImageVersionsClient::ImageVersionsClient(
-    std::shared_ptr<ImageVersionsConnection> connection, Options options)
+    std::shared_ptr<ImageVersionsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), composer_internal::ImageVersionsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), composer_internal::ImageVersionsDefaultOptions(
+                               connection_->options()))) {}
 ImageVersionsClient::~ImageVersionsClient() = default;
 
 StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>
 ImageVersionsClient::ListImageVersions(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orchestration::airflow::service::v1::ListImageVersionsRequest
       request;
   request.set_parent(parent);
@@ -48,9 +47,8 @@ StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>
 ImageVersionsClient::ListImageVersions(
     google::cloud::orchestration::airflow::service::v1::ListImageVersionsRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListImageVersions(std::move(request));
 }
 

--- a/google/cloud/composer/image_versions_client.h
+++ b/google/cloud/composer/image_versions_client.h
@@ -61,8 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImageVersionsClient {
  public:
   explicit ImageVersionsClient(
-      std::shared_ptr<ImageVersionsConnection> connection,
-      Options options = {});
+      std::shared_ptr<ImageVersionsConnection> connection, Options opts = {});
   ~ImageVersionsClient();
 
   //@{
@@ -91,7 +90,8 @@ class ImageVersionsClient {
   /// @param parent  List ImageVersions in the given project and location, in
   /// the form:
   ///  "projects/{projectId}/locations/{locationId}"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::ImageVersion,google/cloud/orchestration/airflow/service/v1/image_versions.proto#L67}
   ///
@@ -101,14 +101,15 @@ class ImageVersionsClient {
   /// @googleapis_reference_link{google/cloud/orchestration/airflow/service/v1/image_versions.proto#L67}
   ///
   StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>
-  ListImageVersions(std::string const& parent, Options options = {});
+  ListImageVersions(std::string const& parent, Options opts = {});
 
   ///
   /// List ImageVersions for provided location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::ListImageVersionsRequest,google/cloud/orchestration/airflow/service/v1/image_versions.proto#L42}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orchestration::airflow::service::v1::ImageVersion,google/cloud/orchestration/airflow/service/v1/image_versions.proto#L67}
   ///
@@ -120,7 +121,7 @@ class ImageVersionsClient {
   StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>
   ListImageVersions(google::cloud::orchestration::airflow::service::v1::
                         ListImageVersionsRequest request,
-                    Options options = {});
+                    Options opts = {});
 
  private:
   std::shared_ptr<ImageVersionsConnection> connection_;

--- a/google/cloud/contactcenterinsights/contact_center_insights_client.cc
+++ b/google/cloud/contactcenterinsights/contact_center_insights_client.cc
@@ -26,11 +26,10 @@ namespace contactcenterinsights {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ContactCenterInsightsClient::ContactCenterInsightsClient(
-    std::shared_ptr<ContactCenterInsightsConnection> connection,
-    Options options)
+    std::shared_ptr<ContactCenterInsightsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           contactcenterinsights_internal::ContactCenterInsightsDefaultOptions(
               connection_->options()))) {}
 ContactCenterInsightsClient::~ContactCenterInsightsClient() = default;
@@ -39,9 +38,8 @@ StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::CreateConversation(
     std::string const& parent,
     google::cloud::contactcenterinsights::v1::Conversation const& conversation,
-    std::string const& conversation_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& conversation_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CreateConversationRequest request;
   request.set_parent(parent);
   *request.mutable_conversation() = conversation;
@@ -53,18 +51,16 @@ StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::CreateConversation(
     google::cloud::contactcenterinsights::v1::CreateConversationRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateConversation(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::UpdateConversation(
     google::cloud::contactcenterinsights::v1::Conversation const& conversation,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UpdateConversationRequest request;
   *request.mutable_conversation() = conversation;
   *request.mutable_update_mask() = update_mask;
@@ -75,17 +71,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::UpdateConversation(
     google::cloud::contactcenterinsights::v1::UpdateConversationRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateConversation(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::GetConversation(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetConversationRequest request;
   request.set_name(name);
   return connection_->GetConversation(request);
@@ -95,17 +89,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::GetConversation(
     google::cloud::contactcenterinsights::v1::GetConversationRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetConversation(request);
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::ListConversations(std::string const& parent,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ListConversationsRequest request;
   request.set_parent(parent);
   return connection_->ListConversations(request);
@@ -114,16 +106,14 @@ ContactCenterInsightsClient::ListConversations(std::string const& parent,
 StreamRange<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsClient::ListConversations(
     google::cloud::contactcenterinsights::v1::ListConversationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListConversations(std::move(request));
 }
 
 Status ContactCenterInsightsClient::DeleteConversation(std::string const& name,
-                                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::DeleteConversationRequest request;
   request.set_name(name);
   return connection_->DeleteConversation(request);
@@ -132,9 +122,8 @@ Status ContactCenterInsightsClient::DeleteConversation(std::string const& name,
 Status ContactCenterInsightsClient::DeleteConversation(
     google::cloud::contactcenterinsights::v1::DeleteConversationRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteConversation(request);
 }
 
@@ -142,9 +131,8 @@ future<StatusOr<google::cloud::contactcenterinsights::v1::Analysis>>
 ContactCenterInsightsClient::CreateAnalysis(
     std::string const& parent,
     google::cloud::contactcenterinsights::v1::Analysis const& analysis,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CreateAnalysisRequest request;
   request.set_parent(parent);
   *request.mutable_analysis() = analysis;
@@ -155,17 +143,15 @@ future<StatusOr<google::cloud::contactcenterinsights::v1::Analysis>>
 ContactCenterInsightsClient::CreateAnalysis(
     google::cloud::contactcenterinsights::v1::CreateAnalysisRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAnalysis(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Analysis>
 ContactCenterInsightsClient::GetAnalysis(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetAnalysisRequest request;
   request.set_name(name);
   return connection_->GetAnalysis(request);
@@ -174,17 +160,15 @@ ContactCenterInsightsClient::GetAnalysis(std::string const& name,
 StatusOr<google::cloud::contactcenterinsights::v1::Analysis>
 ContactCenterInsightsClient::GetAnalysis(
     google::cloud::contactcenterinsights::v1::GetAnalysisRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAnalysis(request);
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::Analysis>
 ContactCenterInsightsClient::ListAnalyses(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ListAnalysesRequest request;
   request.set_parent(parent);
   return connection_->ListAnalyses(request);
@@ -193,16 +177,14 @@ ContactCenterInsightsClient::ListAnalyses(std::string const& parent,
 StreamRange<google::cloud::contactcenterinsights::v1::Analysis>
 ContactCenterInsightsClient::ListAnalyses(
     google::cloud::contactcenterinsights::v1::ListAnalysesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAnalyses(std::move(request));
 }
 
 Status ContactCenterInsightsClient::DeleteAnalysis(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::DeleteAnalysisRequest request;
   request.set_name(name);
   return connection_->DeleteAnalysis(request);
@@ -211,18 +193,16 @@ Status ContactCenterInsightsClient::DeleteAnalysis(std::string const& name,
 Status ContactCenterInsightsClient::DeleteAnalysis(
     google::cloud::contactcenterinsights::v1::DeleteAnalysisRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAnalysis(request);
 }
 
 future<StatusOr<
     google::cloud::contactcenterinsights::v1::ExportInsightsDataResponse>>
 ContactCenterInsightsClient::ExportInsightsData(std::string const& parent,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ExportInsightsDataRequest request;
   request.set_parent(parent);
   return connection_->ExportInsightsData(request);
@@ -233,9 +213,8 @@ future<StatusOr<
 ContactCenterInsightsClient::ExportInsightsData(
     google::cloud::contactcenterinsights::v1::ExportInsightsDataRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExportInsightsData(request);
 }
 
@@ -243,9 +222,8 @@ future<StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>>
 ContactCenterInsightsClient::CreateIssueModel(
     std::string const& parent,
     google::cloud::contactcenterinsights::v1::IssueModel const& issue_model,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CreateIssueModelRequest request;
   request.set_parent(parent);
   *request.mutable_issue_model() = issue_model;
@@ -256,18 +234,16 @@ future<StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>>
 ContactCenterInsightsClient::CreateIssueModel(
     google::cloud::contactcenterinsights::v1::CreateIssueModelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateIssueModel(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>
 ContactCenterInsightsClient::UpdateIssueModel(
     google::cloud::contactcenterinsights::v1::IssueModel const& issue_model,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UpdateIssueModelRequest request;
   *request.mutable_issue_model() = issue_model;
   *request.mutable_update_mask() = update_mask;
@@ -278,17 +254,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>
 ContactCenterInsightsClient::UpdateIssueModel(
     google::cloud::contactcenterinsights::v1::UpdateIssueModelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateIssueModel(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>
 ContactCenterInsightsClient::GetIssueModel(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetIssueModelRequest request;
   request.set_name(name);
   return connection_->GetIssueModel(request);
@@ -298,17 +272,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>
 ContactCenterInsightsClient::GetIssueModel(
     google::cloud::contactcenterinsights::v1::GetIssueModelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIssueModel(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::ListIssueModelsResponse>
 ContactCenterInsightsClient::ListIssueModels(std::string const& parent,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ListIssueModelsRequest request;
   request.set_parent(parent);
   return connection_->ListIssueModels(request);
@@ -318,18 +290,16 @@ StatusOr<google::cloud::contactcenterinsights::v1::ListIssueModelsResponse>
 ContactCenterInsightsClient::ListIssueModels(
     google::cloud::contactcenterinsights::v1::ListIssueModelsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListIssueModels(request);
 }
 
 future<StatusOr<
     google::cloud::contactcenterinsights::v1::DeleteIssueModelMetadata>>
 ContactCenterInsightsClient::DeleteIssueModel(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::DeleteIssueModelRequest request;
   request.set_name(name);
   return connection_->DeleteIssueModel(request);
@@ -340,18 +310,16 @@ future<StatusOr<
 ContactCenterInsightsClient::DeleteIssueModel(
     google::cloud::contactcenterinsights::v1::DeleteIssueModelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteIssueModel(request);
 }
 
 future<StatusOr<
     google::cloud::contactcenterinsights::v1::DeployIssueModelResponse>>
 ContactCenterInsightsClient::DeployIssueModel(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::DeployIssueModelRequest request;
   request.set_name(name);
   return connection_->DeployIssueModel(request);
@@ -362,18 +330,16 @@ future<StatusOr<
 ContactCenterInsightsClient::DeployIssueModel(
     google::cloud::contactcenterinsights::v1::DeployIssueModelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeployIssueModel(request);
 }
 
 future<StatusOr<
     google::cloud::contactcenterinsights::v1::UndeployIssueModelResponse>>
 ContactCenterInsightsClient::UndeployIssueModel(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UndeployIssueModelRequest request;
   request.set_name(name);
   return connection_->UndeployIssueModel(request);
@@ -384,17 +350,14 @@ future<StatusOr<
 ContactCenterInsightsClient::UndeployIssueModel(
     google::cloud::contactcenterinsights::v1::UndeployIssueModelRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeployIssueModel(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Issue>
-ContactCenterInsightsClient::GetIssue(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ContactCenterInsightsClient::GetIssue(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetIssueRequest request;
   request.set_name(name);
   return connection_->GetIssue(request);
@@ -403,17 +366,15 @@ ContactCenterInsightsClient::GetIssue(std::string const& name,
 StatusOr<google::cloud::contactcenterinsights::v1::Issue>
 ContactCenterInsightsClient::GetIssue(
     google::cloud::contactcenterinsights::v1::GetIssueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIssue(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::ListIssuesResponse>
 ContactCenterInsightsClient::ListIssues(std::string const& parent,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ListIssuesRequest request;
   request.set_parent(parent);
   return connection_->ListIssues(request);
@@ -422,18 +383,16 @@ ContactCenterInsightsClient::ListIssues(std::string const& parent,
 StatusOr<google::cloud::contactcenterinsights::v1::ListIssuesResponse>
 ContactCenterInsightsClient::ListIssues(
     google::cloud::contactcenterinsights::v1::ListIssuesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListIssues(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Issue>
 ContactCenterInsightsClient::UpdateIssue(
     google::cloud::contactcenterinsights::v1::Issue const& issue,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UpdateIssueRequest request;
   *request.mutable_issue() = issue;
   *request.mutable_update_mask() = update_mask;
@@ -443,18 +402,16 @@ ContactCenterInsightsClient::UpdateIssue(
 StatusOr<google::cloud::contactcenterinsights::v1::Issue>
 ContactCenterInsightsClient::UpdateIssue(
     google::cloud::contactcenterinsights::v1::UpdateIssueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateIssue(request);
 }
 
 StatusOr<
     google::cloud::contactcenterinsights::v1::CalculateIssueModelStatsResponse>
 ContactCenterInsightsClient::CalculateIssueModelStats(
-    std::string const& issue_model, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& issue_model, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CalculateIssueModelStatsRequest
       request;
   request.set_issue_model(issue_model);
@@ -466,9 +423,8 @@ StatusOr<
 ContactCenterInsightsClient::CalculateIssueModelStats(
     google::cloud::contactcenterinsights::v1::
         CalculateIssueModelStatsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CalculateIssueModelStats(request);
 }
 
@@ -477,9 +433,8 @@ ContactCenterInsightsClient::CreatePhraseMatcher(
     std::string const& parent,
     google::cloud::contactcenterinsights::v1::PhraseMatcher const&
         phrase_matcher,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CreatePhraseMatcherRequest request;
   request.set_parent(parent);
   *request.mutable_phrase_matcher() = phrase_matcher;
@@ -490,17 +445,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::CreatePhraseMatcher(
     google::cloud::contactcenterinsights::v1::CreatePhraseMatcherRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreatePhraseMatcher(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::GetPhraseMatcher(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetPhraseMatcherRequest request;
   request.set_name(name);
   return connection_->GetPhraseMatcher(request);
@@ -510,17 +463,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::GetPhraseMatcher(
     google::cloud::contactcenterinsights::v1::GetPhraseMatcherRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPhraseMatcher(request);
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::ListPhraseMatchers(std::string const& parent,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ListPhraseMatchersRequest request;
   request.set_parent(parent);
   return connection_->ListPhraseMatchers(request);
@@ -529,16 +480,14 @@ ContactCenterInsightsClient::ListPhraseMatchers(std::string const& parent,
 StreamRange<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::ListPhraseMatchers(
     google::cloud::contactcenterinsights::v1::ListPhraseMatchersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPhraseMatchers(std::move(request));
 }
 
 Status ContactCenterInsightsClient::DeletePhraseMatcher(std::string const& name,
-                                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::DeletePhraseMatcherRequest request;
   request.set_name(name);
   return connection_->DeletePhraseMatcher(request);
@@ -547,9 +496,8 @@ Status ContactCenterInsightsClient::DeletePhraseMatcher(std::string const& name,
 Status ContactCenterInsightsClient::DeletePhraseMatcher(
     google::cloud::contactcenterinsights::v1::DeletePhraseMatcherRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeletePhraseMatcher(request);
 }
 
@@ -557,9 +505,8 @@ StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::UpdatePhraseMatcher(
     google::cloud::contactcenterinsights::v1::PhraseMatcher const&
         phrase_matcher,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UpdatePhraseMatcherRequest request;
   *request.mutable_phrase_matcher() = phrase_matcher;
   *request.mutable_update_mask() = update_mask;
@@ -570,17 +517,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
 ContactCenterInsightsClient::UpdatePhraseMatcher(
     google::cloud::contactcenterinsights::v1::UpdatePhraseMatcherRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdatePhraseMatcher(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::CalculateStatsResponse>
 ContactCenterInsightsClient::CalculateStats(std::string const& location,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CalculateStatsRequest request;
   request.set_location(location);
   return connection_->CalculateStats(request);
@@ -590,17 +535,15 @@ StatusOr<google::cloud::contactcenterinsights::v1::CalculateStatsResponse>
 ContactCenterInsightsClient::CalculateStats(
     google::cloud::contactcenterinsights::v1::CalculateStatsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CalculateStats(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Settings>
 ContactCenterInsightsClient::GetSettings(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetSettingsRequest request;
   request.set_name(name);
   return connection_->GetSettings(request);
@@ -609,18 +552,16 @@ ContactCenterInsightsClient::GetSettings(std::string const& name,
 StatusOr<google::cloud::contactcenterinsights::v1::Settings>
 ContactCenterInsightsClient::GetSettings(
     google::cloud::contactcenterinsights::v1::GetSettingsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSettings(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::Settings>
 ContactCenterInsightsClient::UpdateSettings(
     google::cloud::contactcenterinsights::v1::Settings const& settings,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UpdateSettingsRequest request;
   *request.mutable_settings() = settings;
   *request.mutable_update_mask() = update_mask;
@@ -631,19 +572,16 @@ StatusOr<google::cloud::contactcenterinsights::v1::Settings>
 ContactCenterInsightsClient::UpdateSettings(
     google::cloud::contactcenterinsights::v1::UpdateSettingsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSettings(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::CreateView(
     std::string const& parent,
-    google::cloud::contactcenterinsights::v1::View const& view,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::contactcenterinsights::v1::View const& view, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::CreateViewRequest request;
   request.set_parent(parent);
   *request.mutable_view() = view;
@@ -653,16 +591,14 @@ ContactCenterInsightsClient::CreateView(
 StatusOr<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::CreateView(
     google::cloud::contactcenterinsights::v1::CreateViewRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateView(request);
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::View>
-ContactCenterInsightsClient::GetView(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ContactCenterInsightsClient::GetView(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::GetViewRequest request;
   request.set_name(name);
   return connection_->GetView(request);
@@ -671,17 +607,15 @@ ContactCenterInsightsClient::GetView(std::string const& name, Options options) {
 StatusOr<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::GetView(
     google::cloud::contactcenterinsights::v1::GetViewRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetView(request);
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::ListViews(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::ListViewsRequest request;
   request.set_parent(parent);
   return connection_->ListViews(request);
@@ -690,18 +624,16 @@ ContactCenterInsightsClient::ListViews(std::string const& parent,
 StreamRange<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::ListViews(
     google::cloud::contactcenterinsights::v1::ListViewsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListViews(std::move(request));
 }
 
 StatusOr<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::UpdateView(
     google::cloud::contactcenterinsights::v1::View const& view,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::UpdateViewRequest request;
   *request.mutable_view() = view;
   *request.mutable_update_mask() = update_mask;
@@ -711,16 +643,14 @@ ContactCenterInsightsClient::UpdateView(
 StatusOr<google::cloud::contactcenterinsights::v1::View>
 ContactCenterInsightsClient::UpdateView(
     google::cloud::contactcenterinsights::v1::UpdateViewRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateView(request);
 }
 
 Status ContactCenterInsightsClient::DeleteView(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::contactcenterinsights::v1::DeleteViewRequest request;
   request.set_name(name);
   return connection_->DeleteView(request);
@@ -728,9 +658,8 @@ Status ContactCenterInsightsClient::DeleteView(std::string const& name,
 
 Status ContactCenterInsightsClient::DeleteView(
     google::cloud::contactcenterinsights::v1::DeleteViewRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteView(request);
 }
 

--- a/google/cloud/contactcenterinsights/contact_center_insights_client.h
+++ b/google/cloud/contactcenterinsights/contact_center_insights_client.h
@@ -64,7 +64,7 @@ class ContactCenterInsightsClient {
  public:
   explicit ContactCenterInsightsClient(
       std::shared_ptr<ContactCenterInsightsConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ContactCenterInsightsClient();
 
   //@{
@@ -100,7 +100,8 @@ class ContactCenterInsightsClient {
   ///  server-generated ID will be used.
   ///  This value should be 4-64 characters and must match the regular
   ///  expression `^[a-z0-9-]{4,64}$`. Valid characters are `[a-z][0-9]-`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -114,14 +115,15 @@ class ContactCenterInsightsClient {
       std::string const& parent,
       google::cloud::contactcenterinsights::v1::Conversation const&
           conversation,
-      std::string const& conversation_id, Options options = {});
+      std::string const& conversation_id, Options opts = {});
 
   ///
   /// Creates a conversation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CreateConversationRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L462}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -134,14 +136,15 @@ class ContactCenterInsightsClient {
   CreateConversation(
       google::cloud::contactcenterinsights::v1::CreateConversationRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a conversation.
   ///
   /// @param conversation  Required. The new values for the conversation.
   /// @param update_mask  The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -154,14 +157,15 @@ class ContactCenterInsightsClient {
   UpdateConversation(
       google::cloud::contactcenterinsights::v1::Conversation const&
           conversation,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a conversation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UpdateConversationRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L538}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -174,13 +178,14 @@ class ContactCenterInsightsClient {
   UpdateConversation(
       google::cloud::contactcenterinsights::v1::UpdateConversationRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a conversation.
   ///
   /// @param name  Required. The name of the conversation to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -190,14 +195,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
-  GetConversation(std::string const& name, Options options = {});
+  GetConversation(std::string const& name, Options opts = {});
 
   ///
   /// Gets a conversation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetConversationRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L524}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -210,13 +216,14 @@ class ContactCenterInsightsClient {
   GetConversation(
       google::cloud::contactcenterinsights::v1::GetConversationRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists conversations.
   ///
   /// @param parent  Required. The parent resource of the conversation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -226,14 +233,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
   StreamRange<google::cloud::contactcenterinsights::v1::Conversation>
-  ListConversations(std::string const& parent, Options options = {});
+  ListConversations(std::string const& parent, Options opts = {});
 
   ///
   /// Lists conversations.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListConversationsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L484}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Conversation,google/cloud/contactcenterinsights/v1/resources.proto#L38}
   ///
@@ -246,25 +254,27 @@ class ContactCenterInsightsClient {
   ListConversations(
       google::cloud::contactcenterinsights::v1::ListConversationsRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a conversation.
   ///
   /// @param name  Required. The name of the conversation to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeleteConversationRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L547}
   ///
-  Status DeleteConversation(std::string const& name, Options options = {});
+  Status DeleteConversation(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a conversation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeleteConversationRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L547}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeleteConversationRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L547}
@@ -272,7 +282,7 @@ class ContactCenterInsightsClient {
   Status DeleteConversation(
       google::cloud::contactcenterinsights::v1::DeleteConversationRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an analysis. The long running operation is done when the analysis
@@ -280,7 +290,8 @@ class ContactCenterInsightsClient {
   ///
   /// @param parent  Required. The parent resource of the analysis.
   /// @param analysis  Required. The analysis to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Analysis,google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
@@ -293,7 +304,7 @@ class ContactCenterInsightsClient {
   CreateAnalysis(
       std::string const& parent,
       google::cloud::contactcenterinsights::v1::Analysis const& analysis,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an analysis. The long running operation is done when the analysis
@@ -301,7 +312,8 @@ class ContactCenterInsightsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CreateAnalysisRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L563}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Analysis,google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
@@ -314,13 +326,14 @@ class ContactCenterInsightsClient {
   CreateAnalysis(
       google::cloud::contactcenterinsights::v1::CreateAnalysisRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an analysis.
   ///
   /// @param name  Required. The name of the analysis to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Analysis,google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
@@ -330,14 +343,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Analysis> GetAnalysis(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an analysis.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetAnalysisRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L613}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Analysis,google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
@@ -349,13 +363,14 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::Analysis> GetAnalysis(
       google::cloud::contactcenterinsights::v1::GetAnalysisRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists analyses.
   ///
   /// @param parent  Required. The parent resource of the analyses.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Analysis,google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
@@ -365,14 +380,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
   StreamRange<google::cloud::contactcenterinsights::v1::Analysis> ListAnalyses(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists analyses.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListAnalysesRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L577}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Analysis,google/cloud/contactcenterinsights/v1/resources.proto#L209}
   ///
@@ -383,25 +399,27 @@ class ContactCenterInsightsClient {
   ///
   StreamRange<google::cloud::contactcenterinsights::v1::Analysis> ListAnalyses(
       google::cloud::contactcenterinsights::v1::ListAnalysesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an analysis.
   ///
   /// @param name  Required. The name of the analysis to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeleteAnalysisRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L624}
   ///
-  Status DeleteAnalysis(std::string const& name, Options options = {});
+  Status DeleteAnalysis(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an analysis.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeleteAnalysisRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L624}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeleteAnalysisRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L624}
@@ -409,13 +427,14 @@ class ContactCenterInsightsClient {
   Status DeleteAnalysis(
       google::cloud::contactcenterinsights::v1::DeleteAnalysisRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Export insights data to a destination defined in the request body.
   ///
   /// @param parent  Required. The parent resource to export data from.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ExportInsightsDataResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L711}
   ///
@@ -426,14 +445,15 @@ class ContactCenterInsightsClient {
   ///
   future<StatusOr<
       google::cloud::contactcenterinsights::v1::ExportInsightsDataResponse>>
-  ExportInsightsData(std::string const& parent, Options options = {});
+  ExportInsightsData(std::string const& parent, Options opts = {});
 
   ///
   /// Export insights data to a destination defined in the request body.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ExportInsightsDataRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L635}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ExportInsightsDataResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L711}
   ///
@@ -447,14 +467,15 @@ class ContactCenterInsightsClient {
   ExportInsightsData(
       google::cloud::contactcenterinsights::v1::ExportInsightsDataRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an issue model.
   ///
   /// @param parent  Required. The parent resource of the issue model.
   /// @param issue_model  Required. The issue model to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::IssueModel,google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
@@ -467,14 +488,15 @@ class ContactCenterInsightsClient {
   CreateIssueModel(
       std::string const& parent,
       google::cloud::contactcenterinsights::v1::IssueModel const& issue_model,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an issue model.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CreateIssueModelRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L716}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::IssueModel,google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
@@ -487,14 +509,15 @@ class ContactCenterInsightsClient {
   CreateIssueModel(
       google::cloud::contactcenterinsights::v1::CreateIssueModelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an issue model.
   ///
   /// @param issue_model  Required. The new values for the issue model.
   /// @param update_mask  The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::IssueModel,google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
@@ -506,14 +529,15 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::IssueModel>
   UpdateIssueModel(
       google::cloud::contactcenterinsights::v1::IssueModel const& issue_model,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an issue model.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UpdateIssueModelRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L742}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::IssueModel,google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
@@ -526,13 +550,14 @@ class ContactCenterInsightsClient {
   UpdateIssueModel(
       google::cloud::contactcenterinsights::v1::UpdateIssueModelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an issue model.
   ///
   /// @param name  Required. The name of the issue model to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::IssueModel,google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
@@ -542,14 +567,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::IssueModel> GetIssueModel(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an issue model.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetIssueModelRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L768}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::IssueModel,google/cloud/contactcenterinsights/v1/resources.proto#L583}
   ///
@@ -561,13 +587,14 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::IssueModel> GetIssueModel(
       google::cloud::contactcenterinsights::v1::GetIssueModelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists issue models.
   ///
   /// @param parent  Required. The parent resource of the issue model.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListIssueModelsResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L762}
   ///
@@ -577,14 +604,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L762}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::ListIssueModelsResponse>
-  ListIssueModels(std::string const& parent, Options options = {});
+  ListIssueModels(std::string const& parent, Options opts = {});
 
   ///
   /// Lists issue models.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListIssueModelsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L751}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListIssueModelsResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L762}
   ///
@@ -597,13 +625,14 @@ class ContactCenterInsightsClient {
   ListIssueModels(
       google::cloud::contactcenterinsights::v1::ListIssueModelsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an issue model.
   ///
   /// @param name  Required. The name of the issue model to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeleteIssueModelMetadata,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L790}
   ///
@@ -614,14 +643,15 @@ class ContactCenterInsightsClient {
   ///
   future<StatusOr<
       google::cloud::contactcenterinsights::v1::DeleteIssueModelMetadata>>
-  DeleteIssueModel(std::string const& name, Options options = {});
+  DeleteIssueModel(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an issue model.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeleteIssueModelRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L779}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeleteIssueModelMetadata,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L790}
   ///
@@ -635,14 +665,15 @@ class ContactCenterInsightsClient {
   DeleteIssueModel(
       google::cloud::contactcenterinsights::v1::DeleteIssueModelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deploys an issue model. Returns an error if a model is already deployed.
   /// An issue model can only be used in analysis after it has been deployed.
   ///
   /// @param name  Required. The issue model to deploy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeployIssueModelResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L813}
   ///
@@ -653,7 +684,7 @@ class ContactCenterInsightsClient {
   ///
   future<StatusOr<
       google::cloud::contactcenterinsights::v1::DeployIssueModelResponse>>
-  DeployIssueModel(std::string const& name, Options options = {});
+  DeployIssueModel(std::string const& name, Options opts = {});
 
   ///
   /// Deploys an issue model. Returns an error if a model is already deployed.
@@ -661,7 +692,8 @@ class ContactCenterInsightsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeployIssueModelRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L802}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeployIssueModelResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L813}
   ///
@@ -675,14 +707,15 @@ class ContactCenterInsightsClient {
   DeployIssueModel(
       google::cloud::contactcenterinsights::v1::DeployIssueModelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Undeploys an issue model.
   /// An issue model can not be used in analysis after it has been undeployed.
   ///
   /// @param name  Required. The issue model to undeploy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UndeployIssueModelResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L841}
   ///
@@ -693,7 +726,7 @@ class ContactCenterInsightsClient {
   ///
   future<StatusOr<
       google::cloud::contactcenterinsights::v1::UndeployIssueModelResponse>>
-  UndeployIssueModel(std::string const& name, Options options = {});
+  UndeployIssueModel(std::string const& name, Options opts = {});
 
   ///
   /// Undeploys an issue model.
@@ -701,7 +734,8 @@ class ContactCenterInsightsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UndeployIssueModelRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L830}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UndeployIssueModelResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L841}
   ///
@@ -715,13 +749,14 @@ class ContactCenterInsightsClient {
   UndeployIssueModel(
       google::cloud::contactcenterinsights::v1::UndeployIssueModelRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an issue.
   ///
   /// @param name  Required. The name of the issue to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Issue,google/cloud/contactcenterinsights/v1/resources.proto#L654}
   ///
@@ -731,14 +766,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L654}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Issue> GetIssue(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an issue.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetIssueRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L858}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Issue,google/cloud/contactcenterinsights/v1/resources.proto#L654}
   ///
@@ -749,13 +785,14 @@ class ContactCenterInsightsClient {
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Issue> GetIssue(
       google::cloud::contactcenterinsights::v1::GetIssueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists issues.
   ///
   /// @param parent  Required. The parent resource of the issue.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListIssuesResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L880}
   ///
@@ -765,14 +802,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L880}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::ListIssuesResponse>
-  ListIssues(std::string const& parent, Options options = {});
+  ListIssues(std::string const& parent, Options opts = {});
 
   ///
   /// Lists issues.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListIssuesRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L869}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListIssuesResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L880}
   ///
@@ -784,14 +822,15 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::ListIssuesResponse>
   ListIssues(google::cloud::contactcenterinsights::v1::ListIssuesRequest const&
                  request,
-             Options options = {});
+             Options opts = {});
 
   ///
   /// Updates an issue.
   ///
   /// @param issue  Required. The new values for the issue.
   /// @param update_mask  The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Issue,google/cloud/contactcenterinsights/v1/resources.proto#L654}
   ///
@@ -802,14 +841,15 @@ class ContactCenterInsightsClient {
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Issue> UpdateIssue(
       google::cloud::contactcenterinsights::v1::Issue const& issue,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an issue.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UpdateIssueRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L886}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Issue,google/cloud/contactcenterinsights/v1/resources.proto#L654}
   ///
@@ -821,14 +861,15 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::Issue> UpdateIssue(
       google::cloud::contactcenterinsights::v1::UpdateIssueRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an issue model's statistics.
   ///
   /// @param issue_model  Required. The resource name of the issue model to
   /// query against.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CalculateIssueModelStatsResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L906}
   ///
@@ -839,15 +880,15 @@ class ContactCenterInsightsClient {
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::
                CalculateIssueModelStatsResponse>
-  CalculateIssueModelStats(std::string const& issue_model,
-                           Options options = {});
+  CalculateIssueModelStats(std::string const& issue_model, Options opts = {});
 
   ///
   /// Gets an issue model's statistics.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CalculateIssueModelStatsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L895}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CalculateIssueModelStatsResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L906}
   ///
@@ -860,7 +901,7 @@ class ContactCenterInsightsClient {
                CalculateIssueModelStatsResponse>
   CalculateIssueModelStats(google::cloud::contactcenterinsights::v1::
                                CalculateIssueModelStatsRequest const& request,
-                           Options options = {});
+                           Options opts = {});
 
   ///
   /// Creates a phrase matcher.
@@ -871,7 +912,8 @@ class ContactCenterInsightsClient {
   ///  Format: `projects/<Project ID>/locations/<Location ID>` or
   ///  `projects/<Project Number>/locations/<Location ID>`
   /// @param phrase_matcher  Required. The phrase matcher resource to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -885,14 +927,15 @@ class ContactCenterInsightsClient {
       std::string const& parent,
       google::cloud::contactcenterinsights::v1::PhraseMatcher const&
           phrase_matcher,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a phrase matcher.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CreatePhraseMatcherRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L913}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -904,13 +947,14 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
   CreatePhraseMatcher(google::cloud::contactcenterinsights::v1::
                           CreatePhraseMatcherRequest const& request,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Gets a phrase matcher.
   ///
   /// @param name  Required. The name of the phrase matcher to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -920,14 +964,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
-  GetPhraseMatcher(std::string const& name, Options options = {});
+  GetPhraseMatcher(std::string const& name, Options opts = {});
 
   ///
   /// Gets a phrase matcher.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetPhraseMatcherRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L966}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -940,13 +985,14 @@ class ContactCenterInsightsClient {
   GetPhraseMatcher(
       google::cloud::contactcenterinsights::v1::GetPhraseMatcherRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists phrase matchers.
   ///
   /// @param parent  Required. The parent resource of the phrase matcher.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -956,14 +1002,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
   StreamRange<google::cloud::contactcenterinsights::v1::PhraseMatcher>
-  ListPhraseMatchers(std::string const& parent, Options options = {});
+  ListPhraseMatchers(std::string const& parent, Options opts = {});
 
   ///
   /// Lists phrase matchers.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListPhraseMatchersRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L930}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -976,39 +1023,42 @@ class ContactCenterInsightsClient {
   ListPhraseMatchers(
       google::cloud::contactcenterinsights::v1::ListPhraseMatchersRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a phrase matcher.
   ///
   /// @param name  Required. The name of the phrase matcher to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeletePhraseMatcherRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L977}
   ///
-  Status DeletePhraseMatcher(std::string const& name, Options options = {});
+  Status DeletePhraseMatcher(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a phrase matcher.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeletePhraseMatcherRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L977}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeletePhraseMatcherRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L977}
   ///
   Status DeletePhraseMatcher(google::cloud::contactcenterinsights::v1::
                                  DeletePhraseMatcherRequest const& request,
-                             Options options = {});
+                             Options opts = {});
 
   ///
   /// Updates a phrase matcher.
   ///
   /// @param phrase_matcher  Required. The new values for the phrase matcher.
   /// @param update_mask  The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -1021,14 +1071,15 @@ class ContactCenterInsightsClient {
   UpdatePhraseMatcher(
       google::cloud::contactcenterinsights::v1::PhraseMatcher const&
           phrase_matcher,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a phrase matcher.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UpdatePhraseMatcherRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L988}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::PhraseMatcher,google/cloud/contactcenterinsights/v1/resources.proto#L703}
   ///
@@ -1040,13 +1091,14 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::PhraseMatcher>
   UpdatePhraseMatcher(google::cloud::contactcenterinsights::v1::
                           UpdatePhraseMatcherRequest const& request,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Gets conversation statistics.
   ///
   /// @param location  Required. The location of the conversations.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CalculateStatsResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L389}
   ///
@@ -1056,14 +1108,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L389}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::CalculateStatsResponse>
-  CalculateStats(std::string const& location, Options options = {});
+  CalculateStats(std::string const& location, Options opts = {});
 
   ///
   /// Gets conversation statistics.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CalculateStatsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L374}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CalculateStatsResponse,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L389}
   ///
@@ -1076,13 +1129,14 @@ class ContactCenterInsightsClient {
   CalculateStats(
       google::cloud::contactcenterinsights::v1::CalculateStatsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets project-level settings.
   ///
   /// @param name  Required. The name of the settings resource to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Settings,google/cloud/contactcenterinsights/v1/resources.proto#L820}
   ///
@@ -1092,14 +1146,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L820}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Settings> GetSettings(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets project-level settings.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetSettingsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L997}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Settings,google/cloud/contactcenterinsights/v1/resources.proto#L820}
   ///
@@ -1111,14 +1166,15 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::Settings> GetSettings(
       google::cloud::contactcenterinsights::v1::GetSettingsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates project-level settings.
   ///
   /// @param settings  Required. The new settings values.
   /// @param update_mask  Required. The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Settings,google/cloud/contactcenterinsights/v1/resources.proto#L820}
   ///
@@ -1129,14 +1185,15 @@ class ContactCenterInsightsClient {
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::Settings> UpdateSettings(
       google::cloud::contactcenterinsights::v1::Settings const& settings,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates project-level settings.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UpdateSettingsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1008}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::Settings,google/cloud/contactcenterinsights/v1/resources.proto#L820}
   ///
@@ -1148,7 +1205,7 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::Settings> UpdateSettings(
       google::cloud::contactcenterinsights::v1::UpdateSettingsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a view.
@@ -1159,7 +1216,8 @@ class ContactCenterInsightsClient {
   ///  Format: `projects/<Project ID>/locations/<Location ID>` or
   ///  `projects/<Project Number>/locations/<Location ID>`
   /// @param view  Required. The view resource to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1171,14 +1229,15 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::View> CreateView(
       std::string const& parent,
       google::cloud::contactcenterinsights::v1::View const& view,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a view.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::CreateViewRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1017}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1190,13 +1249,14 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::View> CreateView(
       google::cloud::contactcenterinsights::v1::CreateViewRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a view.
   ///
   /// @param name  Required. The name of the view to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1206,14 +1266,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::View> GetView(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a view.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::GetViewRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1034}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1224,13 +1285,14 @@ class ContactCenterInsightsClient {
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::View> GetView(
       google::cloud::contactcenterinsights::v1::GetViewRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists views.
   ///
   /// @param parent  Required. The parent resource of the views.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1240,14 +1302,15 @@ class ContactCenterInsightsClient {
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
   StreamRange<google::cloud::contactcenterinsights::v1::View> ListViews(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists views.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::ListViewsRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1045}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1258,14 +1321,15 @@ class ContactCenterInsightsClient {
   ///
   StreamRange<google::cloud::contactcenterinsights::v1::View> ListViews(
       google::cloud::contactcenterinsights::v1::ListViewsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a view.
   ///
   /// @param view  Required. The new view.
   /// @param update_mask  The list of fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1276,14 +1340,15 @@ class ContactCenterInsightsClient {
   ///
   StatusOr<google::cloud::contactcenterinsights::v1::View> UpdateView(
       google::cloud::contactcenterinsights::v1::View const& view,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a view.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::UpdateViewRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1077}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::View,google/cloud/contactcenterinsights/v1/resources.proto#L1094}
   ///
@@ -1295,25 +1360,27 @@ class ContactCenterInsightsClient {
   StatusOr<google::cloud::contactcenterinsights::v1::View> UpdateView(
       google::cloud::contactcenterinsights::v1::UpdateViewRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a view.
   ///
   /// @param name  Required. The name of the view to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeleteViewRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1086}
   ///
-  Status DeleteView(std::string const& name, Options options = {});
+  Status DeleteView(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a view.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::contactcenterinsights::v1::DeleteViewRequest,google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1086}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.contactcenterinsights.v1.DeleteViewRequest]:
   /// @googleapis_reference_link{google/cloud/contactcenterinsights/v1/contact_center_insights.proto#L1086}
@@ -1321,7 +1388,7 @@ class ContactCenterInsightsClient {
   Status DeleteView(
       google::cloud::contactcenterinsights::v1::DeleteViewRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ContactCenterInsightsConnection> connection_;

--- a/google/cloud/container/cluster_manager_client.cc
+++ b/google/cloud/container/cluster_manager_client.cc
@@ -26,17 +26,16 @@ namespace container {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ClusterManagerClient::ClusterManagerClient(
-    std::shared_ptr<ClusterManagerConnection> connection, Options options)
+    std::shared_ptr<ClusterManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), container_internal::ClusterManagerDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), container_internal::ClusterManagerDefaultOptions(
+                               connection_->options()))) {}
 ClusterManagerClient::~ClusterManagerClient() = default;
 
 StatusOr<google::container::v1::ListClustersResponse>
-ClusterManagerClient::ListClusters(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ClusterManagerClient::ListClusters(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::ListClustersRequest request;
   request.set_parent(parent);
   return connection_->ListClusters(request);
@@ -44,34 +43,29 @@ ClusterManagerClient::ListClusters(std::string const& parent, Options options) {
 
 StatusOr<google::container::v1::ListClustersResponse>
 ClusterManagerClient::ListClusters(
-    google::container::v1::ListClustersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::ListClustersRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListClusters(request);
 }
 
 StatusOr<google::container::v1::Cluster> ClusterManagerClient::GetCluster(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::GetClusterRequest request;
   request.set_name(name);
   return connection_->GetCluster(request);
 }
 
 StatusOr<google::container::v1::Cluster> ClusterManagerClient::GetCluster(
-    google::container::v1::GetClusterRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::GetClusterRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCluster(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::CreateCluster(
     std::string const& parent, google::container::v1::Cluster const& cluster,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::CreateClusterRequest request;
   request.set_parent(parent);
   *request.mutable_cluster() = cluster;
@@ -79,18 +73,15 @@ StatusOr<google::container::v1::Operation> ClusterManagerClient::CreateCluster(
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::CreateCluster(
-    google::container::v1::CreateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::CreateClusterRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCluster(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateCluster(
     std::string const& name, google::container::v1::ClusterUpdate const& update,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::UpdateClusterRequest request;
   request.set_name(name);
   *request.mutable_update() = update;
@@ -98,36 +89,30 @@ StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateCluster(
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateCluster(
-    google::container::v1::UpdateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::UpdateClusterRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCluster(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateNodePool(
-    google::container::v1::UpdateNodePoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::UpdateNodePoolRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateNodePool(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetNodePoolAutoscaling(
     google::container::v1::SetNodePoolAutoscalingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetNodePoolAutoscaling(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetLoggingService(std::string const& name,
                                         std::string const& logging_service,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetLoggingServiceRequest request;
   request.set_name(name);
   request.set_logging_service(logging_service);
@@ -137,18 +122,16 @@ ClusterManagerClient::SetLoggingService(std::string const& name,
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetLoggingService(
     google::container::v1::SetLoggingServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetLoggingService(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetMonitoringService(
     std::string const& name, std::string const& monitoring_service,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetMonitoringServiceRequest request;
   request.set_name(name);
   request.set_monitoring_service(monitoring_service);
@@ -158,18 +141,16 @@ ClusterManagerClient::SetMonitoringService(
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetMonitoringService(
     google::container::v1::SetMonitoringServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetMonitoringService(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetAddonsConfig(
     std::string const& name,
-    google::container::v1::AddonsConfig const& addons_config, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::AddonsConfig const& addons_config, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetAddonsConfigRequest request;
   request.set_name(name);
   *request.mutable_addons_config() = addons_config;
@@ -179,17 +160,15 @@ ClusterManagerClient::SetAddonsConfig(
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetAddonsConfig(
     google::container::v1::SetAddonsConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetAddonsConfig(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLocations(
     std::string const& name, std::vector<std::string> const& locations,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetLocationsRequest request;
   request.set_name(name);
   *request.mutable_locations() = {locations.begin(), locations.end()};
@@ -197,18 +176,14 @@ StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLocations(
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLocations(
-    google::container::v1::SetLocationsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::SetLocationsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetLocations(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateMaster(
-    std::string const& name, std::string const& master_version,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, std::string const& master_version, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::UpdateMasterRequest request;
   request.set_name(name);
   request.set_master_version(master_version);
@@ -216,68 +191,55 @@ StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateMaster(
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::UpdateMaster(
-    google::container::v1::UpdateMasterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::UpdateMasterRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMaster(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::SetMasterAuth(
-    google::container::v1::SetMasterAuthRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::SetMasterAuthRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetMasterAuth(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::DeleteCluster(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::DeleteClusterRequest request;
   request.set_name(name);
   return connection_->DeleteCluster(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::DeleteCluster(
-    google::container::v1::DeleteClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::DeleteClusterRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCluster(request);
 }
 
 StatusOr<google::container::v1::ListOperationsResponse>
 ClusterManagerClient::ListOperations(
-    google::container::v1::ListOperationsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::ListOperationsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListOperations(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::GetOperation(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::GetOperationRequest request;
   request.set_name(name);
   return connection_->GetOperation(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::GetOperation(
-    google::container::v1::GetOperationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::GetOperationRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetOperation(request);
 }
 
 Status ClusterManagerClient::CancelOperation(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::CancelOperationRequest request;
   request.set_name(name);
   return connection_->CancelOperation(request);
@@ -285,17 +247,14 @@ Status ClusterManagerClient::CancelOperation(std::string const& name,
 
 Status ClusterManagerClient::CancelOperation(
     google::container::v1::CancelOperationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelOperation(request);
 }
 
 StatusOr<google::container::v1::ServerConfig>
-ClusterManagerClient::GetServerConfig(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ClusterManagerClient::GetServerConfig(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::GetServerConfigRequest request;
   request.set_name(name);
   return connection_->GetServerConfig(request);
@@ -304,26 +263,21 @@ ClusterManagerClient::GetServerConfig(std::string const& name,
 StatusOr<google::container::v1::ServerConfig>
 ClusterManagerClient::GetServerConfig(
     google::container::v1::GetServerConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServerConfig(request);
 }
 
 StatusOr<google::container::v1::GetJSONWebKeysResponse>
 ClusterManagerClient::GetJSONWebKeys(
-    google::container::v1::GetJSONWebKeysRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::GetJSONWebKeysRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetJSONWebKeys(request);
 }
 
 StatusOr<google::container::v1::ListNodePoolsResponse>
-ClusterManagerClient::ListNodePools(std::string const& parent,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ClusterManagerClient::ListNodePools(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::ListNodePoolsRequest request;
   request.set_parent(parent);
   return connection_->ListNodePools(request);
@@ -331,34 +285,29 @@ ClusterManagerClient::ListNodePools(std::string const& parent,
 
 StatusOr<google::container::v1::ListNodePoolsResponse>
 ClusterManagerClient::ListNodePools(
-    google::container::v1::ListNodePoolsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::ListNodePoolsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNodePools(request);
 }
 
 StatusOr<google::container::v1::NodePool> ClusterManagerClient::GetNodePool(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::GetNodePoolRequest request;
   request.set_name(name);
   return connection_->GetNodePool(request);
 }
 
 StatusOr<google::container::v1::NodePool> ClusterManagerClient::GetNodePool(
-    google::container::v1::GetNodePoolRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::GetNodePoolRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNodePool(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::CreateNodePool(
     std::string const& parent, google::container::v1::NodePool const& node_pool,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::CreateNodePoolRequest request;
   request.set_parent(parent);
   *request.mutable_node_pool() = node_pool;
@@ -366,35 +315,29 @@ StatusOr<google::container::v1::Operation> ClusterManagerClient::CreateNodePool(
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::CreateNodePool(
-    google::container::v1::CreateNodePoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::CreateNodePoolRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateNodePool(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::DeleteNodePool(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::DeleteNodePoolRequest request;
   request.set_name(name);
   return connection_->DeleteNodePool(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::DeleteNodePool(
-    google::container::v1::DeleteNodePoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::DeleteNodePoolRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteNodePool(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::RollbackNodePoolUpgrade(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::RollbackNodePoolUpgradeRequest request;
   request.set_name(name);
   return connection_->RollbackNodePoolUpgrade(request);
@@ -403,32 +346,28 @@ ClusterManagerClient::RollbackNodePoolUpgrade(std::string const& name,
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::RollbackNodePoolUpgrade(
     google::container::v1::RollbackNodePoolUpgradeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RollbackNodePoolUpgrade(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetNodePoolManagement(
     google::container::v1::SetNodePoolManagementRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetNodePoolManagement(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLabels(
-    google::container::v1::SetLabelsRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::SetLabelsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetLabels(request);
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLegacyAbac(
-    std::string const& name, bool enabled, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, bool enabled, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetLegacyAbacRequest request;
   request.set_name(name);
   request.set_enabled(enabled);
@@ -436,18 +375,14 @@ StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLegacyAbac(
 }
 
 StatusOr<google::container::v1::Operation> ClusterManagerClient::SetLegacyAbac(
-    google::container::v1::SetLegacyAbacRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::SetLegacyAbacRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetLegacyAbac(request);
 }
 
 StatusOr<google::container::v1::Operation>
-ClusterManagerClient::StartIPRotation(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ClusterManagerClient::StartIPRotation(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::StartIPRotationRequest request;
   request.set_name(name);
   return connection_->StartIPRotation(request);
@@ -456,17 +391,15 @@ ClusterManagerClient::StartIPRotation(std::string const& name,
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::StartIPRotation(
     google::container::v1::StartIPRotationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartIPRotation(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::CompleteIPRotation(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::CompleteIPRotationRequest request;
   request.set_name(name);
   return connection_->CompleteIPRotation(request);
@@ -475,28 +408,24 @@ ClusterManagerClient::CompleteIPRotation(std::string const& name,
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::CompleteIPRotation(
     google::container::v1::CompleteIPRotationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CompleteIPRotation(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetNodePoolSize(
     google::container::v1::SetNodePoolSizeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetNodePoolSize(request);
 }
 
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetNetworkPolicy(
     std::string const& name,
-    google::container::v1::NetworkPolicy const& network_policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::NetworkPolicy const& network_policy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetNetworkPolicyRequest request;
   request.set_name(name);
   *request.mutable_network_policy() = network_policy;
@@ -506,9 +435,8 @@ ClusterManagerClient::SetNetworkPolicy(
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetNetworkPolicy(
     google::container::v1::SetNetworkPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetNetworkPolicy(request);
 }
 
@@ -517,9 +445,8 @@ ClusterManagerClient::SetMaintenancePolicy(
     std::string const& project_id, std::string const& zone,
     std::string const& cluster_id,
     google::container::v1::MaintenancePolicy const& maintenance_policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetMaintenancePolicyRequest request;
   request.set_project_id(project_id);
   request.set_zone(zone);
@@ -532,9 +459,8 @@ StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetMaintenancePolicy(
     std::string const& name,
     google::container::v1::MaintenancePolicy const& maintenance_policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::container::v1::SetMaintenancePolicyRequest request;
   request.set_name(name);
   *request.mutable_maintenance_policy() = maintenance_policy;
@@ -544,18 +470,15 @@ ClusterManagerClient::SetMaintenancePolicy(
 StatusOr<google::container::v1::Operation>
 ClusterManagerClient::SetMaintenancePolicy(
     google::container::v1::SetMaintenancePolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetMaintenancePolicy(request);
 }
 
 StreamRange<google::container::v1::UsableSubnetwork>
 ClusterManagerClient::ListUsableSubnetworks(
-    google::container::v1::ListUsableSubnetworksRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::container::v1::ListUsableSubnetworksRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListUsableSubnetworks(std::move(request));
 }
 

--- a/google/cloud/container/cluster_manager_client.h
+++ b/google/cloud/container/cluster_manager_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ClusterManagerClient {
  public:
   explicit ClusterManagerClient(
-      std::shared_ptr<ClusterManagerConnection> connection,
-      Options options = {});
+      std::shared_ptr<ClusterManagerConnection> connection, Options opts = {});
   ~ClusterManagerClient();
 
   //@{
@@ -94,7 +93,8 @@ class ClusterManagerClient {
   /// be listed.
   ///  Specified in the format `projects/*/locations/*`.
   ///  Location "-" matches all zones and all regions.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ListClustersResponse,google/container/v1/cluster_service.proto#L2350}
   ///
@@ -104,7 +104,7 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L2350}
   ///
   StatusOr<google::container::v1::ListClustersResponse> ListClusters(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all clusters owned by a project in either the specified zone or all
@@ -112,7 +112,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::ListClustersRequest,google/container/v1/cluster_service.proto#L2331}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ListClustersResponse,google/container/v1/cluster_service.proto#L2350}
   ///
@@ -123,7 +124,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::ListClustersResponse> ListClusters(
       google::container::v1::ListClustersRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the details of a specific cluster.
@@ -131,7 +132,8 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, cluster) of the cluster to
   /// retrieve.
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Cluster,google/container/v1/cluster_service.proto#L1261}
   ///
@@ -141,14 +143,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1261}
   ///
   StatusOr<google::container::v1::Cluster> GetCluster(std::string const& name,
-                                                      Options options = {});
+                                                      Options opts = {});
 
   ///
   /// Gets the details of a specific cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::GetClusterRequest,google/container/v1/cluster_service.proto#L1957}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Cluster,google/container/v1/cluster_service.proto#L1261}
   ///
@@ -159,7 +162,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Cluster> GetCluster(
       google::container::v1::GetClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a cluster, consisting of the specified number and type of Google
@@ -182,7 +185,8 @@ class ClusterManagerClient {
   ///  Specified in the format `projects/*/locations/*`.
   /// @param cluster  Required. A [cluster
   ///  resource](https://cloud.google.com/container-engine/reference/rest/v1/projects.locations.clusters)
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -193,7 +197,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> CreateCluster(
       std::string const& parent, google::container::v1::Cluster const& cluster,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a cluster, consisting of the specified number and type of Google
@@ -213,7 +217,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::CreateClusterRequest,google/container/v1/cluster_service.proto#L1935}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -224,7 +229,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> CreateCluster(
       google::container::v1::CreateClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the settings of a specific cluster.
@@ -233,7 +238,8 @@ class ClusterManagerClient {
   /// update.
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
   /// @param update  Required. A description of the update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -244,14 +250,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> UpdateCluster(
       std::string const& name,
-      google::container::v1::ClusterUpdate const& update, Options options = {});
+      google::container::v1::ClusterUpdate const& update, Options opts = {});
 
   ///
   /// Updates the settings of a specific cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::UpdateClusterRequest,google/container/v1/cluster_service.proto#L1979}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -262,14 +269,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> UpdateCluster(
       google::container::v1::UpdateClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the version and/or image type for the specified node pool.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::UpdateNodePoolRequest,google/container/v1/cluster_service.proto#L2004}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -280,14 +288,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> UpdateNodePool(
       google::container::v1::UpdateNodePoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the autoscaling settings for the specified node pool.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetNodePoolAutoscalingRequest,google/container/v1/cluster_service.proto#L2072}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -298,7 +307,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetNodePoolAutoscaling(
       google::container::v1::SetNodePoolAutoscalingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the logging service for a specific cluster.
@@ -316,7 +325,8 @@ class ClusterManagerClient {
   ///  * `none` - no logs will be exported from the cluster.
   ///  If left as an empty string,`logging.googleapis.com/kubernetes` will be
   ///  used for GKE 1.14+ or `logging.googleapis.com` for earlier versions.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -327,14 +337,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetLoggingService(
       std::string const& name, std::string const& logging_service,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the logging service for a specific cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetLoggingServiceRequest,google/container/v1/cluster_service.proto#L2102}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -345,7 +356,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetLoggingService(
       google::container::v1::SetLoggingServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the monitoring service for a specific cluster.
@@ -363,7 +374,8 @@ class ClusterManagerClient {
   ///  * `none` - No metrics will be exported from the cluster.
   ///  If left as an empty string,`monitoring.googleapis.com/kubernetes` will be
   ///  used for GKE 1.14+ or `monitoring.googleapis.com` for earlier versions.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -374,14 +386,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetMonitoringService(
       std::string const& name, std::string const& monitoring_service,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the monitoring service for a specific cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetMonitoringServiceRequest,google/container/v1/cluster_service.proto#L2137}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -392,7 +405,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetMonitoringService(
       google::container::v1::SetMonitoringServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the addons for a specific cluster.
@@ -403,7 +416,8 @@ class ClusterManagerClient {
   /// @param addons_config  Required. The desired configurations for the various
   /// addons available to run in the
   ///  cluster.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -415,14 +429,15 @@ class ClusterManagerClient {
   StatusOr<google::container::v1::Operation> SetAddonsConfig(
       std::string const& name,
       google::container::v1::AddonsConfig const& addons_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the addons for a specific cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetAddonsConfigRequest,google/container/v1/cluster_service.proto#L2172}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -433,7 +448,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetAddonsConfig(
       google::container::v1::SetAddonsConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the locations for a specific cluster.
@@ -450,7 +465,8 @@ class ClusterManagerClient {
   ///  is in will result in nodes being either created or removed from the
   ///  cluster, depending on whether locations are being added or removed. This
   ///  list must always include the cluster's primary zone.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -461,7 +477,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetLocations(
       std::string const& name, std::vector<std::string> const& locations,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the locations for a specific cluster.
@@ -471,7 +487,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetLocationsRequest,google/container/v1/cluster_service.proto#L2198}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -482,7 +499,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetLocations(
       google::container::v1::SetLocationsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the master for a specific cluster.
@@ -499,7 +516,8 @@ class ClusterManagerClient {
   ///  - "1.X.Y": picks the highest valid gke.N patch in the 1.X.Y version
   ///  - "1.X.Y-gke.N": picks an explicit Kubernetes version
   ///  - "-": picks the default Kubernetes version
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -510,14 +528,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> UpdateMaster(
       std::string const& name, std::string const& master_version,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the master for a specific cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::UpdateMasterRequest,google/container/v1/cluster_service.proto#L2229}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -528,7 +547,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> UpdateMaster(
       google::container::v1::UpdateMasterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets master auth materials. Currently supports changing the admin password
@@ -537,7 +556,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetMasterAuthRequest,google/container/v1/cluster_service.proto#L2263}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -548,7 +568,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetMasterAuth(
       google::container::v1::SetMasterAuthRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the cluster, including the Kubernetes endpoint and all worker
@@ -564,7 +584,8 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, cluster) of the cluster to
   /// delete.
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -574,7 +595,7 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> DeleteCluster(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes the cluster, including the Kubernetes endpoint and all worker
@@ -589,7 +610,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::DeleteClusterRequest,google/container/v1/cluster_service.proto#L2309}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -600,14 +622,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> DeleteCluster(
       google::container::v1::DeleteClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all operations in a project in a specific zone or all zones.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::ListOperationsRequest,google/container/v1/cluster_service.proto#L2383}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ListOperationsResponse,google/container/v1/cluster_service.proto#L2424}
   ///
@@ -618,7 +641,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::ListOperationsResponse> ListOperations(
       google::container::v1::ListOperationsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the specified operation.
@@ -626,7 +649,8 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, operation id) of the operation
   /// to get.
   ///  Specified in the format `projects/*/locations/*/operations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -636,14 +660,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> GetOperation(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the specified operation.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::GetOperationRequest,google/container/v1/cluster_service.proto#L2361}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -654,7 +679,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> GetOperation(
       google::container::v1::GetOperationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Cancels the specified operation.
@@ -662,33 +687,36 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, operation id) of the operation
   /// to cancel.
   ///  Specified in the format `projects/*/locations/*/operations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.container.v1.CancelOperationRequest]:
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L2402}
   ///
-  Status CancelOperation(std::string const& name, Options options = {});
+  Status CancelOperation(std::string const& name, Options opts = {});
 
   ///
   /// Cancels the specified operation.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::CancelOperationRequest,google/container/v1/cluster_service.proto#L2402}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.container.v1.CancelOperationRequest]:
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L2402}
   ///
   Status CancelOperation(
       google::container::v1::CancelOperationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns configuration info about the Google Kubernetes Engine service.
   ///
   /// @param name  The name (project and location) of the server config to get,
   ///  specified in the format `projects/*/locations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ServerConfig,google/container/v1/cluster_service.proto#L2452}
   ///
@@ -698,14 +726,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L2452}
   ///
   StatusOr<google::container::v1::ServerConfig> GetServerConfig(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns configuration info about the Google Kubernetes Engine service.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::GetServerConfigRequest,google/container/v1/cluster_service.proto#L2434}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ServerConfig,google/container/v1/cluster_service.proto#L2452}
   ///
@@ -716,7 +745,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::ServerConfig> GetServerConfig(
       google::container::v1::GetServerConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the public component of the cluster signing keys in
@@ -726,7 +755,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::GetJSONWebKeysRequest,google/container/v1/cluster_service.proto#L3424}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::GetJSONWebKeysResponse,google/container/v1/cluster_service.proto#L3461}
   ///
@@ -737,7 +767,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::GetJSONWebKeysResponse> GetJSONWebKeys(
       google::container::v1::GetJSONWebKeysRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the node pools for a cluster.
@@ -745,7 +775,8 @@ class ClusterManagerClient {
   /// @param parent  The parent (project, location, cluster id) where the node
   /// pools will be
   ///  listed. Specified in the format `projects/*/locations/*/clusters/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ListNodePoolsResponse,google/container/v1/cluster_service.proto#L2972}
   ///
@@ -755,14 +786,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L2972}
   ///
   StatusOr<google::container::v1::ListNodePoolsResponse> ListNodePools(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists the node pools for a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::ListNodePoolsRequest,google/container/v1/cluster_service.proto#L2538}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::ListNodePoolsResponse,google/container/v1/cluster_service.proto#L2972}
   ///
@@ -773,7 +805,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::ListNodePoolsResponse> ListNodePools(
       google::container::v1::ListNodePoolsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves the requested node pool.
@@ -782,7 +814,8 @@ class ClusterManagerClient {
   /// node pool to
   ///  get. Specified in the format
   ///  `projects/*/locations/*/clusters/*/nodePools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::NodePool,google/container/v1/cluster_service.proto#L2592}
   ///
@@ -792,14 +825,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L2592}
   ///
   StatusOr<google::container::v1::NodePool> GetNodePool(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Retrieves the requested node pool.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::GetNodePoolRequest,google/container/v1/cluster_service.proto#L2560}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::NodePool,google/container/v1/cluster_service.proto#L2592}
   ///
@@ -810,7 +844,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::NodePool> GetNodePool(
       google::container::v1::GetNodePoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a node pool for a cluster.
@@ -820,7 +854,8 @@ class ClusterManagerClient {
   ///  created. Specified in the format
   ///  `projects/*/locations/*/clusters/*`.
   /// @param node_pool  Required. The node pool to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -831,14 +866,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> CreateNodePool(
       std::string const& parent,
-      google::container::v1::NodePool const& node_pool, Options options = {});
+      google::container::v1::NodePool const& node_pool, Options opts = {});
 
   ///
   /// Creates a node pool for a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::CreateNodePoolRequest,google/container/v1/cluster_service.proto#L2485}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -849,7 +885,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> CreateNodePool(
       google::container::v1::CreateNodePoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a node pool from a cluster.
@@ -858,7 +894,8 @@ class ClusterManagerClient {
   /// node pool to
   ///  delete. Specified in the format
   ///  `projects/*/locations/*/clusters/*/nodePools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -868,14 +905,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> DeleteNodePool(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a node pool from a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::DeleteNodePoolRequest,google/container/v1/cluster_service.proto#L2511}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -886,7 +924,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> DeleteNodePool(
       google::container::v1::DeleteNodePoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Rolls back a previously Aborted or Failed NodePool upgrade.
@@ -896,7 +934,8 @@ class ClusterManagerClient {
   /// node poll to
   ///  rollback upgrade.
   ///  Specified in the format `projects/*/locations/*/clusters/*/nodePools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -906,7 +945,7 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> RollbackNodePoolUpgrade(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Rolls back a previously Aborted or Failed NodePool upgrade.
@@ -914,7 +953,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::RollbackNodePoolUpgradeRequest,google/container/v1/cluster_service.proto#L2945}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -925,14 +965,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> RollbackNodePoolUpgrade(
       google::container::v1::RollbackNodePoolUpgradeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the NodeManagement options for a node pool.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetNodePoolManagementRequest,google/container/v1/cluster_service.proto#L2883}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -943,14 +984,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetNodePoolManagement(
       google::container::v1::SetNodePoolManagementRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets labels on a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetLabelsRequest,google/container/v1/cluster_service.proto#L3101}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -961,7 +1003,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetLabels(
       google::container::v1::SetLabelsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables or disables the ABAC authorization mechanism on a cluster.
@@ -971,7 +1013,8 @@ class ClusterManagerClient {
   ///  Specified in the format `projects/*/locations/*/clusters/*`.
   /// @param enabled  Required. Whether ABAC authorization will be enabled in
   /// the cluster.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -981,14 +1024,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> SetLegacyAbac(
-      std::string const& name, bool enabled, Options options = {});
+      std::string const& name, bool enabled, Options opts = {});
 
   ///
   /// Enables or disables the ABAC authorization mechanism on a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetLegacyAbacRequest,google/container/v1/cluster_service.proto#L3135}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -999,7 +1043,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetLegacyAbac(
       google::container::v1::SetLegacyAbacRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts master IP rotation.
@@ -1007,7 +1051,8 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, cluster id) of the cluster to
   /// start IP
   ///  rotation. Specified in the format `projects/*/locations/*/clusters/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1017,14 +1062,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> StartIPRotation(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Starts master IP rotation.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::StartIPRotationRequest,google/container/v1/cluster_service.proto#L3161}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1035,7 +1081,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> StartIPRotation(
       google::container::v1::StartIPRotationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Completes master IP rotation.
@@ -1043,7 +1089,8 @@ class ClusterManagerClient {
   /// @param name  The name (project, location, cluster id) of the cluster to
   /// complete IP
   ///  rotation. Specified in the format `projects/*/locations/*/clusters/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1053,14 +1100,15 @@ class ClusterManagerClient {
   /// @googleapis_reference_link{google/container/v1/cluster_service.proto#L1761}
   ///
   StatusOr<google::container::v1::Operation> CompleteIPRotation(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Completes master IP rotation.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::CompleteIPRotationRequest,google/container/v1/cluster_service.proto#L3186}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1071,7 +1119,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> CompleteIPRotation(
       google::container::v1::CompleteIPRotationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the size for a specific node pool. The new size will be used for all
@@ -1080,7 +1128,8 @@ class ClusterManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetNodePoolSizeRequest,google/container/v1/cluster_service.proto#L2913}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1091,7 +1140,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetNodePoolSize(
       google::container::v1::SetNodePoolSizeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables or disables Network Policy for a cluster.
@@ -1101,7 +1150,8 @@ class ClusterManagerClient {
   ///  policy. Specified in the format `projects/*/locations/*/clusters/*`.
   /// @param network_policy  Required. Configuration options for the
   /// NetworkPolicy feature.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1113,14 +1163,15 @@ class ClusterManagerClient {
   StatusOr<google::container::v1::Operation> SetNetworkPolicy(
       std::string const& name,
       google::container::v1::NetworkPolicy const& network_policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables or disables Network Policy for a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetNetworkPolicyRequest,google/container/v1/cluster_service.proto#L3248}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1131,7 +1182,7 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetNetworkPolicy(
       google::container::v1::SetNetworkPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the maintenance policy for a cluster.
@@ -1146,7 +1197,8 @@ class ClusterManagerClient {
   /// @param maintenance_policy  Required. The maintenance policy to be set for
   /// the cluster. An empty field
   ///  clears the existing maintenance policy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1159,7 +1211,7 @@ class ClusterManagerClient {
       std::string const& project_id, std::string const& zone,
       std::string const& cluster_id,
       google::container::v1::MaintenancePolicy const& maintenance_policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the maintenance policy for a cluster.
@@ -1171,7 +1223,8 @@ class ClusterManagerClient {
   /// @param maintenance_policy  Required. The maintenance policy to be set for
   /// the cluster. An empty field
   ///  clears the existing maintenance policy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1183,14 +1236,15 @@ class ClusterManagerClient {
   StatusOr<google::container::v1::Operation> SetMaintenancePolicy(
       std::string const& name,
       google::container::v1::MaintenancePolicy const& maintenance_policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the maintenance policy for a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::SetMaintenancePolicyRequest,google/container/v1/cluster_service.proto#L3273}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::Operation,google/container/v1/cluster_service.proto#L1761}
   ///
@@ -1201,14 +1255,15 @@ class ClusterManagerClient {
   ///
   StatusOr<google::container::v1::Operation> SetMaintenancePolicy(
       google::container::v1::SetMaintenancePolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists subnetworks that are usable for creating clusters in a project.
   ///
   /// @param request
   /// @googleapis_link{google::container::v1::ListUsableSubnetworksRequest,google/container/v1/cluster_service.proto#L3600}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::container::v1::UsableSubnetwork,google/container/v1/cluster_service.proto#L3672}
   ///
@@ -1219,7 +1274,7 @@ class ClusterManagerClient {
   ///
   StreamRange<google::container::v1::UsableSubnetwork> ListUsableSubnetworks(
       google::container::v1::ListUsableSubnetworksRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ClusterManagerConnection> connection_;

--- a/google/cloud/containeranalysis/container_analysis_client.cc
+++ b/google/cloud/containeranalysis/container_analysis_client.cc
@@ -28,19 +28,18 @@ namespace containeranalysis {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ContainerAnalysisClient::ContainerAnalysisClient(
-    std::shared_ptr<ContainerAnalysisConnection> connection, Options options)
+    std::shared_ptr<ContainerAnalysisConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           containeranalysis_internal::ContainerAnalysisDefaultOptions(
               connection_->options()))) {}
 ContainerAnalysisClient::~ContainerAnalysisClient() = default;
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -48,11 +47,10 @@ StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
+    std::string const& resource, IamUpdater const& updater, Options opts) {
   internal::CheckExpectedOptions<ContainerAnalysisBackoffPolicyOption>(
-      options, __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+      opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -79,34 +77,30 @@ StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 ContainerAnalysisClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -115,19 +109,16 @@ ContainerAnalysisClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 ContainerAnalysisClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StatusOr<
     google::devtools::containeranalysis::v1::VulnerabilityOccurrencesSummary>
 ContainerAnalysisClient::GetVulnerabilityOccurrencesSummary(
-    std::string const& parent, std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::containeranalysis::v1::
       GetVulnerabilityOccurrencesSummaryRequest request;
   request.set_parent(parent);
@@ -140,9 +131,8 @@ StatusOr<
 ContainerAnalysisClient::GetVulnerabilityOccurrencesSummary(
     google::devtools::containeranalysis::v1::
         GetVulnerabilityOccurrencesSummaryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetVulnerabilityOccurrencesSummary(request);
 }
 

--- a/google/cloud/containeranalysis/container_analysis_client.h
+++ b/google/cloud/containeranalysis/container_analysis_client.h
@@ -146,8 +146,8 @@ class ContainerAnalysisClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/containeranalysis/container_analysis_client.h
+++ b/google/cloud/containeranalysis/container_analysis_client.h
@@ -75,7 +75,7 @@ class ContainerAnalysisClient {
  public:
   explicit ContainerAnalysisClient(
       std::shared_ptr<ContainerAnalysisConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ContainerAnalysisClient();
 
   //@{
@@ -116,7 +116,8 @@ class ContainerAnalysisClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -127,7 +128,7 @@ class ContainerAnalysisClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -145,14 +146,13 @@ class ContainerAnalysisClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `ContainerAnalysisBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on the specified note or occurrence.
@@ -166,7 +166,8 @@ class ContainerAnalysisClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -176,8 +177,7 @@ class ContainerAnalysisClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for a note or an occurrence resource.
@@ -192,7 +192,8 @@ class ContainerAnalysisClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -202,7 +203,7 @@ class ContainerAnalysisClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a note or an occurrence resource.
@@ -216,7 +217,8 @@ class ContainerAnalysisClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -226,8 +228,7 @@ class ContainerAnalysisClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns the permissions that a caller has on the specified note or
@@ -246,7 +247,8 @@ class ContainerAnalysisClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -257,7 +259,7 @@ class ContainerAnalysisClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the permissions that a caller has on the specified note or
@@ -270,7 +272,8 @@ class ContainerAnalysisClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -281,7 +284,7 @@ class ContainerAnalysisClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a summary of the number and severity of occurrences.
@@ -290,7 +293,8 @@ class ContainerAnalysisClient {
   /// summary for in the form of
   ///  `projects/[PROJECT_ID]`.
   /// @param filter  The filter expression.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::containeranalysis::v1::VulnerabilityOccurrencesSummary,google/devtools/containeranalysis/v1/containeranalysis.proto#L140}
   ///
@@ -303,14 +307,15 @@ class ContainerAnalysisClient {
       google::devtools::containeranalysis::v1::VulnerabilityOccurrencesSummary>
   GetVulnerabilityOccurrencesSummary(std::string const& parent,
                                      std::string const& filter,
-                                     Options options = {});
+                                     Options opts = {});
 
   ///
   /// Gets a summary of the number and severity of occurrences.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::containeranalysis::v1::GetVulnerabilityOccurrencesSummaryRequest,google/devtools/containeranalysis/v1/containeranalysis.proto#L124}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::containeranalysis::v1::VulnerabilityOccurrencesSummary,google/devtools/containeranalysis/v1/containeranalysis.proto#L140}
   ///
@@ -324,7 +329,7 @@ class ContainerAnalysisClient {
   GetVulnerabilityOccurrencesSummary(
       google::devtools::containeranalysis::v1::
           GetVulnerabilityOccurrencesSummaryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ContainerAnalysisConnection> connection_;

--- a/google/cloud/containeranalysis/grafeas_client.cc
+++ b/google/cloud/containeranalysis/grafeas_client.cc
@@ -26,33 +26,30 @@ namespace containeranalysis {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GrafeasClient::GrafeasClient(std::shared_ptr<GrafeasConnection> connection,
-                             Options options)
+                             Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), containeranalysis_internal::GrafeasDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), containeranalysis_internal::GrafeasDefaultOptions(
+                               connection_->options()))) {}
 GrafeasClient::~GrafeasClient() = default;
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::GetOccurrence(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::GetOccurrenceRequest request;
   request.set_name(name);
   return connection_->GetOccurrence(request);
 }
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::GetOccurrence(
-    grafeas::v1::GetOccurrenceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::GetOccurrenceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetOccurrence(request);
 }
 
 StreamRange<grafeas::v1::Occurrence> GrafeasClient::ListOccurrences(
-    std::string const& parent, std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::ListOccurrencesRequest request;
   request.set_parent(parent);
   request.set_filter(filter);
@@ -60,33 +57,28 @@ StreamRange<grafeas::v1::Occurrence> GrafeasClient::ListOccurrences(
 }
 
 StreamRange<grafeas::v1::Occurrence> GrafeasClient::ListOccurrences(
-    grafeas::v1::ListOccurrencesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::ListOccurrencesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListOccurrences(std::move(request));
 }
 
-Status GrafeasClient::DeleteOccurrence(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status GrafeasClient::DeleteOccurrence(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::DeleteOccurrenceRequest request;
   request.set_name(name);
   return connection_->DeleteOccurrence(request);
 }
 
 Status GrafeasClient::DeleteOccurrence(
-    grafeas::v1::DeleteOccurrenceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::DeleteOccurrenceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteOccurrence(request);
 }
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::CreateOccurrence(
     std::string const& parent, grafeas::v1::Occurrence const& occurrence,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::CreateOccurrenceRequest request;
   request.set_parent(parent);
   *request.mutable_occurrence() = occurrence;
@@ -94,18 +86,16 @@ StatusOr<grafeas::v1::Occurrence> GrafeasClient::CreateOccurrence(
 }
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::CreateOccurrence(
-    grafeas::v1::CreateOccurrenceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::CreateOccurrenceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateOccurrence(request);
 }
 
 StatusOr<grafeas::v1::BatchCreateOccurrencesResponse>
 GrafeasClient::BatchCreateOccurrences(
     std::string const& parent,
-    std::vector<grafeas::v1::Occurrence> const& occurrences, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<grafeas::v1::Occurrence> const& occurrences, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::BatchCreateOccurrencesRequest request;
   request.set_parent(parent);
   *request.mutable_occurrences() = {occurrences.begin(), occurrences.end()};
@@ -114,18 +104,15 @@ GrafeasClient::BatchCreateOccurrences(
 
 StatusOr<grafeas::v1::BatchCreateOccurrencesResponse>
 GrafeasClient::BatchCreateOccurrences(
-    grafeas::v1::BatchCreateOccurrencesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::BatchCreateOccurrencesRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchCreateOccurrences(request);
 }
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::UpdateOccurrence(
     std::string const& name, grafeas::v1::Occurrence const& occurrence,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::UpdateOccurrenceRequest request;
   request.set_name(name);
   *request.mutable_occurrence() = occurrence;
@@ -134,48 +121,42 @@ StatusOr<grafeas::v1::Occurrence> GrafeasClient::UpdateOccurrence(
 }
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::UpdateOccurrence(
-    grafeas::v1::UpdateOccurrenceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::UpdateOccurrenceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateOccurrence(request);
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::GetOccurrenceNote(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::GetOccurrenceNoteRequest request;
   request.set_name(name);
   return connection_->GetOccurrenceNote(request);
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::GetOccurrenceNote(
-    grafeas::v1::GetOccurrenceNoteRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::GetOccurrenceNoteRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetOccurrenceNote(request);
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::GetNote(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::GetNoteRequest request;
   request.set_name(name);
   return connection_->GetNote(request);
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::GetNote(
-    grafeas::v1::GetNoteRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::GetNoteRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNote(request);
 }
 
 StreamRange<grafeas::v1::Note> GrafeasClient::ListNotes(
-    std::string const& parent, std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::ListNotesRequest request;
   request.set_parent(parent);
   request.set_filter(filter);
@@ -183,32 +164,28 @@ StreamRange<grafeas::v1::Note> GrafeasClient::ListNotes(
 }
 
 StreamRange<grafeas::v1::Note> GrafeasClient::ListNotes(
-    grafeas::v1::ListNotesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::ListNotesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNotes(std::move(request));
 }
 
-Status GrafeasClient::DeleteNote(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status GrafeasClient::DeleteNote(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::DeleteNoteRequest request;
   request.set_name(name);
   return connection_->DeleteNote(request);
 }
 
 Status GrafeasClient::DeleteNote(grafeas::v1::DeleteNoteRequest const& request,
-                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteNote(request);
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::CreateNote(
     std::string const& parent, std::string const& note_id,
-    grafeas::v1::Note const& note, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::Note const& note, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::CreateNoteRequest request;
   request.set_parent(parent);
   request.set_note_id(note_id);
@@ -217,17 +194,15 @@ StatusOr<grafeas::v1::Note> GrafeasClient::CreateNote(
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::CreateNote(
-    grafeas::v1::CreateNoteRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::CreateNoteRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateNote(request);
 }
 
 StatusOr<grafeas::v1::BatchCreateNotesResponse> GrafeasClient::BatchCreateNotes(
     std::string const& parent,
-    std::map<std::string, grafeas::v1::Note> const& notes, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::map<std::string, grafeas::v1::Note> const& notes, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::BatchCreateNotesRequest request;
   request.set_parent(parent);
   *request.mutable_notes() = {notes.begin(), notes.end()};
@@ -235,17 +210,15 @@ StatusOr<grafeas::v1::BatchCreateNotesResponse> GrafeasClient::BatchCreateNotes(
 }
 
 StatusOr<grafeas::v1::BatchCreateNotesResponse> GrafeasClient::BatchCreateNotes(
-    grafeas::v1::BatchCreateNotesRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::BatchCreateNotesRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchCreateNotes(request);
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::UpdateNote(
     std::string const& name, grafeas::v1::Note const& note,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::UpdateNoteRequest request;
   request.set_name(name);
   *request.mutable_note() = note;
@@ -254,16 +227,14 @@ StatusOr<grafeas::v1::Note> GrafeasClient::UpdateNote(
 }
 
 StatusOr<grafeas::v1::Note> GrafeasClient::UpdateNote(
-    grafeas::v1::UpdateNoteRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::UpdateNoteRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateNote(request);
 }
 
 StreamRange<grafeas::v1::Occurrence> GrafeasClient::ListNoteOccurrences(
-    std::string const& name, std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   grafeas::v1::ListNoteOccurrencesRequest request;
   request.set_name(name);
   request.set_filter(filter);
@@ -271,9 +242,8 @@ StreamRange<grafeas::v1::Occurrence> GrafeasClient::ListNoteOccurrences(
 }
 
 StreamRange<grafeas::v1::Occurrence> GrafeasClient::ListNoteOccurrences(
-    grafeas::v1::ListNoteOccurrencesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    grafeas::v1::ListNoteOccurrencesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNoteOccurrences(std::move(request));
 }
 

--- a/google/cloud/containeranalysis/grafeas_client.h
+++ b/google/cloud/containeranalysis/grafeas_client.h
@@ -75,7 +75,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GrafeasClient {
  public:
   explicit GrafeasClient(std::shared_ptr<GrafeasConnection> connection,
-                         Options options = {});
+                         Options opts = {});
   ~GrafeasClient();
 
   //@{
@@ -101,7 +101,8 @@ class GrafeasClient {
   ///
   /// @param name  The name of the occurrence in the form of
   ///  `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -111,14 +112,15 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StatusOr<grafeas::v1::Occurrence> GetOccurrence(std::string const& name,
-                                                  Options options = {});
+                                                  Options opts = {});
 
   ///
   /// Gets the specified occurrence.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::GetOccurrenceRequest,grafeas/v1/grafeas.proto#L321}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -128,7 +130,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StatusOr<grafeas::v1::Occurrence> GetOccurrence(
-      grafeas::v1::GetOccurrenceRequest const& request, Options options = {});
+      grafeas::v1::GetOccurrenceRequest const& request, Options opts = {});
 
   ///
   /// Lists occurrences for the specified project.
@@ -137,7 +139,8 @@ class GrafeasClient {
   /// of
   ///  `projects/[PROJECT_ID]`.
   /// @param filter  The filter expression.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -147,15 +150,15 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StreamRange<grafeas::v1::Occurrence> ListOccurrences(
-      std::string const& parent, std::string const& filter,
-      Options options = {});
+      std::string const& parent, std::string const& filter, Options opts = {});
 
   ///
   /// Lists occurrences for the specified project.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::ListOccurrencesRequest,grafeas/v1/grafeas.proto#L331}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -165,7 +168,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StreamRange<grafeas::v1::Occurrence> ListOccurrences(
-      grafeas::v1::ListOccurrencesRequest request, Options options = {});
+      grafeas::v1::ListOccurrencesRequest request, Options opts = {});
 
   ///
   /// Deletes the specified occurrence. For example, use this method to delete
@@ -174,12 +177,13 @@ class GrafeasClient {
   ///
   /// @param name  The name of the occurrence in the form of
   ///  `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [grafeas.v1.DeleteOccurrenceRequest]:
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L361}
   ///
-  Status DeleteOccurrence(std::string const& name, Options options = {});
+  Status DeleteOccurrence(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the specified occurrence. For example, use this method to delete
@@ -188,13 +192,14 @@ class GrafeasClient {
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::DeleteOccurrenceRequest,grafeas/v1/grafeas.proto#L361}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [grafeas.v1.DeleteOccurrenceRequest]:
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L361}
   ///
   Status DeleteOccurrence(grafeas::v1::DeleteOccurrenceRequest const& request,
-                          Options options = {});
+                          Options opts = {});
 
   ///
   /// Creates a new occurrence.
@@ -203,7 +208,8 @@ class GrafeasClient {
   /// `projects/[PROJECT_ID]`, under which
   ///  the occurrence is to be created.
   /// @param occurrence  The occurrence to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -214,14 +220,15 @@ class GrafeasClient {
   ///
   StatusOr<grafeas::v1::Occurrence> CreateOccurrence(
       std::string const& parent, grafeas::v1::Occurrence const& occurrence,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new occurrence.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::CreateOccurrenceRequest,grafeas/v1/grafeas.proto#L371}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -231,8 +238,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StatusOr<grafeas::v1::Occurrence> CreateOccurrence(
-      grafeas::v1::CreateOccurrenceRequest const& request,
-      Options options = {});
+      grafeas::v1::CreateOccurrenceRequest const& request, Options opts = {});
 
   ///
   /// Creates new occurrences in batch.
@@ -241,7 +247,8 @@ class GrafeasClient {
   /// `projects/[PROJECT_ID]`, under which
   ///  the occurrences are to be created.
   /// @param occurrences  The occurrences to create. Max allowed length is 1000.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::BatchCreateOccurrencesResponse,grafeas/v1/grafeas.proto#L541}
   ///
@@ -253,14 +260,15 @@ class GrafeasClient {
   StatusOr<grafeas::v1::BatchCreateOccurrencesResponse> BatchCreateOccurrences(
       std::string const& parent,
       std::vector<grafeas::v1::Occurrence> const& occurrences,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates new occurrences in batch.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::BatchCreateOccurrencesRequest,grafeas/v1/grafeas.proto#L528}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::BatchCreateOccurrencesResponse,grafeas/v1/grafeas.proto#L541}
   ///
@@ -271,7 +279,7 @@ class GrafeasClient {
   ///
   StatusOr<grafeas::v1::BatchCreateOccurrencesResponse> BatchCreateOccurrences(
       grafeas::v1::BatchCreateOccurrencesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the specified occurrence.
@@ -280,7 +288,8 @@ class GrafeasClient {
   ///  `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
   /// @param occurrence  The updated occurrence.
   /// @param update_mask  The fields to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -291,14 +300,15 @@ class GrafeasClient {
   ///
   StatusOr<grafeas::v1::Occurrence> UpdateOccurrence(
       std::string const& name, grafeas::v1::Occurrence const& occurrence,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the specified occurrence.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::UpdateOccurrenceRequest,grafeas/v1/grafeas.proto#L383}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -308,8 +318,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StatusOr<grafeas::v1::Occurrence> UpdateOccurrence(
-      grafeas::v1::UpdateOccurrenceRequest const& request,
-      Options options = {});
+      grafeas::v1::UpdateOccurrenceRequest const& request, Options opts = {});
 
   ///
   /// Gets the note attached to the specified occurrence. Consumer projects can
@@ -317,7 +326,8 @@ class GrafeasClient {
   ///
   /// @param name  The name of the occurrence in the form of
   ///  `projects/[PROJECT_ID]/occurrences/[OCCURRENCE_ID]`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.GetOccurrenceNoteRequest]:
@@ -326,7 +336,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StatusOr<grafeas::v1::Note> GetOccurrenceNote(std::string const& name,
-                                                Options options = {});
+                                                Options opts = {});
 
   ///
   /// Gets the note attached to the specified occurrence. Consumer projects can
@@ -334,7 +344,8 @@ class GrafeasClient {
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::GetOccurrenceNoteRequest,grafeas/v1/grafeas.proto#L407}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.GetOccurrenceNoteRequest]:
@@ -343,15 +354,15 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StatusOr<grafeas::v1::Note> GetOccurrenceNote(
-      grafeas::v1::GetOccurrenceNoteRequest const& request,
-      Options options = {});
+      grafeas::v1::GetOccurrenceNoteRequest const& request, Options opts = {});
 
   ///
   /// Gets the specified note.
   ///
   /// @param name  The name of the note in the form of
   ///  `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.GetNoteRequest]:
@@ -360,14 +371,15 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StatusOr<grafeas::v1::Note> GetNote(std::string const& name,
-                                      Options options = {});
+                                      Options opts = {});
 
   ///
   /// Gets the specified note.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::GetNoteRequest,grafeas/v1/grafeas.proto#L397}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.GetNoteRequest]:
@@ -376,7 +388,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StatusOr<grafeas::v1::Note> GetNote(
-      grafeas::v1::GetNoteRequest const& request, Options options = {});
+      grafeas::v1::GetNoteRequest const& request, Options opts = {});
 
   ///
   /// Lists notes for the specified project.
@@ -384,7 +396,8 @@ class GrafeasClient {
   /// @param parent  The name of the project to list notes for in the form of
   ///  `projects/[PROJECT_ID]`.
   /// @param filter  The filter expression.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.ListNotesRequest]:
@@ -394,14 +407,15 @@ class GrafeasClient {
   ///
   StreamRange<grafeas::v1::Note> ListNotes(std::string const& parent,
                                            std::string const& filter,
-                                           Options options = {});
+                                           Options opts = {});
 
   ///
   /// Lists notes for the specified project.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::ListNotesRequest,grafeas/v1/grafeas.proto#L417}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.ListNotesRequest]:
@@ -410,32 +424,34 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StreamRange<grafeas::v1::Note> ListNotes(
-      grafeas::v1::ListNotesRequest request, Options options = {});
+      grafeas::v1::ListNotesRequest request, Options opts = {});
 
   ///
   /// Deletes the specified note.
   ///
   /// @param name  The name of the note in the form of
   ///  `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [grafeas.v1.DeleteNoteRequest]:
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L447}
   ///
-  Status DeleteNote(std::string const& name, Options options = {});
+  Status DeleteNote(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the specified note.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::DeleteNoteRequest,grafeas/v1/grafeas.proto#L447}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [grafeas.v1.DeleteNoteRequest]:
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L447}
   ///
   Status DeleteNote(grafeas::v1::DeleteNoteRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Creates a new note.
@@ -445,7 +461,8 @@ class GrafeasClient {
   ///  the note is to be created.
   /// @param note_id  The ID to use for this note.
   /// @param note  The note to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.CreateNoteRequest]:
@@ -456,14 +473,15 @@ class GrafeasClient {
   StatusOr<grafeas::v1::Note> CreateNote(std::string const& parent,
                                          std::string const& note_id,
                                          grafeas::v1::Note const& note,
-                                         Options options = {});
+                                         Options opts = {});
 
   ///
   /// Creates a new note.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::CreateNoteRequest,grafeas/v1/grafeas.proto#L457}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.CreateNoteRequest]:
@@ -472,7 +490,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StatusOr<grafeas::v1::Note> CreateNote(
-      grafeas::v1::CreateNoteRequest const& request, Options options = {});
+      grafeas::v1::CreateNoteRequest const& request, Options opts = {});
 
   ///
   /// Creates new notes in batch.
@@ -481,7 +499,8 @@ class GrafeasClient {
   /// `projects/[PROJECT_ID]`, under which
   ///  the notes are to be created.
   /// @param notes  The notes to create. Max allowed length is 1000.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::BatchCreateNotesResponse,grafeas/v1/grafeas.proto#L522}
   ///
@@ -492,15 +511,15 @@ class GrafeasClient {
   ///
   StatusOr<grafeas::v1::BatchCreateNotesResponse> BatchCreateNotes(
       std::string const& parent,
-      std::map<std::string, grafeas::v1::Note> const& notes,
-      Options options = {});
+      std::map<std::string, grafeas::v1::Note> const& notes, Options opts = {});
 
   ///
   /// Creates new notes in batch.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::BatchCreateNotesRequest,grafeas/v1/grafeas.proto#L509}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::BatchCreateNotesResponse,grafeas/v1/grafeas.proto#L522}
   ///
@@ -510,8 +529,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L522}
   ///
   StatusOr<grafeas::v1::BatchCreateNotesResponse> BatchCreateNotes(
-      grafeas::v1::BatchCreateNotesRequest const& request,
-      Options options = {});
+      grafeas::v1::BatchCreateNotesRequest const& request, Options opts = {});
 
   ///
   /// Updates the specified note.
@@ -520,7 +538,8 @@ class GrafeasClient {
   ///  `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   /// @param note  The updated note.
   /// @param update_mask  The fields to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.UpdateNoteRequest]:
@@ -530,14 +549,15 @@ class GrafeasClient {
   ///
   StatusOr<grafeas::v1::Note> UpdateNote(
       std::string const& name, grafeas::v1::Note const& note,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the specified note.
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::UpdateNoteRequest,grafeas/v1/grafeas.proto#L471}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return @googleapis_link{grafeas::v1::Note,grafeas/v1/grafeas.proto#L258}
   ///
   /// [grafeas.v1.UpdateNoteRequest]:
@@ -546,7 +566,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L258}
   ///
   StatusOr<grafeas::v1::Note> UpdateNote(
-      grafeas::v1::UpdateNoteRequest const& request, Options options = {});
+      grafeas::v1::UpdateNoteRequest const& request, Options opts = {});
 
   ///
   /// Lists occurrences referencing the specified note. Provider projects can
@@ -556,7 +576,8 @@ class GrafeasClient {
   /// @param name  The name of the note to list occurrences for in the form of
   ///  `projects/[PROVIDER_ID]/notes/[NOTE_ID]`.
   /// @param filter  The filter expression.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -566,7 +587,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StreamRange<grafeas::v1::Occurrence> ListNoteOccurrences(
-      std::string const& name, std::string const& filter, Options options = {});
+      std::string const& name, std::string const& filter, Options opts = {});
 
   ///
   /// Lists occurrences referencing the specified note. Provider projects can
@@ -575,7 +596,8 @@ class GrafeasClient {
   ///
   /// @param request
   /// @googleapis_link{grafeas::v1::ListNoteOccurrencesRequest,grafeas/v1/grafeas.proto#L485}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{grafeas::v1::Occurrence,grafeas/v1/grafeas.proto#L194}
   ///
@@ -585,7 +607,7 @@ class GrafeasClient {
   /// @googleapis_reference_link{grafeas/v1/grafeas.proto#L194}
   ///
   StreamRange<grafeas::v1::Occurrence> ListNoteOccurrences(
-      grafeas::v1::ListNoteOccurrencesRequest request, Options options = {});
+      grafeas::v1::ListNoteOccurrencesRequest request, Options opts = {});
 
  private:
   std::shared_ptr<GrafeasConnection> connection_;

--- a/google/cloud/datacatalog/data_catalog_client.cc
+++ b/google/cloud/datacatalog/data_catalog_client.cc
@@ -28,19 +28,18 @@ namespace datacatalog {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataCatalogClient::DataCatalogClient(
-    std::shared_ptr<DataCatalogConnection> connection, Options options)
+    std::shared_ptr<DataCatalogConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), datacatalog_internal::DataCatalogDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), datacatalog_internal::DataCatalogDefaultOptions(
+                               connection_->options()))) {}
 DataCatalogClient::~DataCatalogClient() = default;
 
 StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>
 DataCatalogClient::SearchCatalog(
     google::cloud::datacatalog::v1::SearchCatalogRequest::Scope const& scope,
-    std::string const& query, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& query, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::SearchCatalogRequest request;
   *request.mutable_scope() = scope;
   request.set_query(query);
@@ -50,9 +49,8 @@ DataCatalogClient::SearchCatalog(
 StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>
 DataCatalogClient::SearchCatalog(
     google::cloud::datacatalog::v1::SearchCatalogRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchCatalog(std::move(request));
 }
 
@@ -60,9 +58,8 @@ StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::CreateEntryGroup(
     std::string const& parent, std::string const& entry_group_id,
     google::cloud::datacatalog::v1::EntryGroup const& entry_group,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreateEntryGroupRequest request;
   request.set_parent(parent);
   request.set_entry_group_id(entry_group_id);
@@ -73,16 +70,14 @@ DataCatalogClient::CreateEntryGroup(
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::CreateEntryGroup(
     google::cloud::datacatalog::v1::CreateEntryGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEntryGroup(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
-DataCatalogClient::GetEntryGroup(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DataCatalogClient::GetEntryGroup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::GetEntryGroupRequest request;
   request.set_name(name);
   return connection_->GetEntryGroup(request);
@@ -91,9 +86,8 @@ DataCatalogClient::GetEntryGroup(std::string const& name, Options options) {
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::GetEntryGroup(std::string const& name,
                                  google::protobuf::FieldMask const& read_mask,
-                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::GetEntryGroupRequest request;
   request.set_name(name);
   *request.mutable_read_mask() = read_mask;
@@ -103,18 +97,16 @@ DataCatalogClient::GetEntryGroup(std::string const& name,
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::GetEntryGroup(
     google::cloud::datacatalog::v1::GetEntryGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEntryGroup(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::UpdateEntryGroup(
     google::cloud::datacatalog::v1::EntryGroup const& entry_group,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateEntryGroupRequest request;
   *request.mutable_entry_group() = entry_group;
   return connection_->UpdateEntryGroup(request);
@@ -123,9 +115,8 @@ DataCatalogClient::UpdateEntryGroup(
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::UpdateEntryGroup(
     google::cloud::datacatalog::v1::EntryGroup const& entry_group,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateEntryGroupRequest request;
   *request.mutable_entry_group() = entry_group;
   *request.mutable_update_mask() = update_mask;
@@ -135,16 +126,14 @@ DataCatalogClient::UpdateEntryGroup(
 StatusOr<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::UpdateEntryGroup(
     google::cloud::datacatalog::v1::UpdateEntryGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateEntryGroup(request);
 }
 
 Status DataCatalogClient::DeleteEntryGroup(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeleteEntryGroupRequest request;
   request.set_name(name);
   return connection_->DeleteEntryGroup(request);
@@ -152,16 +141,14 @@ Status DataCatalogClient::DeleteEntryGroup(std::string const& name,
 
 Status DataCatalogClient::DeleteEntryGroup(
     google::cloud::datacatalog::v1::DeleteEntryGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteEntryGroup(request);
 }
 
 StreamRange<google::cloud::datacatalog::v1::EntryGroup>
-DataCatalogClient::ListEntryGroups(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DataCatalogClient::ListEntryGroups(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::ListEntryGroupsRequest request;
   request.set_parent(parent);
   return connection_->ListEntryGroups(request);
@@ -170,17 +157,15 @@ DataCatalogClient::ListEntryGroups(std::string const& parent, Options options) {
 StreamRange<google::cloud::datacatalog::v1::EntryGroup>
 DataCatalogClient::ListEntryGroups(
     google::cloud::datacatalog::v1::ListEntryGroupsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEntryGroups(std::move(request));
 }
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::CreateEntry(
     std::string const& parent, std::string const& entry_id,
-    google::cloud::datacatalog::v1::Entry const& entry, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::Entry const& entry, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreateEntryRequest request;
   request.set_parent(parent);
   request.set_entry_id(entry_id);
@@ -190,16 +175,14 @@ StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::CreateEntry(
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::CreateEntry(
     google::cloud::datacatalog::v1::CreateEntryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEntry(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::UpdateEntry(
-    google::cloud::datacatalog::v1::Entry const& entry, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::Entry const& entry, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateEntryRequest request;
   *request.mutable_entry() = entry;
   return connection_->UpdateEntry(request);
@@ -207,9 +190,8 @@ StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::UpdateEntry(
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::UpdateEntry(
     google::cloud::datacatalog::v1::Entry const& entry,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateEntryRequest request;
   *request.mutable_entry() = entry;
   *request.mutable_update_mask() = update_mask;
@@ -218,16 +200,13 @@ StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::UpdateEntry(
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::UpdateEntry(
     google::cloud::datacatalog::v1::UpdateEntryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateEntry(request);
 }
 
-Status DataCatalogClient::DeleteEntry(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status DataCatalogClient::DeleteEntry(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeleteEntryRequest request;
   request.set_name(name);
   return connection_->DeleteEntry(request);
@@ -235,16 +214,14 @@ Status DataCatalogClient::DeleteEntry(std::string const& name,
 
 Status DataCatalogClient::DeleteEntry(
     google::cloud::datacatalog::v1::DeleteEntryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteEntry(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::GetEntry(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::GetEntryRequest request;
   request.set_name(name);
   return connection_->GetEntry(request);
@@ -252,24 +229,21 @@ StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::GetEntry(
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::GetEntry(
     google::cloud::datacatalog::v1::GetEntryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEntry(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::Entry> DataCatalogClient::LookupEntry(
     google::cloud::datacatalog::v1::LookupEntryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->LookupEntry(request);
 }
 
 StreamRange<google::cloud::datacatalog::v1::Entry>
-DataCatalogClient::ListEntries(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DataCatalogClient::ListEntries(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::ListEntriesRequest request;
   request.set_parent(parent);
   return connection_->ListEntries(request);
@@ -277,10 +251,8 @@ DataCatalogClient::ListEntries(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::datacatalog::v1::Entry>
 DataCatalogClient::ListEntries(
-    google::cloud::datacatalog::v1::ListEntriesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::ListEntriesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEntries(std::move(request));
 }
 
@@ -288,9 +260,8 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplate>
 DataCatalogClient::CreateTagTemplate(
     std::string const& parent, std::string const& tag_template_id,
     google::cloud::datacatalog::v1::TagTemplate const& tag_template,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreateTagTemplateRequest request;
   request.set_parent(parent);
   request.set_tag_template_id(tag_template_id);
@@ -301,16 +272,14 @@ DataCatalogClient::CreateTagTemplate(
 StatusOr<google::cloud::datacatalog::v1::TagTemplate>
 DataCatalogClient::CreateTagTemplate(
     google::cloud::datacatalog::v1::CreateTagTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTagTemplate(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::TagTemplate>
-DataCatalogClient::GetTagTemplate(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DataCatalogClient::GetTagTemplate(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::GetTagTemplateRequest request;
   request.set_name(name);
   return connection_->GetTagTemplate(request);
@@ -319,18 +288,16 @@ DataCatalogClient::GetTagTemplate(std::string const& name, Options options) {
 StatusOr<google::cloud::datacatalog::v1::TagTemplate>
 DataCatalogClient::GetTagTemplate(
     google::cloud::datacatalog::v1::GetTagTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTagTemplate(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::TagTemplate>
 DataCatalogClient::UpdateTagTemplate(
     google::cloud::datacatalog::v1::TagTemplate const& tag_template,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTagTemplateRequest request;
   *request.mutable_tag_template() = tag_template;
   return connection_->UpdateTagTemplate(request);
@@ -339,9 +306,8 @@ DataCatalogClient::UpdateTagTemplate(
 StatusOr<google::cloud::datacatalog::v1::TagTemplate>
 DataCatalogClient::UpdateTagTemplate(
     google::cloud::datacatalog::v1::TagTemplate const& tag_template,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTagTemplateRequest request;
   *request.mutable_tag_template() = tag_template;
   *request.mutable_update_mask() = update_mask;
@@ -351,16 +317,14 @@ DataCatalogClient::UpdateTagTemplate(
 StatusOr<google::cloud::datacatalog::v1::TagTemplate>
 DataCatalogClient::UpdateTagTemplate(
     google::cloud::datacatalog::v1::UpdateTagTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTagTemplate(request);
 }
 
 Status DataCatalogClient::DeleteTagTemplate(std::string const& name, bool force,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeleteTagTemplateRequest request;
   request.set_name(name);
   request.set_force(force);
@@ -369,9 +333,8 @@ Status DataCatalogClient::DeleteTagTemplate(std::string const& name, bool force,
 
 Status DataCatalogClient::DeleteTagTemplate(
     google::cloud::datacatalog::v1::DeleteTagTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTagTemplate(request);
 }
 
@@ -379,9 +342,8 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::CreateTagTemplateField(
     std::string const& parent, std::string const& tag_template_field_id,
     google::cloud::datacatalog::v1::TagTemplateField const& tag_template_field,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreateTagTemplateFieldRequest request;
   request.set_parent(parent);
   request.set_tag_template_field_id(tag_template_field_id);
@@ -393,9 +355,8 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::CreateTagTemplateField(
     google::cloud::datacatalog::v1::CreateTagTemplateFieldRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTagTemplateField(request);
 }
 
@@ -403,9 +364,8 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::UpdateTagTemplateField(
     std::string const& name,
     google::cloud::datacatalog::v1::TagTemplateField const& tag_template_field,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTagTemplateFieldRequest request;
   request.set_name(name);
   *request.mutable_tag_template_field() = tag_template_field;
@@ -416,9 +376,8 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::UpdateTagTemplateField(
     std::string const& name,
     google::cloud::datacatalog::v1::TagTemplateField const& tag_template_field,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTagTemplateFieldRequest request;
   request.set_name(name);
   *request.mutable_tag_template_field() = tag_template_field;
@@ -430,18 +389,16 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::UpdateTagTemplateField(
     google::cloud::datacatalog::v1::UpdateTagTemplateFieldRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTagTemplateField(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::RenameTagTemplateField(
     std::string const& name, std::string const& new_tag_template_field_id,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::RenameTagTemplateFieldRequest request;
   request.set_name(name);
   request.set_new_tag_template_field_id(new_tag_template_field_id);
@@ -452,18 +409,16 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::RenameTagTemplateField(
     google::cloud::datacatalog::v1::RenameTagTemplateFieldRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RenameTagTemplateField(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::RenameTagTemplateFieldEnumValue(
     std::string const& name, std::string const& new_enum_value_display_name,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::RenameTagTemplateFieldEnumValueRequest
       request;
   request.set_name(name);
@@ -475,16 +430,14 @@ StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
 DataCatalogClient::RenameTagTemplateFieldEnumValue(
     google::cloud::datacatalog::v1::
         RenameTagTemplateFieldEnumValueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RenameTagTemplateFieldEnumValue(request);
 }
 
 Status DataCatalogClient::DeleteTagTemplateField(std::string const& name,
-                                                 bool force, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 bool force, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeleteTagTemplateFieldRequest request;
   request.set_name(name);
   request.set_force(force);
@@ -494,17 +447,15 @@ Status DataCatalogClient::DeleteTagTemplateField(std::string const& name,
 Status DataCatalogClient::DeleteTagTemplateField(
     google::cloud::datacatalog::v1::DeleteTagTemplateFieldRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTagTemplateField(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::CreateTag(
     std::string const& parent, google::cloud::datacatalog::v1::Tag const& tag,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreateTagRequest request;
   request.set_parent(parent);
   *request.mutable_tag() = tag;
@@ -513,16 +464,14 @@ StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::CreateTag(
 
 StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::CreateTag(
     google::cloud::datacatalog::v1::CreateTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTag(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::UpdateTag(
-    google::cloud::datacatalog::v1::Tag const& tag, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::Tag const& tag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTagRequest request;
   *request.mutable_tag() = tag;
   return connection_->UpdateTag(request);
@@ -530,9 +479,8 @@ StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::UpdateTag(
 
 StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::UpdateTag(
     google::cloud::datacatalog::v1::Tag const& tag,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTagRequest request;
   *request.mutable_tag() = tag;
   *request.mutable_update_mask() = update_mask;
@@ -541,15 +489,13 @@ StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::UpdateTag(
 
 StatusOr<google::cloud::datacatalog::v1::Tag> DataCatalogClient::UpdateTag(
     google::cloud::datacatalog::v1::UpdateTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTag(request);
 }
 
-Status DataCatalogClient::DeleteTag(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status DataCatalogClient::DeleteTag(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeleteTagRequest request;
   request.set_name(name);
   return connection_->DeleteTag(request);
@@ -557,33 +503,29 @@ Status DataCatalogClient::DeleteTag(std::string const& name, Options options) {
 
 Status DataCatalogClient::DeleteTag(
     google::cloud::datacatalog::v1::DeleteTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTag(request);
 }
 
 StreamRange<google::cloud::datacatalog::v1::Tag> DataCatalogClient::ListTags(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::ListTagsRequest request;
   request.set_parent(parent);
   return connection_->ListTags(request);
 }
 
 StreamRange<google::cloud::datacatalog::v1::Tag> DataCatalogClient::ListTags(
-    google::cloud::datacatalog::v1::ListTagsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::ListTagsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTags(std::move(request));
 }
 
 StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -591,11 +533,10 @@ StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<DataCatalogBackoffPolicyOption>(options,
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<DataCatalogBackoffPolicyOption>(opts,
                                                                  __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -621,34 +562,29 @@ StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DataCatalogClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DataCatalogClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DataCatalogClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/datacatalog/data_catalog_client.h
+++ b/google/cloud/datacatalog/data_catalog_client.h
@@ -64,7 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DataCatalogClient {
  public:
   explicit DataCatalogClient(std::shared_ptr<DataCatalogConnection> connection,
-                             Options options = {});
+                             Options opts = {});
   ~DataCatalogClient();
 
   //@{
@@ -119,7 +119,8 @@ class DataCatalogClient {
   ///  * `name:x`
   ///  * `column:y`
   ///  * `description:z`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::SearchCatalogResult,google/cloud/datacatalog/v1/search.proto#L34}
   ///
@@ -131,7 +132,7 @@ class DataCatalogClient {
   StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>
   SearchCatalog(
       google::cloud::datacatalog::v1::SearchCatalogRequest::Scope const& scope,
-      std::string const& query, Options options = {});
+      std::string const& query, Options opts = {});
 
   ///
   /// Searches Data Catalog for multiple resources like entries and tags that
@@ -152,7 +153,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::SearchCatalogRequest,google/cloud/datacatalog/v1/datacatalog.proto#L517}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::SearchCatalogResult,google/cloud/datacatalog/v1/search.proto#L34}
   ///
@@ -163,7 +165,7 @@ class DataCatalogClient {
   ///
   StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>
   SearchCatalog(google::cloud::datacatalog::v1::SearchCatalogRequest request,
-                Options options = {});
+                Options opts = {});
 
   ///
   /// Creates an entry group.
@@ -203,7 +205,8 @@ class DataCatalogClient {
   ///  underscores (_), and must start with a letter or underscore.
   ///  The maximum size is 64 bytes when encoded in UTF-8.
   /// @param entry_group  The entry group to create. Defaults to empty.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -215,7 +218,7 @@ class DataCatalogClient {
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> CreateEntryGroup(
       std::string const& parent, std::string const& entry_group_id,
       google::cloud::datacatalog::v1::EntryGroup const& entry_group,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an entry group.
@@ -248,7 +251,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreateEntryGroupRequest,google/cloud/datacatalog/v1/datacatalog.proto#L634}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -259,13 +263,14 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> CreateEntryGroup(
       google::cloud::datacatalog::v1::CreateEntryGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an entry group.
   ///
   /// @param name  Required. The name of the entry group to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -275,7 +280,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> GetEntryGroup(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an entry group.
@@ -283,7 +288,8 @@ class DataCatalogClient {
   /// @param name  Required. The name of the entry group to get.
   /// @param read_mask  The fields to return. If empty or omitted, all fields
   /// are returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -294,14 +300,15 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> GetEntryGroup(
       std::string const& name, google::protobuf::FieldMask const& read_mask,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an entry group.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::GetEntryGroupRequest,google/cloud/datacatalog/v1/datacatalog.proto#L673}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -312,7 +319,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> GetEntryGroup(
       google::cloud::datacatalog::v1::GetEntryGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an entry group.
@@ -324,7 +331,8 @@ class DataCatalogClient {
   ///
   /// @param entry_group  Required. Updates for the entry group. The `name`
   /// field must be set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -335,7 +343,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> UpdateEntryGroup(
       google::cloud::datacatalog::v1::EntryGroup const& entry_group,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an entry group.
@@ -352,7 +360,8 @@ class DataCatalogClient {
   ///  If this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the
   ///  request body, their values are emptied.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -363,7 +372,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> UpdateEntryGroup(
       google::cloud::datacatalog::v1::EntryGroup const& entry_group,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an entry group.
@@ -375,7 +384,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdateEntryGroupRequest,google/cloud/datacatalog/v1/datacatalog.proto#L659}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -386,7 +396,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::EntryGroup> UpdateEntryGroup(
       google::cloud::datacatalog::v1::UpdateEntryGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an entry group.
@@ -397,12 +407,13 @@ class DataCatalogClient {
   /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
   ///
   /// @param name  Required. The name of the entry group to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteEntryGroupRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L688}
   ///
-  Status DeleteEntryGroup(std::string const& name, Options options = {});
+  Status DeleteEntryGroup(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an entry group.
@@ -414,14 +425,15 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeleteEntryGroupRequest,google/cloud/datacatalog/v1/datacatalog.proto#L688}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteEntryGroupRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L688}
   ///
   Status DeleteEntryGroup(
       google::cloud::datacatalog::v1::DeleteEntryGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists entry groups.
@@ -429,7 +441,8 @@ class DataCatalogClient {
   /// @param parent  Required. The name of the location that contains the entry
   /// groups to list.
   ///  Can be provided as a URL.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -439,14 +452,15 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
   StreamRange<google::cloud::datacatalog::v1::EntryGroup> ListEntryGroups(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists entry groups.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ListEntryGroupsRequest,google/cloud/datacatalog/v1/datacatalog.proto#L703}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::EntryGroup,google/cloud/datacatalog/v1/datacatalog.proto#L1166}
   ///
@@ -457,7 +471,7 @@ class DataCatalogClient {
   ///
   StreamRange<google::cloud::datacatalog::v1::EntryGroup> ListEntryGroups(
       google::cloud::datacatalog::v1::ListEntryGroupsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an entry.
@@ -481,7 +495,8 @@ class DataCatalogClient {
   ///  and underscores (_).
   ///  The maximum size is 64 bytes when encoded in UTF-8.
   /// @param entry  Required. The entry to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -492,7 +507,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> CreateEntry(
       std::string const& parent, std::string const& entry_id,
-      google::cloud::datacatalog::v1::Entry const& entry, Options options = {});
+      google::cloud::datacatalog::v1::Entry const& entry, Options opts = {});
 
   ///
   /// Creates an entry.
@@ -509,7 +524,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreateEntryRequest,google/cloud/datacatalog/v1/datacatalog.proto#L738}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -520,7 +536,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> CreateEntry(
       google::cloud::datacatalog::v1::CreateEntryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing entry.
@@ -532,7 +548,8 @@ class DataCatalogClient {
   ///
   /// @param entry  Required. Updates for the entry. The `name` field must be
   /// set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -542,7 +559,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> UpdateEntry(
-      google::cloud::datacatalog::v1::Entry const& entry, Options options = {});
+      google::cloud::datacatalog::v1::Entry const& entry, Options opts = {});
 
   ///
   /// Updates an existing entry.
@@ -575,7 +592,8 @@ class DataCatalogClient {
   ///  * `user_specified_system`
   ///  * `linked_resource`
   ///  * `source_system_timestamps`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -586,7 +604,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> UpdateEntry(
       google::cloud::datacatalog::v1::Entry const& entry,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing entry.
@@ -598,7 +616,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdateEntryRequest,google/cloud/datacatalog/v1/datacatalog.proto#L763}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -609,7 +628,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> UpdateEntry(
       google::cloud::datacatalog::v1::UpdateEntryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an existing entry.
@@ -624,12 +643,13 @@ class DataCatalogClient {
   /// project](https://cloud.google.com/data-catalog/docs/concepts/resource-project).
   ///
   /// @param name  Required. The name of the entry to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteEntryRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L801}
   ///
-  Status DeleteEntry(std::string const& name, Options options = {});
+  Status DeleteEntry(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an existing entry.
@@ -645,20 +665,22 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeleteEntryRequest,google/cloud/datacatalog/v1/datacatalog.proto#L801}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteEntryRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L801}
   ///
   Status DeleteEntry(
       google::cloud::datacatalog::v1::DeleteEntryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an entry.
   ///
   /// @param name  Required. The name of the entry to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -668,14 +690,15 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> GetEntry(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an entry.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::GetEntryRequest,google/cloud/datacatalog/v1/datacatalog.proto#L813}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -686,7 +709,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> GetEntry(
       google::cloud::datacatalog::v1::GetEntryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an entry by its target resource name.
@@ -695,7 +718,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::LookupEntryRequest,google/cloud/datacatalog/v1/datacatalog.proto#L825}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -706,7 +730,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Entry> LookupEntry(
       google::cloud::datacatalog::v1::LookupEntryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists entries.
@@ -718,7 +742,8 @@ class DataCatalogClient {
   /// @param parent  Required. The name of the entry group that contains the
   /// entries to list.
   ///  Can be provided in URL format.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -728,7 +753,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
   StreamRange<google::cloud::datacatalog::v1::Entry> ListEntries(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists entries.
@@ -739,7 +764,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ListEntriesRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1453}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Entry,google/cloud/datacatalog/v1/datacatalog.proto#L883}
   ///
@@ -750,7 +776,7 @@ class DataCatalogClient {
   ///
   StreamRange<google::cloud::datacatalog::v1::Entry> ListEntries(
       google::cloud::datacatalog::v1::ListEntriesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a tag template.
@@ -767,7 +793,8 @@ class DataCatalogClient {
   ///  or underscores (_), and must start with a letter or underscore.
   ///  The maximum size is 64 bytes when encoded in UTF-8.
   /// @param tag_template  Required. The tag template to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -779,7 +806,7 @@ class DataCatalogClient {
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> CreateTagTemplate(
       std::string const& parent, std::string const& tag_template_id,
       google::cloud::datacatalog::v1::TagTemplate const& tag_template,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a tag template.
@@ -791,7 +818,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreateTagTemplateRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1193}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -802,13 +830,14 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> CreateTagTemplate(
       google::cloud::datacatalog::v1::CreateTagTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a tag template.
   ///
   /// @param name  Required. The name of the tag template to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -818,14 +847,15 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/tags.proto#L143}
   ///
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> GetTagTemplate(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a tag template.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::GetTagTemplateRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1216}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -836,7 +866,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> GetTagTemplate(
       google::cloud::datacatalog::v1::GetTagTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a tag template.
@@ -851,7 +881,8 @@ class DataCatalogClient {
   ///
   /// @param tag_template  Required. The template to update. The `name` field
   /// must be set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -862,7 +893,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> UpdateTagTemplate(
       google::cloud::datacatalog::v1::TagTemplate const& tag_template,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a tag template.
@@ -887,7 +918,8 @@ class DataCatalogClient {
   ///  hours to take effect in search results. Additionally, it also requires
   ///  the `tagTemplates.getIamPolicy` and `tagTemplates.setIamPolicy`
   ///  permissions.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -898,7 +930,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> UpdateTagTemplate(
       google::cloud::datacatalog::v1::TagTemplate const& tag_template,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a tag template.
@@ -913,7 +945,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdateTagTemplateRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1228}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplate,google/cloud/datacatalog/v1/tags.proto#L143}
   ///
@@ -924,7 +957,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::TagTemplate> UpdateTagTemplate(
       google::cloud::datacatalog::v1::UpdateTagTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a tag template and all tags that use it.
@@ -936,13 +969,14 @@ class DataCatalogClient {
   /// @param name  Required. The name of the tag template to delete.
   /// @param force  Required. If true, deletes all tags that use this template.
   ///  Currently, `true` is the only supported value.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTagTemplateRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1248}
   ///
   Status DeleteTagTemplate(std::string const& name, bool force,
-                           Options options = {});
+                           Options opts = {});
 
   ///
   /// Deletes a tag template and all tags that use it.
@@ -953,14 +987,15 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeleteTagTemplateRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1248}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTagTemplateRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1248}
   ///
   Status DeleteTagTemplate(
       google::cloud::datacatalog::v1::DeleteTagTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a field in a tag template.
@@ -979,7 +1014,8 @@ class DataCatalogClient {
   ///  character long and at most 128 characters long. Field IDs must also be
   ///  unique within their template.
   /// @param tag_template_field  Required. The tag template field to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -993,7 +1029,7 @@ class DataCatalogClient {
                          std::string const& tag_template_field_id,
                          google::cloud::datacatalog::v1::TagTemplateField const&
                              tag_template_field,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Creates a field in a tag template.
@@ -1004,7 +1040,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreateTagTemplateFieldRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1313}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1017,7 +1054,7 @@ class DataCatalogClient {
   CreateTagTemplateField(
       google::cloud::datacatalog::v1::CreateTagTemplateFieldRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a field in a tag template.
@@ -1031,7 +1068,8 @@ class DataCatalogClient {
   ///
   /// @param name  Required. The name of the tag template field.
   /// @param tag_template_field  Required. The template to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1044,7 +1082,7 @@ class DataCatalogClient {
   UpdateTagTemplateField(std::string const& name,
                          google::cloud::datacatalog::v1::TagTemplateField const&
                              tag_template_field,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Updates a field in a tag template.
@@ -1071,7 +1109,8 @@ class DataCatalogClient {
   ///  Therefore, enum values can only be added, existing enum values cannot be
   ///  deleted or renamed. Additionally, updating a template field from optional
   ///  to required is *not* allowed.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1085,7 +1124,7 @@ class DataCatalogClient {
                          google::cloud::datacatalog::v1::TagTemplateField const&
                              tag_template_field,
                          google::protobuf::FieldMask const& update_mask,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Updates a field in a tag template.
@@ -1099,7 +1138,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdateTagTemplateFieldRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1339}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1112,7 +1152,7 @@ class DataCatalogClient {
   UpdateTagTemplateField(
       google::cloud::datacatalog::v1::UpdateTagTemplateFieldRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Renames a field in a tag template.
@@ -1125,7 +1165,8 @@ class DataCatalogClient {
   /// @param name  Required. The name of the tag template field.
   /// @param new_tag_template_field_id  Required. The new ID of this tag
   /// template field. For example, `my_new_field`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1137,7 +1178,7 @@ class DataCatalogClient {
   StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
   RenameTagTemplateField(std::string const& name,
                          std::string const& new_tag_template_field_id,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Renames a field in a tag template.
@@ -1149,7 +1190,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::RenameTagTemplateFieldRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1372}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1162,7 +1204,7 @@ class DataCatalogClient {
   RenameTagTemplateField(
       google::cloud::datacatalog::v1::RenameTagTemplateFieldRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Renames an enum value in a tag template.
@@ -1172,7 +1214,8 @@ class DataCatalogClient {
   /// @param name  Required. The name of the enum field value.
   /// @param new_enum_value_display_name  Required. The new display name of the
   /// enum value. For example, `my_new_enum_value`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1184,7 +1227,7 @@ class DataCatalogClient {
   StatusOr<google::cloud::datacatalog::v1::TagTemplateField>
   RenameTagTemplateFieldEnumValue(
       std::string const& name, std::string const& new_enum_value_display_name,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Renames an enum value in a tag template.
@@ -1193,7 +1236,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::RenameTagTemplateFieldEnumValueRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1387}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::TagTemplateField,google/cloud/datacatalog/v1/tags.proto#L206}
   ///
@@ -1206,7 +1250,7 @@ class DataCatalogClient {
   RenameTagTemplateFieldEnumValue(
       google::cloud::datacatalog::v1::
           RenameTagTemplateFieldEnumValueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a field in a tag template and all uses of this field from the tags
@@ -1220,13 +1264,14 @@ class DataCatalogClient {
   /// @param force  Required. If true, deletes this field from any tags that use
   /// it.
   ///  Currently, `true` is the only supported value.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTagTemplateFieldRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1402}
   ///
   Status DeleteTagTemplateField(std::string const& name, bool force,
-                                Options options = {});
+                                Options opts = {});
 
   ///
   /// Deletes a field in a tag template and all uses of this field from the tags
@@ -1238,7 +1283,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeleteTagTemplateFieldRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1402}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTagTemplateFieldRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1402}
@@ -1246,7 +1292,7 @@ class DataCatalogClient {
   Status DeleteTagTemplateField(
       google::cloud::datacatalog::v1::DeleteTagTemplateFieldRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a tag and assigns it to:
@@ -1268,7 +1314,8 @@ class DataCatalogClient {
   ///  Note: The tag and its child resources might not be stored in
   ///  the location specified in its name.
   /// @param tag  Required. The tag to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1279,7 +1326,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Tag> CreateTag(
       std::string const& parent, google::cloud::datacatalog::v1::Tag const& tag,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a tag and assigns it to:
@@ -1297,7 +1344,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreateTagRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1265}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1308,13 +1356,14 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Tag> CreateTag(
       google::cloud::datacatalog::v1::CreateTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing tag.
   ///
   /// @param tag  Required. The updated tag. The "name" field must be set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1324,7 +1373,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/tags.proto#L37}
   ///
   StatusOr<google::cloud::datacatalog::v1::Tag> UpdateTag(
-      google::cloud::datacatalog::v1::Tag const& tag, Options options = {});
+      google::cloud::datacatalog::v1::Tag const& tag, Options opts = {});
 
   ///
   /// Updates an existing tag.
@@ -1336,7 +1385,8 @@ class DataCatalogClient {
   ///  In general, if this parameter is absent or empty, all modifiable fields
   ///  are overwritten. If such fields are non-required and omitted in the
   ///  request body, their values are emptied.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1347,14 +1397,15 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Tag> UpdateTag(
       google::cloud::datacatalog::v1::Tag const& tag,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing tag.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdateTagRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1286}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1365,32 +1416,34 @@ class DataCatalogClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Tag> UpdateTag(
       google::cloud::datacatalog::v1::UpdateTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a tag.
   ///
   /// @param name  Required. The name of the tag to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTagRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1301}
   ///
-  Status DeleteTag(std::string const& name, Options options = {});
+  Status DeleteTag(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a tag.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeleteTagRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1301}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTagRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/datacatalog.proto#L1301}
   ///
   Status DeleteTag(
       google::cloud::datacatalog::v1::DeleteTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists tags assigned to an [Entry][google.cloud.datacatalog.v1.Entry].
@@ -1400,7 +1453,8 @@ class DataCatalogClient {
   ///  The resource can be an [Entry][google.cloud.datacatalog.v1.Entry]
   ///  or an [EntryGroup][google.cloud.datacatalog.v1.EntryGroup]
   ///  (without `/entries/{entries}` at the end).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1410,14 +1464,15 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/tags.proto#L37}
   ///
   StreamRange<google::cloud::datacatalog::v1::Tag> ListTags(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists tags assigned to an [Entry][google.cloud.datacatalog.v1.Entry].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ListTagsRequest,google/cloud/datacatalog/v1/datacatalog.proto#L1419}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Tag,google/cloud/datacatalog/v1/tags.proto#L37}
   ///
@@ -1428,7 +1483,7 @@ class DataCatalogClient {
   ///
   StreamRange<google::cloud::datacatalog::v1::Tag> ListTags(
       google::cloud::datacatalog::v1::ListTagsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets an access control policy for a resource. Replaces any existing
@@ -1457,7 +1512,8 @@ class DataCatalogClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -1468,7 +1524,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -1486,14 +1542,13 @@ class DataCatalogClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `DataCatalogBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets an access control policy for a resource. Replaces any existing
@@ -1516,7 +1571,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -1526,8 +1582,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for a resource.
@@ -1555,7 +1610,8 @@ class DataCatalogClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -1565,7 +1621,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a resource.
@@ -1592,7 +1648,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -1602,8 +1659,7 @@ class DataCatalogClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets your permissions on a resource.
@@ -1623,7 +1679,8 @@ class DataCatalogClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -1634,7 +1691,7 @@ class DataCatalogClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DataCatalogConnection> connection_;

--- a/google/cloud/datacatalog/data_catalog_client.h
+++ b/google/cloud/datacatalog/data_catalog_client.h
@@ -1542,8 +1542,8 @@ class DataCatalogClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/datacatalog/policy_tag_manager_client.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_client.cc
@@ -26,20 +26,18 @@ namespace datacatalog {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PolicyTagManagerClient::PolicyTagManagerClient(
-    std::shared_ptr<PolicyTagManagerConnection> connection, Options options)
+    std::shared_ptr<PolicyTagManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          datacatalog_internal::PolicyTagManagerDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), datacatalog_internal::PolicyTagManagerDefaultOptions(
+                               connection_->options()))) {}
 PolicyTagManagerClient::~PolicyTagManagerClient() = default;
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::CreateTaxonomy(
     std::string const& parent,
-    google::cloud::datacatalog::v1::Taxonomy const& taxonomy, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::Taxonomy const& taxonomy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreateTaxonomyRequest request;
   request.set_parent(parent);
   *request.mutable_taxonomy() = taxonomy;
@@ -49,16 +47,14 @@ PolicyTagManagerClient::CreateTaxonomy(
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::CreateTaxonomy(
     google::cloud::datacatalog::v1::CreateTaxonomyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTaxonomy(request);
 }
 
 Status PolicyTagManagerClient::DeleteTaxonomy(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeleteTaxonomyRequest request;
   request.set_name(name);
   return connection_->DeleteTaxonomy(request);
@@ -66,17 +62,15 @@ Status PolicyTagManagerClient::DeleteTaxonomy(std::string const& name,
 
 Status PolicyTagManagerClient::DeleteTaxonomy(
     google::cloud::datacatalog::v1::DeleteTaxonomyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTaxonomy(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::UpdateTaxonomy(
-    google::cloud::datacatalog::v1::Taxonomy const& taxonomy, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::Taxonomy const& taxonomy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdateTaxonomyRequest request;
   *request.mutable_taxonomy() = taxonomy;
   return connection_->UpdateTaxonomy(request);
@@ -85,17 +79,15 @@ PolicyTagManagerClient::UpdateTaxonomy(
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::UpdateTaxonomy(
     google::cloud::datacatalog::v1::UpdateTaxonomyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTaxonomy(request);
 }
 
 StreamRange<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::ListTaxonomies(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::ListTaxonomiesRequest request;
   request.set_parent(parent);
   return connection_->ListTaxonomies(request);
@@ -104,16 +96,14 @@ PolicyTagManagerClient::ListTaxonomies(std::string const& parent,
 StreamRange<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::ListTaxonomies(
     google::cloud::datacatalog::v1::ListTaxonomiesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTaxonomies(std::move(request));
 }
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
-PolicyTagManagerClient::GetTaxonomy(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+PolicyTagManagerClient::GetTaxonomy(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::GetTaxonomyRequest request;
   request.set_name(name);
   return connection_->GetTaxonomy(request);
@@ -122,19 +112,16 @@ PolicyTagManagerClient::GetTaxonomy(std::string const& name, Options options) {
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerClient::GetTaxonomy(
     google::cloud::datacatalog::v1::GetTaxonomyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTaxonomy(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::CreatePolicyTag(
     std::string const& parent,
-    google::cloud::datacatalog::v1::PolicyTag const& policy_tag,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::PolicyTag const& policy_tag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::CreatePolicyTagRequest request;
   request.set_parent(parent);
   *request.mutable_policy_tag() = policy_tag;
@@ -144,16 +131,14 @@ PolicyTagManagerClient::CreatePolicyTag(
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::CreatePolicyTag(
     google::cloud::datacatalog::v1::CreatePolicyTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreatePolicyTag(request);
 }
 
 Status PolicyTagManagerClient::DeletePolicyTag(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::DeletePolicyTagRequest request;
   request.set_name(name);
   return connection_->DeletePolicyTag(request);
@@ -161,18 +146,15 @@ Status PolicyTagManagerClient::DeletePolicyTag(std::string const& name,
 
 Status PolicyTagManagerClient::DeletePolicyTag(
     google::cloud::datacatalog::v1::DeletePolicyTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeletePolicyTag(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::UpdatePolicyTag(
-    google::cloud::datacatalog::v1::PolicyTag const& policy_tag,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::datacatalog::v1::PolicyTag const& policy_tag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::UpdatePolicyTagRequest request;
   *request.mutable_policy_tag() = policy_tag;
   return connection_->UpdatePolicyTag(request);
@@ -181,17 +163,15 @@ PolicyTagManagerClient::UpdatePolicyTag(
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::UpdatePolicyTag(
     google::cloud::datacatalog::v1::UpdatePolicyTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdatePolicyTag(request);
 }
 
 StreamRange<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::ListPolicyTags(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::ListPolicyTagsRequest request;
   request.set_parent(parent);
   return connection_->ListPolicyTags(request);
@@ -200,16 +180,14 @@ PolicyTagManagerClient::ListPolicyTags(std::string const& parent,
 StreamRange<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::ListPolicyTags(
     google::cloud::datacatalog::v1::ListPolicyTagsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPolicyTags(std::move(request));
 }
 
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>
-PolicyTagManagerClient::GetPolicyTag(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+PolicyTagManagerClient::GetPolicyTag(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::datacatalog::v1::GetPolicyTagRequest request;
   request.set_name(name);
   return connection_->GetPolicyTag(request);
@@ -218,32 +196,27 @@ PolicyTagManagerClient::GetPolicyTag(std::string const& name, Options options) {
 StatusOr<google::cloud::datacatalog::v1::PolicyTag>
 PolicyTagManagerClient::GetPolicyTag(
     google::cloud::datacatalog::v1::GetPolicyTagRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPolicyTag(request);
 }
 
 StatusOr<google::iam::v1::Policy> PolicyTagManagerClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> PolicyTagManagerClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 PolicyTagManagerClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/datacatalog/policy_tag_manager_client.h
+++ b/google/cloud/datacatalog/policy_tag_manager_client.h
@@ -67,7 +67,7 @@ class PolicyTagManagerClient {
  public:
   explicit PolicyTagManagerClient(
       std::shared_ptr<PolicyTagManagerConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~PolicyTagManagerClient();
 
   //@{
@@ -98,7 +98,8 @@ class PolicyTagManagerClient {
   /// @param parent  Required. Resource name of the project that the taxonomy
   /// will belong to.
   /// @param taxonomy  The taxonomy to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -110,7 +111,7 @@ class PolicyTagManagerClient {
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> CreateTaxonomy(
       std::string const& parent,
       google::cloud::datacatalog::v1::Taxonomy const& taxonomy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a taxonomy in a specified project.
@@ -119,7 +120,8 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreateTaxonomyRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L303}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -130,7 +132,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> CreateTaxonomy(
       google::cloud::datacatalog::v1::CreateTaxonomyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a taxonomy, including all policy tags in this
@@ -139,12 +141,13 @@ class PolicyTagManagerClient {
   ///
   /// @param name  Required. Resource name of the taxonomy to delete.
   ///  Note: All policy tags in this taxonomy are also deleted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTaxonomyRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L318}
   ///
-  Status DeleteTaxonomy(std::string const& name, Options options = {});
+  Status DeleteTaxonomy(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a taxonomy, including all policy tags in this
@@ -153,14 +156,15 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeleteTaxonomyRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L318}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeleteTaxonomyRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L318}
   ///
   Status DeleteTaxonomy(
       google::cloud::datacatalog::v1::DeleteTaxonomyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a taxonomy, including its display name,
@@ -169,7 +173,8 @@ class PolicyTagManagerClient {
   /// @param taxonomy  The taxonomy to update. You can update only its
   /// description, display name,
   ///  and activated policy types.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -180,7 +185,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> UpdateTaxonomy(
       google::cloud::datacatalog::v1::Taxonomy const& taxonomy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a taxonomy, including its display name,
@@ -188,7 +193,8 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdateTaxonomyRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L332}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -199,7 +205,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> UpdateTaxonomy(
       google::cloud::datacatalog::v1::UpdateTaxonomyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all taxonomies in a project in a particular location that you
@@ -207,7 +213,8 @@ class PolicyTagManagerClient {
   ///
   /// @param parent  Required. Resource name of the project to list the
   /// taxonomies of.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -217,7 +224,7 @@ class PolicyTagManagerClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
   StreamRange<google::cloud::datacatalog::v1::Taxonomy> ListTaxonomies(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all taxonomies in a project in a particular location that you
@@ -225,7 +232,8 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ListTaxonomiesRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L347}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -236,13 +244,14 @@ class PolicyTagManagerClient {
   ///
   StreamRange<google::cloud::datacatalog::v1::Taxonomy> ListTaxonomies(
       google::cloud::datacatalog::v1::ListTaxonomiesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a taxonomy.
   ///
   /// @param name  Required. Resource name of the taxonomy to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -252,14 +261,15 @@ class PolicyTagManagerClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> GetTaxonomy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a taxonomy.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::GetTaxonomyRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L380}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -270,7 +280,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> GetTaxonomy(
       google::cloud::datacatalog::v1::GetTaxonomyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a policy tag in a taxonomy.
@@ -278,7 +288,8 @@ class PolicyTagManagerClient {
   /// @param parent  Required. Resource name of the taxonomy that the policy tag
   /// will belong to.
   /// @param policy_tag  The policy tag to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -290,14 +301,15 @@ class PolicyTagManagerClient {
   StatusOr<google::cloud::datacatalog::v1::PolicyTag> CreatePolicyTag(
       std::string const& parent,
       google::cloud::datacatalog::v1::PolicyTag const& policy_tag,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a policy tag in a taxonomy.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::CreatePolicyTagRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L392}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -308,7 +320,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::PolicyTag> CreatePolicyTag(
       google::cloud::datacatalog::v1::CreatePolicyTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a policy tag together with the following:
@@ -320,12 +332,13 @@ class PolicyTagManagerClient {
   ///
   /// @param name  Required. Resource name of the policy tag to delete.
   ///  Note: All of its descendant policy tags are also deleted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeletePolicyTagRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L407}
   ///
-  Status DeletePolicyTag(std::string const& name, Options options = {});
+  Status DeletePolicyTag(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a policy tag together with the following:
@@ -337,14 +350,15 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::DeletePolicyTagRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L407}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.datacatalog.v1.DeletePolicyTagRequest]:
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L407}
   ///
   Status DeletePolicyTag(
       google::cloud::datacatalog::v1::DeletePolicyTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a policy tag, including its display
@@ -353,7 +367,8 @@ class PolicyTagManagerClient {
   /// @param policy_tag  The policy tag to update. You can update only its
   /// description, display
   ///  name, and parent policy tag fields.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -364,7 +379,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::PolicyTag> UpdatePolicyTag(
       google::cloud::datacatalog::v1::PolicyTag const& policy_tag,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a policy tag, including its display
@@ -372,7 +387,8 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::UpdatePolicyTagRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L421}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -383,14 +399,15 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::PolicyTag> UpdatePolicyTag(
       google::cloud::datacatalog::v1::UpdatePolicyTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all policy tags in a taxonomy.
   ///
   /// @param parent  Required. Resource name of the taxonomy to list the policy
   /// tags of.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -400,14 +417,15 @@ class PolicyTagManagerClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
   StreamRange<google::cloud::datacatalog::v1::PolicyTag> ListPolicyTags(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all policy tags in a taxonomy.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ListPolicyTagsRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L437}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -418,13 +436,14 @@ class PolicyTagManagerClient {
   ///
   StreamRange<google::cloud::datacatalog::v1::PolicyTag> ListPolicyTags(
       google::cloud::datacatalog::v1::ListPolicyTagsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a policy tag.
   ///
   /// @param name  Required. Resource name of the policy tag.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -434,14 +453,15 @@ class PolicyTagManagerClient {
   /// @googleapis_reference_link{google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
   StatusOr<google::cloud::datacatalog::v1::PolicyTag> GetPolicyTag(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a policy tag.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::GetPolicyTagRequest,google/cloud/datacatalog/v1/policytagmanager.proto#L471}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::PolicyTag,google/cloud/datacatalog/v1/policytagmanager.proto#L264}
   ///
@@ -452,14 +472,15 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::PolicyTag> GetPolicyTag(
       google::cloud::datacatalog::v1::GetPolicyTagRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the IAM policy for a policy tag or a taxonomy.
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -469,15 +490,15 @@ class PolicyTagManagerClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the IAM policy for a policy tag or a taxonomy.
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -487,8 +508,7 @@ class PolicyTagManagerClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns your permissions on a specified policy tag or
@@ -496,7 +516,8 @@ class PolicyTagManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -507,7 +528,7 @@ class PolicyTagManagerClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<PolicyTagManagerConnection> connection_;

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_client.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PolicyTagManagerSerializationClient::PolicyTagManagerSerializationClient(
     std::shared_ptr<PolicyTagManagerSerializationConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           datacatalog_internal::PolicyTagManagerSerializationDefaultOptions(
               connection_->options()))) {}
 PolicyTagManagerSerializationClient::~PolicyTagManagerSerializationClient() =
@@ -39,27 +39,24 @@ PolicyTagManagerSerializationClient::~PolicyTagManagerSerializationClient() =
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerSerializationClient::ReplaceTaxonomy(
     google::cloud::datacatalog::v1::ReplaceTaxonomyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReplaceTaxonomy(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::ImportTaxonomiesResponse>
 PolicyTagManagerSerializationClient::ImportTaxonomies(
     google::cloud::datacatalog::v1::ImportTaxonomiesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportTaxonomies(request);
 }
 
 StatusOr<google::cloud::datacatalog::v1::ExportTaxonomiesResponse>
 PolicyTagManagerSerializationClient::ExportTaxonomies(
     google::cloud::datacatalog::v1::ExportTaxonomiesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExportTaxonomies(request);
 }
 

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_client.h
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_client.h
@@ -65,7 +65,7 @@ class PolicyTagManagerSerializationClient {
  public:
   explicit PolicyTagManagerSerializationClient(
       std::shared_ptr<PolicyTagManagerSerializationConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~PolicyTagManagerSerializationClient();
 
   //@{
@@ -109,7 +109,8 @@ class PolicyTagManagerSerializationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ReplaceTaxonomyRequest,google/cloud/datacatalog/v1/policytagmanagerserialization.proto#L132}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::Taxonomy,google/cloud/datacatalog/v1/policytagmanager.proto#L206}
   ///
@@ -120,7 +121,7 @@ class PolicyTagManagerSerializationClient {
   ///
   StatusOr<google::cloud::datacatalog::v1::Taxonomy> ReplaceTaxonomy(
       google::cloud::datacatalog::v1::ReplaceTaxonomyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates new taxonomies (including their policy tags) in a given project
@@ -134,7 +135,8 @@ class PolicyTagManagerSerializationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ImportTaxonomiesRequest,google/cloud/datacatalog/v1/policytagmanagerserialization.proto#L147}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::ImportTaxonomiesResponse,google/cloud/datacatalog/v1/policytagmanagerserialization.proto#L186}
   ///
@@ -146,7 +148,7 @@ class PolicyTagManagerSerializationClient {
   StatusOr<google::cloud::datacatalog::v1::ImportTaxonomiesResponse>
   ImportTaxonomies(
       google::cloud::datacatalog::v1::ImportTaxonomiesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Exports taxonomies in the requested type and returns them,
@@ -158,7 +160,8 @@ class PolicyTagManagerSerializationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::datacatalog::v1::ExportTaxonomiesRequest,google/cloud/datacatalog/v1/policytagmanagerserialization.proto#L193}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::datacatalog::v1::ExportTaxonomiesResponse,google/cloud/datacatalog/v1/policytagmanagerserialization.proto#L220}
   ///
@@ -170,7 +173,7 @@ class PolicyTagManagerSerializationClient {
   StatusOr<google::cloud::datacatalog::v1::ExportTaxonomiesResponse>
   ExportTaxonomies(
       google::cloud::datacatalog::v1::ExportTaxonomiesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<PolicyTagManagerSerializationConnection> connection_;

--- a/google/cloud/datamigration/data_migration_client.cc
+++ b/google/cloud/datamigration/data_migration_client.cc
@@ -26,19 +26,18 @@ namespace datamigration {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataMigrationServiceClient::DataMigrationServiceClient(
-    std::shared_ptr<DataMigrationServiceConnection> connection, Options options)
+    std::shared_ptr<DataMigrationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           datamigration_internal::DataMigrationServiceDefaultOptions(
               connection_->options()))) {}
 DataMigrationServiceClient::~DataMigrationServiceClient() = default;
 
 StreamRange<google::cloud::clouddms::v1::MigrationJob>
 DataMigrationServiceClient::ListMigrationJobs(std::string const& parent,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::ListMigrationJobsRequest request;
   request.set_parent(parent);
   return connection_->ListMigrationJobs(request);
@@ -47,17 +46,15 @@ DataMigrationServiceClient::ListMigrationJobs(std::string const& parent,
 StreamRange<google::cloud::clouddms::v1::MigrationJob>
 DataMigrationServiceClient::ListMigrationJobs(
     google::cloud::clouddms::v1::ListMigrationJobsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMigrationJobs(std::move(request));
 }
 
 StatusOr<google::cloud::clouddms::v1::MigrationJob>
 DataMigrationServiceClient::GetMigrationJob(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::GetMigrationJobRequest request;
   request.set_name(name);
   return connection_->GetMigrationJob(request);
@@ -66,9 +63,8 @@ DataMigrationServiceClient::GetMigrationJob(std::string const& name,
 StatusOr<google::cloud::clouddms::v1::MigrationJob>
 DataMigrationServiceClient::GetMigrationJob(
     google::cloud::clouddms::v1::GetMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMigrationJob(request);
 }
 
@@ -76,9 +72,8 @@ future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::CreateMigrationJob(
     std::string const& parent,
     google::cloud::clouddms::v1::MigrationJob const& migration_job,
-    std::string const& migration_job_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& migration_job_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::CreateMigrationJobRequest request;
   request.set_parent(parent);
   *request.mutable_migration_job() = migration_job;
@@ -89,18 +84,16 @@ DataMigrationServiceClient::CreateMigrationJob(
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::CreateMigrationJob(
     google::cloud::clouddms::v1::CreateMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::UpdateMigrationJob(
     google::cloud::clouddms::v1::MigrationJob const& migration_job,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::UpdateMigrationJobRequest request;
   *request.mutable_migration_job() = migration_job;
   *request.mutable_update_mask() = update_mask;
@@ -110,17 +103,15 @@ DataMigrationServiceClient::UpdateMigrationJob(
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::UpdateMigrationJob(
     google::cloud::clouddms::v1::UpdateMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
 DataMigrationServiceClient::DeleteMigrationJob(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::DeleteMigrationJobRequest request;
   request.set_name(name);
   return connection_->DeleteMigrationJob(request);
@@ -129,80 +120,71 @@ DataMigrationServiceClient::DeleteMigrationJob(std::string const& name,
 future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
 DataMigrationServiceClient::DeleteMigrationJob(
     google::cloud::clouddms::v1::DeleteMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::StartMigrationJob(
     google::cloud::clouddms::v1::StartMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::StopMigrationJob(
     google::cloud::clouddms::v1::StopMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StopMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::ResumeMigrationJob(
     google::cloud::clouddms::v1::ResumeMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResumeMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::PromoteMigrationJob(
     google::cloud::clouddms::v1::PromoteMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PromoteMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::VerifyMigrationJob(
     google::cloud::clouddms::v1::VerifyMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->VerifyMigrationJob(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
 DataMigrationServiceClient::RestartMigrationJob(
     google::cloud::clouddms::v1::RestartMigrationJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RestartMigrationJob(request);
 }
 
 StatusOr<google::cloud::clouddms::v1::SshScript>
 DataMigrationServiceClient::GenerateSshScript(
     google::cloud::clouddms::v1::GenerateSshScriptRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateSshScript(request);
 }
 
 StreamRange<google::cloud::clouddms::v1::ConnectionProfile>
 DataMigrationServiceClient::ListConnectionProfiles(std::string const& parent,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::ListConnectionProfilesRequest request;
   request.set_parent(parent);
   return connection_->ListConnectionProfiles(request);
@@ -211,17 +193,15 @@ DataMigrationServiceClient::ListConnectionProfiles(std::string const& parent,
 StreamRange<google::cloud::clouddms::v1::ConnectionProfile>
 DataMigrationServiceClient::ListConnectionProfiles(
     google::cloud::clouddms::v1::ListConnectionProfilesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListConnectionProfiles(std::move(request));
 }
 
 StatusOr<google::cloud::clouddms::v1::ConnectionProfile>
 DataMigrationServiceClient::GetConnectionProfile(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::GetConnectionProfileRequest request;
   request.set_name(name);
   return connection_->GetConnectionProfile(request);
@@ -230,9 +210,8 @@ DataMigrationServiceClient::GetConnectionProfile(std::string const& name,
 StatusOr<google::cloud::clouddms::v1::ConnectionProfile>
 DataMigrationServiceClient::GetConnectionProfile(
     google::cloud::clouddms::v1::GetConnectionProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetConnectionProfile(request);
 }
 
@@ -240,9 +219,8 @@ future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>
 DataMigrationServiceClient::CreateConnectionProfile(
     std::string const& parent,
     google::cloud::clouddms::v1::ConnectionProfile const& connection_profile,
-    std::string const& connection_profile_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& connection_profile_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::CreateConnectionProfileRequest request;
   request.set_parent(parent);
   *request.mutable_connection_profile() = connection_profile;
@@ -253,18 +231,16 @@ DataMigrationServiceClient::CreateConnectionProfile(
 future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>
 DataMigrationServiceClient::CreateConnectionProfile(
     google::cloud::clouddms::v1::CreateConnectionProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateConnectionProfile(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>
 DataMigrationServiceClient::UpdateConnectionProfile(
     google::cloud::clouddms::v1::ConnectionProfile const& connection_profile,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::UpdateConnectionProfileRequest request;
   *request.mutable_connection_profile() = connection_profile;
   *request.mutable_update_mask() = update_mask;
@@ -274,17 +250,15 @@ DataMigrationServiceClient::UpdateConnectionProfile(
 future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>
 DataMigrationServiceClient::UpdateConnectionProfile(
     google::cloud::clouddms::v1::UpdateConnectionProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateConnectionProfile(request);
 }
 
 future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
 DataMigrationServiceClient::DeleteConnectionProfile(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::clouddms::v1::DeleteConnectionProfileRequest request;
   request.set_name(name);
   return connection_->DeleteConnectionProfile(request);
@@ -293,9 +267,8 @@ DataMigrationServiceClient::DeleteConnectionProfile(std::string const& name,
 future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
 DataMigrationServiceClient::DeleteConnectionProfile(
     google::cloud::clouddms::v1::DeleteConnectionProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteConnectionProfile(request);
 }
 

--- a/google/cloud/datamigration/data_migration_client.h
+++ b/google/cloud/datamigration/data_migration_client.h
@@ -64,7 +64,7 @@ class DataMigrationServiceClient {
  public:
   explicit DataMigrationServiceClient(
       std::shared_ptr<DataMigrationServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~DataMigrationServiceClient();
 
   //@{
@@ -93,7 +93,8 @@ class DataMigrationServiceClient {
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// migrationJobs.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -103,14 +104,15 @@ class DataMigrationServiceClient {
   /// @googleapis_reference_link{google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
   StreamRange<google::cloud::clouddms::v1::MigrationJob> ListMigrationJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists migration jobs in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::ListMigrationJobsRequest,google/cloud/clouddms/v1/clouddms.proto#L239}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -121,13 +123,14 @@ class DataMigrationServiceClient {
   ///
   StreamRange<google::cloud::clouddms::v1::MigrationJob> ListMigrationJobs(
       google::cloud::clouddms::v1::ListMigrationJobsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single migration job.
   ///
   /// @param name  Required. Name of the migration job resource to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -137,14 +140,15 @@ class DataMigrationServiceClient {
   /// @googleapis_reference_link{google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
   StatusOr<google::cloud::clouddms::v1::MigrationJob> GetMigrationJob(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single migration job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::GetMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L291}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -155,7 +159,7 @@ class DataMigrationServiceClient {
   ///
   StatusOr<google::cloud::clouddms::v1::MigrationJob> GetMigrationJob(
       google::cloud::clouddms::v1::GetMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new migration job in a given project and location.
@@ -166,7 +170,8 @@ class DataMigrationServiceClient {
   ///  job](https://cloud.google.com/database-migration/docs/reference/rest/v1/projects.locations.migrationJobs)
   ///  object.
   /// @param migration_job_id  Required. The ID of the instance to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -179,14 +184,15 @@ class DataMigrationServiceClient {
   CreateMigrationJob(
       std::string const& parent,
       google::cloud::clouddms::v1::MigrationJob const& migration_job,
-      std::string const& migration_job_id, Options options = {});
+      std::string const& migration_job_id, Options opts = {});
 
   ///
   /// Creates a new migration job in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::CreateMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L303}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -198,7 +204,7 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   CreateMigrationJob(
       google::cloud::clouddms::v1::CreateMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single migration job.
@@ -207,7 +213,8 @@ class DataMigrationServiceClient {
   /// @param update_mask  Required. Field mask is used to specify the fields to
   /// be overwritten in the
   ///  migration job resource by the update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -219,14 +226,15 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   UpdateMigrationJob(
       google::cloud::clouddms::v1::MigrationJob const& migration_job,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single migration job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::UpdateMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L331}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -238,13 +246,14 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   UpdateMigrationJob(
       google::cloud::clouddms::v1::UpdateMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single migration job.
   ///
   /// @param name  Required. Name of the migration job resource to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::OperationMetadata,google/cloud/clouddms/v1/clouddms.proto#L601}
   ///
@@ -254,14 +263,15 @@ class DataMigrationServiceClient {
   /// @googleapis_reference_link{google/cloud/clouddms/v1/clouddms.proto#L601}
   ///
   future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
-  DeleteMigrationJob(std::string const& name, Options options = {});
+  DeleteMigrationJob(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single migration job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::DeleteMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L350}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::OperationMetadata,google/cloud/clouddms/v1/clouddms.proto#L601}
   ///
@@ -273,14 +283,15 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
   DeleteMigrationJob(
       google::cloud::clouddms::v1::DeleteMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Start an already created migration job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::StartMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L375}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -291,14 +302,15 @@ class DataMigrationServiceClient {
   ///
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>> StartMigrationJob(
       google::cloud::clouddms::v1::StartMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a running migration job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::StopMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L383}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -309,7 +321,7 @@ class DataMigrationServiceClient {
   ///
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>> StopMigrationJob(
       google::cloud::clouddms::v1::StopMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resume a migration job that is currently stopped and is resumable (was
@@ -317,7 +329,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::ResumeMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L391}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -329,7 +342,7 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   ResumeMigrationJob(
       google::cloud::clouddms::v1::ResumeMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Promote a migration job, stopping replication to the destination and
@@ -337,7 +350,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::PromoteMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L399}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -349,7 +363,7 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   PromoteMigrationJob(
       google::cloud::clouddms::v1::PromoteMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Verify a migration job, making sure the destination can reach the source
@@ -357,7 +371,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::VerifyMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L407}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -369,7 +384,7 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   VerifyMigrationJob(
       google::cloud::clouddms::v1::VerifyMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Restart a stopped or failed migration job, resetting the destination
@@ -378,7 +393,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::RestartMigrationJobRequest,google/cloud/clouddms/v1/clouddms.proto#L415}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::MigrationJob,google/cloud/clouddms/v1/clouddms_resources.proto#L373}
   ///
@@ -390,7 +406,7 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::MigrationJob>>
   RestartMigrationJob(
       google::cloud::clouddms::v1::RestartMigrationJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Generate a SSH configuration script to configure the reverse SSH
@@ -398,7 +414,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::GenerateSshScriptRequest,google/cloud/clouddms/v1/clouddms.proto#L423}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::SshScript,google/cloud/clouddms/v1/clouddms.proto#L464}
   ///
@@ -409,7 +426,7 @@ class DataMigrationServiceClient {
   ///
   StatusOr<google::cloud::clouddms::v1::SshScript> GenerateSshScript(
       google::cloud::clouddms::v1::GenerateSshScriptRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieve a list of all connection profiles in a given project and
@@ -417,7 +434,8 @@ class DataMigrationServiceClient {
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// connection profiles.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -427,7 +445,7 @@ class DataMigrationServiceClient {
   /// @googleapis_reference_link{google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
   StreamRange<google::cloud::clouddms::v1::ConnectionProfile>
-  ListConnectionProfiles(std::string const& parent, Options options = {});
+  ListConnectionProfiles(std::string const& parent, Options opts = {});
 
   ///
   /// Retrieve a list of all connection profiles in a given project and
@@ -435,7 +453,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::ListConnectionProfilesRequest,google/cloud/clouddms/v1/clouddms.proto#L470}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -447,13 +466,14 @@ class DataMigrationServiceClient {
   StreamRange<google::cloud::clouddms::v1::ConnectionProfile>
   ListConnectionProfiles(
       google::cloud::clouddms::v1::ListConnectionProfilesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single connection profile.
   ///
   /// @param name  Required. Name of the connection profile resource to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -463,14 +483,15 @@ class DataMigrationServiceClient {
   /// @googleapis_reference_link{google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
   StatusOr<google::cloud::clouddms::v1::ConnectionProfile> GetConnectionProfile(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single connection profile.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::GetConnectionProfileRequest,google/cloud/clouddms/v1/clouddms.proto#L521}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -481,7 +502,7 @@ class DataMigrationServiceClient {
   ///
   StatusOr<google::cloud::clouddms::v1::ConnectionProfile> GetConnectionProfile(
       google::cloud::clouddms::v1::GetConnectionProfileRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new connection profile in a given project and location.
@@ -491,7 +512,8 @@ class DataMigrationServiceClient {
   /// @param connection_profile  Required. The create request body including the
   /// connection profile data
   /// @param connection_profile_id  Required. The connection profile identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -504,14 +526,15 @@ class DataMigrationServiceClient {
   CreateConnectionProfile(
       std::string const& parent,
       google::cloud::clouddms::v1::ConnectionProfile const& connection_profile,
-      std::string const& connection_profile_id, Options options = {});
+      std::string const& connection_profile_id, Options opts = {});
 
   ///
   /// Creates a new connection profile in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::CreateConnectionProfileRequest,google/cloud/clouddms/v1/clouddms.proto#L532}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -524,7 +547,7 @@ class DataMigrationServiceClient {
   CreateConnectionProfile(
       google::cloud::clouddms::v1::CreateConnectionProfileRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update the configuration of a single connection profile.
@@ -534,7 +557,8 @@ class DataMigrationServiceClient {
   /// @param update_mask  Required. Field mask is used to specify the fields to
   /// be overwritten in the
   ///  connection profile resource by the update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -546,14 +570,15 @@ class DataMigrationServiceClient {
   future<StatusOr<google::cloud::clouddms::v1::ConnectionProfile>>
   UpdateConnectionProfile(
       google::cloud::clouddms::v1::ConnectionProfile const& connection_profile,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update the configuration of a single connection profile.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::UpdateConnectionProfileRequest,google/cloud/clouddms/v1/clouddms.proto#L558}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::ConnectionProfile,google/cloud/clouddms/v1/clouddms_resources.proto#L537}
   ///
@@ -566,7 +591,7 @@ class DataMigrationServiceClient {
   UpdateConnectionProfile(
       google::cloud::clouddms::v1::UpdateConnectionProfileRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Database Migration Service connection profile.
@@ -574,7 +599,8 @@ class DataMigrationServiceClient {
   /// active migration jobs.
   ///
   /// @param name  Required. Name of the connection profile resource to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::OperationMetadata,google/cloud/clouddms/v1/clouddms.proto#L601}
   ///
@@ -584,7 +610,7 @@ class DataMigrationServiceClient {
   /// @googleapis_reference_link{google/cloud/clouddms/v1/clouddms.proto#L601}
   ///
   future<StatusOr<google::cloud::clouddms::v1::OperationMetadata>>
-  DeleteConnectionProfile(std::string const& name, Options options = {});
+  DeleteConnectionProfile(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Database Migration Service connection profile.
@@ -593,7 +619,8 @@ class DataMigrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::clouddms::v1::DeleteConnectionProfileRequest,google/cloud/clouddms/v1/clouddms.proto#L577}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::clouddms::v1::OperationMetadata,google/cloud/clouddms/v1/clouddms.proto#L601}
   ///
@@ -606,7 +633,7 @@ class DataMigrationServiceClient {
   DeleteConnectionProfile(
       google::cloud::clouddms::v1::DeleteConnectionProfileRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DataMigrationServiceConnection> connection_;

--- a/google/cloud/dataproc/autoscaling_policy_client.cc
+++ b/google/cloud/dataproc/autoscaling_policy_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AutoscalingPolicyServiceClient::AutoscalingPolicyServiceClient(
     std::shared_ptr<AutoscalingPolicyServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           dataproc_internal::AutoscalingPolicyServiceDefaultOptions(
               connection_->options()))) {}
 AutoscalingPolicyServiceClient::~AutoscalingPolicyServiceClient() = default;
@@ -39,9 +39,8 @@ StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::CreateAutoscalingPolicy(
     std::string const& parent,
     google::cloud::dataproc::v1::AutoscalingPolicy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::CreateAutoscalingPolicyRequest request;
   request.set_parent(parent);
   *request.mutable_policy() = policy;
@@ -51,18 +50,16 @@ AutoscalingPolicyServiceClient::CreateAutoscalingPolicy(
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::CreateAutoscalingPolicy(
     google::cloud::dataproc::v1::CreateAutoscalingPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAutoscalingPolicy(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::UpdateAutoscalingPolicy(
     google::cloud::dataproc::v1::AutoscalingPolicy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::UpdateAutoscalingPolicyRequest request;
   *request.mutable_policy() = policy;
   return connection_->UpdateAutoscalingPolicy(request);
@@ -71,17 +68,15 @@ AutoscalingPolicyServiceClient::UpdateAutoscalingPolicy(
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::UpdateAutoscalingPolicy(
     google::cloud::dataproc::v1::UpdateAutoscalingPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAutoscalingPolicy(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::GetAutoscalingPolicy(std::string const& name,
-                                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::GetAutoscalingPolicyRequest request;
   request.set_name(name);
   return connection_->GetAutoscalingPolicy(request);
@@ -90,17 +85,15 @@ AutoscalingPolicyServiceClient::GetAutoscalingPolicy(std::string const& name,
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::GetAutoscalingPolicy(
     google::cloud::dataproc::v1::GetAutoscalingPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAutoscalingPolicy(request);
 }
 
 StreamRange<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::ListAutoscalingPolicies(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListAutoscalingPoliciesRequest request;
   request.set_parent(parent);
   return connection_->ListAutoscalingPolicies(request);
@@ -109,16 +102,14 @@ AutoscalingPolicyServiceClient::ListAutoscalingPolicies(
 StreamRange<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceClient::ListAutoscalingPolicies(
     google::cloud::dataproc::v1::ListAutoscalingPoliciesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAutoscalingPolicies(std::move(request));
 }
 
 Status AutoscalingPolicyServiceClient::DeleteAutoscalingPolicy(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::DeleteAutoscalingPolicyRequest request;
   request.set_name(name);
   return connection_->DeleteAutoscalingPolicy(request);
@@ -126,9 +117,8 @@ Status AutoscalingPolicyServiceClient::DeleteAutoscalingPolicy(
 
 Status AutoscalingPolicyServiceClient::DeleteAutoscalingPolicy(
     google::cloud::dataproc::v1::DeleteAutoscalingPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAutoscalingPolicy(request);
 }
 

--- a/google/cloud/dataproc/autoscaling_policy_client.h
+++ b/google/cloud/dataproc/autoscaling_policy_client.h
@@ -64,7 +64,7 @@ class AutoscalingPolicyServiceClient {
  public:
   explicit AutoscalingPolicyServiceClient(
       std::shared_ptr<AutoscalingPolicyServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AutoscalingPolicyServiceClient();
 
   //@{
@@ -103,7 +103,8 @@ class AutoscalingPolicyServiceClient {
   ///    of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
   /// @param policy  Required. The autoscaling policy to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -116,14 +117,15 @@ class AutoscalingPolicyServiceClient {
   CreateAutoscalingPolicy(
       std::string const& parent,
       google::cloud::dataproc::v1::AutoscalingPolicy const& policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates new autoscaling policy.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::CreateAutoscalingPolicyRequest,google/cloud/dataproc/v1/autoscaling_policies.proto#L258}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -136,7 +138,7 @@ class AutoscalingPolicyServiceClient {
   CreateAutoscalingPolicy(
       google::cloud::dataproc::v1::CreateAutoscalingPolicyRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates (replaces) autoscaling policy.
@@ -145,7 +147,8 @@ class AutoscalingPolicyServiceClient {
   /// replacements.
   ///
   /// @param policy  Required. The updated autoscaling policy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -157,7 +160,7 @@ class AutoscalingPolicyServiceClient {
   StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
   UpdateAutoscalingPolicy(
       google::cloud::dataproc::v1::AutoscalingPolicy const& policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates (replaces) autoscaling policy.
@@ -167,7 +170,8 @@ class AutoscalingPolicyServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::UpdateAutoscalingPolicyRequest,google/cloud/dataproc/v1/autoscaling_policies.proto#L301}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -180,7 +184,7 @@ class AutoscalingPolicyServiceClient {
   UpdateAutoscalingPolicy(
       google::cloud::dataproc::v1::UpdateAutoscalingPolicyRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves autoscaling policy.
@@ -194,7 +198,8 @@ class AutoscalingPolicyServiceClient {
   ///  * For `projects.locations.autoscalingPolicies.get`, the resource name
   ///    of the policy has the following format:
   ///    `projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -204,14 +209,15 @@ class AutoscalingPolicyServiceClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
   StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy> GetAutoscalingPolicy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves autoscaling policy.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::GetAutoscalingPolicyRequest,google/cloud/dataproc/v1/autoscaling_policies.proto#L281}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -222,7 +228,7 @@ class AutoscalingPolicyServiceClient {
   ///
   StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy> GetAutoscalingPolicy(
       google::cloud::dataproc::v1::GetAutoscalingPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists autoscaling policies in the project.
@@ -236,7 +242,8 @@ class AutoscalingPolicyServiceClient {
   ///  * For `projects.locations.autoscalingPolicies.list`, the resource name
   ///    of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -246,14 +253,15 @@ class AutoscalingPolicyServiceClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
   StreamRange<google::cloud::dataproc::v1::AutoscalingPolicy>
-  ListAutoscalingPolicies(std::string const& parent, Options options = {});
+  ListAutoscalingPolicies(std::string const& parent, Options opts = {});
 
   ///
   /// Lists autoscaling policies in the project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::ListAutoscalingPoliciesRequest,google/cloud/dataproc/v1/autoscaling_policies.proto#L329}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::AutoscalingPolicy,google/cloud/dataproc/v1/autoscaling_policies.proto#L106}
   ///
@@ -265,7 +273,7 @@ class AutoscalingPolicyServiceClient {
   StreamRange<google::cloud::dataproc::v1::AutoscalingPolicy>
   ListAutoscalingPolicies(
       google::cloud::dataproc::v1::ListAutoscalingPoliciesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an autoscaling policy. It is an error to delete an autoscaling
@@ -280,12 +288,13 @@ class AutoscalingPolicyServiceClient {
   ///  * For `projects.locations.autoscalingPolicies.delete`, the resource name
   ///    of the policy has the following format:
   ///    `projects/{project_id}/locations/{location}/autoscalingPolicies/{policy_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/autoscaling_policies.proto#L309}
   ///
-  Status DeleteAutoscalingPolicy(std::string const& name, Options options = {});
+  Status DeleteAutoscalingPolicy(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an autoscaling policy. It is an error to delete an autoscaling
@@ -293,7 +302,8 @@ class AutoscalingPolicyServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::DeleteAutoscalingPolicyRequest,google/cloud/dataproc/v1/autoscaling_policies.proto#L309}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteAutoscalingPolicyRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/autoscaling_policies.proto#L309}
@@ -301,7 +311,7 @@ class AutoscalingPolicyServiceClient {
   Status DeleteAutoscalingPolicy(
       google::cloud::dataproc::v1::DeleteAutoscalingPolicyRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AutoscalingPolicyServiceConnection> connection_;

--- a/google/cloud/dataproc/batch_controller_client.cc
+++ b/google/cloud/dataproc/batch_controller_client.cc
@@ -26,19 +26,18 @@ namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 BatchControllerClient::BatchControllerClient(
-    std::shared_ptr<BatchControllerConnection> connection, Options options)
+    std::shared_ptr<BatchControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), dataproc_internal::BatchControllerDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), dataproc_internal::BatchControllerDefaultOptions(
+                               connection_->options()))) {}
 BatchControllerClient::~BatchControllerClient() = default;
 
 future<StatusOr<google::cloud::dataproc::v1::Batch>>
 BatchControllerClient::CreateBatch(
     std::string const& parent, google::cloud::dataproc::v1::Batch const& batch,
-    std::string const& batch_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& batch_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::CreateBatchRequest request;
   request.set_parent(parent);
   *request.mutable_batch() = batch;
@@ -49,33 +48,28 @@ BatchControllerClient::CreateBatch(
 future<StatusOr<google::cloud::dataproc::v1::Batch>>
 BatchControllerClient::CreateBatch(
     google::cloud::dataproc::v1::CreateBatchRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBatch(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::Batch> BatchControllerClient::GetBatch(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::GetBatchRequest request;
   request.set_name(name);
   return connection_->GetBatch(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::Batch> BatchControllerClient::GetBatch(
-    google::cloud::dataproc::v1::GetBatchRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::GetBatchRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBatch(request);
 }
 
 StreamRange<google::cloud::dataproc::v1::Batch>
-BatchControllerClient::ListBatches(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+BatchControllerClient::ListBatches(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListBatchesRequest request;
   request.set_parent(parent);
   return connection_->ListBatches(request);
@@ -83,16 +77,14 @@ BatchControllerClient::ListBatches(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::dataproc::v1::Batch>
 BatchControllerClient::ListBatches(
-    google::cloud::dataproc::v1::ListBatchesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::ListBatchesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBatches(std::move(request));
 }
 
 Status BatchControllerClient::DeleteBatch(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::DeleteBatchRequest request;
   request.set_name(name);
   return connection_->DeleteBatch(request);
@@ -100,9 +92,8 @@ Status BatchControllerClient::DeleteBatch(std::string const& name,
 
 Status BatchControllerClient::DeleteBatch(
     google::cloud::dataproc::v1::DeleteBatchRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBatch(request);
 }
 

--- a/google/cloud/dataproc/batch_controller_client.h
+++ b/google/cloud/dataproc/batch_controller_client.h
@@ -63,8 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class BatchControllerClient {
  public:
   explicit BatchControllerClient(
-      std::shared_ptr<BatchControllerConnection> connection,
-      Options options = {});
+      std::shared_ptr<BatchControllerConnection> connection, Options opts = {});
   ~BatchControllerClient();
 
   //@{
@@ -97,7 +96,8 @@ class BatchControllerClient {
   /// the final component of
   ///  the batch's resource name.
   ///  This value must be 4-63 characters. Valid characters are `/[a-z][0-9]-/`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Batch,google/cloud/dataproc/v1/batches.proto#L164}
   ///
@@ -109,14 +109,15 @@ class BatchControllerClient {
   future<StatusOr<google::cloud::dataproc::v1::Batch>> CreateBatch(
       std::string const& parent,
       google::cloud::dataproc::v1::Batch const& batch,
-      std::string const& batch_id, Options options = {});
+      std::string const& batch_id, Options opts = {});
 
   ///
   /// Creates a batch workload that executes asynchronously.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::CreateBatchRequest,google/cloud/dataproc/v1/batches.proto#L78}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Batch,google/cloud/dataproc/v1/batches.proto#L164}
   ///
@@ -127,13 +128,14 @@ class BatchControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Batch>> CreateBatch(
       google::cloud::dataproc::v1::CreateBatchRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the batch workload resource representation.
   ///
   /// @param name  Required. The name of the batch to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Batch,google/cloud/dataproc/v1/batches.proto#L164}
   ///
@@ -143,14 +145,15 @@ class BatchControllerClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/batches.proto#L164}
   ///
   StatusOr<google::cloud::dataproc::v1::Batch> GetBatch(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Gets the batch workload resource representation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::GetBatchRequest,google/cloud/dataproc/v1/batches.proto#L112}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Batch,google/cloud/dataproc/v1/batches.proto#L164}
   ///
@@ -161,14 +164,15 @@ class BatchControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Batch> GetBatch(
       google::cloud::dataproc::v1::GetBatchRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists batch workloads.
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// batches.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Batch,google/cloud/dataproc/v1/batches.proto#L164}
   ///
@@ -178,14 +182,15 @@ class BatchControllerClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/batches.proto#L164}
   ///
   StreamRange<google::cloud::dataproc::v1::Batch> ListBatches(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists batch workloads.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::ListBatchesRequest,google/cloud/dataproc/v1/batches.proto#L123}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Batch,google/cloud/dataproc/v1/batches.proto#L164}
   ///
@@ -196,19 +201,20 @@ class BatchControllerClient {
   ///
   StreamRange<google::cloud::dataproc::v1::Batch> ListBatches(
       google::cloud::dataproc::v1::ListBatchesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the batch workload resource. If the batch is not in terminal
   /// state, the delete fails and the response returns `FAILED_PRECONDITION`.
   ///
   /// @param name  Required. The name of the batch resource to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteBatchRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/batches.proto#L153}
   ///
-  Status DeleteBatch(std::string const& name, Options options = {});
+  Status DeleteBatch(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the batch workload resource. If the batch is not in terminal
@@ -216,14 +222,15 @@ class BatchControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::DeleteBatchRequest,google/cloud/dataproc/v1/batches.proto#L153}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteBatchRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/batches.proto#L153}
   ///
   Status DeleteBatch(
       google::cloud::dataproc::v1::DeleteBatchRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<BatchControllerConnection> connection_;

--- a/google/cloud/dataproc/cluster_controller_client.cc
+++ b/google/cloud/dataproc/cluster_controller_client.cc
@@ -26,20 +26,18 @@ namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ClusterControllerClient::ClusterControllerClient(
-    std::shared_ptr<ClusterControllerConnection> connection, Options options)
+    std::shared_ptr<ClusterControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dataproc_internal::ClusterControllerDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), dataproc_internal::ClusterControllerDefaultOptions(
+                               connection_->options()))) {}
 ClusterControllerClient::~ClusterControllerClient() = default;
 
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>
 ClusterControllerClient::CreateCluster(
     std::string const& project_id, std::string const& region,
-    google::cloud::dataproc::v1::Cluster const& cluster, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::Cluster const& cluster, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::CreateClusterRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -50,9 +48,8 @@ ClusterControllerClient::CreateCluster(
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>
 ClusterControllerClient::CreateCluster(
     google::cloud::dataproc::v1::CreateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCluster(request);
 }
 
@@ -61,9 +58,8 @@ ClusterControllerClient::UpdateCluster(
     std::string const& project_id, std::string const& region,
     std::string const& cluster_name,
     google::cloud::dataproc::v1::Cluster const& cluster,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::UpdateClusterRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -76,27 +72,24 @@ ClusterControllerClient::UpdateCluster(
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>
 ClusterControllerClient::UpdateCluster(
     google::cloud::dataproc::v1::UpdateClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCluster(request);
 }
 
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>
 ClusterControllerClient::StopCluster(
     google::cloud::dataproc::v1::StopClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StopCluster(request);
 }
 
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>
 ClusterControllerClient::StartCluster(
     google::cloud::dataproc::v1::StartClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartCluster(request);
 }
 
@@ -104,9 +97,8 @@ future<StatusOr<google::cloud::dataproc::v1::ClusterOperationMetadata>>
 ClusterControllerClient::DeleteCluster(std::string const& project_id,
                                        std::string const& region,
                                        std::string const& cluster_name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::DeleteClusterRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -117,9 +109,8 @@ ClusterControllerClient::DeleteCluster(std::string const& project_id,
 future<StatusOr<google::cloud::dataproc::v1::ClusterOperationMetadata>>
 ClusterControllerClient::DeleteCluster(
     google::cloud::dataproc::v1::DeleteClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCluster(request);
 }
 
@@ -127,9 +118,8 @@ StatusOr<google::cloud::dataproc::v1::Cluster>
 ClusterControllerClient::GetCluster(std::string const& project_id,
                                     std::string const& region,
                                     std::string const& cluster_name,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::GetClusterRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -140,18 +130,15 @@ ClusterControllerClient::GetCluster(std::string const& project_id,
 StatusOr<google::cloud::dataproc::v1::Cluster>
 ClusterControllerClient::GetCluster(
     google::cloud::dataproc::v1::GetClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCluster(request);
 }
 
 StreamRange<google::cloud::dataproc::v1::Cluster>
 ClusterControllerClient::ListClusters(std::string const& project_id,
-                                      std::string const& region,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                      std::string const& region, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListClustersRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -161,10 +148,8 @@ ClusterControllerClient::ListClusters(std::string const& project_id,
 StreamRange<google::cloud::dataproc::v1::Cluster>
 ClusterControllerClient::ListClusters(std::string const& project_id,
                                       std::string const& region,
-                                      std::string const& filter,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                      std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListClustersRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -174,9 +159,8 @@ ClusterControllerClient::ListClusters(std::string const& project_id,
 
 StreamRange<google::cloud::dataproc::v1::Cluster>
 ClusterControllerClient::ListClusters(
-    google::cloud::dataproc::v1::ListClustersRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::ListClustersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListClusters(std::move(request));
 }
 
@@ -184,9 +168,8 @@ future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>
 ClusterControllerClient::DiagnoseCluster(std::string const& project_id,
                                          std::string const& region,
                                          std::string const& cluster_name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::DiagnoseClusterRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -197,9 +180,8 @@ ClusterControllerClient::DiagnoseCluster(std::string const& project_id,
 future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>
 ClusterControllerClient::DiagnoseCluster(
     google::cloud::dataproc::v1::DiagnoseClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DiagnoseCluster(request);
 }
 

--- a/google/cloud/dataproc/cluster_controller_client.h
+++ b/google/cloud/dataproc/cluster_controller_client.h
@@ -65,7 +65,7 @@ class ClusterControllerClient {
  public:
   explicit ClusterControllerClient(
       std::shared_ptr<ClusterControllerConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ClusterControllerClient();
 
   //@{
@@ -99,7 +99,8 @@ class ClusterControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param cluster  Required. The cluster to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -110,8 +111,7 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Cluster>> CreateCluster(
       std::string const& project_id, std::string const& region,
-      google::cloud::dataproc::v1::Cluster const& cluster,
-      Options options = {});
+      google::cloud::dataproc::v1::Cluster const& cluster, Options opts = {});
 
   ///
   /// Creates a cluster in a project. The returned
@@ -120,7 +120,8 @@ class ClusterControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::CreateClusterRequest,google/cloud/dataproc/v1/clusters.proto#L937}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -131,7 +132,7 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Cluster>> CreateCluster(
       google::cloud::dataproc::v1::CreateClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a cluster in a project. The returned
@@ -198,7 +199,8 @@ class ClusterControllerClient {
   ///   </tr>
   ///   <!--</tbody>-->
   ///   </table>
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -211,7 +213,7 @@ class ClusterControllerClient {
       std::string const& project_id, std::string const& region,
       std::string const& cluster_name,
       google::cloud::dataproc::v1::Cluster const& cluster,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a cluster in a project. The returned
@@ -223,7 +225,8 @@ class ClusterControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::UpdateClusterRequest,google/cloud/dataproc/v1/clusters.proto#L966}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -234,14 +237,15 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Cluster>> UpdateCluster(
       google::cloud::dataproc::v1::UpdateClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a cluster in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::StopClusterRequest,google/cloud/dataproc/v1/clusters.proto#L1060}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -252,14 +256,15 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Cluster>> StopCluster(
       google::cloud::dataproc::v1::StopClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts a cluster in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::StartClusterRequest,google/cloud/dataproc/v1/clusters.proto#L1091}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -270,7 +275,7 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Cluster>> StartCluster(
       google::cloud::dataproc::v1::StartClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a cluster in a project. The returned
@@ -283,7 +288,8 @@ class ClusterControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param cluster_name  Required. The cluster name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::ClusterOperationMetadata,google/cloud/dataproc/v1/operations.proto#L94}
   ///
@@ -294,7 +300,7 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::ClusterOperationMetadata>>
   DeleteCluster(std::string const& project_id, std::string const& region,
-                std::string const& cluster_name, Options options = {});
+                std::string const& cluster_name, Options opts = {});
 
   ///
   /// Deletes a cluster in a project. The returned
@@ -303,7 +309,8 @@ class ClusterControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::DeleteClusterRequest,google/cloud/dataproc/v1/clusters.proto#L1122}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::ClusterOperationMetadata,google/cloud/dataproc/v1/operations.proto#L94}
   ///
@@ -315,7 +322,7 @@ class ClusterControllerClient {
   future<StatusOr<google::cloud::dataproc::v1::ClusterOperationMetadata>>
   DeleteCluster(
       google::cloud::dataproc::v1::DeleteClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the resource representation for a cluster in a project.
@@ -326,7 +333,8 @@ class ClusterControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param cluster_name  Required. The cluster name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -337,14 +345,15 @@ class ClusterControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Cluster> GetCluster(
       std::string const& project_id, std::string const& region,
-      std::string const& cluster_name, Options options = {});
+      std::string const& cluster_name, Options opts = {});
 
   ///
   /// Gets the resource representation for a cluster in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::GetClusterRequest,google/cloud/dataproc/v1/clusters.proto#L1153}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -355,7 +364,7 @@ class ClusterControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Cluster> GetCluster(
       google::cloud::dataproc::v1::GetClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all regions/{region}/clusters in a project alphabetically.
@@ -365,7 +374,8 @@ class ClusterControllerClient {
   ///  belongs to.
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -376,7 +386,7 @@ class ClusterControllerClient {
   ///
   StreamRange<google::cloud::dataproc::v1::Cluster> ListClusters(
       std::string const& project_id, std::string const& region,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all regions/{region}/clusters in a project alphabetically.
@@ -400,7 +410,8 @@ class ClusterControllerClient {
   ///  operator is supported; space-separated items are treated as having an
   ///  implicit `AND` operator. Example filter: status.state = ACTIVE AND
   ///  clusterName = mycluster AND labels.env = staging AND labels.starred = *
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -411,14 +422,15 @@ class ClusterControllerClient {
   ///
   StreamRange<google::cloud::dataproc::v1::Cluster> ListClusters(
       std::string const& project_id, std::string const& region,
-      std::string const& filter, Options options = {});
+      std::string const& filter, Options opts = {});
 
   ///
   /// Lists all regions/{region}/clusters in a project alphabetically.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::ListClustersRequest,google/cloud/dataproc/v1/clusters.proto#L1166}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Cluster,google/cloud/dataproc/v1/clusters.proto#L157}
   ///
@@ -429,7 +441,7 @@ class ClusterControllerClient {
   ///
   StreamRange<google::cloud::dataproc::v1::Cluster> ListClusters(
       google::cloud::dataproc::v1::ListClustersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets cluster diagnostic information. The returned
@@ -446,7 +458,8 @@ class ClusterControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param cluster_name  Required. The cluster name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::DiagnoseClusterResults,google/cloud/dataproc/v1/clusters.proto#L1227}
   ///
@@ -457,7 +470,7 @@ class ClusterControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>
   DiagnoseCluster(std::string const& project_id, std::string const& region,
-                  std::string const& cluster_name, Options options = {});
+                  std::string const& cluster_name, Options opts = {});
 
   ///
   /// Gets cluster diagnostic information. The returned
@@ -470,7 +483,8 @@ class ClusterControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::DiagnoseClusterRequest,google/cloud/dataproc/v1/clusters.proto#L1214}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::DiagnoseClusterResults,google/cloud/dataproc/v1/clusters.proto#L1227}
   ///
@@ -482,7 +496,7 @@ class ClusterControllerClient {
   future<StatusOr<google::cloud::dataproc::v1::DiagnoseClusterResults>>
   DiagnoseCluster(
       google::cloud::dataproc::v1::DiagnoseClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ClusterControllerConnection> connection_;

--- a/google/cloud/dataproc/job_controller_client.cc
+++ b/google/cloud/dataproc/job_controller_client.cc
@@ -26,18 +26,17 @@ namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 JobControllerClient::JobControllerClient(
-    std::shared_ptr<JobControllerConnection> connection, Options options)
+    std::shared_ptr<JobControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), dataproc_internal::JobControllerDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), dataproc_internal::JobControllerDefaultOptions(
+                               connection_->options()))) {}
 JobControllerClient::~JobControllerClient() = default;
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::SubmitJob(
     std::string const& project_id, std::string const& region,
-    google::cloud::dataproc::v1::Job const& job, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::Job const& job, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::SubmitJobRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -47,18 +46,16 @@ StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::SubmitJob(
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::SubmitJob(
     google::cloud::dataproc::v1::SubmitJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SubmitJob(request);
 }
 
 future<StatusOr<google::cloud::dataproc::v1::Job>>
 JobControllerClient::SubmitJobAsOperation(
     std::string const& project_id, std::string const& region,
-    google::cloud::dataproc::v1::Job const& job, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::Job const& job, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::SubmitJobRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -69,17 +66,15 @@ JobControllerClient::SubmitJobAsOperation(
 future<StatusOr<google::cloud::dataproc::v1::Job>>
 JobControllerClient::SubmitJobAsOperation(
     google::cloud::dataproc::v1::SubmitJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SubmitJobAsOperation(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::GetJob(
     std::string const& project_id, std::string const& region,
-    std::string const& job_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& job_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::GetJobRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -88,17 +83,14 @@ StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::GetJob(
 }
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::GetJob(
-    google::cloud::dataproc::v1::GetJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::GetJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetJob(request);
 }
 
 StreamRange<google::cloud::dataproc::v1::Job> JobControllerClient::ListJobs(
-    std::string const& project_id, std::string const& region, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& project_id, std::string const& region, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListJobsRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -107,9 +99,8 @@ StreamRange<google::cloud::dataproc::v1::Job> JobControllerClient::ListJobs(
 
 StreamRange<google::cloud::dataproc::v1::Job> JobControllerClient::ListJobs(
     std::string const& project_id, std::string const& region,
-    std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListJobsRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -118,25 +109,22 @@ StreamRange<google::cloud::dataproc::v1::Job> JobControllerClient::ListJobs(
 }
 
 StreamRange<google::cloud::dataproc::v1::Job> JobControllerClient::ListJobs(
-    google::cloud::dataproc::v1::ListJobsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::dataproc::v1::ListJobsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListJobs(std::move(request));
 }
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::UpdateJob(
     google::cloud::dataproc::v1::UpdateJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateJob(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::CancelJob(
     std::string const& project_id, std::string const& region,
-    std::string const& job_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& job_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::CancelJobRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -146,18 +134,15 @@ StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::CancelJob(
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::CancelJob(
     google::cloud::dataproc::v1::CancelJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelJob(request);
 }
 
 Status JobControllerClient::DeleteJob(std::string const& project_id,
                                       std::string const& region,
-                                      std::string const& job_id,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                      std::string const& job_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::DeleteJobRequest request;
   request.set_project_id(project_id);
   request.set_region(region);
@@ -167,9 +152,8 @@ Status JobControllerClient::DeleteJob(std::string const& project_id,
 
 Status JobControllerClient::DeleteJob(
     google::cloud::dataproc::v1::DeleteJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteJob(request);
 }
 

--- a/google/cloud/dataproc/job_controller_client.h
+++ b/google/cloud/dataproc/job_controller_client.h
@@ -63,8 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class JobControllerClient {
  public:
   explicit JobControllerClient(
-      std::shared_ptr<JobControllerConnection> connection,
-      Options options = {});
+      std::shared_ptr<JobControllerConnection> connection, Options opts = {});
   ~JobControllerClient();
 
   //@{
@@ -96,7 +95,8 @@ class JobControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param job  Required. The job resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -107,14 +107,15 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> SubmitJob(
       std::string const& project_id, std::string const& region,
-      google::cloud::dataproc::v1::Job const& job, Options options = {});
+      google::cloud::dataproc::v1::Job const& job, Options opts = {});
 
   ///
   /// Submits a job to a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::SubmitJobRequest,google/cloud/dataproc/v1/jobs.proto#L755}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -125,7 +126,7 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> SubmitJob(
       google::cloud::dataproc::v1::SubmitJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Submits job to a cluster.
@@ -136,7 +137,8 @@ class JobControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param job  Required. The job resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -147,14 +149,15 @@ class JobControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Job>> SubmitJobAsOperation(
       std::string const& project_id, std::string const& region,
-      google::cloud::dataproc::v1::Job const& job, Options options = {});
+      google::cloud::dataproc::v1::Job const& job, Options opts = {});
 
   ///
   /// Submits job to a cluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::SubmitJobRequest,google/cloud/dataproc/v1/jobs.proto#L755}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -165,7 +168,7 @@ class JobControllerClient {
   ///
   future<StatusOr<google::cloud::dataproc::v1::Job>> SubmitJobAsOperation(
       google::cloud::dataproc::v1::SubmitJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the resource representation for a job in a project.
@@ -176,7 +179,8 @@ class JobControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param job_id  Required. The job ID.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -187,14 +191,15 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> GetJob(
       std::string const& project_id, std::string const& region,
-      std::string const& job_id, Options options = {});
+      std::string const& job_id, Options opts = {});
 
   ///
   /// Gets the resource representation for a job in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::GetJobRequest,google/cloud/dataproc/v1/jobs.proto#L797}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -205,7 +210,7 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> GetJob(
       google::cloud::dataproc::v1::GetJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists regions/{region}/jobs in a project.
@@ -215,7 +220,8 @@ class JobControllerClient {
   ///  belongs to.
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -226,7 +232,7 @@ class JobControllerClient {
   ///
   StreamRange<google::cloud::dataproc::v1::Job> ListJobs(
       std::string const& project_id, std::string const& region,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists regions/{region}/jobs in a project.
@@ -246,7 +252,8 @@ class JobControllerClient {
   ///  supported; space-separated items are treated as having an implicit `AND`
   ///  operator. Example filter: status.state = ACTIVE AND labels.env = staging
   ///  AND labels.starred = *
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -257,14 +264,15 @@ class JobControllerClient {
   ///
   StreamRange<google::cloud::dataproc::v1::Job> ListJobs(
       std::string const& project_id, std::string const& region,
-      std::string const& filter, Options options = {});
+      std::string const& filter, Options opts = {});
 
   ///
   /// Lists regions/{region}/jobs in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::ListJobsRequest,google/cloud/dataproc/v1/jobs.proto#L810}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -274,15 +282,15 @@ class JobControllerClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/jobs.proto#L639}
   ///
   StreamRange<google::cloud::dataproc::v1::Job> ListJobs(
-      google::cloud::dataproc::v1::ListJobsRequest request,
-      Options options = {});
+      google::cloud::dataproc::v1::ListJobsRequest request, Options opts = {});
 
   ///
   /// Updates a job in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::UpdateJobRequest,google/cloud/dataproc/v1/jobs.proto#L866}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -293,7 +301,7 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> UpdateJob(
       google::cloud::dataproc::v1::UpdateJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts a job cancellation request. To access the job resource
@@ -308,7 +316,8 @@ class JobControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param job_id  Required. The job ID.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -319,7 +328,7 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> CancelJob(
       std::string const& project_id, std::string const& region,
-      std::string const& job_id, Options options = {});
+      std::string const& job_id, Options opts = {});
 
   ///
   /// Starts a job cancellation request. To access the job resource
@@ -330,7 +339,8 @@ class JobControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::CancelJobRequest,google/cloud/dataproc/v1/jobs.proto#L901}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::Job,google/cloud/dataproc/v1/jobs.proto#L639}
   ///
@@ -341,7 +351,7 @@ class JobControllerClient {
   ///
   StatusOr<google::cloud::dataproc::v1::Job> CancelJob(
       google::cloud::dataproc::v1::CancelJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the job from the project. If the job is active, the delete fails,
@@ -353,13 +363,14 @@ class JobControllerClient {
   /// @param region  Required. The Dataproc region in which to handle the
   /// request.
   /// @param job_id  Required. The job ID.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteJobRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/jobs.proto#L914}
   ///
   Status DeleteJob(std::string const& project_id, std::string const& region,
-                   std::string const& job_id, Options options = {});
+                   std::string const& job_id, Options opts = {});
 
   ///
   /// Deletes the job from the project. If the job is active, the delete fails,
@@ -367,13 +378,14 @@ class JobControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::DeleteJobRequest,google/cloud/dataproc/v1/jobs.proto#L914}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteJobRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/jobs.proto#L914}
   ///
   Status DeleteJob(google::cloud::dataproc::v1::DeleteJobRequest const& request,
-                   Options options = {});
+                   Options opts = {});
 
  private:
   std::shared_ptr<JobControllerConnection> connection_;

--- a/google/cloud/dataproc/workflow_template_client.cc
+++ b/google/cloud/dataproc/workflow_template_client.cc
@@ -26,11 +26,10 @@ namespace dataproc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WorkflowTemplateServiceClient::WorkflowTemplateServiceClient(
-    std::shared_ptr<WorkflowTemplateServiceConnection> connection,
-    Options options)
+    std::shared_ptr<WorkflowTemplateServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           dataproc_internal::WorkflowTemplateServiceDefaultOptions(
               connection_->options()))) {}
 WorkflowTemplateServiceClient::~WorkflowTemplateServiceClient() = default;
@@ -39,9 +38,8 @@ StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::CreateWorkflowTemplate(
     std::string const& parent,
     google::cloud::dataproc::v1::WorkflowTemplate const& template_,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::CreateWorkflowTemplateRequest request;
   request.set_parent(parent);
   *request.mutable_template_() = template_;
@@ -51,17 +49,15 @@ WorkflowTemplateServiceClient::CreateWorkflowTemplate(
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::CreateWorkflowTemplate(
     google::cloud::dataproc::v1::CreateWorkflowTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateWorkflowTemplate(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::GetWorkflowTemplate(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::GetWorkflowTemplateRequest request;
   request.set_name(name);
   return connection_->GetWorkflowTemplate(request);
@@ -70,17 +66,15 @@ WorkflowTemplateServiceClient::GetWorkflowTemplate(std::string const& name,
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::GetWorkflowTemplate(
     google::cloud::dataproc::v1::GetWorkflowTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetWorkflowTemplate(request);
 }
 
 future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
 WorkflowTemplateServiceClient::InstantiateWorkflowTemplate(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::InstantiateWorkflowTemplateRequest request;
   request.set_name(name);
   return connection_->InstantiateWorkflowTemplate(request);
@@ -89,9 +83,8 @@ WorkflowTemplateServiceClient::InstantiateWorkflowTemplate(
 future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
 WorkflowTemplateServiceClient::InstantiateWorkflowTemplate(
     std::string const& name,
-    std::map<std::string, std::string> const& parameters, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::map<std::string, std::string> const& parameters, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::InstantiateWorkflowTemplateRequest request;
   request.set_name(name);
   *request.mutable_parameters() = {parameters.begin(), parameters.end()};
@@ -102,9 +95,8 @@ future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
 WorkflowTemplateServiceClient::InstantiateWorkflowTemplate(
     google::cloud::dataproc::v1::InstantiateWorkflowTemplateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->InstantiateWorkflowTemplate(request);
 }
 
@@ -112,9 +104,8 @@ future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
 WorkflowTemplateServiceClient::InstantiateInlineWorkflowTemplate(
     std::string const& parent,
     google::cloud::dataproc::v1::WorkflowTemplate const& template_,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::InstantiateInlineWorkflowTemplateRequest request;
   request.set_parent(parent);
   *request.mutable_template_() = template_;
@@ -125,18 +116,16 @@ future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
 WorkflowTemplateServiceClient::InstantiateInlineWorkflowTemplate(
     google::cloud::dataproc::v1::InstantiateInlineWorkflowTemplateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->InstantiateInlineWorkflowTemplate(request);
 }
 
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::UpdateWorkflowTemplate(
     google::cloud::dataproc::v1::WorkflowTemplate const& template_,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::UpdateWorkflowTemplateRequest request;
   *request.mutable_template_() = template_;
   return connection_->UpdateWorkflowTemplate(request);
@@ -145,17 +134,15 @@ WorkflowTemplateServiceClient::UpdateWorkflowTemplate(
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::UpdateWorkflowTemplate(
     google::cloud::dataproc::v1::UpdateWorkflowTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateWorkflowTemplate(request);
 }
 
 StreamRange<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::ListWorkflowTemplates(std::string const& parent,
-                                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::ListWorkflowTemplatesRequest request;
   request.set_parent(parent);
   return connection_->ListWorkflowTemplates(request);
@@ -164,16 +151,14 @@ WorkflowTemplateServiceClient::ListWorkflowTemplates(std::string const& parent,
 StreamRange<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceClient::ListWorkflowTemplates(
     google::cloud::dataproc::v1::ListWorkflowTemplatesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListWorkflowTemplates(std::move(request));
 }
 
 Status WorkflowTemplateServiceClient::DeleteWorkflowTemplate(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::dataproc::v1::DeleteWorkflowTemplateRequest request;
   request.set_name(name);
   return connection_->DeleteWorkflowTemplate(request);
@@ -181,9 +166,8 @@ Status WorkflowTemplateServiceClient::DeleteWorkflowTemplate(
 
 Status WorkflowTemplateServiceClient::DeleteWorkflowTemplate(
     google::cloud::dataproc::v1::DeleteWorkflowTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteWorkflowTemplate(request);
 }
 

--- a/google/cloud/dataproc/workflow_template_client.h
+++ b/google/cloud/dataproc/workflow_template_client.h
@@ -65,7 +65,7 @@ class WorkflowTemplateServiceClient {
  public:
   explicit WorkflowTemplateServiceClient(
       std::shared_ptr<WorkflowTemplateServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~WorkflowTemplateServiceClient();
 
   //@{
@@ -104,7 +104,8 @@ class WorkflowTemplateServiceClient {
   ///    the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
   /// @param template_  Required. The Dataproc workflow template to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -117,14 +118,15 @@ class WorkflowTemplateServiceClient {
   CreateWorkflowTemplate(
       std::string const& parent,
       google::cloud::dataproc::v1::WorkflowTemplate const& template_,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates new workflow template.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::CreateWorkflowTemplateRequest,google/cloud/dataproc/v1/workflow_templates.proto#L611}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -136,7 +138,7 @@ class WorkflowTemplateServiceClient {
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
   CreateWorkflowTemplate(
       google::cloud::dataproc::v1::CreateWorkflowTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves the latest workflow template.
@@ -154,7 +156,8 @@ class WorkflowTemplateServiceClient {
   ///  the
   ///    template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -164,7 +167,7 @@ class WorkflowTemplateServiceClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate> GetWorkflowTemplate(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves the latest workflow template.
@@ -174,7 +177,8 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::GetWorkflowTemplateRequest,google/cloud/dataproc/v1/workflow_templates.proto#L634}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -185,7 +189,7 @@ class WorkflowTemplateServiceClient {
   ///
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate> GetWorkflowTemplate(
       google::cloud::dataproc::v1::GetWorkflowTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Instantiates a template and begins execution.
@@ -219,7 +223,8 @@ class WorkflowTemplateServiceClient {
   ///  name
   ///    of the template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowMetadata,google/cloud/dataproc/v1/workflow_templates.proto#L480}
   ///
@@ -229,7 +234,7 @@ class WorkflowTemplateServiceClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/workflow_templates.proto#L480}
   ///
   future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
-  InstantiateWorkflowTemplate(std::string const& name, Options options = {});
+  InstantiateWorkflowTemplate(std::string const& name, Options opts = {});
 
   ///
   /// Instantiates a template and begins execution.
@@ -266,7 +271,8 @@ class WorkflowTemplateServiceClient {
   /// @param parameters  Optional. Map from parameter names to values that
   /// should be used for those
   ///  parameters. Values may not exceed 1000 characters.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowMetadata,google/cloud/dataproc/v1/workflow_templates.proto#L480}
   ///
@@ -278,8 +284,7 @@ class WorkflowTemplateServiceClient {
   future<StatusOr<google::cloud::dataproc::v1::WorkflowMetadata>>
   InstantiateWorkflowTemplate(
       std::string const& name,
-      std::map<std::string, std::string> const& parameters,
-      Options options = {});
+      std::map<std::string, std::string> const& parameters, Options opts = {});
 
   ///
   /// Instantiates a template and begins execution.
@@ -305,7 +310,8 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::InstantiateWorkflowTemplateRequest,google/cloud/dataproc/v1/workflow_templates.proto#L660}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowMetadata,google/cloud/dataproc/v1/workflow_templates.proto#L480}
   ///
@@ -318,7 +324,7 @@ class WorkflowTemplateServiceClient {
   InstantiateWorkflowTemplate(
       google::cloud::dataproc::v1::InstantiateWorkflowTemplateRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Instantiates a template and begins execution.
@@ -358,7 +364,8 @@ class WorkflowTemplateServiceClient {
   ///    resource name of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
   /// @param template_  Required. The workflow template to instantiate.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowMetadata,google/cloud/dataproc/v1/workflow_templates.proto#L480}
   ///
@@ -371,7 +378,7 @@ class WorkflowTemplateServiceClient {
   InstantiateInlineWorkflowTemplate(
       std::string const& parent,
       google::cloud::dataproc::v1::WorkflowTemplate const& template_,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Instantiates a template and begins execution.
@@ -402,7 +409,8 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::InstantiateInlineWorkflowTemplateRequest,google/cloud/dataproc/v1/workflow_templates.proto#L703}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowMetadata,google/cloud/dataproc/v1/workflow_templates.proto#L480}
   ///
@@ -415,7 +423,7 @@ class WorkflowTemplateServiceClient {
   InstantiateInlineWorkflowTemplate(
       google::cloud::dataproc::v1::
           InstantiateInlineWorkflowTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates (replaces) workflow template. The updated template
@@ -423,7 +431,8 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param template_  Required. The updated workflow template.
   ///  The `template.version` field must match the current version.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -435,7 +444,7 @@ class WorkflowTemplateServiceClient {
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
   UpdateWorkflowTemplate(
       google::cloud::dataproc::v1::WorkflowTemplate const& template_,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates (replaces) workflow template. The updated template
@@ -443,7 +452,8 @@ class WorkflowTemplateServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::UpdateWorkflowTemplateRequest,google/cloud/dataproc/v1/workflow_templates.proto#L737}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -455,7 +465,7 @@ class WorkflowTemplateServiceClient {
   StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
   UpdateWorkflowTemplate(
       google::cloud::dataproc::v1::UpdateWorkflowTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists workflows that match the specified filter in the request.
@@ -469,7 +479,8 @@ class WorkflowTemplateServiceClient {
   ///  * For `projects.locations.workflowTemplates.list`, the
   ///    resource name of the location has the following format:
   ///    `projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -479,14 +490,15 @@ class WorkflowTemplateServiceClient {
   /// @googleapis_reference_link{google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
   StreamRange<google::cloud::dataproc::v1::WorkflowTemplate>
-  ListWorkflowTemplates(std::string const& parent, Options options = {});
+  ListWorkflowTemplates(std::string const& parent, Options opts = {});
 
   ///
   /// Lists workflows that match the specified filter in the request.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::ListWorkflowTemplatesRequest,google/cloud/dataproc/v1/workflow_templates.proto#L745}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::dataproc::v1::WorkflowTemplate,google/cloud/dataproc/v1/workflow_templates.proto#L183}
   ///
@@ -498,7 +510,7 @@ class WorkflowTemplateServiceClient {
   StreamRange<google::cloud::dataproc::v1::WorkflowTemplate>
   ListWorkflowTemplates(
       google::cloud::dataproc::v1::ListWorkflowTemplatesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a workflow template. It does not cancel in-progress workflows.
@@ -513,26 +525,28 @@ class WorkflowTemplateServiceClient {
   ///  name
   ///    of the template has the following format:
   ///    `projects/{project_id}/locations/{location}/workflowTemplates/{template_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/workflow_templates.proto#L785}
   ///
-  Status DeleteWorkflowTemplate(std::string const& name, Options options = {});
+  Status DeleteWorkflowTemplate(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a workflow template. It does not cancel in-progress workflows.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::dataproc::v1::DeleteWorkflowTemplateRequest,google/cloud/dataproc/v1/workflow_templates.proto#L785}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.dataproc.v1.DeleteWorkflowTemplateRequest]:
   /// @googleapis_reference_link{google/cloud/dataproc/v1/workflow_templates.proto#L785}
   ///
   Status DeleteWorkflowTemplate(
       google::cloud::dataproc::v1::DeleteWorkflowTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<WorkflowTemplateServiceConnection> connection_;

--- a/google/cloud/debugger/controller2_client.cc
+++ b/google/cloud/debugger/controller2_client.cc
@@ -26,19 +26,18 @@ namespace debugger {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Controller2Client::Controller2Client(
-    std::shared_ptr<Controller2Connection> connection, Options options)
+    std::shared_ptr<Controller2Connection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), debugger_internal::Controller2DefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), debugger_internal::Controller2DefaultOptions(
+                               connection_->options()))) {}
 Controller2Client::~Controller2Client() = default;
 
 StatusOr<google::devtools::clouddebugger::v2::RegisterDebuggeeResponse>
 Controller2Client::RegisterDebuggee(
     google::devtools::clouddebugger::v2::Debuggee const& debuggee,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::RegisterDebuggeeRequest request;
   *request.mutable_debuggee() = debuggee;
   return connection_->RegisterDebuggee(request);
@@ -47,17 +46,15 @@ Controller2Client::RegisterDebuggee(
 StatusOr<google::devtools::clouddebugger::v2::RegisterDebuggeeResponse>
 Controller2Client::RegisterDebuggee(
     google::devtools::clouddebugger::v2::RegisterDebuggeeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RegisterDebuggee(request);
 }
 
 StatusOr<google::devtools::clouddebugger::v2::ListActiveBreakpointsResponse>
 Controller2Client::ListActiveBreakpoints(std::string const& debuggee_id,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::ListActiveBreakpointsRequest request;
   request.set_debuggee_id(debuggee_id);
   return connection_->ListActiveBreakpoints(request);
@@ -67,9 +64,8 @@ StatusOr<google::devtools::clouddebugger::v2::ListActiveBreakpointsResponse>
 Controller2Client::ListActiveBreakpoints(
     google::devtools::clouddebugger::v2::ListActiveBreakpointsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListActiveBreakpoints(request);
 }
 
@@ -77,9 +73,8 @@ StatusOr<google::devtools::clouddebugger::v2::UpdateActiveBreakpointResponse>
 Controller2Client::UpdateActiveBreakpoint(
     std::string const& debuggee_id,
     google::devtools::clouddebugger::v2::Breakpoint const& breakpoint,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::UpdateActiveBreakpointRequest request;
   request.set_debuggee_id(debuggee_id);
   *request.mutable_breakpoint() = breakpoint;
@@ -90,9 +85,8 @@ StatusOr<google::devtools::clouddebugger::v2::UpdateActiveBreakpointResponse>
 Controller2Client::UpdateActiveBreakpoint(
     google::devtools::clouddebugger::v2::UpdateActiveBreakpointRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateActiveBreakpoint(request);
 }
 

--- a/google/cloud/debugger/controller2_client.h
+++ b/google/cloud/debugger/controller2_client.h
@@ -80,7 +80,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class Controller2Client {
  public:
   explicit Controller2Client(std::shared_ptr<Controller2Connection> connection,
-                             Options options = {});
+                             Options opts = {});
   ~Controller2Client();
 
   //@{
@@ -118,7 +118,8 @@ class Controller2Client {
   /// @param debuggee  Required. Debuggee information to register.
   ///  The fields `project`, `uniquifier`, `description` and `agent_version`
   ///  of the debuggee must be set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::RegisterDebuggeeResponse,google/devtools/clouddebugger/v2/controller.proto#L124}
   ///
@@ -130,7 +131,7 @@ class Controller2Client {
   StatusOr<google::devtools::clouddebugger::v2::RegisterDebuggeeResponse>
   RegisterDebuggee(
       google::devtools::clouddebugger::v2::Debuggee const& debuggee,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Registers the debuggee with the controller service.
@@ -146,7 +147,8 @@ class Controller2Client {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::RegisterDebuggeeRequest,google/devtools/clouddebugger/v2/controller.proto#L116}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::RegisterDebuggeeResponse,google/devtools/clouddebugger/v2/controller.proto#L124}
   ///
@@ -159,7 +161,7 @@ class Controller2Client {
   RegisterDebuggee(
       google::devtools::clouddebugger::v2::RegisterDebuggeeRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the list of all active breakpoints for the debuggee.
@@ -177,7 +179,8 @@ class Controller2Client {
   /// setting those breakpoints again.
   ///
   /// @param debuggee_id  Required. Identifies the debuggee.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListActiveBreakpointsResponse,google/devtools/clouddebugger/v2/controller.proto#L154}
   ///
@@ -187,7 +190,7 @@ class Controller2Client {
   /// @googleapis_reference_link{google/devtools/clouddebugger/v2/controller.proto#L154}
   ///
   StatusOr<google::devtools::clouddebugger::v2::ListActiveBreakpointsResponse>
-  ListActiveBreakpoints(std::string const& debuggee_id, Options options = {});
+  ListActiveBreakpoints(std::string const& debuggee_id, Options opts = {});
 
   ///
   /// Returns the list of all active breakpoints for the debuggee.
@@ -206,7 +209,8 @@ class Controller2Client {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListActiveBreakpointsRequest,google/devtools/clouddebugger/v2/controller.proto#L134}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListActiveBreakpointsResponse,google/devtools/clouddebugger/v2/controller.proto#L154}
   ///
@@ -219,7 +223,7 @@ class Controller2Client {
   ListActiveBreakpoints(
       google::devtools::clouddebugger::v2::ListActiveBreakpointsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the breakpoint state or mutable fields.
@@ -235,7 +239,8 @@ class Controller2Client {
   /// @param breakpoint  Required. Updated breakpoint information.
   ///  The field `id` must be set.
   ///  The agent must echo all Breakpoint specification fields in the update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::UpdateActiveBreakpointResponse,google/devtools/clouddebugger/v2/controller.proto#L182}
   ///
@@ -248,7 +253,7 @@ class Controller2Client {
   UpdateActiveBreakpoint(
       std::string const& debuggee_id,
       google::devtools::clouddebugger::v2::Breakpoint const& breakpoint,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the breakpoint state or mutable fields.
@@ -262,7 +267,8 @@ class Controller2Client {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::UpdateActiveBreakpointRequest,google/devtools/clouddebugger/v2/controller.proto#L170}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::UpdateActiveBreakpointResponse,google/devtools/clouddebugger/v2/controller.proto#L182}
   ///
@@ -275,7 +281,7 @@ class Controller2Client {
   UpdateActiveBreakpoint(
       google::devtools::clouddebugger::v2::UpdateActiveBreakpointRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<Controller2Connection> connection_;

--- a/google/cloud/debugger/debugger2_client.cc
+++ b/google/cloud/debugger/debugger2_client.cc
@@ -26,10 +26,10 @@ namespace debugger {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 Debugger2Client::Debugger2Client(
-    std::shared_ptr<Debugger2Connection> connection, Options options)
+    std::shared_ptr<Debugger2Connection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           debugger_internal::Debugger2DefaultOptions(connection_->options()))) {
 }
 Debugger2Client::~Debugger2Client() = default;
@@ -38,9 +38,8 @@ StatusOr<google::devtools::clouddebugger::v2::SetBreakpointResponse>
 Debugger2Client::SetBreakpoint(
     std::string const& debuggee_id,
     google::devtools::clouddebugger::v2::Breakpoint const& breakpoint,
-    std::string const& client_version, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& client_version, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::SetBreakpointRequest request;
   request.set_debuggee_id(debuggee_id);
   *request.mutable_breakpoint() = breakpoint;
@@ -51,9 +50,8 @@ Debugger2Client::SetBreakpoint(
 StatusOr<google::devtools::clouddebugger::v2::SetBreakpointResponse>
 Debugger2Client::SetBreakpoint(
     google::devtools::clouddebugger::v2::SetBreakpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetBreakpoint(request);
 }
 
@@ -61,9 +59,8 @@ StatusOr<google::devtools::clouddebugger::v2::GetBreakpointResponse>
 Debugger2Client::GetBreakpoint(std::string const& debuggee_id,
                                std::string const& breakpoint_id,
                                std::string const& client_version,
-                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::GetBreakpointRequest request;
   request.set_debuggee_id(debuggee_id);
   request.set_breakpoint_id(breakpoint_id);
@@ -74,18 +71,16 @@ Debugger2Client::GetBreakpoint(std::string const& debuggee_id,
 StatusOr<google::devtools::clouddebugger::v2::GetBreakpointResponse>
 Debugger2Client::GetBreakpoint(
     google::devtools::clouddebugger::v2::GetBreakpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBreakpoint(request);
 }
 
 Status Debugger2Client::DeleteBreakpoint(std::string const& debuggee_id,
                                          std::string const& breakpoint_id,
                                          std::string const& client_version,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::DeleteBreakpointRequest request;
   request.set_debuggee_id(debuggee_id);
   request.set_breakpoint_id(breakpoint_id);
@@ -95,18 +90,16 @@ Status Debugger2Client::DeleteBreakpoint(std::string const& debuggee_id,
 
 Status Debugger2Client::DeleteBreakpoint(
     google::devtools::clouddebugger::v2::DeleteBreakpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBreakpoint(request);
 }
 
 StatusOr<google::devtools::clouddebugger::v2::ListBreakpointsResponse>
 Debugger2Client::ListBreakpoints(std::string const& debuggee_id,
                                  std::string const& client_version,
-                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::ListBreakpointsRequest request;
   request.set_debuggee_id(debuggee_id);
   request.set_client_version(client_version);
@@ -116,18 +109,16 @@ Debugger2Client::ListBreakpoints(std::string const& debuggee_id,
 StatusOr<google::devtools::clouddebugger::v2::ListBreakpointsResponse>
 Debugger2Client::ListBreakpoints(
     google::devtools::clouddebugger::v2::ListBreakpointsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBreakpoints(request);
 }
 
 StatusOr<google::devtools::clouddebugger::v2::ListDebuggeesResponse>
 Debugger2Client::ListDebuggees(std::string const& project,
                                std::string const& client_version,
-                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::clouddebugger::v2::ListDebuggeesRequest request;
   request.set_project(project);
   request.set_client_version(client_version);
@@ -137,9 +128,8 @@ Debugger2Client::ListDebuggees(std::string const& project,
 StatusOr<google::devtools::clouddebugger::v2::ListDebuggeesResponse>
 Debugger2Client::ListDebuggees(
     google::devtools::clouddebugger::v2::ListDebuggeesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDebuggees(request);
 }
 

--- a/google/cloud/debugger/debugger2_client.h
+++ b/google/cloud/debugger/debugger2_client.h
@@ -72,7 +72,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class Debugger2Client {
  public:
   explicit Debugger2Client(std::shared_ptr<Debugger2Connection> connection,
-                           Options options = {});
+                           Options opts = {});
   ~Debugger2Client();
 
   //@{
@@ -102,7 +102,8 @@ class Debugger2Client {
   ///  The field `location` of the breakpoint must be set.
   /// @param client_version  Required. The client version making the call.
   ///  Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::SetBreakpointResponse,google/devtools/clouddebugger/v2/debugger.proto#L109}
   ///
@@ -115,14 +116,15 @@ class Debugger2Client {
   SetBreakpoint(
       std::string const& debuggee_id,
       google::devtools::clouddebugger::v2::Breakpoint const& breakpoint,
-      std::string const& client_version, Options options = {});
+      std::string const& client_version, Options opts = {});
 
   ///
   /// Sets the breakpoint to the debuggee.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::SetBreakpointRequest,google/devtools/clouddebugger/v2/debugger.proto#L95}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::SetBreakpointResponse,google/devtools/clouddebugger/v2/debugger.proto#L109}
   ///
@@ -134,7 +136,7 @@ class Debugger2Client {
   StatusOr<google::devtools::clouddebugger::v2::SetBreakpointResponse>
   SetBreakpoint(
       google::devtools::clouddebugger::v2::SetBreakpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets breakpoint information.
@@ -143,7 +145,8 @@ class Debugger2Client {
   /// @param breakpoint_id  Required. ID of the breakpoint to get.
   /// @param client_version  Required. The client version making the call.
   ///  Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::GetBreakpointResponse,google/devtools/clouddebugger/v2/debugger.proto#L129}
   ///
@@ -155,14 +158,15 @@ class Debugger2Client {
   StatusOr<google::devtools::clouddebugger::v2::GetBreakpointResponse>
   GetBreakpoint(std::string const& debuggee_id,
                 std::string const& breakpoint_id,
-                std::string const& client_version, Options options = {});
+                std::string const& client_version, Options opts = {});
 
   ///
   /// Gets breakpoint information.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::GetBreakpointRequest,google/devtools/clouddebugger/v2/debugger.proto#L116}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::GetBreakpointResponse,google/devtools/clouddebugger/v2/debugger.proto#L129}
   ///
@@ -174,7 +178,7 @@ class Debugger2Client {
   StatusOr<google::devtools::clouddebugger::v2::GetBreakpointResponse>
   GetBreakpoint(
       google::devtools::clouddebugger::v2::GetBreakpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the breakpoint from the debuggee.
@@ -184,22 +188,23 @@ class Debugger2Client {
   /// @param breakpoint_id  Required. ID of the breakpoint to delete.
   /// @param client_version  Required. The client version making the call.
   ///  Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.devtools.clouddebugger.v2.DeleteBreakpointRequest]:
   /// @googleapis_reference_link{google/devtools/clouddebugger/v2/debugger.proto#L136}
   ///
   Status DeleteBreakpoint(std::string const& debuggee_id,
                           std::string const& breakpoint_id,
-                          std::string const& client_version,
-                          Options options = {});
+                          std::string const& client_version, Options opts = {});
 
   ///
   /// Deletes the breakpoint from the debuggee.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::DeleteBreakpointRequest,google/devtools/clouddebugger/v2/debugger.proto#L136}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.devtools.clouddebugger.v2.DeleteBreakpointRequest]:
   /// @googleapis_reference_link{google/devtools/clouddebugger/v2/debugger.proto#L136}
@@ -207,7 +212,7 @@ class Debugger2Client {
   Status DeleteBreakpoint(
       google::devtools::clouddebugger::v2::DeleteBreakpointRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all breakpoints for the debuggee.
@@ -216,7 +221,8 @@ class Debugger2Client {
   /// list.
   /// @param client_version  Required. The client version making the call.
   ///  Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListBreakpointsResponse,google/devtools/clouddebugger/v2/debugger.proto#L188}
   ///
@@ -227,14 +233,15 @@ class Debugger2Client {
   ///
   StatusOr<google::devtools::clouddebugger::v2::ListBreakpointsResponse>
   ListBreakpoints(std::string const& debuggee_id,
-                  std::string const& client_version, Options options = {});
+                  std::string const& client_version, Options opts = {});
 
   ///
   /// Lists all breakpoints for the debuggee.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListBreakpointsRequest,google/devtools/clouddebugger/v2/debugger.proto#L149}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListBreakpointsResponse,google/devtools/clouddebugger/v2/debugger.proto#L188}
   ///
@@ -247,7 +254,7 @@ class Debugger2Client {
   ListBreakpoints(
       google::devtools::clouddebugger::v2::ListBreakpointsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all the debuggees that the user has access to.
@@ -256,7 +263,8 @@ class Debugger2Client {
   /// debuggees to list.
   /// @param client_version  Required. The client version making the call.
   ///  Schema: `domain/type/version` (e.g., `google.com/intellij/v1`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListDebuggeesResponse,google/devtools/clouddebugger/v2/debugger.proto#L215}
   ///
@@ -267,14 +275,15 @@ class Debugger2Client {
   ///
   StatusOr<google::devtools::clouddebugger::v2::ListDebuggeesResponse>
   ListDebuggees(std::string const& project, std::string const& client_version,
-                Options options = {});
+                Options opts = {});
 
   ///
   /// Lists all the debuggees that the user has access to.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListDebuggeesRequest,google/devtools/clouddebugger/v2/debugger.proto#L201}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::clouddebugger::v2::ListDebuggeesResponse,google/devtools/clouddebugger/v2/debugger.proto#L215}
   ///
@@ -286,7 +295,7 @@ class Debugger2Client {
   StatusOr<google::devtools::clouddebugger::v2::ListDebuggeesResponse>
   ListDebuggees(
       google::devtools::clouddebugger::v2::ListDebuggeesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<Debugger2Connection> connection_;

--- a/google/cloud/dlp/dlp_client.cc
+++ b/google/cloud/dlp/dlp_client.cc
@@ -26,53 +26,47 @@ namespace dlp {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DlpServiceClient::DlpServiceClient(
-    std::shared_ptr<DlpServiceConnection> connection, Options options)
+    std::shared_ptr<DlpServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           dlp_internal::DlpServiceDefaultOptions(connection_->options()))) {}
 DlpServiceClient::~DlpServiceClient() = default;
 
 StatusOr<google::privacy::dlp::v2::InspectContentResponse>
 DlpServiceClient::InspectContent(
     google::privacy::dlp::v2::InspectContentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->InspectContent(request);
 }
 
 StatusOr<google::privacy::dlp::v2::RedactImageResponse>
 DlpServiceClient::RedactImage(
-    google::privacy::dlp::v2::RedactImageRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::privacy::dlp::v2::RedactImageRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RedactImage(request);
 }
 
 StatusOr<google::privacy::dlp::v2::DeidentifyContentResponse>
 DlpServiceClient::DeidentifyContent(
     google::privacy::dlp::v2::DeidentifyContentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeidentifyContent(request);
 }
 
 StatusOr<google::privacy::dlp::v2::ReidentifyContentResponse>
 DlpServiceClient::ReidentifyContent(
     google::privacy::dlp::v2::ReidentifyContentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReidentifyContent(request);
 }
 
 StatusOr<google::privacy::dlp::v2::ListInfoTypesResponse>
-DlpServiceClient::ListInfoTypes(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::ListInfoTypes(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::ListInfoTypesRequest request;
   request.set_parent(parent);
   return connection_->ListInfoTypes(request);
@@ -81,9 +75,8 @@ DlpServiceClient::ListInfoTypes(std::string const& parent, Options options) {
 StatusOr<google::privacy::dlp::v2::ListInfoTypesResponse>
 DlpServiceClient::ListInfoTypes(
     google::privacy::dlp::v2::ListInfoTypesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInfoTypes(request);
 }
 
@@ -91,9 +84,8 @@ StatusOr<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::CreateInspectTemplate(
     std::string const& parent,
     google::privacy::dlp::v2::InspectTemplate const& inspect_template,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::CreateInspectTemplateRequest request;
   request.set_parent(parent);
   *request.mutable_inspect_template() = inspect_template;
@@ -103,9 +95,8 @@ DlpServiceClient::CreateInspectTemplate(
 StatusOr<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::CreateInspectTemplate(
     google::privacy::dlp::v2::CreateInspectTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInspectTemplate(request);
 }
 
@@ -113,9 +104,8 @@ StatusOr<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::UpdateInspectTemplate(
     std::string const& name,
     google::privacy::dlp::v2::InspectTemplate const& inspect_template,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::UpdateInspectTemplateRequest request;
   request.set_name(name);
   *request.mutable_inspect_template() = inspect_template;
@@ -126,16 +116,14 @@ DlpServiceClient::UpdateInspectTemplate(
 StatusOr<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::UpdateInspectTemplate(
     google::privacy::dlp::v2::UpdateInspectTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInspectTemplate(request);
 }
 
 StatusOr<google::privacy::dlp::v2::InspectTemplate>
-DlpServiceClient::GetInspectTemplate(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::GetInspectTemplate(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::GetInspectTemplateRequest request;
   request.set_name(name);
   return connection_->GetInspectTemplate(request);
@@ -144,17 +132,15 @@ DlpServiceClient::GetInspectTemplate(std::string const& name, Options options) {
 StatusOr<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::GetInspectTemplate(
     google::privacy::dlp::v2::GetInspectTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInspectTemplate(request);
 }
 
 StreamRange<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::ListInspectTemplates(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::ListInspectTemplatesRequest request;
   request.set_parent(parent);
   return connection_->ListInspectTemplates(request);
@@ -163,16 +149,14 @@ DlpServiceClient::ListInspectTemplates(std::string const& parent,
 StreamRange<google::privacy::dlp::v2::InspectTemplate>
 DlpServiceClient::ListInspectTemplates(
     google::privacy::dlp::v2::ListInspectTemplatesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInspectTemplates(std::move(request));
 }
 
 Status DlpServiceClient::DeleteInspectTemplate(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::DeleteInspectTemplateRequest request;
   request.set_name(name);
   return connection_->DeleteInspectTemplate(request);
@@ -180,9 +164,8 @@ Status DlpServiceClient::DeleteInspectTemplate(std::string const& name,
 
 Status DlpServiceClient::DeleteInspectTemplate(
     google::privacy::dlp::v2::DeleteInspectTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInspectTemplate(request);
 }
 
@@ -190,9 +173,8 @@ StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::CreateDeidentifyTemplate(
     std::string const& parent,
     google::privacy::dlp::v2::DeidentifyTemplate const& deidentify_template,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::CreateDeidentifyTemplateRequest request;
   request.set_parent(parent);
   *request.mutable_deidentify_template() = deidentify_template;
@@ -202,9 +184,8 @@ DlpServiceClient::CreateDeidentifyTemplate(
 StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::CreateDeidentifyTemplate(
     google::privacy::dlp::v2::CreateDeidentifyTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDeidentifyTemplate(request);
 }
 
@@ -212,9 +193,8 @@ StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::UpdateDeidentifyTemplate(
     std::string const& name,
     google::privacy::dlp::v2::DeidentifyTemplate const& deidentify_template,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::UpdateDeidentifyTemplateRequest request;
   request.set_name(name);
   *request.mutable_deidentify_template() = deidentify_template;
@@ -225,17 +205,14 @@ DlpServiceClient::UpdateDeidentifyTemplate(
 StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::UpdateDeidentifyTemplate(
     google::privacy::dlp::v2::UpdateDeidentifyTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDeidentifyTemplate(request);
 }
 
 StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
-DlpServiceClient::GetDeidentifyTemplate(std::string const& name,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::GetDeidentifyTemplate(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::GetDeidentifyTemplateRequest request;
   request.set_name(name);
   return connection_->GetDeidentifyTemplate(request);
@@ -244,17 +221,15 @@ DlpServiceClient::GetDeidentifyTemplate(std::string const& name,
 StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::GetDeidentifyTemplate(
     google::privacy::dlp::v2::GetDeidentifyTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDeidentifyTemplate(request);
 }
 
 StreamRange<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::ListDeidentifyTemplates(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::ListDeidentifyTemplatesRequest request;
   request.set_parent(parent);
   return connection_->ListDeidentifyTemplates(request);
@@ -263,16 +238,14 @@ DlpServiceClient::ListDeidentifyTemplates(std::string const& parent,
 StreamRange<google::privacy::dlp::v2::DeidentifyTemplate>
 DlpServiceClient::ListDeidentifyTemplates(
     google::privacy::dlp::v2::ListDeidentifyTemplatesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDeidentifyTemplates(std::move(request));
 }
 
 Status DlpServiceClient::DeleteDeidentifyTemplate(std::string const& name,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::DeleteDeidentifyTemplateRequest request;
   request.set_name(name);
   return connection_->DeleteDeidentifyTemplate(request);
@@ -280,18 +253,16 @@ Status DlpServiceClient::DeleteDeidentifyTemplate(std::string const& name,
 
 Status DlpServiceClient::DeleteDeidentifyTemplate(
     google::privacy::dlp::v2::DeleteDeidentifyTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDeidentifyTemplate(request);
 }
 
 StatusOr<google::privacy::dlp::v2::JobTrigger>
 DlpServiceClient::CreateJobTrigger(
     std::string const& parent,
-    google::privacy::dlp::v2::JobTrigger const& job_trigger, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::privacy::dlp::v2::JobTrigger const& job_trigger, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::CreateJobTriggerRequest request;
   request.set_parent(parent);
   *request.mutable_job_trigger() = job_trigger;
@@ -301,9 +272,8 @@ DlpServiceClient::CreateJobTrigger(
 StatusOr<google::privacy::dlp::v2::JobTrigger>
 DlpServiceClient::CreateJobTrigger(
     google::privacy::dlp::v2::CreateJobTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateJobTrigger(request);
 }
 
@@ -311,9 +281,8 @@ StatusOr<google::privacy::dlp::v2::JobTrigger>
 DlpServiceClient::UpdateJobTrigger(
     std::string const& name,
     google::privacy::dlp::v2::JobTrigger const& job_trigger,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::UpdateJobTriggerRequest request;
   request.set_name(name);
   *request.mutable_job_trigger() = job_trigger;
@@ -324,17 +293,15 @@ DlpServiceClient::UpdateJobTrigger(
 StatusOr<google::privacy::dlp::v2::JobTrigger>
 DlpServiceClient::UpdateJobTrigger(
     google::privacy::dlp::v2::UpdateJobTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateJobTrigger(request);
 }
 
 StatusOr<google::privacy::dlp::v2::HybridInspectResponse>
 DlpServiceClient::HybridInspectJobTrigger(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::HybridInspectJobTriggerRequest request;
   request.set_name(name);
   return connection_->HybridInspectJobTrigger(request);
@@ -343,16 +310,14 @@ DlpServiceClient::HybridInspectJobTrigger(std::string const& name,
 StatusOr<google::privacy::dlp::v2::HybridInspectResponse>
 DlpServiceClient::HybridInspectJobTrigger(
     google::privacy::dlp::v2::HybridInspectJobTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->HybridInspectJobTrigger(request);
 }
 
 StatusOr<google::privacy::dlp::v2::JobTrigger> DlpServiceClient::GetJobTrigger(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::GetJobTriggerRequest request;
   request.set_name(name);
   return connection_->GetJobTrigger(request);
@@ -360,16 +325,14 @@ StatusOr<google::privacy::dlp::v2::JobTrigger> DlpServiceClient::GetJobTrigger(
 
 StatusOr<google::privacy::dlp::v2::JobTrigger> DlpServiceClient::GetJobTrigger(
     google::privacy::dlp::v2::GetJobTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetJobTrigger(request);
 }
 
 StreamRange<google::privacy::dlp::v2::JobTrigger>
-DlpServiceClient::ListJobTriggers(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::ListJobTriggers(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::ListJobTriggersRequest request;
   request.set_parent(parent);
   return connection_->ListJobTriggers(request);
@@ -377,16 +340,14 @@ DlpServiceClient::ListJobTriggers(std::string const& parent, Options options) {
 
 StreamRange<google::privacy::dlp::v2::JobTrigger>
 DlpServiceClient::ListJobTriggers(
-    google::privacy::dlp::v2::ListJobTriggersRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::privacy::dlp::v2::ListJobTriggersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListJobTriggers(std::move(request));
 }
 
 Status DlpServiceClient::DeleteJobTrigger(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::DeleteJobTriggerRequest request;
   request.set_name(name);
   return connection_->DeleteJobTrigger(request);
@@ -394,26 +355,23 @@ Status DlpServiceClient::DeleteJobTrigger(std::string const& name,
 
 Status DlpServiceClient::DeleteJobTrigger(
     google::privacy::dlp::v2::DeleteJobTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteJobTrigger(request);
 }
 
 StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::ActivateJobTrigger(
     google::privacy::dlp::v2::ActivateJobTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ActivateJobTrigger(request);
 }
 
 StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::CreateDlpJob(
     std::string const& parent,
     google::privacy::dlp::v2::InspectJobConfig const& inspect_job,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::CreateDlpJobRequest request;
   request.set_parent(parent);
   *request.mutable_inspect_job() = inspect_job;
@@ -423,9 +381,8 @@ StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::CreateDlpJob(
 StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::CreateDlpJob(
     std::string const& parent,
     google::privacy::dlp::v2::RiskAnalysisJobConfig const& risk_job,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::CreateDlpJobRequest request;
   request.set_parent(parent);
   *request.mutable_risk_job() = risk_job;
@@ -434,49 +391,41 @@ StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::CreateDlpJob(
 
 StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::CreateDlpJob(
     google::privacy::dlp::v2::CreateDlpJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDlpJob(request);
 }
 
 StreamRange<google::privacy::dlp::v2::DlpJob> DlpServiceClient::ListDlpJobs(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::ListDlpJobsRequest request;
   request.set_parent(parent);
   return connection_->ListDlpJobs(request);
 }
 
 StreamRange<google::privacy::dlp::v2::DlpJob> DlpServiceClient::ListDlpJobs(
-    google::privacy::dlp::v2::ListDlpJobsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::privacy::dlp::v2::ListDlpJobsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDlpJobs(std::move(request));
 }
 
 StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::GetDlpJob(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::GetDlpJobRequest request;
   request.set_name(name);
   return connection_->GetDlpJob(request);
 }
 
 StatusOr<google::privacy::dlp::v2::DlpJob> DlpServiceClient::GetDlpJob(
-    google::privacy::dlp::v2::GetDlpJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::privacy::dlp::v2::GetDlpJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDlpJob(request);
 }
 
-Status DlpServiceClient::DeleteDlpJob(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status DlpServiceClient::DeleteDlpJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::DeleteDlpJobRequest request;
   request.set_name(name);
   return connection_->DeleteDlpJob(request);
@@ -484,17 +433,15 @@ Status DlpServiceClient::DeleteDlpJob(std::string const& name,
 
 Status DlpServiceClient::DeleteDlpJob(
     google::privacy::dlp::v2::DeleteDlpJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDlpJob(request);
 }
 
 Status DlpServiceClient::CancelDlpJob(
     google::privacy::dlp::v2::CancelDlpJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelDlpJob(request);
 }
 
@@ -502,9 +449,8 @@ StatusOr<google::privacy::dlp::v2::StoredInfoType>
 DlpServiceClient::CreateStoredInfoType(
     std::string const& parent,
     google::privacy::dlp::v2::StoredInfoTypeConfig const& config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::CreateStoredInfoTypeRequest request;
   request.set_parent(parent);
   *request.mutable_config() = config;
@@ -514,9 +460,8 @@ DlpServiceClient::CreateStoredInfoType(
 StatusOr<google::privacy::dlp::v2::StoredInfoType>
 DlpServiceClient::CreateStoredInfoType(
     google::privacy::dlp::v2::CreateStoredInfoTypeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateStoredInfoType(request);
 }
 
@@ -524,9 +469,8 @@ StatusOr<google::privacy::dlp::v2::StoredInfoType>
 DlpServiceClient::UpdateStoredInfoType(
     std::string const& name,
     google::privacy::dlp::v2::StoredInfoTypeConfig const& config,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::UpdateStoredInfoTypeRequest request;
   request.set_name(name);
   *request.mutable_config() = config;
@@ -537,16 +481,14 @@ DlpServiceClient::UpdateStoredInfoType(
 StatusOr<google::privacy::dlp::v2::StoredInfoType>
 DlpServiceClient::UpdateStoredInfoType(
     google::privacy::dlp::v2::UpdateStoredInfoTypeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateStoredInfoType(request);
 }
 
 StatusOr<google::privacy::dlp::v2::StoredInfoType>
-DlpServiceClient::GetStoredInfoType(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::GetStoredInfoType(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::GetStoredInfoTypeRequest request;
   request.set_name(name);
   return connection_->GetStoredInfoType(request);
@@ -555,17 +497,14 @@ DlpServiceClient::GetStoredInfoType(std::string const& name, Options options) {
 StatusOr<google::privacy::dlp::v2::StoredInfoType>
 DlpServiceClient::GetStoredInfoType(
     google::privacy::dlp::v2::GetStoredInfoTypeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetStoredInfoType(request);
 }
 
 StreamRange<google::privacy::dlp::v2::StoredInfoType>
-DlpServiceClient::ListStoredInfoTypes(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::ListStoredInfoTypes(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::ListStoredInfoTypesRequest request;
   request.set_parent(parent);
   return connection_->ListStoredInfoTypes(request);
@@ -574,16 +513,14 @@ DlpServiceClient::ListStoredInfoTypes(std::string const& parent,
 StreamRange<google::privacy::dlp::v2::StoredInfoType>
 DlpServiceClient::ListStoredInfoTypes(
     google::privacy::dlp::v2::ListStoredInfoTypesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListStoredInfoTypes(std::move(request));
 }
 
 Status DlpServiceClient::DeleteStoredInfoType(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::DeleteStoredInfoTypeRequest request;
   request.set_name(name);
   return connection_->DeleteStoredInfoType(request);
@@ -591,17 +528,14 @@ Status DlpServiceClient::DeleteStoredInfoType(std::string const& name,
 
 Status DlpServiceClient::DeleteStoredInfoType(
     google::privacy::dlp::v2::DeleteStoredInfoTypeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteStoredInfoType(request);
 }
 
 StatusOr<google::privacy::dlp::v2::HybridInspectResponse>
-DlpServiceClient::HybridInspectDlpJob(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DlpServiceClient::HybridInspectDlpJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::privacy::dlp::v2::HybridInspectDlpJobRequest request;
   request.set_name(name);
   return connection_->HybridInspectDlpJob(request);
@@ -610,17 +544,15 @@ DlpServiceClient::HybridInspectDlpJob(std::string const& name,
 StatusOr<google::privacy::dlp::v2::HybridInspectResponse>
 DlpServiceClient::HybridInspectDlpJob(
     google::privacy::dlp::v2::HybridInspectDlpJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->HybridInspectDlpJob(request);
 }
 
 Status DlpServiceClient::FinishDlpJob(
     google::privacy::dlp::v2::FinishDlpJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FinishDlpJob(request);
 }
 

--- a/google/cloud/dlp/dlp_client.h
+++ b/google/cloud/dlp/dlp_client.h
@@ -69,7 +69,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DlpServiceClient {
  public:
   explicit DlpServiceClient(std::shared_ptr<DlpServiceConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~DlpServiceClient();
 
   //@{
@@ -103,7 +103,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::InspectContentRequest,google/privacy/dlp/v2/dlp.proto#L1372}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectContentResponse,google/privacy/dlp/v2/dlp.proto#L1412}
   ///
@@ -114,7 +115,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::InspectContentResponse> InspectContent(
       google::privacy::dlp::v2::InspectContentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Redacts potentially sensitive info from an image.
@@ -128,7 +129,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::RedactImageRequest,google/privacy/dlp/v2/dlp.proto#L1153}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::RedactImageResponse,google/privacy/dlp/v2/dlp.proto#L1224}
   ///
@@ -139,7 +141,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::RedactImageResponse> RedactImage(
       google::privacy::dlp::v2::RedactImageRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// De-identifies potentially sensitive info from a ContentItem.
@@ -153,7 +155,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyContentRequest,google/privacy/dlp/v2/dlp.proto#L1238}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyContentResponse,google/privacy/dlp/v2/dlp.proto#L1291}
   ///
@@ -165,7 +168,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::DeidentifyContentResponse>
   DeidentifyContent(
       google::privacy::dlp::v2::DeidentifyContentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Re-identifies content that has been de-identified.
@@ -175,7 +178,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ReidentifyContentRequest,google/privacy/dlp/v2/dlp.proto#L1300}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::ReidentifyContentResponse,google/privacy/dlp/v2/dlp.proto#L1363}
   ///
@@ -187,7 +191,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::ReidentifyContentResponse>
   ReidentifyContent(
       google::privacy::dlp::v2::ReidentifyContentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a list of the sensitive information types that the DLP API
@@ -197,7 +201,8 @@ class DlpServiceClient {
   /// @param parent  The parent resource name.
   ///  The format of this value is as follows:
   ///      locations/<var>LOCATION_ID</var>
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::ListInfoTypesResponse,google/privacy/dlp/v2/dlp.proto#L1574}
   ///
@@ -207,7 +212,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L1574}
   ///
   StatusOr<google::privacy::dlp::v2::ListInfoTypesResponse> ListInfoTypes(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Returns a list of the sensitive information types that the DLP API
@@ -216,7 +221,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ListInfoTypesRequest,google/privacy/dlp/v2/dlp.proto#L1552}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::ListInfoTypesResponse,google/privacy/dlp/v2/dlp.proto#L1574}
   ///
@@ -227,7 +233,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::ListInfoTypesResponse> ListInfoTypes(
       google::privacy::dlp::v2::ListInfoTypesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an InspectTemplate for re-using frequently used configuration
@@ -251,7 +257,8 @@ class DlpServiceClient {
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
   /// @param inspect_template  Required. The InspectTemplate to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -263,7 +270,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::InspectTemplate> CreateInspectTemplate(
       std::string const& parent,
       google::privacy::dlp::v2::InspectTemplate const& inspect_template,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an InspectTemplate for re-using frequently used configuration
@@ -272,7 +279,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::CreateInspectTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3180}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -283,7 +291,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::InspectTemplate> CreateInspectTemplate(
       google::privacy::dlp::v2::CreateInspectTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the InspectTemplate.
@@ -295,7 +303,8 @@ class DlpServiceClient {
   ///  projects/project-id/inspectTemplates/432452342.
   /// @param inspect_template  New InspectTemplate value.
   /// @param update_mask  Mask to control which fields get updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -307,7 +316,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::InspectTemplate> UpdateInspectTemplate(
       std::string const& name,
       google::privacy::dlp::v2::InspectTemplate const& inspect_template,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the InspectTemplate.
@@ -315,7 +324,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::UpdateInspectTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3222}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -326,7 +336,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::InspectTemplate> UpdateInspectTemplate(
       google::privacy::dlp::v2::UpdateInspectTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets an InspectTemplate.
@@ -336,7 +346,8 @@ class DlpServiceClient {
   /// inspectTemplate to be read, for
   ///  example `organizations/433245324/inspectTemplates/432452342` or
   ///  projects/project-id/inspectTemplates/432452342.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -346,7 +357,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L2935}
   ///
   StatusOr<google::privacy::dlp::v2::InspectTemplate> GetInspectTemplate(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an InspectTemplate.
@@ -354,7 +365,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::GetInspectTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3241}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -365,7 +377,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::InspectTemplate> GetInspectTemplate(
       google::privacy::dlp::v2::GetInspectTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists InspectTemplates.
@@ -387,7 +399,8 @@ class DlpServiceClient {
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -397,7 +410,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L2935}
   ///
   StreamRange<google::privacy::dlp::v2::InspectTemplate> ListInspectTemplates(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists InspectTemplates.
@@ -405,7 +418,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ListInspectTemplatesRequest,google/privacy/dlp/v2/dlp.proto#L3254}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::InspectTemplate,google/privacy/dlp/v2/dlp.proto#L2935}
   ///
@@ -416,7 +430,7 @@ class DlpServiceClient {
   ///
   StreamRange<google::privacy::dlp::v2::InspectTemplate> ListInspectTemplates(
       google::privacy::dlp::v2::ListInspectTemplatesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an InspectTemplate.
@@ -426,12 +440,13 @@ class DlpServiceClient {
   /// inspectTemplate to be deleted, for
   ///  example `organizations/433245324/inspectTemplates/432452342` or
   ///  projects/project-id/inspectTemplates/432452342.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteInspectTemplateRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3320}
   ///
-  Status DeleteInspectTemplate(std::string const& name, Options options = {});
+  Status DeleteInspectTemplate(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an InspectTemplate.
@@ -439,14 +454,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::DeleteInspectTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3320}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteInspectTemplateRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3320}
   ///
   Status DeleteInspectTemplate(
       google::privacy::dlp::v2::DeleteInspectTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a DeidentifyTemplate for re-using frequently used configuration
@@ -471,7 +487,8 @@ class DlpServiceClient {
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
   /// @param deidentify_template  Required. The DeidentifyTemplate to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -484,7 +501,7 @@ class DlpServiceClient {
   CreateDeidentifyTemplate(
       std::string const& parent,
       google::privacy::dlp::v2::DeidentifyTemplate const& deidentify_template,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a DeidentifyTemplate for re-using frequently used configuration
@@ -494,7 +511,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::CreateDeidentifyTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3788}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -506,7 +524,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
   CreateDeidentifyTemplate(
       google::privacy::dlp::v2::CreateDeidentifyTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the DeidentifyTemplate.
@@ -519,7 +537,8 @@ class DlpServiceClient {
   ///  projects/project-id/deidentifyTemplates/432452342.
   /// @param deidentify_template  New DeidentifyTemplate value.
   /// @param update_mask  Mask to control which fields get updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -532,7 +551,7 @@ class DlpServiceClient {
   UpdateDeidentifyTemplate(
       std::string const& name,
       google::privacy::dlp::v2::DeidentifyTemplate const& deidentify_template,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the DeidentifyTemplate.
@@ -541,7 +560,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::UpdateDeidentifyTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3830}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -553,7 +573,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::DeidentifyTemplate>
   UpdateDeidentifyTemplate(
       google::privacy::dlp::v2::UpdateDeidentifyTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a DeidentifyTemplate.
@@ -564,7 +584,8 @@ class DlpServiceClient {
   /// template to be read, for
   ///  example `organizations/433245324/deidentifyTemplates/432452342` or
   ///  projects/project-id/deidentifyTemplates/432452342.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -574,7 +595,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L2969}
   ///
   StatusOr<google::privacy::dlp::v2::DeidentifyTemplate> GetDeidentifyTemplate(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a DeidentifyTemplate.
@@ -583,7 +604,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::GetDeidentifyTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3849}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -594,7 +616,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::DeidentifyTemplate> GetDeidentifyTemplate(
       google::privacy::dlp::v2::GetDeidentifyTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists DeidentifyTemplates.
@@ -617,7 +639,8 @@ class DlpServiceClient {
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -627,7 +650,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L2969}
   ///
   StreamRange<google::privacy::dlp::v2::DeidentifyTemplate>
-  ListDeidentifyTemplates(std::string const& parent, Options options = {});
+  ListDeidentifyTemplates(std::string const& parent, Options opts = {});
 
   ///
   /// Lists DeidentifyTemplates.
@@ -636,7 +659,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ListDeidentifyTemplatesRequest,google/privacy/dlp/v2/dlp.proto#L3862}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DeidentifyTemplate,google/privacy/dlp/v2/dlp.proto#L2969}
   ///
@@ -648,7 +672,7 @@ class DlpServiceClient {
   StreamRange<google::privacy::dlp::v2::DeidentifyTemplate>
   ListDeidentifyTemplates(
       google::privacy::dlp::v2::ListDeidentifyTemplatesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a DeidentifyTemplate.
@@ -659,13 +683,13 @@ class DlpServiceClient {
   /// template to be deleted,
   ///  for example `organizations/433245324/deidentifyTemplates/432452342` or
   ///  projects/project-id/deidentifyTemplates/432452342.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3929}
   ///
-  Status DeleteDeidentifyTemplate(std::string const& name,
-                                  Options options = {});
+  Status DeleteDeidentifyTemplate(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a DeidentifyTemplate.
@@ -674,14 +698,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::DeleteDeidentifyTemplateRequest,google/privacy/dlp/v2/dlp.proto#L3929}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteDeidentifyTemplateRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3929}
   ///
   Status DeleteDeidentifyTemplate(
       google::privacy::dlp::v2::DeleteDeidentifyTemplateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a job trigger to run DLP actions such as scanning storage for
@@ -701,7 +726,8 @@ class DlpServiceClient {
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
   /// @param job_trigger  Required. The JobTrigger to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -713,7 +739,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::JobTrigger> CreateJobTrigger(
       std::string const& parent,
       google::privacy::dlp::v2::JobTrigger const& job_trigger,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a job trigger to run DLP actions such as scanning storage for
@@ -722,7 +748,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::CreateJobTriggerRequest,google/privacy/dlp/v2/dlp.proto#L3333}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -733,7 +760,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::JobTrigger> CreateJobTrigger(
       google::privacy::dlp::v2::CreateJobTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a job trigger.
@@ -744,7 +771,8 @@ class DlpServiceClient {
   ///  `projects/dlp-test-project/jobTriggers/53234423`.
   /// @param job_trigger  New JobTrigger value.
   /// @param update_mask  Mask to control which fields get updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -756,7 +784,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::JobTrigger> UpdateJobTrigger(
       std::string const& name,
       google::privacy::dlp::v2::JobTrigger const& job_trigger,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a job trigger.
@@ -764,7 +792,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::UpdateJobTriggerRequest,google/privacy/dlp/v2/dlp.proto#L3383}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -775,7 +804,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::JobTrigger> UpdateJobTrigger(
       google::privacy::dlp::v2::UpdateJobTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Inspect hybrid content and store findings to a trigger. The inspection
@@ -785,7 +814,8 @@ class DlpServiceClient {
   /// @param name  Required. Resource name of the trigger to execute a hybrid
   /// inspect on, for example
   ///  `projects/dlp-test-project/jobTriggers/53234423`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::HybridInspectResponse,google/privacy/dlp/v2/dlp.proto#L4295}
   ///
@@ -795,7 +825,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L4295}
   ///
   StatusOr<google::privacy::dlp::v2::HybridInspectResponse>
-  HybridInspectJobTrigger(std::string const& name, Options options = {});
+  HybridInspectJobTrigger(std::string const& name, Options opts = {});
 
   ///
   /// Inspect hybrid content and store findings to a trigger. The inspection
@@ -804,7 +834,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::HybridInspectJobTriggerRequest,google/privacy/dlp/v2/dlp.proto#L4213}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::HybridInspectResponse,google/privacy/dlp/v2/dlp.proto#L4295}
   ///
@@ -816,7 +847,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::HybridInspectResponse>
   HybridInspectJobTrigger(
       google::privacy::dlp::v2::HybridInspectJobTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a job trigger.
@@ -825,7 +856,8 @@ class DlpServiceClient {
   /// @param name  Required. Resource name of the project and the triggeredJob,
   /// for example
   ///  `projects/dlp-test-project/jobTriggers/53234423`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -835,7 +867,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3013}
   ///
   StatusOr<google::privacy::dlp::v2::JobTrigger> GetJobTrigger(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a job trigger.
@@ -843,7 +875,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::GetJobTriggerRequest,google/privacy/dlp/v2/dlp.proto#L3401}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -854,7 +887,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::JobTrigger> GetJobTrigger(
       google::privacy::dlp::v2::GetJobTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists job triggers.
@@ -872,7 +905,8 @@ class DlpServiceClient {
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -882,7 +916,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3013}
   ///
   StreamRange<google::privacy::dlp::v2::JobTrigger> ListJobTriggers(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists job triggers.
@@ -890,7 +924,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ListJobTriggersRequest,google/privacy/dlp/v2/dlp.proto#L3460}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::JobTrigger,google/privacy/dlp/v2/dlp.proto#L3013}
   ///
@@ -901,7 +936,7 @@ class DlpServiceClient {
   ///
   StreamRange<google::privacy::dlp::v2::JobTrigger> ListJobTriggers(
       google::privacy::dlp::v2::ListJobTriggersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a job trigger.
@@ -910,12 +945,13 @@ class DlpServiceClient {
   /// @param name  Required. Resource name of the project and the triggeredJob,
   /// for example
   ///  `projects/dlp-test-project/jobTriggers/53234423`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteJobTriggerRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3553}
   ///
-  Status DeleteJobTrigger(std::string const& name, Options options = {});
+  Status DeleteJobTrigger(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a job trigger.
@@ -923,14 +959,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::DeleteJobTriggerRequest,google/privacy/dlp/v2/dlp.proto#L3553}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteJobTriggerRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3553}
   ///
   Status DeleteJobTrigger(
       google::privacy::dlp::v2::DeleteJobTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Activate a job trigger. Causes the immediate execute of a trigger
@@ -938,7 +975,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ActivateJobTriggerRequest,google/privacy/dlp/v2/dlp.proto#L3371}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -949,7 +987,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::DlpJob> ActivateJobTrigger(
       google::privacy::dlp::v2::ActivateJobTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new job to inspect storage or calculate risk metrics.
@@ -974,7 +1012,8 @@ class DlpServiceClient {
   ///      parent=projects/example-project/locations/europe-west3
   /// @param inspect_job  An inspection job scans a storage repository for
   /// InfoTypes.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -986,7 +1025,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::DlpJob> CreateDlpJob(
       std::string const& parent,
       google::privacy::dlp::v2::InspectJobConfig const& inspect_job,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new job to inspect storage or calculate risk metrics.
@@ -1012,7 +1051,8 @@ class DlpServiceClient {
   /// @param risk_job  A risk analysis job calculates re-identification risk
   /// metrics for a
   ///  BigQuery table.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -1024,7 +1064,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::DlpJob> CreateDlpJob(
       std::string const& parent,
       google::privacy::dlp::v2::RiskAnalysisJobConfig const& risk_job,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new job to inspect storage or calculate risk metrics.
@@ -1037,7 +1077,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::CreateDlpJobRequest,google/privacy/dlp/v2/dlp.proto#L3415}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -1048,7 +1089,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::DlpJob> CreateDlpJob(
       google::privacy::dlp::v2::CreateDlpJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists DlpJobs that match the specified filter in the request.
@@ -1067,7 +1108,8 @@ class DlpServiceClient {
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -1077,7 +1119,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3582}
   ///
   StreamRange<google::privacy::dlp::v2::DlpJob> ListDlpJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists DlpJobs that match the specified filter in the request.
@@ -1086,7 +1128,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ListDlpJobsRequest,google/privacy/dlp/v2/dlp.proto#L3663}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -1096,8 +1139,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3582}
   ///
   StreamRange<google::privacy::dlp::v2::DlpJob> ListDlpJobs(
-      google::privacy::dlp::v2::ListDlpJobsRequest request,
-      Options options = {});
+      google::privacy::dlp::v2::ListDlpJobsRequest request, Options opts = {});
 
   ///
   /// Gets the latest state of a long-running DlpJob.
@@ -1105,7 +1147,8 @@ class DlpServiceClient {
   /// https://cloud.google.com/dlp/docs/compute-risk-analysis to learn more.
   ///
   /// @param name  Required. The name of the DlpJob resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -1115,7 +1158,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3582}
   ///
   StatusOr<google::privacy::dlp::v2::DlpJob> GetDlpJob(std::string const& name,
-                                                       Options options = {});
+                                                       Options opts = {});
 
   ///
   /// Gets the latest state of a long-running DlpJob.
@@ -1124,7 +1167,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::GetDlpJobRequest,google/privacy/dlp/v2/dlp.proto#L3652}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::DlpJob,google/privacy/dlp/v2/dlp.proto#L3582}
   ///
@@ -1135,7 +1179,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::DlpJob> GetDlpJob(
       google::privacy::dlp::v2::GetDlpJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a long-running DlpJob. This method indicates that the client is
@@ -1145,12 +1189,13 @@ class DlpServiceClient {
   /// https://cloud.google.com/dlp/docs/compute-risk-analysis to learn more.
   ///
   /// @param name  Required. The name of the DlpJob resource to be deleted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteDlpJobRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3777}
   ///
-  Status DeleteDlpJob(std::string const& name, Options options = {});
+  Status DeleteDlpJob(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a long-running DlpJob. This method indicates that the client is
@@ -1161,14 +1206,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::DeleteDlpJobRequest,google/privacy/dlp/v2/dlp.proto#L3777}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteDlpJobRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3777}
   ///
   Status DeleteDlpJob(
       google::privacy::dlp::v2::DeleteDlpJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts asynchronous cancellation on a long-running DlpJob. The server
@@ -1179,14 +1225,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::CancelDlpJobRequest,google/privacy/dlp/v2/dlp.proto#L3755}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.CancelDlpJobRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3755}
   ///
   Status CancelDlpJob(
       google::privacy::dlp::v2::CancelDlpJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a pre-built stored infoType to be used for inspection.
@@ -1210,7 +1257,8 @@ class DlpServiceClient {
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
   /// @param config  Required. Configuration of the storedInfoType to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1222,7 +1270,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::StoredInfoType> CreateStoredInfoType(
       std::string const& parent,
       google::privacy::dlp::v2::StoredInfoTypeConfig const& config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a pre-built stored infoType to be used for inspection.
@@ -1231,7 +1279,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::CreateStoredInfoTypeRequest,google/privacy/dlp/v2/dlp.proto#L4057}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1242,7 +1291,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::StoredInfoType> CreateStoredInfoType(
       google::privacy::dlp::v2::CreateStoredInfoTypeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the stored infoType by creating a new version. The existing
@@ -1258,7 +1307,8 @@ class DlpServiceClient {
   ///  version of the storedInfoType will be created with the existing
   ///  configuration.
   /// @param update_mask  Mask to control which fields get updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1270,7 +1320,7 @@ class DlpServiceClient {
   StatusOr<google::privacy::dlp::v2::StoredInfoType> UpdateStoredInfoType(
       std::string const& name,
       google::privacy::dlp::v2::StoredInfoTypeConfig const& config,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the stored infoType by creating a new version. The existing
@@ -1279,7 +1329,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::UpdateStoredInfoTypeRequest,google/privacy/dlp/v2/dlp.proto#L4099}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1290,7 +1341,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::StoredInfoType> UpdateStoredInfoType(
       google::privacy::dlp::v2::UpdateStoredInfoTypeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a stored infoType.
@@ -1301,7 +1352,8 @@ class DlpServiceClient {
   /// storedInfoType to be read, for
   ///  example `organizations/433245324/storedInfoTypes/432452342` or
   ///  projects/project-id/storedInfoTypes/432452342.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1311,7 +1363,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L4036}
   ///
   StatusOr<google::privacy::dlp::v2::StoredInfoType> GetStoredInfoType(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a stored infoType.
@@ -1320,7 +1372,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::GetStoredInfoTypeRequest,google/privacy/dlp/v2/dlp.proto#L4120}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1331,7 +1384,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::StoredInfoType> GetStoredInfoType(
       google::privacy::dlp::v2::GetStoredInfoTypeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists stored infoTypes.
@@ -1354,7 +1407,8 @@ class DlpServiceClient {
   ///  identifier `example-project`, and specifies the `europe-west3` location
   ///  for processing data:
   ///      parent=projects/example-project/locations/europe-west3
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1364,7 +1418,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L4036}
   ///
   StreamRange<google::privacy::dlp::v2::StoredInfoType> ListStoredInfoTypes(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists stored infoTypes.
@@ -1373,7 +1427,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::ListStoredInfoTypesRequest,google/privacy/dlp/v2/dlp.proto#L4133}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::StoredInfoType,google/privacy/dlp/v2/dlp.proto#L4036}
   ///
@@ -1384,7 +1439,7 @@ class DlpServiceClient {
   ///
   StreamRange<google::privacy::dlp::v2::StoredInfoType> ListStoredInfoTypes(
       google::privacy::dlp::v2::ListStoredInfoTypesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a stored infoType.
@@ -1395,12 +1450,13 @@ class DlpServiceClient {
   /// storedInfoType to be deleted, for
   ///  example `organizations/433245324/storedInfoTypes/432452342` or
   ///  projects/project-id/storedInfoTypes/432452342.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteStoredInfoTypeRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L4200}
   ///
-  Status DeleteStoredInfoType(std::string const& name, Options options = {});
+  Status DeleteStoredInfoType(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a stored infoType.
@@ -1409,14 +1465,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::DeleteStoredInfoTypeRequest,google/privacy/dlp/v2/dlp.proto#L4200}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.DeleteStoredInfoTypeRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L4200}
   ///
   Status DeleteStoredInfoType(
       google::privacy::dlp::v2::DeleteStoredInfoTypeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Inspect hybrid content and store findings to a job.
@@ -1426,7 +1483,8 @@ class DlpServiceClient {
   /// @param name  Required. Resource name of the job to execute a hybrid
   /// inspect on, for example
   ///  `projects/dlp-test-project/dlpJob/53234423`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::HybridInspectResponse,google/privacy/dlp/v2/dlp.proto#L4295}
   ///
@@ -1436,7 +1494,7 @@ class DlpServiceClient {
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L4295}
   ///
   StatusOr<google::privacy::dlp::v2::HybridInspectResponse> HybridInspectDlpJob(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Inspect hybrid content and store findings to a job.
@@ -1445,7 +1503,8 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::HybridInspectDlpJobRequest,google/privacy/dlp/v2/dlp.proto#L4228}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::privacy::dlp::v2::HybridInspectResponse,google/privacy/dlp/v2/dlp.proto#L4295}
   ///
@@ -1456,7 +1515,7 @@ class DlpServiceClient {
   ///
   StatusOr<google::privacy::dlp::v2::HybridInspectResponse> HybridInspectDlpJob(
       google::privacy::dlp::v2::HybridInspectDlpJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Finish a running hybrid DlpJob. Triggers the finalization steps and
@@ -1464,14 +1523,15 @@ class DlpServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::privacy::dlp::v2::FinishDlpJobRequest,google/privacy/dlp/v2/dlp.proto#L3766}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.privacy.dlp.v2.FinishDlpJobRequest]:
   /// @googleapis_reference_link{google/privacy/dlp/v2/dlp.proto#L3766}
   ///
   Status FinishDlpJob(
       google::privacy::dlp::v2::FinishDlpJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DlpServiceConnection> connection_;

--- a/google/cloud/eventarc/eventarc_client.cc
+++ b/google/cloud/eventarc/eventarc_client.cc
@@ -26,17 +26,16 @@ namespace eventarc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EventarcClient::EventarcClient(std::shared_ptr<EventarcConnection> connection,
-                               Options options)
+                               Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           eventarc_internal::EventarcDefaultOptions(connection_->options()))) {}
 EventarcClient::~EventarcClient() = default;
 
 StatusOr<google::cloud::eventarc::v1::Trigger> EventarcClient::GetTrigger(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::eventarc::v1::GetTriggerRequest request;
   request.set_name(name);
   return connection_->GetTrigger(request);
@@ -44,25 +43,22 @@ StatusOr<google::cloud::eventarc::v1::Trigger> EventarcClient::GetTrigger(
 
 StatusOr<google::cloud::eventarc::v1::Trigger> EventarcClient::GetTrigger(
     google::cloud::eventarc::v1::GetTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTrigger(request);
 }
 
 StreamRange<google::cloud::eventarc::v1::Trigger> EventarcClient::ListTriggers(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::eventarc::v1::ListTriggersRequest request;
   request.set_parent(parent);
   return connection_->ListTriggers(request);
 }
 
 StreamRange<google::cloud::eventarc::v1::Trigger> EventarcClient::ListTriggers(
-    google::cloud::eventarc::v1::ListTriggersRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::eventarc::v1::ListTriggersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTriggers(std::move(request));
 }
 
@@ -70,9 +66,8 @@ future<StatusOr<google::cloud::eventarc::v1::Trigger>>
 EventarcClient::CreateTrigger(
     std::string const& parent,
     google::cloud::eventarc::v1::Trigger const& trigger,
-    std::string const& trigger_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& trigger_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::eventarc::v1::CreateTriggerRequest request;
   request.set_parent(parent);
   *request.mutable_trigger() = trigger;
@@ -83,9 +78,8 @@ EventarcClient::CreateTrigger(
 future<StatusOr<google::cloud::eventarc::v1::Trigger>>
 EventarcClient::CreateTrigger(
     google::cloud::eventarc::v1::CreateTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTrigger(request);
 }
 
@@ -93,9 +87,8 @@ future<StatusOr<google::cloud::eventarc::v1::Trigger>>
 EventarcClient::UpdateTrigger(
     google::cloud::eventarc::v1::Trigger const& trigger,
     google::protobuf::FieldMask const& update_mask, bool allow_missing,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::eventarc::v1::UpdateTriggerRequest request;
   *request.mutable_trigger() = trigger;
   *request.mutable_update_mask() = update_mask;
@@ -106,17 +99,15 @@ EventarcClient::UpdateTrigger(
 future<StatusOr<google::cloud::eventarc::v1::Trigger>>
 EventarcClient::UpdateTrigger(
     google::cloud::eventarc::v1::UpdateTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTrigger(request);
 }
 
 future<StatusOr<google::cloud::eventarc::v1::Trigger>>
 EventarcClient::DeleteTrigger(std::string const& name, bool allow_missing,
-                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::eventarc::v1::DeleteTriggerRequest request;
   request.set_name(name);
   request.set_allow_missing(allow_missing);
@@ -126,9 +117,8 @@ EventarcClient::DeleteTrigger(std::string const& name, bool allow_missing,
 future<StatusOr<google::cloud::eventarc::v1::Trigger>>
 EventarcClient::DeleteTrigger(
     google::cloud::eventarc::v1::DeleteTriggerRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTrigger(request);
 }
 

--- a/google/cloud/eventarc/eventarc_client.h
+++ b/google/cloud/eventarc/eventarc_client.h
@@ -64,7 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EventarcClient {
  public:
   explicit EventarcClient(std::shared_ptr<EventarcConnection> connection,
-                          Options options = {});
+                          Options opts = {});
   ~EventarcClient();
 
   //@{
@@ -89,7 +89,8 @@ class EventarcClient {
   /// Get a single trigger.
   ///
   /// @param name  Required. The name of the trigger to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -99,14 +100,15 @@ class EventarcClient {
   /// @googleapis_reference_link{google/cloud/eventarc/v1/trigger.proto#L42}
   ///
   StatusOr<google::cloud::eventarc::v1::Trigger> GetTrigger(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Get a single trigger.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::eventarc::v1::GetTriggerRequest,google/cloud/eventarc/v1/eventarc.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -117,13 +119,14 @@ class EventarcClient {
   ///
   StatusOr<google::cloud::eventarc::v1::Trigger> GetTrigger(
       google::cloud::eventarc::v1::GetTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List triggers.
   ///
   /// @param parent  Required. The parent collection to list triggers on.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -133,14 +136,15 @@ class EventarcClient {
   /// @googleapis_reference_link{google/cloud/eventarc/v1/trigger.proto#L42}
   ///
   StreamRange<google::cloud::eventarc::v1::Trigger> ListTriggers(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// List triggers.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::eventarc::v1::ListTriggersRequest,google/cloud/eventarc/v1/eventarc.proto#L109}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -151,7 +155,7 @@ class EventarcClient {
   ///
   StreamRange<google::cloud::eventarc::v1::Trigger> ListTriggers(
       google::cloud::eventarc::v1::ListTriggersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new trigger in a particular project and location.
@@ -161,7 +165,8 @@ class EventarcClient {
   /// @param trigger  Required. The trigger to create.
   /// @param trigger_id  Required. The user-provided ID to be assigned to the
   /// trigger.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -173,14 +178,15 @@ class EventarcClient {
   future<StatusOr<google::cloud::eventarc::v1::Trigger>> CreateTrigger(
       std::string const& parent,
       google::cloud::eventarc::v1::Trigger const& trigger,
-      std::string const& trigger_id, Options options = {});
+      std::string const& trigger_id, Options opts = {});
 
   ///
   /// Create a new trigger in a particular project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::eventarc::v1::CreateTriggerRequest,google/cloud/eventarc/v1/eventarc.proto#L150}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -191,7 +197,7 @@ class EventarcClient {
   ///
   future<StatusOr<google::cloud::eventarc::v1::Trigger>> CreateTrigger(
       google::cloud::eventarc::v1::CreateTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a single trigger.
@@ -204,7 +210,8 @@ class EventarcClient {
   /// @param allow_missing  If set to true, and the trigger is not found, a new
   /// trigger will be
   ///  created. In this situation, `update_mask` is ignored.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -216,14 +223,15 @@ class EventarcClient {
   future<StatusOr<google::cloud::eventarc::v1::Trigger>> UpdateTrigger(
       google::cloud::eventarc::v1::Trigger const& trigger,
       google::protobuf::FieldMask const& update_mask, bool allow_missing,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a single trigger.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::eventarc::v1::UpdateTriggerRequest,google/cloud/eventarc/v1/eventarc.proto#L171}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -234,7 +242,7 @@ class EventarcClient {
   ///
   future<StatusOr<google::cloud::eventarc::v1::Trigger>> UpdateTrigger(
       google::cloud::eventarc::v1::UpdateTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Delete a single trigger.
@@ -243,7 +251,8 @@ class EventarcClient {
   /// @param allow_missing  If set to true, and the trigger is not found, the
   /// request will succeed
   ///  but no action will be taken on the server.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -253,14 +262,15 @@ class EventarcClient {
   /// @googleapis_reference_link{google/cloud/eventarc/v1/trigger.proto#L42}
   ///
   future<StatusOr<google::cloud::eventarc::v1::Trigger>> DeleteTrigger(
-      std::string const& name, bool allow_missing, Options options = {});
+      std::string const& name, bool allow_missing, Options opts = {});
 
   ///
   /// Delete a single trigger.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::eventarc::v1::DeleteTriggerRequest,google/cloud/eventarc/v1/eventarc.proto#L190}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::v1::Trigger,google/cloud/eventarc/v1/trigger.proto#L42}
   ///
@@ -271,7 +281,7 @@ class EventarcClient {
   ///
   future<StatusOr<google::cloud::eventarc::v1::Trigger>> DeleteTrigger(
       google::cloud::eventarc::v1::DeleteTriggerRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<EventarcConnection> connection_;

--- a/google/cloud/eventarc/publisher_client.cc
+++ b/google/cloud/eventarc/publisher_client.cc
@@ -26,10 +26,10 @@ namespace eventarc {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PublisherClient::PublisherClient(
-    std::shared_ptr<PublisherConnection> connection, Options options)
+    std::shared_ptr<PublisherConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           eventarc_internal::PublisherDefaultOptions(connection_->options()))) {
 }
 PublisherClient::~PublisherClient() = default;
@@ -39,9 +39,8 @@ StatusOr<google::cloud::eventarc::publishing::v1::
 PublisherClient::PublishChannelConnectionEvents(
     google::cloud::eventarc::publishing::v1::
         PublishChannelConnectionEventsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PublishChannelConnectionEvents(request);
 }
 

--- a/google/cloud/eventarc/publisher_client.h
+++ b/google/cloud/eventarc/publisher_client.h
@@ -84,7 +84,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class PublisherClient {
  public:
   explicit PublisherClient(std::shared_ptr<PublisherConnection> connection,
-                           Options options = {});
+                           Options opts = {});
   ~PublisherClient();
 
   //@{
@@ -110,7 +110,8 @@ class PublisherClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::eventarc::publishing::v1::PublishChannelConnectionEventsRequest,google/cloud/eventarc/publishing/v1/publisher.proto#L69}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::eventarc::publishing::v1::PublishChannelConnectionEventsResponse,google/cloud/eventarc/publishing/v1/publisher.proto#L79}
   ///
@@ -124,7 +125,7 @@ class PublisherClient {
   PublishChannelConnectionEvents(
       google::cloud::eventarc::publishing::v1::
           PublishChannelConnectionEventsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<PublisherConnection> connection_;

--- a/google/cloud/filestore/cloud_filestore_manager_client.cc
+++ b/google/cloud/filestore/cloud_filestore_manager_client.cc
@@ -26,20 +26,18 @@ namespace filestore {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudFilestoreManagerClient::CloudFilestoreManagerClient(
-    std::shared_ptr<CloudFilestoreManagerConnection> connection,
-    Options options)
+    std::shared_ptr<CloudFilestoreManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           filestore_internal::CloudFilestoreManagerDefaultOptions(
               connection_->options()))) {}
 CloudFilestoreManagerClient::~CloudFilestoreManagerClient() = default;
 
 StreamRange<google::cloud::filestore::v1::Instance>
 CloudFilestoreManagerClient::ListInstances(std::string const& parent,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
@@ -47,18 +45,15 @@ CloudFilestoreManagerClient::ListInstances(std::string const& parent,
 
 StreamRange<google::cloud::filestore::v1::Instance>
 CloudFilestoreManagerClient::ListInstances(
-    google::cloud::filestore::v1::ListInstancesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::filestore::v1::ListInstancesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::cloud::filestore::v1::Instance>
 CloudFilestoreManagerClient::GetInstance(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -67,9 +62,8 @@ CloudFilestoreManagerClient::GetInstance(std::string const& name,
 StatusOr<google::cloud::filestore::v1::Instance>
 CloudFilestoreManagerClient::GetInstance(
     google::cloud::filestore::v1::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
@@ -77,9 +71,8 @@ future<StatusOr<google::cloud::filestore::v1::Instance>>
 CloudFilestoreManagerClient::CreateInstance(
     std::string const& parent,
     google::cloud::filestore::v1::Instance const& instance,
-    std::string const& instance_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& instance_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::CreateInstanceRequest request;
   request.set_parent(parent);
   *request.mutable_instance() = instance;
@@ -90,18 +83,16 @@ CloudFilestoreManagerClient::CreateInstance(
 future<StatusOr<google::cloud::filestore::v1::Instance>>
 CloudFilestoreManagerClient::CreateInstance(
     google::cloud::filestore::v1::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
 future<StatusOr<google::cloud::filestore::v1::Instance>>
 CloudFilestoreManagerClient::UpdateInstance(
     google::cloud::filestore::v1::Instance const& instance,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::UpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_update_mask() = update_mask;
@@ -111,26 +102,23 @@ CloudFilestoreManagerClient::UpdateInstance(
 future<StatusOr<google::cloud::filestore::v1::Instance>>
 CloudFilestoreManagerClient::UpdateInstance(
     google::cloud::filestore::v1::UpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstance(request);
 }
 
 future<StatusOr<google::cloud::filestore::v1::Instance>>
 CloudFilestoreManagerClient::RestoreInstance(
     google::cloud::filestore::v1::RestoreInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreInstance(request);
 }
 
 future<StatusOr<google::cloud::common::OperationMetadata>>
 CloudFilestoreManagerClient::DeleteInstance(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -139,17 +127,15 @@ CloudFilestoreManagerClient::DeleteInstance(std::string const& name,
 future<StatusOr<google::cloud::common::OperationMetadata>>
 CloudFilestoreManagerClient::DeleteInstance(
     google::cloud::filestore::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
 StreamRange<google::cloud::filestore::v1::Backup>
 CloudFilestoreManagerClient::ListBackups(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
@@ -157,17 +143,14 @@ CloudFilestoreManagerClient::ListBackups(std::string const& parent,
 
 StreamRange<google::cloud::filestore::v1::Backup>
 CloudFilestoreManagerClient::ListBackups(
-    google::cloud::filestore::v1::ListBackupsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::filestore::v1::ListBackupsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackups(std::move(request));
 }
 
 StatusOr<google::cloud::filestore::v1::Backup>
-CloudFilestoreManagerClient::GetBackup(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudFilestoreManagerClient::GetBackup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
@@ -176,9 +159,8 @@ CloudFilestoreManagerClient::GetBackup(std::string const& name,
 StatusOr<google::cloud::filestore::v1::Backup>
 CloudFilestoreManagerClient::GetBackup(
     google::cloud::filestore::v1::GetBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBackup(request);
 }
 
@@ -186,9 +168,8 @@ future<StatusOr<google::cloud::filestore::v1::Backup>>
 CloudFilestoreManagerClient::CreateBackup(
     std::string const& parent,
     google::cloud::filestore::v1::Backup const& backup,
-    std::string const& backup_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& backup_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::CreateBackupRequest request;
   request.set_parent(parent);
   *request.mutable_backup() = backup;
@@ -199,17 +180,15 @@ CloudFilestoreManagerClient::CreateBackup(
 future<StatusOr<google::cloud::filestore::v1::Backup>>
 CloudFilestoreManagerClient::CreateBackup(
     google::cloud::filestore::v1::CreateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(request);
 }
 
 future<StatusOr<google::cloud::common::OperationMetadata>>
 CloudFilestoreManagerClient::DeleteBackup(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
@@ -218,18 +197,16 @@ CloudFilestoreManagerClient::DeleteBackup(std::string const& name,
 future<StatusOr<google::cloud::common::OperationMetadata>>
 CloudFilestoreManagerClient::DeleteBackup(
     google::cloud::filestore::v1::DeleteBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBackup(request);
 }
 
 future<StatusOr<google::cloud::filestore::v1::Backup>>
 CloudFilestoreManagerClient::UpdateBackup(
     google::cloud::filestore::v1::Backup const& backup,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::filestore::v1::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
@@ -239,9 +216,8 @@ CloudFilestoreManagerClient::UpdateBackup(
 future<StatusOr<google::cloud::filestore::v1::Backup>>
 CloudFilestoreManagerClient::UpdateBackup(
     google::cloud::filestore::v1::UpdateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBackup(request);
 }
 

--- a/google/cloud/filestore/cloud_filestore_manager_client.h
+++ b/google/cloud/filestore/cloud_filestore_manager_client.h
@@ -84,7 +84,7 @@ class CloudFilestoreManagerClient {
  public:
   explicit CloudFilestoreManagerClient(
       std::shared_ptr<CloudFilestoreManagerConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~CloudFilestoreManagerClient();
 
   //@{
@@ -120,7 +120,8 @@ class CloudFilestoreManagerClient {
   ///  **us-west1-b**. To retrieve instance information for all locations, use
   ///  "-" for the
   ///  `{location}` value.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -130,7 +131,7 @@ class CloudFilestoreManagerClient {
   /// @googleapis_reference_link{google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
   StreamRange<google::cloud::filestore::v1::Instance> ListInstances(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all instances in a project for either a specified location
@@ -138,7 +139,8 @@ class CloudFilestoreManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::ListInstancesRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L494}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -149,14 +151,15 @@ class CloudFilestoreManagerClient {
   ///
   StreamRange<google::cloud::filestore::v1::Instance> ListInstances(
       google::cloud::filestore::v1::ListInstancesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the details of a specific instance.
   ///
   /// @param name  Required. The instance resource name, in the format
   ///  `projects/{project_id}/locations/{location}/instances/{instance_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -166,14 +169,15 @@ class CloudFilestoreManagerClient {
   /// @googleapis_reference_link{google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
   StatusOr<google::cloud::filestore::v1::Instance> GetInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the details of a specific instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::GetInstanceRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L436}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -184,7 +188,7 @@ class CloudFilestoreManagerClient {
   ///
   StatusOr<google::cloud::filestore::v1::Instance> GetInstance(
       google::cloud::filestore::v1::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an instance.
@@ -200,7 +204,8 @@ class CloudFilestoreManagerClient {
   /// resource][google.cloud.filestore.v1.Instance]
   /// @param instance_id  Required. The name of the instance to create.
   ///  The name must be unique for the specified project and location.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -212,7 +217,7 @@ class CloudFilestoreManagerClient {
   future<StatusOr<google::cloud::filestore::v1::Instance>> CreateInstance(
       std::string const& parent,
       google::cloud::filestore::v1::Instance const& instance,
-      std::string const& instance_id, Options options = {});
+      std::string const& instance_id, Options opts = {});
 
   ///
   /// Creates an instance.
@@ -222,7 +227,8 @@ class CloudFilestoreManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::CreateInstanceRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L416}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -233,7 +239,7 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Instance>> CreateInstance(
       google::cloud::filestore::v1::CreateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the settings of a specific instance.
@@ -246,7 +252,8 @@ class CloudFilestoreManagerClient {
   ///  * "description"
   ///  * "file_shares"
   ///  * "labels"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -257,14 +264,15 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Instance>> UpdateInstance(
       google::cloud::filestore::v1::Instance const& instance,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the settings of a specific instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::UpdateInstanceRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L446}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -275,7 +283,7 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Instance>> UpdateInstance(
       google::cloud::filestore::v1::UpdateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Restores an existing instance's file share from a backup.
@@ -286,7 +294,8 @@ class CloudFilestoreManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::RestoreInstanceRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L462}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Instance,google/cloud/filestore/v1/cloud_filestore_service.proto#L315}
   ///
@@ -297,14 +306,15 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Instance>> RestoreInstance(
       google::cloud::filestore::v1::RestoreInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an instance.
   ///
   /// @param name  Required. The instance resource name, in the format
   ///  `projects/{project_id}/locations/{location}/instances/{instance_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::common::OperationMetadata,google/cloud/common/operation_metadata.proto#L27}
   ///
@@ -314,14 +324,15 @@ class CloudFilestoreManagerClient {
   /// @googleapis_reference_link{google/cloud/common/operation_metadata.proto#L27}
   ///
   future<StatusOr<google::cloud::common::OperationMetadata>> DeleteInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes an instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::DeleteInstanceRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L484}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::common::OperationMetadata,google/cloud/common/operation_metadata.proto#L27}
   ///
@@ -332,7 +343,7 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::common::OperationMetadata>> DeleteInstance(
       google::cloud::filestore::v1::DeleteInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all backups in a project for either a specified location or for all
@@ -345,7 +356,8 @@ class CloudFilestoreManagerClient {
   ///  backup locations map to GCP regions, for example **us-west1**. To
   ///  retrieve backup information for all locations, use "-" for the
   ///  `{location}` value.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -355,7 +367,7 @@ class CloudFilestoreManagerClient {
   /// @googleapis_reference_link{google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
   StreamRange<google::cloud::filestore::v1::Backup> ListBackups(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all backups in a project for either a specified location or for all
@@ -363,7 +375,8 @@ class CloudFilestoreManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::ListBackupsRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L673}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -374,14 +387,15 @@ class CloudFilestoreManagerClient {
   ///
   StreamRange<google::cloud::filestore::v1::Backup> ListBackups(
       google::cloud::filestore::v1::ListBackupsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the details of a specific backup.
   ///
   /// @param name  Required. The backup resource name, in the format
   ///  `projects/{project_number}/locations/{location}/backups/{backup_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -391,14 +405,15 @@ class CloudFilestoreManagerClient {
   /// @googleapis_reference_link{google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
   StatusOr<google::cloud::filestore::v1::Backup> GetBackup(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the details of a specific backup.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::GetBackupRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L663}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -409,7 +424,7 @@ class CloudFilestoreManagerClient {
   ///
   StatusOr<google::cloud::filestore::v1::Backup> GetBackup(
       google::cloud::filestore::v1::GetBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a backup.
@@ -425,7 +440,8 @@ class CloudFilestoreManagerClient {
   ///  lowercase letters, numbers, or hyphens, and cannot end with a hyphen.
   ///  Values that do not match this pattern will trigger an INVALID_ARGUMENT
   ///  error.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -437,14 +453,15 @@ class CloudFilestoreManagerClient {
   future<StatusOr<google::cloud::filestore::v1::Backup>> CreateBackup(
       std::string const& parent,
       google::cloud::filestore::v1::Backup const& backup,
-      std::string const& backup_id, Options options = {});
+      std::string const& backup_id, Options opts = {});
 
   ///
   /// Creates a backup.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::CreateBackupRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L617}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -455,14 +472,15 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Backup>> CreateBackup(
       google::cloud::filestore::v1::CreateBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a backup.
   ///
   /// @param name  Required. The backup resource name, in the format
   ///  `projects/{project_number}/locations/{location}/backups/{backup_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::common::OperationMetadata,google/cloud/common/operation_metadata.proto#L27}
   ///
@@ -472,14 +490,15 @@ class CloudFilestoreManagerClient {
   /// @googleapis_reference_link{google/cloud/common/operation_metadata.proto#L27}
   ///
   future<StatusOr<google::cloud::common::OperationMetadata>> DeleteBackup(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a backup.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::DeleteBackupRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L642}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::common::OperationMetadata,google/cloud/common/operation_metadata.proto#L27}
   ///
@@ -490,7 +509,7 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::common::OperationMetadata>> DeleteBackup(
       google::cloud::filestore::v1::DeleteBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the settings of a specific backup.
@@ -500,7 +519,8 @@ class CloudFilestoreManagerClient {
   /// @param update_mask  Required. Mask of fields to update.  At least one path
   /// must be supplied in
   ///  this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -511,14 +531,15 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Backup>> UpdateBackup(
       google::cloud::filestore::v1::Backup const& backup,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the settings of a specific backup.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::filestore::v1::UpdateBackupRequest,google/cloud/filestore/v1/cloud_filestore_service.proto#L652}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::filestore::v1::Backup,google/cloud/filestore/v1/cloud_filestore_service.proto#L540}
   ///
@@ -529,7 +550,7 @@ class CloudFilestoreManagerClient {
   ///
   future<StatusOr<google::cloud::filestore::v1::Backup>> UpdateBackup(
       google::cloud::filestore::v1::UpdateBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudFilestoreManagerConnection> connection_;

--- a/google/cloud/functions/cloud_functions_client.cc
+++ b/google/cloud/functions/cloud_functions_client.cc
@@ -26,29 +26,25 @@ namespace functions {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudFunctionsServiceClient::CloudFunctionsServiceClient(
-    std::shared_ptr<CloudFunctionsServiceConnection> connection,
-    Options options)
+    std::shared_ptr<CloudFunctionsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           functions_internal::CloudFunctionsServiceDefaultOptions(
               connection_->options()))) {}
 CloudFunctionsServiceClient::~CloudFunctionsServiceClient() = default;
 
 StreamRange<google::cloud::functions::v1::CloudFunction>
 CloudFunctionsServiceClient::ListFunctions(
-    google::cloud::functions::v1::ListFunctionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::functions::v1::ListFunctionsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFunctions(std::move(request));
 }
 
 StatusOr<google::cloud::functions::v1::CloudFunction>
 CloudFunctionsServiceClient::GetFunction(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::functions::v1::GetFunctionRequest request;
   request.set_name(name);
   return connection_->GetFunction(request);
@@ -57,19 +53,16 @@ CloudFunctionsServiceClient::GetFunction(std::string const& name,
 StatusOr<google::cloud::functions::v1::CloudFunction>
 CloudFunctionsServiceClient::GetFunction(
     google::cloud::functions::v1::GetFunctionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetFunction(request);
 }
 
 future<StatusOr<google::cloud::functions::v1::CloudFunction>>
 CloudFunctionsServiceClient::CreateFunction(
     std::string const& location,
-    google::cloud::functions::v1::CloudFunction const& function,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::functions::v1::CloudFunction const& function, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::functions::v1::CreateFunctionRequest request;
   request.set_location(location);
   *request.mutable_function() = function;
@@ -79,18 +72,15 @@ CloudFunctionsServiceClient::CreateFunction(
 future<StatusOr<google::cloud::functions::v1::CloudFunction>>
 CloudFunctionsServiceClient::CreateFunction(
     google::cloud::functions::v1::CreateFunctionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateFunction(request);
 }
 
 future<StatusOr<google::cloud::functions::v1::CloudFunction>>
 CloudFunctionsServiceClient::UpdateFunction(
-    google::cloud::functions::v1::CloudFunction const& function,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::functions::v1::CloudFunction const& function, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::functions::v1::UpdateFunctionRequest request;
   *request.mutable_function() = function;
   return connection_->UpdateFunction(request);
@@ -99,17 +89,15 @@ CloudFunctionsServiceClient::UpdateFunction(
 future<StatusOr<google::cloud::functions::v1::CloudFunction>>
 CloudFunctionsServiceClient::UpdateFunction(
     google::cloud::functions::v1::UpdateFunctionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateFunction(request);
 }
 
 future<StatusOr<google::cloud::functions::v1::OperationMetadataV1>>
 CloudFunctionsServiceClient::DeleteFunction(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::functions::v1::DeleteFunctionRequest request;
   request.set_name(name);
   return connection_->DeleteFunction(request);
@@ -118,18 +106,16 @@ CloudFunctionsServiceClient::DeleteFunction(std::string const& name,
 future<StatusOr<google::cloud::functions::v1::OperationMetadataV1>>
 CloudFunctionsServiceClient::DeleteFunction(
     google::cloud::functions::v1::DeleteFunctionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteFunction(request);
 }
 
 StatusOr<google::cloud::functions::v1::CallFunctionResponse>
 CloudFunctionsServiceClient::CallFunction(std::string const& name,
                                           std::string const& data,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::functions::v1::CallFunctionRequest request;
   request.set_name(name);
   request.set_data(data);
@@ -139,50 +125,43 @@ CloudFunctionsServiceClient::CallFunction(std::string const& name,
 StatusOr<google::cloud::functions::v1::CallFunctionResponse>
 CloudFunctionsServiceClient::CallFunction(
     google::cloud::functions::v1::CallFunctionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CallFunction(request);
 }
 
 StatusOr<google::cloud::functions::v1::GenerateUploadUrlResponse>
 CloudFunctionsServiceClient::GenerateUploadUrl(
     google::cloud::functions::v1::GenerateUploadUrlRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateUploadUrl(request);
 }
 
 StatusOr<google::cloud::functions::v1::GenerateDownloadUrlResponse>
 CloudFunctionsServiceClient::GenerateDownloadUrl(
     google::cloud::functions::v1::GenerateDownloadUrlRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateDownloadUrl(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudFunctionsServiceClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudFunctionsServiceClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudFunctionsServiceClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/functions/cloud_functions_client.h
+++ b/google/cloud/functions/cloud_functions_client.h
@@ -64,7 +64,7 @@ class CloudFunctionsServiceClient {
  public:
   explicit CloudFunctionsServiceClient(
       std::shared_ptr<CloudFunctionsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~CloudFunctionsServiceClient();
 
   //@{
@@ -94,7 +94,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::ListFunctionsRequest,google/cloud/functions/v1/functions.proto#L703}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -105,14 +106,15 @@ class CloudFunctionsServiceClient {
   ///
   StreamRange<google::cloud::functions::v1::CloudFunction> ListFunctions(
       google::cloud::functions::v1::ListFunctionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a function with the given name from the requested project.
   ///
   /// @param name  Required. The name of the function which details should be
   /// obtained.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -122,14 +124,15 @@ class CloudFunctionsServiceClient {
   /// @googleapis_reference_link{google/cloud/functions/v1/functions.proto#L195}
   ///
   StatusOr<google::cloud::functions::v1::CloudFunction> GetFunction(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns a function with the given name from the requested project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::GetFunctionRequest,google/cloud/functions/v1/functions.proto#L692}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -140,7 +143,7 @@ class CloudFunctionsServiceClient {
   ///
   StatusOr<google::cloud::functions::v1::CloudFunction> GetFunction(
       google::cloud::functions::v1::GetFunctionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new function. If a function with the given name already exists
@@ -151,7 +154,8 @@ class CloudFunctionsServiceClient {
   /// should be created, specified
   ///  in the format `projects/*/locations/*`
   /// @param function  Required. Function to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -163,7 +167,7 @@ class CloudFunctionsServiceClient {
   future<StatusOr<google::cloud::functions::v1::CloudFunction>> CreateFunction(
       std::string const& location,
       google::cloud::functions::v1::CloudFunction const& function,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new function. If a function with the given name already exists
@@ -172,7 +176,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::CreateFunctionRequest,google/cloud/functions/v1/functions.proto#L646}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -183,13 +188,14 @@ class CloudFunctionsServiceClient {
   ///
   future<StatusOr<google::cloud::functions::v1::CloudFunction>> CreateFunction(
       google::cloud::functions::v1::CreateFunctionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates existing function.
   ///
   /// @param function  Required. New version of the function.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -200,14 +206,15 @@ class CloudFunctionsServiceClient {
   ///
   future<StatusOr<google::cloud::functions::v1::CloudFunction>> UpdateFunction(
       google::cloud::functions::v1::CloudFunction const& function,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates existing function.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::UpdateFunctionRequest,google/cloud/functions/v1/functions.proto#L661}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CloudFunction,google/cloud/functions/v1/functions.proto#L195}
   ///
@@ -218,7 +225,7 @@ class CloudFunctionsServiceClient {
   ///
   future<StatusOr<google::cloud::functions::v1::CloudFunction>> UpdateFunction(
       google::cloud::functions::v1::UpdateFunctionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a function with the given name from the specified project. If the
@@ -226,7 +233,8 @@ class CloudFunctionsServiceClient {
   /// remove this function.
   ///
   /// @param name  Required. The name of the function which should be deleted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::OperationMetadataV1,google/cloud/functions/v1/operations.proto#L44}
   ///
@@ -236,7 +244,7 @@ class CloudFunctionsServiceClient {
   /// @googleapis_reference_link{google/cloud/functions/v1/operations.proto#L44}
   ///
   future<StatusOr<google::cloud::functions::v1::OperationMetadataV1>>
-  DeleteFunction(std::string const& name, Options options = {});
+  DeleteFunction(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a function with the given name from the specified project. If the
@@ -245,7 +253,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::DeleteFunctionRequest,google/cloud/functions/v1/functions.proto#L741}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::OperationMetadataV1,google/cloud/functions/v1/operations.proto#L44}
   ///
@@ -257,7 +266,7 @@ class CloudFunctionsServiceClient {
   future<StatusOr<google::cloud::functions::v1::OperationMetadataV1>>
   DeleteFunction(
       google::cloud::functions::v1::DeleteFunctionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Synchronously invokes a deployed Cloud Function. To be used for testing
@@ -267,7 +276,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param name  Required. The name of the function to be called.
   /// @param data  Required. Input to be passed to the function.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CallFunctionResponse,google/cloud/functions/v1/functions.proto#L766}
   ///
@@ -277,7 +287,7 @@ class CloudFunctionsServiceClient {
   /// @googleapis_reference_link{google/cloud/functions/v1/functions.proto#L766}
   ///
   StatusOr<google::cloud::functions::v1::CallFunctionResponse> CallFunction(
-      std::string const& name, std::string const& data, Options options = {});
+      std::string const& name, std::string const& data, Options opts = {});
 
   ///
   /// Synchronously invokes a deployed Cloud Function. To be used for testing
@@ -287,7 +297,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::CallFunctionRequest,google/cloud/functions/v1/functions.proto#L752}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::CallFunctionResponse,google/cloud/functions/v1/functions.proto#L766}
   ///
@@ -298,7 +309,7 @@ class CloudFunctionsServiceClient {
   ///
   StatusOr<google::cloud::functions::v1::CallFunctionResponse> CallFunction(
       google::cloud::functions::v1::CallFunctionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a signed URL for uploading a function source code.
@@ -330,7 +341,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::GenerateUploadUrlRequest,google/cloud/functions/v1/functions.proto#L780}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::GenerateUploadUrlResponse,google/cloud/functions/v1/functions.proto#L787}
   ///
@@ -342,7 +354,7 @@ class CloudFunctionsServiceClient {
   StatusOr<google::cloud::functions::v1::GenerateUploadUrlResponse>
   GenerateUploadUrl(
       google::cloud::functions::v1::GenerateUploadUrlRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a signed URL for downloading deployed function source code.
@@ -353,7 +365,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::functions::v1::GenerateDownloadUrlRequest,google/cloud/functions/v1/functions.proto#L795}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::functions::v1::GenerateDownloadUrlResponse,google/cloud/functions/v1/functions.proto#L806}
   ///
@@ -365,7 +378,7 @@ class CloudFunctionsServiceClient {
   StatusOr<google::cloud::functions::v1::GenerateDownloadUrlResponse>
   GenerateDownloadUrl(
       google::cloud::functions::v1::GenerateDownloadUrlRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the IAM access control policy on the specified function.
@@ -373,7 +386,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -383,8 +397,7 @@ class CloudFunctionsServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the IAM access control policy for a function.
@@ -393,7 +406,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -403,8 +417,7 @@ class CloudFunctionsServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Tests the specified permissions against the IAM access control policy
@@ -414,7 +427,8 @@ class CloudFunctionsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -425,7 +439,7 @@ class CloudFunctionsServiceClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudFunctionsServiceConnection> connection_;

--- a/google/cloud/gameservices/game_server_clusters_client.cc
+++ b/google/cloud/gameservices/game_server_clusters_client.cc
@@ -27,19 +27,18 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GameServerClustersServiceClient::GameServerClustersServiceClient(
     std::shared_ptr<GameServerClustersServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           gameservices_internal::GameServerClustersServiceDefaultOptions(
               connection_->options()))) {}
 GameServerClustersServiceClient::~GameServerClustersServiceClient() = default;
 
 StreamRange<google::cloud::gaming::v1::GameServerCluster>
 GameServerClustersServiceClient::ListGameServerClusters(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::ListGameServerClustersRequest request;
   request.set_parent(parent);
   return connection_->ListGameServerClusters(request);
@@ -48,17 +47,15 @@ GameServerClustersServiceClient::ListGameServerClusters(
 StreamRange<google::cloud::gaming::v1::GameServerCluster>
 GameServerClustersServiceClient::ListGameServerClusters(
     google::cloud::gaming::v1::ListGameServerClustersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGameServerClusters(std::move(request));
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerCluster>
 GameServerClustersServiceClient::GetGameServerCluster(std::string const& name,
-                                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                      Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::GetGameServerClusterRequest request;
   request.set_name(name);
   return connection_->GetGameServerCluster(request);
@@ -67,9 +64,8 @@ GameServerClustersServiceClient::GetGameServerCluster(std::string const& name,
 StatusOr<google::cloud::gaming::v1::GameServerCluster>
 GameServerClustersServiceClient::GetGameServerCluster(
     google::cloud::gaming::v1::GetGameServerClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGameServerCluster(request);
 }
 
@@ -77,9 +73,8 @@ future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
 GameServerClustersServiceClient::CreateGameServerCluster(
     std::string const& parent,
     google::cloud::gaming::v1::GameServerCluster const& game_server_cluster,
-    std::string const& game_server_cluster_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& game_server_cluster_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::CreateGameServerClusterRequest request;
   request.set_parent(parent);
   *request.mutable_game_server_cluster() = game_server_cluster;
@@ -90,9 +85,8 @@ GameServerClustersServiceClient::CreateGameServerCluster(
 future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
 GameServerClustersServiceClient::CreateGameServerCluster(
     google::cloud::gaming::v1::CreateGameServerClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGameServerCluster(request);
 }
 
@@ -100,17 +94,15 @@ StatusOr<google::cloud::gaming::v1::PreviewCreateGameServerClusterResponse>
 GameServerClustersServiceClient::PreviewCreateGameServerCluster(
     google::cloud::gaming::v1::PreviewCreateGameServerClusterRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PreviewCreateGameServerCluster(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 GameServerClustersServiceClient::DeleteGameServerCluster(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::DeleteGameServerClusterRequest request;
   request.set_name(name);
   return connection_->DeleteGameServerCluster(request);
@@ -119,9 +111,8 @@ GameServerClustersServiceClient::DeleteGameServerCluster(
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 GameServerClustersServiceClient::DeleteGameServerCluster(
     google::cloud::gaming::v1::DeleteGameServerClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGameServerCluster(request);
 }
 
@@ -129,18 +120,16 @@ StatusOr<google::cloud::gaming::v1::PreviewDeleteGameServerClusterResponse>
 GameServerClustersServiceClient::PreviewDeleteGameServerCluster(
     google::cloud::gaming::v1::PreviewDeleteGameServerClusterRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PreviewDeleteGameServerCluster(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
 GameServerClustersServiceClient::UpdateGameServerCluster(
     google::cloud::gaming::v1::GameServerCluster const& game_server_cluster,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::UpdateGameServerClusterRequest request;
   *request.mutable_game_server_cluster() = game_server_cluster;
   *request.mutable_update_mask() = update_mask;
@@ -150,9 +139,8 @@ GameServerClustersServiceClient::UpdateGameServerCluster(
 future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
 GameServerClustersServiceClient::UpdateGameServerCluster(
     google::cloud::gaming::v1::UpdateGameServerClusterRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGameServerCluster(request);
 }
 
@@ -160,9 +148,8 @@ StatusOr<google::cloud::gaming::v1::PreviewUpdateGameServerClusterResponse>
 GameServerClustersServiceClient::PreviewUpdateGameServerCluster(
     google::cloud::gaming::v1::PreviewUpdateGameServerClusterRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PreviewUpdateGameServerCluster(request);
 }
 

--- a/google/cloud/gameservices/game_server_clusters_client.h
+++ b/google/cloud/gameservices/game_server_clusters_client.h
@@ -65,7 +65,7 @@ class GameServerClustersServiceClient {
  public:
   explicit GameServerClustersServiceClient(
       std::shared_ptr<GameServerClustersServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~GameServerClustersServiceClient();
 
   //@{
@@ -96,7 +96,8 @@ class GameServerClustersServiceClient {
   ///
   /// @param parent  Required. The parent resource name, in the following form:
   ///  "projects/{project}/locations/{location}/realms/{realm}".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -106,14 +107,15 @@ class GameServerClustersServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
   StreamRange<google::cloud::gaming::v1::GameServerCluster>
-  ListGameServerClusters(std::string const& parent, Options options = {});
+  ListGameServerClusters(std::string const& parent, Options opts = {});
 
   ///
   /// Lists game server clusters in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::ListGameServerClustersRequest,google/cloud/gaming/v1/game_server_clusters.proto#L46}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -125,7 +127,7 @@ class GameServerClustersServiceClient {
   StreamRange<google::cloud::gaming::v1::GameServerCluster>
   ListGameServerClusters(
       google::cloud::gaming::v1::ListGameServerClustersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single game server cluster.
@@ -133,7 +135,8 @@ class GameServerClustersServiceClient {
   /// @param name  Required. The name of the game server cluster to retrieve, in
   /// the following form:
   ///  `projects/{project}/locations/{location}/realms/{realm-id}/gameServerClusters/{cluster}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -143,14 +146,15 @@ class GameServerClustersServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
   StatusOr<google::cloud::gaming::v1::GameServerCluster> GetGameServerCluster(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single game server cluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::GetGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L96}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -161,7 +165,7 @@ class GameServerClustersServiceClient {
   ///
   StatusOr<google::cloud::gaming::v1::GameServerCluster> GetGameServerCluster(
       google::cloud::gaming::v1::GetGameServerClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new game server cluster in a given project and location.
@@ -172,7 +176,8 @@ class GameServerClustersServiceClient {
   /// be created.
   /// @param game_server_cluster_id  Required. The ID of the game server cluster
   /// resource to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -185,14 +190,15 @@ class GameServerClustersServiceClient {
   CreateGameServerCluster(
       std::string const& parent,
       google::cloud::gaming::v1::GameServerCluster const& game_server_cluster,
-      std::string const& game_server_cluster_id, Options options = {});
+      std::string const& game_server_cluster_id, Options opts = {});
 
   ///
   /// Creates a new game server cluster in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::CreateGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L116}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -204,7 +210,7 @@ class GameServerClustersServiceClient {
   future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
   CreateGameServerCluster(
       google::cloud::gaming::v1::CreateGameServerClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Previews creation of a new game server cluster in a given project and
@@ -212,7 +218,8 @@ class GameServerClustersServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::PreviewCreateGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L134}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::PreviewCreateGameServerClusterResponse,google/cloud/gaming/v1/game_server_clusters.proto#L163}
   ///
@@ -225,7 +232,7 @@ class GameServerClustersServiceClient {
   PreviewCreateGameServerCluster(
       google::cloud::gaming::v1::PreviewCreateGameServerClusterRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single game server cluster.
@@ -233,7 +240,8 @@ class GameServerClustersServiceClient {
   /// @param name  Required. The name of the game server cluster to delete, in
   /// the following form:
   ///  `projects/{project}/locations/{location}/gameServerClusters/{cluster}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -243,14 +251,15 @@ class GameServerClustersServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/common.proto#L29}
   ///
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
-  DeleteGameServerCluster(std::string const& name, Options options = {});
+  DeleteGameServerCluster(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single game server cluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::DeleteGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L176}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -262,14 +271,15 @@ class GameServerClustersServiceClient {
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
   DeleteGameServerCluster(
       google::cloud::gaming::v1::DeleteGameServerClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Previews deletion of a single game server cluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::PreviewDeleteGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L188}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::PreviewDeleteGameServerClusterResponse,google/cloud/gaming/v1/game_server_clusters.proto#L204}
   ///
@@ -282,7 +292,7 @@ class GameServerClustersServiceClient {
   PreviewDeleteGameServerCluster(
       google::cloud::gaming::v1::PreviewDeleteGameServerClusterRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Patches a single game server cluster.
@@ -294,7 +304,8 @@ class GameServerClustersServiceClient {
   /// must be supplied in
   ///  this field. For the `FieldMask` definition, see
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -306,14 +317,15 @@ class GameServerClustersServiceClient {
   future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
   UpdateGameServerCluster(
       google::cloud::gaming::v1::GameServerCluster const& game_server_cluster,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Patches a single game server cluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::UpdateGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L213}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerCluster,google/cloud/gaming/v1/game_server_clusters.proto#L276}
   ///
@@ -325,14 +337,15 @@ class GameServerClustersServiceClient {
   future<StatusOr<google::cloud::gaming::v1::GameServerCluster>>
   UpdateGameServerCluster(
       google::cloud::gaming::v1::UpdateGameServerClusterRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Previews updating a GameServerCluster.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::PreviewUpdateGameServerClusterRequest,google/cloud/gaming/v1/game_server_clusters.proto#L225}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::PreviewUpdateGameServerClusterResponse,google/cloud/gaming/v1/game_server_clusters.proto#L240}
   ///
@@ -345,7 +358,7 @@ class GameServerClustersServiceClient {
   PreviewUpdateGameServerCluster(
       google::cloud::gaming::v1::PreviewUpdateGameServerClusterRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<GameServerClustersServiceConnection> connection_;

--- a/google/cloud/gameservices/game_server_configs_client.cc
+++ b/google/cloud/gameservices/game_server_configs_client.cc
@@ -27,19 +27,18 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GameServerConfigsServiceClient::GameServerConfigsServiceClient(
     std::shared_ptr<GameServerConfigsServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           gameservices_internal::GameServerConfigsServiceDefaultOptions(
               connection_->options()))) {}
 GameServerConfigsServiceClient::~GameServerConfigsServiceClient() = default;
 
 StreamRange<google::cloud::gaming::v1::GameServerConfig>
 GameServerConfigsServiceClient::ListGameServerConfigs(std::string const& parent,
-                                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                      Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::ListGameServerConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListGameServerConfigs(request);
@@ -48,17 +47,15 @@ GameServerConfigsServiceClient::ListGameServerConfigs(std::string const& parent,
 StreamRange<google::cloud::gaming::v1::GameServerConfig>
 GameServerConfigsServiceClient::ListGameServerConfigs(
     google::cloud::gaming::v1::ListGameServerConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGameServerConfigs(std::move(request));
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerConfig>
 GameServerConfigsServiceClient::GetGameServerConfig(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::GetGameServerConfigRequest request;
   request.set_name(name);
   return connection_->GetGameServerConfig(request);
@@ -67,9 +64,8 @@ GameServerConfigsServiceClient::GetGameServerConfig(std::string const& name,
 StatusOr<google::cloud::gaming::v1::GameServerConfig>
 GameServerConfigsServiceClient::GetGameServerConfig(
     google::cloud::gaming::v1::GetGameServerConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGameServerConfig(request);
 }
 
@@ -77,9 +73,8 @@ future<StatusOr<google::cloud::gaming::v1::GameServerConfig>>
 GameServerConfigsServiceClient::CreateGameServerConfig(
     std::string const& parent,
     google::cloud::gaming::v1::GameServerConfig const& game_server_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::CreateGameServerConfigRequest request;
   request.set_parent(parent);
   *request.mutable_game_server_config() = game_server_config;
@@ -89,17 +84,15 @@ GameServerConfigsServiceClient::CreateGameServerConfig(
 future<StatusOr<google::cloud::gaming::v1::GameServerConfig>>
 GameServerConfigsServiceClient::CreateGameServerConfig(
     google::cloud::gaming::v1::CreateGameServerConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGameServerConfig(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 GameServerConfigsServiceClient::DeleteGameServerConfig(std::string const& name,
-                                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::DeleteGameServerConfigRequest request;
   request.set_name(name);
   return connection_->DeleteGameServerConfig(request);
@@ -108,9 +101,8 @@ GameServerConfigsServiceClient::DeleteGameServerConfig(std::string const& name,
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 GameServerConfigsServiceClient::DeleteGameServerConfig(
     google::cloud::gaming::v1::DeleteGameServerConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGameServerConfig(request);
 }
 

--- a/google/cloud/gameservices/game_server_configs_client.h
+++ b/google/cloud/gameservices/game_server_configs_client.h
@@ -64,7 +64,7 @@ class GameServerConfigsServiceClient {
  public:
   explicit GameServerConfigsServiceClient(
       std::shared_ptr<GameServerConfigsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~GameServerConfigsServiceClient();
 
   //@{
@@ -96,7 +96,8 @@ class GameServerConfigsServiceClient {
   ///
   /// @param parent  Required. The parent resource name, in the following form:
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerConfig,google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
@@ -106,7 +107,7 @@ class GameServerConfigsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
   StreamRange<google::cloud::gaming::v1::GameServerConfig>
-  ListGameServerConfigs(std::string const& parent, Options options = {});
+  ListGameServerConfigs(std::string const& parent, Options opts = {});
 
   ///
   /// Lists game server configs in a given project, location, and game server
@@ -114,7 +115,8 @@ class GameServerConfigsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::ListGameServerConfigsRequest,google/cloud/gaming/v1/game_server_configs.proto#L30}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerConfig,google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
@@ -126,7 +128,7 @@ class GameServerConfigsServiceClient {
   StreamRange<google::cloud::gaming::v1::GameServerConfig>
   ListGameServerConfigs(
       google::cloud::gaming::v1::ListGameServerConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single game server config.
@@ -134,7 +136,8 @@ class GameServerConfigsServiceClient {
   /// @param name  Required. The name of the game server config to retrieve, in
   /// the following form:
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/{config}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerConfig,google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
@@ -144,14 +147,15 @@ class GameServerConfigsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
   StatusOr<google::cloud::gaming::v1::GameServerConfig> GetGameServerConfig(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single game server config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::GetGameServerConfigRequest,google/cloud/gaming/v1/game_server_configs.proto#L72}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerConfig,google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
@@ -162,7 +166,7 @@ class GameServerConfigsServiceClient {
   ///
   StatusOr<google::cloud::gaming::v1::GameServerConfig> GetGameServerConfig(
       google::cloud::gaming::v1::GetGameServerConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new game server config in a given project, location, and game
@@ -173,7 +177,8 @@ class GameServerConfigsServiceClient {
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}/`.
   /// @param game_server_config  Required. The game server config resource to be
   /// created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerConfig,google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
@@ -186,7 +191,7 @@ class GameServerConfigsServiceClient {
   CreateGameServerConfig(
       std::string const& parent,
       google::cloud::gaming::v1::GameServerConfig const& game_server_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new game server config in a given project, location, and game
@@ -195,7 +200,8 @@ class GameServerConfigsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::CreateGameServerConfigRequest,google/cloud/gaming/v1/game_server_configs.proto#L84}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerConfig,google/cloud/gaming/v1/game_server_configs.proto#L142}
   ///
@@ -207,7 +213,7 @@ class GameServerConfigsServiceClient {
   future<StatusOr<google::cloud::gaming::v1::GameServerConfig>>
   CreateGameServerConfig(
       google::cloud::gaming::v1::CreateGameServerConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single game server config. The deletion will fail if the game
@@ -216,7 +222,8 @@ class GameServerConfigsServiceClient {
   /// @param name  Required. The name of the game server config to delete, in
   /// the following form:
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}/configs/{config}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -226,7 +233,7 @@ class GameServerConfigsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/common.proto#L29}
   ///
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
-  DeleteGameServerConfig(std::string const& name, Options options = {});
+  DeleteGameServerConfig(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single game server config. The deletion will fail if the game
@@ -234,7 +241,8 @@ class GameServerConfigsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::DeleteGameServerConfigRequest,google/cloud/gaming/v1/game_server_configs.proto#L102}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -246,7 +254,7 @@ class GameServerConfigsServiceClient {
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
   DeleteGameServerConfig(
       google::cloud::gaming::v1::DeleteGameServerConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<GameServerConfigsServiceConnection> connection_;

--- a/google/cloud/gameservices/game_server_deployments_client.cc
+++ b/google/cloud/gameservices/game_server_deployments_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GameServerDeploymentsServiceClient::GameServerDeploymentsServiceClient(
     std::shared_ptr<GameServerDeploymentsServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           gameservices_internal::GameServerDeploymentsServiceDefaultOptions(
               connection_->options()))) {}
 GameServerDeploymentsServiceClient::~GameServerDeploymentsServiceClient() =
@@ -38,9 +38,8 @@ GameServerDeploymentsServiceClient::~GameServerDeploymentsServiceClient() =
 
 StreamRange<google::cloud::gaming::v1::GameServerDeployment>
 GameServerDeploymentsServiceClient::ListGameServerDeployments(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::ListGameServerDeploymentsRequest request;
   request.set_parent(parent);
   return connection_->ListGameServerDeployments(request);
@@ -49,17 +48,15 @@ GameServerDeploymentsServiceClient::ListGameServerDeployments(
 StreamRange<google::cloud::gaming::v1::GameServerDeployment>
 GameServerDeploymentsServiceClient::ListGameServerDeployments(
     google::cloud::gaming::v1::ListGameServerDeploymentsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGameServerDeployments(std::move(request));
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerDeployment>
 GameServerDeploymentsServiceClient::GetGameServerDeployment(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::GetGameServerDeploymentRequest request;
   request.set_name(name);
   return connection_->GetGameServerDeployment(request);
@@ -68,9 +65,8 @@ GameServerDeploymentsServiceClient::GetGameServerDeployment(
 StatusOr<google::cloud::gaming::v1::GameServerDeployment>
 GameServerDeploymentsServiceClient::GetGameServerDeployment(
     google::cloud::gaming::v1::GetGameServerDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGameServerDeployment(request);
 }
 
@@ -79,9 +75,8 @@ GameServerDeploymentsServiceClient::CreateGameServerDeployment(
     std::string const& parent,
     google::cloud::gaming::v1::GameServerDeployment const&
         game_server_deployment,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::CreateGameServerDeploymentRequest request;
   request.set_parent(parent);
   *request.mutable_game_server_deployment() = game_server_deployment;
@@ -91,17 +86,15 @@ GameServerDeploymentsServiceClient::CreateGameServerDeployment(
 future<StatusOr<google::cloud::gaming::v1::GameServerDeployment>>
 GameServerDeploymentsServiceClient::CreateGameServerDeployment(
     google::cloud::gaming::v1::CreateGameServerDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGameServerDeployment(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 GameServerDeploymentsServiceClient::DeleteGameServerDeployment(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::DeleteGameServerDeploymentRequest request;
   request.set_name(name);
   return connection_->DeleteGameServerDeployment(request);
@@ -110,9 +103,8 @@ GameServerDeploymentsServiceClient::DeleteGameServerDeployment(
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 GameServerDeploymentsServiceClient::DeleteGameServerDeployment(
     google::cloud::gaming::v1::DeleteGameServerDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGameServerDeployment(request);
 }
 
@@ -120,9 +112,8 @@ future<StatusOr<google::cloud::gaming::v1::GameServerDeployment>>
 GameServerDeploymentsServiceClient::UpdateGameServerDeployment(
     google::cloud::gaming::v1::GameServerDeployment const&
         game_server_deployment,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::UpdateGameServerDeploymentRequest request;
   *request.mutable_game_server_deployment() = game_server_deployment;
   *request.mutable_update_mask() = update_mask;
@@ -132,17 +123,15 @@ GameServerDeploymentsServiceClient::UpdateGameServerDeployment(
 future<StatusOr<google::cloud::gaming::v1::GameServerDeployment>>
 GameServerDeploymentsServiceClient::UpdateGameServerDeployment(
     google::cloud::gaming::v1::UpdateGameServerDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGameServerDeployment(request);
 }
 
 StatusOr<google::cloud::gaming::v1::GameServerDeploymentRollout>
 GameServerDeploymentsServiceClient::GetGameServerDeploymentRollout(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::GetGameServerDeploymentRolloutRequest request;
   request.set_name(name);
   return connection_->GetGameServerDeploymentRollout(request);
@@ -152,18 +141,16 @@ StatusOr<google::cloud::gaming::v1::GameServerDeploymentRollout>
 GameServerDeploymentsServiceClient::GetGameServerDeploymentRollout(
     google::cloud::gaming::v1::GetGameServerDeploymentRolloutRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGameServerDeploymentRollout(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::GameServerDeployment>>
 GameServerDeploymentsServiceClient::UpdateGameServerDeploymentRollout(
     google::cloud::gaming::v1::GameServerDeploymentRollout const& rollout,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::UpdateGameServerDeploymentRolloutRequest request;
   *request.mutable_rollout() = rollout;
   *request.mutable_update_mask() = update_mask;
@@ -174,9 +161,8 @@ future<StatusOr<google::cloud::gaming::v1::GameServerDeployment>>
 GameServerDeploymentsServiceClient::UpdateGameServerDeploymentRollout(
     google::cloud::gaming::v1::UpdateGameServerDeploymentRolloutRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGameServerDeploymentRollout(request);
 }
 
@@ -184,18 +170,16 @@ StatusOr<google::cloud::gaming::v1::PreviewGameServerDeploymentRolloutResponse>
 GameServerDeploymentsServiceClient::PreviewGameServerDeploymentRollout(
     google::cloud::gaming::v1::PreviewGameServerDeploymentRolloutRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PreviewGameServerDeploymentRollout(request);
 }
 
 StatusOr<google::cloud::gaming::v1::FetchDeploymentStateResponse>
 GameServerDeploymentsServiceClient::FetchDeploymentState(
     google::cloud::gaming::v1::FetchDeploymentStateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FetchDeploymentState(request);
 }
 

--- a/google/cloud/gameservices/game_server_deployments_client.h
+++ b/google/cloud/gameservices/game_server_deployments_client.h
@@ -65,7 +65,7 @@ class GameServerDeploymentsServiceClient {
  public:
   explicit GameServerDeploymentsServiceClient(
       std::shared_ptr<GameServerDeploymentsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~GameServerDeploymentsServiceClient();
 
   //@{
@@ -97,7 +97,8 @@ class GameServerDeploymentsServiceClient {
   ///
   /// @param parent  Required. The parent resource name, in the following form:
   ///  `projects/{project}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -107,14 +108,15 @@ class GameServerDeploymentsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
   StreamRange<google::cloud::gaming::v1::GameServerDeployment>
-  ListGameServerDeployments(std::string const& parent, Options options = {});
+  ListGameServerDeployments(std::string const& parent, Options opts = {});
 
   ///
   /// Lists game server deployments in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::ListGameServerDeploymentsRequest,google/cloud/gaming/v1/game_server_deployments.proto#L31}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -126,7 +128,7 @@ class GameServerDeploymentsServiceClient {
   StreamRange<google::cloud::gaming::v1::GameServerDeployment>
   ListGameServerDeployments(
       google::cloud::gaming::v1::ListGameServerDeploymentsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single game server deployment.
@@ -134,7 +136,8 @@ class GameServerDeploymentsServiceClient {
   /// @param name  Required. The name of the game server delpoyment to retrieve,
   /// in the following form:
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -144,14 +147,15 @@ class GameServerDeploymentsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
   StatusOr<google::cloud::gaming::v1::GameServerDeployment>
-  GetGameServerDeployment(std::string const& name, Options options = {});
+  GetGameServerDeployment(std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single game server deployment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::GetGameServerDeploymentRequest,google/cloud/gaming/v1/game_server_deployments.proto#L74}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -163,7 +167,7 @@ class GameServerDeploymentsServiceClient {
   StatusOr<google::cloud::gaming::v1::GameServerDeployment>
   GetGameServerDeployment(
       google::cloud::gaming::v1::GetGameServerDeploymentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new game server deployment in a given project and location.
@@ -172,7 +176,8 @@ class GameServerDeploymentsServiceClient {
   ///  `projects/{project}/locations/{location}`.
   /// @param game_server_deployment  Required. The game server delpoyment
   /// resource to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -186,14 +191,15 @@ class GameServerDeploymentsServiceClient {
       std::string const& parent,
       google::cloud::gaming::v1::GameServerDeployment const&
           game_server_deployment,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new game server deployment in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::CreateGameServerDeploymentRequest,google/cloud/gaming/v1/game_server_deployments.proto#L99}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -206,7 +212,7 @@ class GameServerDeploymentsServiceClient {
   CreateGameServerDeployment(
       google::cloud::gaming::v1::CreateGameServerDeploymentRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single game server deployment.
@@ -214,7 +220,8 @@ class GameServerDeploymentsServiceClient {
   /// @param name  Required. The name of the game server delpoyment to delete,
   /// in the following form:
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -224,14 +231,15 @@ class GameServerDeploymentsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/common.proto#L29}
   ///
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
-  DeleteGameServerDeployment(std::string const& name, Options options = {});
+  DeleteGameServerDeployment(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single game server deployment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::DeleteGameServerDeploymentRequest,google/cloud/gaming/v1/game_server_deployments.proto#L117}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -244,7 +252,7 @@ class GameServerDeploymentsServiceClient {
   DeleteGameServerDeployment(
       google::cloud::gaming::v1::DeleteGameServerDeploymentRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Patches a game server deployment.
@@ -256,7 +264,8 @@ class GameServerDeploymentsServiceClient {
   /// must be supplied in
   ///  this field. For the `FieldMask` definition, see
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -269,14 +278,15 @@ class GameServerDeploymentsServiceClient {
   UpdateGameServerDeployment(
       google::cloud::gaming::v1::GameServerDeployment const&
           game_server_deployment,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Patches a game server deployment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::UpdateGameServerDeploymentRequest,google/cloud/gaming/v1/game_server_deployments.proto#L130}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -289,7 +299,7 @@ class GameServerDeploymentsServiceClient {
   UpdateGameServerDeployment(
       google::cloud::gaming::v1::UpdateGameServerDeploymentRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details a single game server deployment rollout.
@@ -297,7 +307,8 @@ class GameServerDeploymentsServiceClient {
   /// @param name  Required. The name of the game server delpoyment to retrieve,
   /// in the following form:
   ///  `projects/{project}/locations/{location}/gameServerDeployments/{deployment}/rollout`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeploymentRollout,google/cloud/gaming/v1/game_server_deployments.proto#L227}
   ///
@@ -307,14 +318,15 @@ class GameServerDeploymentsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/game_server_deployments.proto#L227}
   ///
   StatusOr<google::cloud::gaming::v1::GameServerDeploymentRollout>
-  GetGameServerDeploymentRollout(std::string const& name, Options options = {});
+  GetGameServerDeploymentRollout(std::string const& name, Options opts = {});
 
   ///
   /// Gets details a single game server deployment rollout.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::GetGameServerDeploymentRolloutRequest,google/cloud/gaming/v1/game_server_deployments.proto#L87}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeploymentRollout,google/cloud/gaming/v1/game_server_deployments.proto#L227}
   ///
@@ -327,7 +339,7 @@ class GameServerDeploymentsServiceClient {
   GetGameServerDeploymentRollout(
       google::cloud::gaming::v1::GetGameServerDeploymentRolloutRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Patches a single game server deployment rollout.
@@ -344,7 +356,8 @@ class GameServerDeploymentsServiceClient {
   /// must be supplied in
   ///  this field. For the `FieldMask` definition, see
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -356,7 +369,7 @@ class GameServerDeploymentsServiceClient {
   future<StatusOr<google::cloud::gaming::v1::GameServerDeployment>>
   UpdateGameServerDeploymentRollout(
       google::cloud::gaming::v1::GameServerDeploymentRollout const& rollout,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Patches a single game server deployment rollout.
@@ -368,7 +381,8 @@ class GameServerDeploymentsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::UpdateGameServerDeploymentRolloutRequest,google/cloud/gaming/v1/game_server_deployments.proto#L143}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::GameServerDeployment,google/cloud/gaming/v1/game_server_deployments.proto#L181}
   ///
@@ -381,7 +395,7 @@ class GameServerDeploymentsServiceClient {
   UpdateGameServerDeploymentRollout(
       google::cloud::gaming::v1::UpdateGameServerDeploymentRolloutRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Previews the game server deployment rollout. This API does not mutate the
@@ -389,7 +403,8 @@ class GameServerDeploymentsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::PreviewGameServerDeploymentRolloutRequest,google/cloud/gaming/v1/game_server_deployments.proto#L261}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::PreviewGameServerDeploymentRolloutResponse,google/cloud/gaming/v1/game_server_deployments.proto#L278}
   ///
@@ -403,7 +418,7 @@ class GameServerDeploymentsServiceClient {
   PreviewGameServerDeploymentRollout(
       google::cloud::gaming::v1::
           PreviewGameServerDeploymentRolloutRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves information about the current state of the game server
@@ -412,7 +427,8 @@ class GameServerDeploymentsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::FetchDeploymentStateRequest,google/cloud/gaming/v1/game_server_deployments.proto#L155}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::FetchDeploymentStateResponse,google/cloud/gaming/v1/game_server_deployments.proto#L162}
   ///
@@ -424,7 +440,7 @@ class GameServerDeploymentsServiceClient {
   StatusOr<google::cloud::gaming::v1::FetchDeploymentStateResponse>
   FetchDeploymentState(
       google::cloud::gaming::v1::FetchDeploymentStateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<GameServerDeploymentsServiceConnection> connection_;

--- a/google/cloud/gameservices/realms_client.cc
+++ b/google/cloud/gameservices/realms_client.cc
@@ -26,53 +26,46 @@ namespace gameservices {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 RealmsServiceClient::RealmsServiceClient(
-    std::shared_ptr<RealmsServiceConnection> connection, Options options)
+    std::shared_ptr<RealmsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          gameservices_internal::RealmsServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), gameservices_internal::RealmsServiceDefaultOptions(
+                               connection_->options()))) {}
 RealmsServiceClient::~RealmsServiceClient() = default;
 
 StreamRange<google::cloud::gaming::v1::Realm> RealmsServiceClient::ListRealms(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::ListRealmsRequest request;
   request.set_parent(parent);
   return connection_->ListRealms(request);
 }
 
 StreamRange<google::cloud::gaming::v1::Realm> RealmsServiceClient::ListRealms(
-    google::cloud::gaming::v1::ListRealmsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::gaming::v1::ListRealmsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListRealms(std::move(request));
 }
 
 StatusOr<google::cloud::gaming::v1::Realm> RealmsServiceClient::GetRealm(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::GetRealmRequest request;
   request.set_name(name);
   return connection_->GetRealm(request);
 }
 
 StatusOr<google::cloud::gaming::v1::Realm> RealmsServiceClient::GetRealm(
-    google::cloud::gaming::v1::GetRealmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::gaming::v1::GetRealmRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetRealm(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::Realm>>
 RealmsServiceClient::CreateRealm(std::string const& parent,
                                  google::cloud::gaming::v1::Realm const& realm,
-                                 std::string const& realm_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                 std::string const& realm_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::CreateRealmRequest request;
   request.set_parent(parent);
   *request.mutable_realm() = realm;
@@ -83,16 +76,14 @@ RealmsServiceClient::CreateRealm(std::string const& parent,
 future<StatusOr<google::cloud::gaming::v1::Realm>>
 RealmsServiceClient::CreateRealm(
     google::cloud::gaming::v1::CreateRealmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateRealm(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
-RealmsServiceClient::DeleteRealm(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+RealmsServiceClient::DeleteRealm(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::DeleteRealmRequest request;
   request.set_name(name);
   return connection_->DeleteRealm(request);
@@ -101,18 +92,16 @@ RealmsServiceClient::DeleteRealm(std::string const& name, Options options) {
 future<StatusOr<google::cloud::gaming::v1::OperationMetadata>>
 RealmsServiceClient::DeleteRealm(
     google::cloud::gaming::v1::DeleteRealmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteRealm(request);
 }
 
 future<StatusOr<google::cloud::gaming::v1::Realm>>
 RealmsServiceClient::UpdateRealm(google::cloud::gaming::v1::Realm const& realm,
                                  google::protobuf::FieldMask const& update_mask,
-                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gaming::v1::UpdateRealmRequest request;
   *request.mutable_realm() = realm;
   *request.mutable_update_mask() = update_mask;
@@ -122,18 +111,16 @@ RealmsServiceClient::UpdateRealm(google::cloud::gaming::v1::Realm const& realm,
 future<StatusOr<google::cloud::gaming::v1::Realm>>
 RealmsServiceClient::UpdateRealm(
     google::cloud::gaming::v1::UpdateRealmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateRealm(request);
 }
 
 StatusOr<google::cloud::gaming::v1::PreviewRealmUpdateResponse>
 RealmsServiceClient::PreviewRealmUpdate(
     google::cloud::gaming::v1::PreviewRealmUpdateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PreviewRealmUpdate(request);
 }
 

--- a/google/cloud/gameservices/realms_client.h
+++ b/google/cloud/gameservices/realms_client.h
@@ -64,8 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RealmsServiceClient {
  public:
   explicit RealmsServiceClient(
-      std::shared_ptr<RealmsServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<RealmsServiceConnection> connection, Options opts = {});
   ~RealmsServiceClient();
 
   //@{
@@ -93,7 +92,8 @@ class RealmsServiceClient {
   ///
   /// @param parent  Required. The parent resource name, in the following form:
   ///  `projects/{project}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -103,14 +103,15 @@ class RealmsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/realms.proto#L152}
   ///
   StreamRange<google::cloud::gaming::v1::Realm> ListRealms(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists realms in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::ListRealmsRequest,google/cloud/gaming/v1/realms.proto#L31}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -120,8 +121,7 @@ class RealmsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/realms.proto#L152}
   ///
   StreamRange<google::cloud::gaming::v1::Realm> ListRealms(
-      google::cloud::gaming::v1::ListRealmsRequest request,
-      Options options = {});
+      google::cloud::gaming::v1::ListRealmsRequest request, Options opts = {});
 
   ///
   /// Gets details of a single realm.
@@ -129,7 +129,8 @@ class RealmsServiceClient {
   /// @param name  Required. The name of the realm to retrieve, in the following
   /// form:
   ///  `projects/{project}/locations/{location}/realms/{realm}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -139,14 +140,15 @@ class RealmsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/realms.proto#L152}
   ///
   StatusOr<google::cloud::gaming::v1::Realm> GetRealm(std::string const& name,
-                                                      Options options = {});
+                                                      Options opts = {});
 
   ///
   /// Gets details of a single realm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::GetRealmRequest,google/cloud/gaming/v1/realms.proto#L74}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -157,7 +159,7 @@ class RealmsServiceClient {
   ///
   StatusOr<google::cloud::gaming::v1::Realm> GetRealm(
       google::cloud::gaming::v1::GetRealmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new realm in a given project and location.
@@ -166,7 +168,8 @@ class RealmsServiceClient {
   ///  `projects/{project}/locations/{location}`.
   /// @param realm  Required. The realm resource to be created.
   /// @param realm_id  Required. The ID of the realm resource to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -177,14 +180,15 @@ class RealmsServiceClient {
   ///
   future<StatusOr<google::cloud::gaming::v1::Realm>> CreateRealm(
       std::string const& parent, google::cloud::gaming::v1::Realm const& realm,
-      std::string const& realm_id, Options options = {});
+      std::string const& realm_id, Options opts = {});
 
   ///
   /// Creates a new realm in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::CreateRealmRequest,google/cloud/gaming/v1/realms.proto#L86}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -195,7 +199,7 @@ class RealmsServiceClient {
   ///
   future<StatusOr<google::cloud::gaming::v1::Realm>> CreateRealm(
       google::cloud::gaming::v1::CreateRealmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single realm.
@@ -203,7 +207,8 @@ class RealmsServiceClient {
   /// @param name  Required. The name of the realm to delete, in the following
   /// form:
   ///  `projects/{project}/locations/{location}/realms/{realm}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -213,14 +218,15 @@ class RealmsServiceClient {
   /// @googleapis_reference_link{google/cloud/gaming/v1/common.proto#L29}
   ///
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>> DeleteRealm(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single realm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::DeleteRealmRequest,google/cloud/gaming/v1/realms.proto#L104}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::OperationMetadata,google/cloud/gaming/v1/common.proto#L29}
   ///
@@ -231,7 +237,7 @@ class RealmsServiceClient {
   ///
   future<StatusOr<google::cloud::gaming::v1::OperationMetadata>> DeleteRealm(
       google::cloud::gaming::v1::DeleteRealmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Patches a single realm.
@@ -242,7 +248,8 @@ class RealmsServiceClient {
   /// the `FieldMask`
   ///  definition, see
   ///  https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#fieldmask
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -253,14 +260,15 @@ class RealmsServiceClient {
   ///
   future<StatusOr<google::cloud::gaming::v1::Realm>> UpdateRealm(
       google::cloud::gaming::v1::Realm const& realm,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Patches a single realm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::UpdateRealmRequest,google/cloud/gaming/v1/realms.proto#L116}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::Realm,google/cloud/gaming/v1/realms.proto#L152}
   ///
@@ -271,14 +279,15 @@ class RealmsServiceClient {
   ///
   future<StatusOr<google::cloud::gaming::v1::Realm>> UpdateRealm(
       google::cloud::gaming::v1::UpdateRealmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Previews patches to a single realm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gaming::v1::PreviewRealmUpdateRequest,google/cloud/gaming/v1/realms.proto#L128}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gaming::v1::PreviewRealmUpdateResponse,google/cloud/gaming/v1/realms.proto#L143}
   ///
@@ -290,7 +299,7 @@ class RealmsServiceClient {
   StatusOr<google::cloud::gaming::v1::PreviewRealmUpdateResponse>
   PreviewRealmUpdate(
       google::cloud::gaming::v1::PreviewRealmUpdateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<RealmsServiceConnection> connection_;

--- a/google/cloud/gkehub/gke_hub_client.cc
+++ b/google/cloud/gkehub/gke_hub_client.cc
@@ -26,17 +26,16 @@ namespace gkehub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GkeHubClient::GkeHubClient(std::shared_ptr<GkeHubConnection> connection,
-                           Options options)
+                           Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           gkehub_internal::GkeHubDefaultOptions(connection_->options()))) {}
 GkeHubClient::~GkeHubClient() = default;
 
 StreamRange<google::cloud::gkehub::v1::Membership>
-GkeHubClient::ListMemberships(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+GkeHubClient::ListMemberships(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::ListMembershipsRequest request;
   request.set_parent(parent);
   return connection_->ListMemberships(request);
@@ -44,33 +43,28 @@ GkeHubClient::ListMemberships(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::gkehub::v1::Membership>
 GkeHubClient::ListMemberships(
-    google::cloud::gkehub::v1::ListMembershipsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::gkehub::v1::ListMembershipsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMemberships(std::move(request));
 }
 
 StreamRange<google::cloud::gkehub::v1::Feature> GkeHubClient::ListFeatures(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::ListFeaturesRequest request;
   request.set_parent(parent);
   return connection_->ListFeatures(request);
 }
 
 StreamRange<google::cloud::gkehub::v1::Feature> GkeHubClient::ListFeatures(
-    google::cloud::gkehub::v1::ListFeaturesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::gkehub::v1::ListFeaturesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFeatures(std::move(request));
 }
 
 StatusOr<google::cloud::gkehub::v1::Membership> GkeHubClient::GetMembership(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::GetMembershipRequest request;
   request.set_name(name);
   return connection_->GetMembership(request);
@@ -78,26 +72,22 @@ StatusOr<google::cloud::gkehub::v1::Membership> GkeHubClient::GetMembership(
 
 StatusOr<google::cloud::gkehub::v1::Membership> GkeHubClient::GetMembership(
     google::cloud::gkehub::v1::GetMembershipRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMembership(request);
 }
 
 StatusOr<google::cloud::gkehub::v1::Feature> GkeHubClient::GetFeature(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::GetFeatureRequest request;
   request.set_name(name);
   return connection_->GetFeature(request);
 }
 
 StatusOr<google::cloud::gkehub::v1::Feature> GkeHubClient::GetFeature(
-    google::cloud::gkehub::v1::GetFeatureRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::gkehub::v1::GetFeatureRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetFeature(request);
 }
 
@@ -105,9 +95,8 @@ future<StatusOr<google::cloud::gkehub::v1::Membership>>
 GkeHubClient::CreateMembership(
     std::string const& parent,
     google::cloud::gkehub::v1::Membership const& resource,
-    std::string const& membership_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& membership_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::CreateMembershipRequest request;
   request.set_parent(parent);
   *request.mutable_resource() = resource;
@@ -118,18 +107,16 @@ GkeHubClient::CreateMembership(
 future<StatusOr<google::cloud::gkehub::v1::Membership>>
 GkeHubClient::CreateMembership(
     google::cloud::gkehub::v1::CreateMembershipRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMembership(request);
 }
 
 future<StatusOr<google::cloud::gkehub::v1::Feature>>
 GkeHubClient::CreateFeature(std::string const& parent,
                             google::cloud::gkehub::v1::Feature const& resource,
-                            std::string const& feature_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                            std::string const& feature_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::CreateFeatureRequest request;
   request.set_parent(parent);
   *request.mutable_resource() = resource;
@@ -140,16 +127,14 @@ GkeHubClient::CreateFeature(std::string const& parent,
 future<StatusOr<google::cloud::gkehub::v1::Feature>>
 GkeHubClient::CreateFeature(
     google::cloud::gkehub::v1::CreateFeatureRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateFeature(request);
 }
 
 future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>
-GkeHubClient::DeleteMembership(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+GkeHubClient::DeleteMembership(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::DeleteMembershipRequest request;
   request.set_name(name);
   return connection_->DeleteMembership(request);
@@ -158,16 +143,14 @@ GkeHubClient::DeleteMembership(std::string const& name, Options options) {
 future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>
 GkeHubClient::DeleteMembership(
     google::cloud::gkehub::v1::DeleteMembershipRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMembership(request);
 }
 
 future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>
-GkeHubClient::DeleteFeature(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+GkeHubClient::DeleteFeature(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::DeleteFeatureRequest request;
   request.set_name(name);
   return connection_->DeleteFeature(request);
@@ -176,9 +159,8 @@ GkeHubClient::DeleteFeature(std::string const& name, Options options) {
 future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>
 GkeHubClient::DeleteFeature(
     google::cloud::gkehub::v1::DeleteFeatureRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteFeature(request);
 }
 
@@ -186,9 +168,8 @@ future<StatusOr<google::cloud::gkehub::v1::Membership>>
 GkeHubClient::UpdateMembership(
     std::string const& name,
     google::cloud::gkehub::v1::Membership const& resource,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::UpdateMembershipRequest request;
   request.set_name(name);
   *request.mutable_resource() = resource;
@@ -199,9 +180,8 @@ GkeHubClient::UpdateMembership(
 future<StatusOr<google::cloud::gkehub::v1::Membership>>
 GkeHubClient::UpdateMembership(
     google::cloud::gkehub::v1::UpdateMembershipRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMembership(request);
 }
 
@@ -209,9 +189,8 @@ future<StatusOr<google::cloud::gkehub::v1::Feature>>
 GkeHubClient::UpdateFeature(std::string const& name,
                             google::cloud::gkehub::v1::Feature const& resource,
                             google::protobuf::FieldMask const& update_mask,
-                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::gkehub::v1::UpdateFeatureRequest request;
   request.set_name(name);
   *request.mutable_resource() = resource;
@@ -222,18 +201,16 @@ GkeHubClient::UpdateFeature(std::string const& name,
 future<StatusOr<google::cloud::gkehub::v1::Feature>>
 GkeHubClient::UpdateFeature(
     google::cloud::gkehub::v1::UpdateFeatureRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateFeature(request);
 }
 
 StatusOr<google::cloud::gkehub::v1::GenerateConnectManifestResponse>
 GkeHubClient::GenerateConnectManifest(
     google::cloud::gkehub::v1::GenerateConnectManifestRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateConnectManifest(request);
 }
 

--- a/google/cloud/gkehub/gke_hub_client.h
+++ b/google/cloud/gkehub/gke_hub_client.h
@@ -76,7 +76,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GkeHubClient {
  public:
   explicit GkeHubClient(std::shared_ptr<GkeHubConnection> connection,
-                        Options options = {});
+                        Options opts = {});
   ~GkeHubClient();
 
   //@{
@@ -103,7 +103,8 @@ class GkeHubClient {
   /// @param parent  Required. The parent (project and location) where the
   /// Memberships will be listed.
   ///  Specified in the format `projects/*/locations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -113,14 +114,15 @@ class GkeHubClient {
   /// @googleapis_reference_link{google/cloud/gkehub/v1/membership.proto#L33}
   ///
   StreamRange<google::cloud::gkehub::v1::Membership> ListMemberships(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Memberships in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::ListMembershipsRequest,google/cloud/gkehub/v1/service.proto#L184}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -131,7 +133,7 @@ class GkeHubClient {
   ///
   StreamRange<google::cloud::gkehub::v1::Membership> ListMemberships(
       google::cloud::gkehub::v1::ListMembershipsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Features in a given project and location.
@@ -139,7 +141,8 @@ class GkeHubClient {
   /// @param parent  Required. The parent (project and location) where the
   /// Features will be listed.
   ///  Specified in the format `projects/*/locations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -149,14 +152,15 @@ class GkeHubClient {
   /// @googleapis_reference_link{google/cloud/gkehub/v1/feature.proto#L35}
   ///
   StreamRange<google::cloud::gkehub::v1::Feature> ListFeatures(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Features in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::ListFeaturesRequest,google/cloud/gkehub/v1/service.proto#L436}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -167,14 +171,15 @@ class GkeHubClient {
   ///
   StreamRange<google::cloud::gkehub::v1::Feature> ListFeatures(
       google::cloud::gkehub::v1::ListFeaturesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the details of a Membership.
   ///
   /// @param name  Required. The Membership resource name in the format
   ///  `projects/*/locations/*/memberships/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -184,14 +189,15 @@ class GkeHubClient {
   /// @googleapis_reference_link{google/cloud/gkehub/v1/membership.proto#L33}
   ///
   StatusOr<google::cloud::gkehub::v1::Membership> GetMembership(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the details of a Membership.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::GetMembershipRequest,google/cloud/gkehub/v1/service.proto#L246}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -202,14 +208,15 @@ class GkeHubClient {
   ///
   StatusOr<google::cloud::gkehub::v1::Membership> GetMembership(
       google::cloud::gkehub::v1::GetMembershipRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Feature.
   ///
   /// @param name  Required. The Feature resource name in the format
   ///  `projects/*/locations/*/features/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -219,14 +226,15 @@ class GkeHubClient {
   /// @googleapis_reference_link{google/cloud/gkehub/v1/feature.proto#L35}
   ///
   StatusOr<google::cloud::gkehub::v1::Feature> GetFeature(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Feature.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::GetFeatureRequest,google/cloud/gkehub/v1/service.proto#L490}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -237,7 +245,7 @@ class GkeHubClient {
   ///
   StatusOr<google::cloud::gkehub::v1::Feature> GetFeature(
       google::cloud::gkehub::v1::GetFeatureRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Membership.
@@ -258,7 +266,8 @@ class GkeHubClient {
   ///    3. It must start and end with an alphanumeric character
   ///  Which can be expressed as the regex: `[a-z0-9]([-a-z0-9]*[a-z0-9])?`,
   ///  with a maximum length of 63 characters.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -270,7 +279,7 @@ class GkeHubClient {
   future<StatusOr<google::cloud::gkehub::v1::Membership>> CreateMembership(
       std::string const& parent,
       google::cloud::gkehub::v1::Membership const& resource,
-      std::string const& membership_id, Options options = {});
+      std::string const& membership_id, Options opts = {});
 
   ///
   /// Creates a new Membership.
@@ -281,7 +290,8 @@ class GkeHubClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::CreateMembershipRequest,google/cloud/gkehub/v1/service.proto#L258}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -292,7 +302,7 @@ class GkeHubClient {
   ///
   future<StatusOr<google::cloud::gkehub::v1::Membership>> CreateMembership(
       google::cloud::gkehub::v1::CreateMembershipRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds a new Feature.
@@ -302,7 +312,8 @@ class GkeHubClient {
   ///  Specified in the format `projects/*/locations/*`.
   /// @param resource  The Feature resource to create.
   /// @param feature_id  The ID of the feature to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -314,14 +325,15 @@ class GkeHubClient {
   future<StatusOr<google::cloud::gkehub::v1::Feature>> CreateFeature(
       std::string const& parent,
       google::cloud::gkehub::v1::Feature const& resource,
-      std::string const& feature_id, Options options = {});
+      std::string const& feature_id, Options opts = {});
 
   ///
   /// Adds a new Feature.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::CreateFeatureRequest,google/cloud/gkehub/v1/service.proto#L501}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -332,7 +344,7 @@ class GkeHubClient {
   ///
   future<StatusOr<google::cloud::gkehub::v1::Feature>> CreateFeature(
       google::cloud::gkehub::v1::CreateFeatureRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes a Membership.
@@ -343,7 +355,8 @@ class GkeHubClient {
   ///
   /// @param name  Required. The Membership resource name in the format
   ///  `projects/*/locations/*/memberships/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::OperationMetadata,google/cloud/gkehub/v1/service.proto#L603}
   ///
@@ -353,7 +366,7 @@ class GkeHubClient {
   /// @googleapis_reference_link{google/cloud/gkehub/v1/service.proto#L603}
   ///
   future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>
-  DeleteMembership(std::string const& name, Options options = {});
+  DeleteMembership(std::string const& name, Options opts = {});
 
   ///
   /// Removes a Membership.
@@ -364,7 +377,8 @@ class GkeHubClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::DeleteMembershipRequest,google/cloud/gkehub/v1/service.proto#L299}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::OperationMetadata,google/cloud/gkehub/v1/service.proto#L603}
   ///
@@ -376,14 +390,15 @@ class GkeHubClient {
   future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>>
   DeleteMembership(
       google::cloud::gkehub::v1::DeleteMembershipRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes a Feature.
   ///
   /// @param name  Required. The Feature resource name in the format
   ///  `projects/*/locations/*/features/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::OperationMetadata,google/cloud/gkehub/v1/service.proto#L603}
   ///
@@ -393,14 +408,15 @@ class GkeHubClient {
   /// @googleapis_reference_link{google/cloud/gkehub/v1/service.proto#L603}
   ///
   future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>> DeleteFeature(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Removes a Feature.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::DeleteFeatureRequest,google/cloud/gkehub/v1/service.proto#L533}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::OperationMetadata,google/cloud/gkehub/v1/service.proto#L603}
   ///
@@ -411,7 +427,7 @@ class GkeHubClient {
   ///
   future<StatusOr<google::cloud::gkehub::v1::OperationMetadata>> DeleteFeature(
       google::cloud::gkehub::v1::DeleteFeatureRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing Membership.
@@ -427,7 +443,8 @@ class GkeHubClient {
   ///  specify the update_mask to be a special path "*", fully replaces all
   ///  user-modifiable fields to match `resource`.
   /// @param update_mask  Required. Mask of fields to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -439,14 +456,15 @@ class GkeHubClient {
   future<StatusOr<google::cloud::gkehub::v1::Membership>> UpdateMembership(
       std::string const& name,
       google::cloud::gkehub::v1::Membership const& resource,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing Membership.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::UpdateMembershipRequest,google/cloud/gkehub/v1/service.proto#L326}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Membership,google/cloud/gkehub/v1/membership.proto#L33}
   ///
@@ -457,7 +475,7 @@ class GkeHubClient {
   ///
   future<StatusOr<google::cloud::gkehub::v1::Membership>> UpdateMembership(
       google::cloud::gkehub::v1::UpdateMembershipRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing Feature.
@@ -472,7 +490,8 @@ class GkeHubClient {
   ///  specify the update_mask to be a special path "*", fully replaces all
   ///  user-modifiable fields to match `resource`.
   /// @param update_mask  Mask of fields to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -484,14 +503,15 @@ class GkeHubClient {
   future<StatusOr<google::cloud::gkehub::v1::Feature>> UpdateFeature(
       std::string const& name,
       google::cloud::gkehub::v1::Feature const& resource,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing Feature.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::UpdateFeatureRequest,google/cloud/gkehub/v1/service.proto#L564}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::Feature,google/cloud/gkehub/v1/feature.proto#L35}
   ///
@@ -502,7 +522,7 @@ class GkeHubClient {
   ///
   future<StatusOr<google::cloud::gkehub::v1::Feature>> UpdateFeature(
       google::cloud::gkehub::v1::UpdateFeatureRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Generates the manifest for deployment of the GKE connect agent.
@@ -512,7 +532,8 @@ class GkeHubClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::gkehub::v1::GenerateConnectManifestRequest,google/cloud/gkehub/v1/service.proto#L368}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::gkehub::v1::GenerateConnectManifestResponse,google/cloud/gkehub/v1/service.proto#L409}
   ///
@@ -524,7 +545,7 @@ class GkeHubClient {
   StatusOr<google::cloud::gkehub::v1::GenerateConnectManifestResponse>
   GenerateConnectManifest(
       google::cloud::gkehub::v1::GenerateConnectManifestRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<GkeHubConnection> connection_;

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -27,17 +27,16 @@ namespace cloud {
 namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IAMClient::IAMClient(std::shared_ptr<IAMConnection> connection, Options options)
+IAMClient::IAMClient(std::shared_ptr<IAMConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           iam_internal::IAMDefaultOptions(connection_->options()))) {}
 IAMClient::~IAMClient() = default;
 
 StreamRange<google::iam::admin::v1::ServiceAccount>
-IAMClient::ListServiceAccounts(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+IAMClient::ListServiceAccounts(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::ListServiceAccountsRequest request;
   request.set_name(name);
   return connection_->ListServiceAccounts(request);
@@ -45,17 +44,14 @@ IAMClient::ListServiceAccounts(std::string const& name, Options options) {
 
 StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMClient::ListServiceAccounts(
-    google::iam::admin::v1::ListServiceAccountsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::ListServiceAccountsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServiceAccounts(std::move(request));
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::GetServiceAccountRequest request;
   request.set_name(name);
   return connection_->GetServiceAccount(request);
@@ -63,9 +59,8 @@ StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
 
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::GetServiceAccount(
     google::iam::admin::v1::GetServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServiceAccount(request);
 }
 
@@ -73,9 +68,8 @@ StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMClient::CreateServiceAccount(
     std::string const& name, std::string const& account_id,
     google::iam::admin::v1::ServiceAccount const& service_account,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::CreateServiceAccountRequest request;
   request.set_name(name);
   request.set_account_id(account_id);
@@ -86,24 +80,20 @@ IAMClient::CreateServiceAccount(
 StatusOr<google::iam::admin::v1::ServiceAccount>
 IAMClient::CreateServiceAccount(
     google::iam::admin::v1::CreateServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccount> IAMClient::PatchServiceAccount(
     google::iam::admin::v1::PatchServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PatchServiceAccount(request);
 }
 
-Status IAMClient::DeleteServiceAccount(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status IAMClient::DeleteServiceAccount(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::DeleteServiceAccountRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccount(request);
@@ -111,34 +101,30 @@ Status IAMClient::DeleteServiceAccount(std::string const& name,
 
 Status IAMClient::DeleteServiceAccount(
     google::iam::admin::v1::DeleteServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteServiceAccount(request);
 }
 
 StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
 IAMClient::UndeleteServiceAccount(
     google::iam::admin::v1::UndeleteServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteServiceAccount(request);
 }
 
 Status IAMClient::EnableServiceAccount(
     google::iam::admin::v1::EnableServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->EnableServiceAccount(request);
 }
 
 Status IAMClient::DisableServiceAccount(
     google::iam::admin::v1::DisableServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DisableServiceAccount(request);
 }
 
@@ -148,9 +134,8 @@ IAMClient::ListServiceAccountKeys(
     std::vector<
         google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
         key_types,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::ListServiceAccountKeysRequest request;
   request.set_name(name);
   *request.mutable_key_types() = {key_types.begin(), key_types.end()};
@@ -160,9 +145,8 @@ IAMClient::ListServiceAccountKeys(
 StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
 IAMClient::ListServiceAccountKeys(
     google::iam::admin::v1::ListServiceAccountKeysRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServiceAccountKeys(request);
 }
 
@@ -170,9 +154,8 @@ StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
     std::string const& name,
     google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::GetServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_public_key_type(public_key_type);
@@ -182,9 +165,8 @@ IAMClient::GetServiceAccountKey(
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::GetServiceAccountKey(
     google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServiceAccountKey(request);
 }
 
@@ -193,9 +175,8 @@ IAMClient::CreateServiceAccountKey(
     std::string const& name,
     google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
     google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::CreateServiceAccountKeyRequest request;
   request.set_name(name);
   request.set_private_key_type(private_key_type);
@@ -206,25 +187,22 @@ IAMClient::CreateServiceAccountKey(
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::CreateServiceAccountKey(
     google::iam::admin::v1::CreateServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServiceAccountKey(request);
 }
 
 StatusOr<google::iam::admin::v1::ServiceAccountKey>
 IAMClient::UploadServiceAccountKey(
     google::iam::admin::v1::UploadServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UploadServiceAccountKey(request);
 }
 
 Status IAMClient::DeleteServiceAccountKey(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::DeleteServiceAccountKeyRequest request;
   request.set_name(name);
   return connection_->DeleteServiceAccountKey(request);
@@ -232,33 +210,29 @@ Status IAMClient::DeleteServiceAccountKey(std::string const& name,
 
 Status IAMClient::DeleteServiceAccountKey(
     google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteServiceAccountKey(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -266,10 +240,9 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<IAMBackoffPolicyOption>(options, __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<IAMBackoffPolicyOption>(opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -295,18 +268,16 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(std::string const& resource,
                               std::vector<std::string> const& permissions,
-                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -315,95 +286,80 @@ IAMClient::TestIamPermissions(std::string const& resource,
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IAMClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
-    std::string const& full_resource_name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& full_resource_name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::admin::v1::QueryGrantableRolesRequest request;
   request.set_full_resource_name(full_resource_name);
   return connection_->QueryGrantableRoles(request);
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::QueryGrantableRoles(
-    google::iam::admin::v1::QueryGrantableRolesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::QueryGrantableRolesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->QueryGrantableRoles(std::move(request));
 }
 
 StreamRange<google::iam::admin::v1::Role> IAMClient::ListRoles(
-    google::iam::admin::v1::ListRolesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::ListRolesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListRoles(std::move(request));
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::GetRole(
-    google::iam::admin::v1::GetRoleRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::GetRoleRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::CreateRole(
-    google::iam::admin::v1::CreateRoleRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::CreateRoleRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::UpdateRole(
-    google::iam::admin::v1::UpdateRoleRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::UpdateRoleRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::DeleteRole(
-    google::iam::admin::v1::DeleteRoleRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::DeleteRoleRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteRole(request);
 }
 
 StatusOr<google::iam::admin::v1::Role> IAMClient::UndeleteRole(
-    google::iam::admin::v1::UndeleteRoleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::UndeleteRoleRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteRole(request);
 }
 
 StreamRange<google::iam::admin::v1::Permission>
 IAMClient::QueryTestablePermissions(
     google::iam::admin::v1::QueryTestablePermissionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->QueryTestablePermissions(std::move(request));
 }
 
 StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
 IAMClient::QueryAuditableServices(
     google::iam::admin::v1::QueryAuditableServicesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->QueryAuditableServices(request);
 }
 
 StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMClient::LintPolicy(
-    google::iam::admin::v1::LintPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::admin::v1::LintPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->LintPolicy(request);
 }
 

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -80,7 +80,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMClient {
  public:
   explicit IAMClient(std::shared_ptr<IAMConnection> connection,
-                     Options options = {});
+                     Options opts = {});
   ~IAMClient();
 
   //@{
@@ -108,7 +108,8 @@ class IAMClient {
   /// @param name  Required. The resource name of the project associated with
   /// the service
   ///  accounts, such as `projects/my-project-123`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -118,7 +119,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Lists every [ServiceAccount][google.iam.admin.v1.ServiceAccount] that
@@ -126,7 +127,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountsRequest,google/iam/admin/v1/iam.proto#L544}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -137,7 +139,7 @@ class IAMClient {
   ///
   StreamRange<google::iam::admin::v1::ServiceAccount> ListServiceAccounts(
       google::iam::admin::v1::ListServiceAccountsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -148,7 +150,8 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -158,14 +161,15 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L461}
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetServiceAccountRequest,google/iam/admin/v1/iam.proto#L579}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -176,7 +180,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> GetServiceAccount(
       google::iam::admin::v1::GetServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -193,7 +197,8 @@ class IAMClient {
   /// [ServiceAccount][google.iam.admin.v1.ServiceAccount] resource to
   ///  create. Currently, only the following values are user assignable:
   ///  `display_name` and `description`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -205,14 +210,15 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       std::string const& name, std::string const& account_id,
       google::iam::admin::v1::ServiceAccount const& service_account,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountRequest,google/iam/admin/v1/iam.proto#L521}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -223,14 +229,15 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> CreateServiceAccount(
       google::iam::admin::v1::CreateServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Patches a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::PatchServiceAccountRequest,google/iam/admin/v1/iam.proto#L616}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccount,google/iam/admin/v1/iam.proto#L461}
   ///
@@ -241,7 +248,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccount> PatchServiceAccount(
       google::iam::admin::v1::PatchServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -269,12 +276,13 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
   ///
-  Status DeleteServiceAccount(std::string const& name, Options options = {});
+  Status DeleteServiceAccount(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -298,14 +306,15 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L594}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L594}
   ///
   Status DeleteServiceAccount(
       google::iam::admin::v1::DeleteServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Restores a deleted [ServiceAccount][google.iam.admin.v1.ServiceAccount].
@@ -319,7 +328,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountRequest,google/iam/admin/v1/iam.proto#L623}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::UndeleteServiceAccountResponse,google/iam/admin/v1/iam.proto#L631}
   ///
@@ -331,7 +341,7 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::UndeleteServiceAccountResponse>
   UndeleteServiceAccount(
       google::iam::admin::v1::UndeleteServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables a [ServiceAccount][google.iam.admin.v1.ServiceAccount] that was
@@ -346,14 +356,15 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::EnableServiceAccountRequest,google/iam/admin/v1/iam.proto#L637}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.iam.admin.v1.EnableServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L637}
   ///
   Status EnableServiceAccount(
       google::iam::admin::v1::EnableServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Disables a [ServiceAccount][google.iam.admin.v1.ServiceAccount]
@@ -378,14 +389,15 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DisableServiceAccountRequest,google/iam/admin/v1/iam.proto#L647}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.iam.admin.v1.DisableServiceAccountRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L647}
   ///
   Status DisableServiceAccount(
       google::iam::admin::v1::DisableServiceAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
@@ -401,7 +413,8 @@ class IAMClient {
   /// the list
   ///  response. Duplicate key types are not allowed. If no key type
   ///  is provided, all keys are returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
@@ -416,7 +429,7 @@ class IAMClient {
       std::vector<
           google::iam::admin::v1::ListServiceAccountKeysRequest::KeyType> const&
           key_types,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for
@@ -424,7 +437,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysRequest,google/iam/admin/v1/iam.proto#L657}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ListServiceAccountKeysResponse,google/iam/admin/v1/iam.proto#L692}
   ///
@@ -436,7 +450,7 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(
       google::iam::admin::v1::ListServiceAccountKeysRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -449,7 +463,8 @@ class IAMClient {
   ///  `unique_id` of the service account.
   /// @param public_key_type  The output format of the public key requested.
   ///  X509_PEM is the default output format.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -461,14 +476,15 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       std::string const& name,
       google::iam::admin::v1::ServiceAccountPublicKeyType public_key_type,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L698}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -479,7 +495,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> GetServiceAccountKey(
       google::iam::admin::v1::GetServiceAccountKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -497,7 +513,8 @@ class IAMClient {
   /// @param key_algorithm  Which type of key and algorithm to use for the key.
   ///  The default is currently a 2K RSA key.  However this may change in the
   ///  future.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -510,14 +527,15 @@ class IAMClient {
       std::string const& name,
       google::iam::admin::v1::ServiceAccountPrivateKeyType private_key_type,
       google::iam::admin::v1::ServiceAccountKeyAlgorithm key_algorithm,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L791}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -528,7 +546,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> CreateServiceAccountKey(
       google::iam::admin::v1::CreateServiceAccountKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey],
@@ -536,7 +554,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UploadServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L816}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::ServiceAccountKey,google/iam/admin/v1/iam.proto#L741}
   ///
@@ -547,7 +566,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::ServiceAccountKey> UploadServiceAccountKey(
       google::iam::admin::v1::UploadServiceAccountKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -560,12 +579,13 @@ class IAMClient {
   ///  Using `-` as a wildcard for the `PROJECT_ID` will infer the project from
   ///  the account. The `ACCOUNT` value can be the `email` address or the
   ///  `unique_id` of the service account.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
   ///
-  Status DeleteServiceAccountKey(std::string const& name, Options options = {});
+  Status DeleteServiceAccountKey(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey].
@@ -574,14 +594,15 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteServiceAccountKeyRequest,google/iam/admin/v1/iam.proto#L832}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.iam.admin.v1.DeleteServiceAccountKeyRequest]:
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L832}
   ///
   Status DeleteServiceAccountKey(
       google::iam::admin::v1::DeleteServiceAccountKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the IAM policy that is attached to a
@@ -599,7 +620,8 @@ class IAMClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -609,7 +631,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the IAM policy that is attached to a
@@ -626,7 +648,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -636,8 +659,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the IAM policy that is attached to a
@@ -668,7 +690,8 @@ class IAMClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -679,7 +702,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -697,14 +720,13 @@ class IAMClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `IAMBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the IAM policy that is attached to a
@@ -729,7 +751,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -739,8 +762,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Tests whether the caller has the specified permissions on a
@@ -754,7 +776,8 @@ class IAMClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -765,7 +788,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Tests whether the caller has the specified permissions on a
@@ -773,7 +796,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -784,7 +808,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists roles that can be granted on a Google Cloud resource. A role is
@@ -796,7 +820,8 @@ class IAMClient {
   ///  The name follows the Google Cloud Platform resource format.
   ///  For example, a Cloud Platform project with id `my-project` will be named
   ///  `//cloudresourcemanager.googleapis.com/projects/my-project`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -806,7 +831,7 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
-      std::string const& full_resource_name, Options options = {});
+      std::string const& full_resource_name, Options opts = {});
 
   ///
   /// Lists roles that can be granted on a Google Cloud resource. A role is
@@ -815,7 +840,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryGrantableRolesRequest,google/iam/admin/v1/iam.proto#L1062}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -826,7 +852,7 @@ class IAMClient {
   ///
   StreamRange<google::iam::admin::v1::Role> QueryGrantableRoles(
       google::iam::admin::v1::QueryGrantableRolesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists every predefined [Role][google.iam.admin.v1.Role] that IAM supports,
@@ -834,7 +860,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::ListRolesRequest,google/iam/admin/v1/iam.proto#L1093}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -844,14 +871,15 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StreamRange<google::iam::admin::v1::Role> ListRoles(
-      google::iam::admin::v1::ListRolesRequest request, Options options = {});
+      google::iam::admin::v1::ListRolesRequest request, Options opts = {});
 
   ///
   /// Gets the definition of a [Role][google.iam.admin.v1.Role].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::GetRoleRequest,google/iam/admin/v1/iam.proto#L1152}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -861,15 +889,15 @@ class IAMClient {
   /// @googleapis_reference_link{google/iam/admin/v1/iam.proto#L1004}
   ///
   StatusOr<google::iam::admin::v1::Role> GetRole(
-      google::iam::admin::v1::GetRoleRequest const& request,
-      Options options = {});
+      google::iam::admin::v1::GetRoleRequest const& request, Options opts = {});
 
   ///
   /// Creates a new custom [Role][google.iam.admin.v1.Role].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::CreateRoleRequest,google/iam/admin/v1/iam.proto#L1184}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -880,14 +908,15 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::Role> CreateRole(
       google::iam::admin::v1::CreateRoleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the definition of a custom [Role][google.iam.admin.v1.Role].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UpdateRoleRequest,google/iam/admin/v1/iam.proto#L1219}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -898,7 +927,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::Role> UpdateRole(
       google::iam::admin::v1::UpdateRoleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a custom [Role][google.iam.admin.v1.Role].
@@ -922,7 +951,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::DeleteRoleRequest,google/iam/admin/v1/iam.proto#L1250}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -933,14 +963,15 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::Role> DeleteRole(
       google::iam::admin::v1::DeleteRoleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Undeletes a custom [Role][google.iam.admin.v1.Role].
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::UndeleteRoleRequest,google/iam/admin/v1/iam.proto#L1278}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Role,google/iam/admin/v1/iam.proto#L1004}
   ///
@@ -951,7 +982,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::Role> UndeleteRole(
       google::iam::admin::v1::UndeleteRoleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists every permission that you can test on a resource. A permission is
@@ -960,7 +991,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryTestablePermissionsRequest,google/iam/admin/v1/iam.proto#L1361}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::Permission,google/iam/admin/v1/iam.proto#L1306}
   ///
@@ -971,7 +1003,7 @@ class IAMClient {
   ///
   StreamRange<google::iam::admin::v1::Permission> QueryTestablePermissions(
       google::iam::admin::v1::QueryTestablePermissionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a list of services that allow you to opt into audit logs that are
@@ -982,7 +1014,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesRequest,google/iam/admin/v1/iam.proto#L1391}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::QueryAuditableServicesResponse,google/iam/admin/v1/iam.proto#L1402}
   ///
@@ -994,7 +1027,7 @@ class IAMClient {
   StatusOr<google::iam::admin::v1::QueryAuditableServicesResponse>
   QueryAuditableServices(
       google::iam::admin::v1::QueryAuditableServicesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lints, or validates, an IAM policy. Currently checks the
@@ -1006,7 +1039,8 @@ class IAMClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::admin::v1::LintPolicyRequest,google/iam/admin/v1/iam.proto#L1415}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::admin::v1::LintPolicyResponse,google/iam/admin/v1/iam.proto#L1513}
   ///
@@ -1017,7 +1051,7 @@ class IAMClient {
   ///
   StatusOr<google::iam::admin::v1::LintPolicyResponse> LintPolicy(
       google::iam::admin::v1::LintPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<IAMConnection> connection_;

--- a/google/cloud/iam/iam_client.h
+++ b/google/cloud/iam/iam_client.h
@@ -720,8 +720,8 @@ class IAMClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/iam/iam_credentials_client.cc
+++ b/google/cloud/iam/iam_credentials_client.cc
@@ -26,10 +26,10 @@ namespace iam {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IAMCredentialsClient::IAMCredentialsClient(
-    std::shared_ptr<IAMCredentialsConnection> connection, Options options)
+    std::shared_ptr<IAMCredentialsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           iam_internal::IAMCredentialsDefaultOptions(connection_->options()))) {
 }
 IAMCredentialsClient::~IAMCredentialsClient() = default;
@@ -38,9 +38,8 @@ StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsClient::GenerateAccessToken(
     std::string const& name, std::vector<std::string> const& delegates,
     std::vector<std::string> const& scope,
-    google::protobuf::Duration const& lifetime, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::Duration const& lifetime, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::credentials::v1::GenerateAccessTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -52,9 +51,8 @@ IAMCredentialsClient::GenerateAccessToken(
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsClient::GenerateAccessToken(
     google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateAccessToken(request);
 }
 
@@ -62,9 +60,8 @@ StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(std::string const& name,
                                       std::vector<std::string> const& delegates,
                                       std::string const& audience,
-                                      bool include_email, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                      bool include_email, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::credentials::v1::GenerateIdTokenRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -76,18 +73,16 @@ IAMCredentialsClient::GenerateIdToken(std::string const& name,
 StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
 IAMCredentialsClient::GenerateIdToken(
     google::iam::credentials::v1::GenerateIdTokenRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateIdToken(request);
 }
 
 StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsClient::SignBlob(std::string const& name,
                                std::vector<std::string> const& delegates,
-                               std::string const& payload, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                               std::string const& payload, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::credentials::v1::SignBlobRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -98,18 +93,16 @@ IAMCredentialsClient::SignBlob(std::string const& name,
 StatusOr<google::iam::credentials::v1::SignBlobResponse>
 IAMCredentialsClient::SignBlob(
     google::iam::credentials::v1::SignBlobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SignBlob(request);
 }
 
 StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(std::string const& name,
                               std::vector<std::string> const& delegates,
-                              std::string const& payload, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                              std::string const& payload, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::credentials::v1::SignJwtRequest request;
   request.set_name(name);
   *request.mutable_delegates() = {delegates.begin(), delegates.end()};
@@ -119,10 +112,8 @@ IAMCredentialsClient::SignJwt(std::string const& name,
 
 StatusOr<google::iam::credentials::v1::SignJwtResponse>
 IAMCredentialsClient::SignJwt(
-    google::iam::credentials::v1::SignJwtRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::credentials::v1::SignJwtRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SignJwt(request);
 }
 

--- a/google/cloud/iam/iam_credentials_client.h
+++ b/google/cloud/iam/iam_credentials_client.h
@@ -70,8 +70,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IAMCredentialsClient {
  public:
   explicit IAMCredentialsClient(
-      std::shared_ptr<IAMCredentialsConnection> connection,
-      Options options = {});
+      std::shared_ptr<IAMCredentialsConnection> connection, Options opts = {});
   ~IAMCredentialsClient();
 
   //@{
@@ -123,7 +122,8 @@ class IAMCredentialsClient {
   ///  Must be set to a value less than or equal to 3600 (1 hour). If a value is
   ///  not specified, the token's lifetime will be set to a default value of one
   ///  hour.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
@@ -137,14 +137,15 @@ class IAMCredentialsClient {
                       std::vector<std::string> const& delegates,
                       std::vector<std::string> const& scope,
                       google::protobuf::Duration const& lifetime,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenRequest,google/iam/credentials/v1/common.proto#L35}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateAccessTokenResponse,google/iam/credentials/v1/common.proto#L72}
   ///
@@ -156,7 +157,7 @@ class IAMCredentialsClient {
   StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(
       google::iam::credentials::v1::GenerateAccessTokenRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
@@ -184,7 +185,8 @@ class IAMCredentialsClient {
   /// @param include_email  Include the service account email in the token. If
   /// set to `true`, the
   ///  token will contain `email` and `email_verified` claims.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
@@ -197,14 +199,15 @@ class IAMCredentialsClient {
   GenerateIdToken(std::string const& name,
                   std::vector<std::string> const& delegates,
                   std::string const& audience, bool include_email,
-                  Options options = {});
+                  Options opts = {});
 
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenRequest,google/iam/credentials/v1/common.proto#L153}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::GenerateIdTokenResponse,google/iam/credentials/v1/common.proto#L186}
   ///
@@ -216,7 +219,7 @@ class IAMCredentialsClient {
   StatusOr<google::iam::credentials::v1::GenerateIdTokenResponse>
   GenerateIdToken(
       google::iam::credentials::v1::GenerateIdTokenRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Signs a blob using a service account's system-managed private key.
@@ -239,7 +242,8 @@ class IAMCredentialsClient {
   ///  wildcard character is required; replacing it with a project ID is
   ///  invalid.
   /// @param payload  Required. The bytes to sign.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
@@ -250,14 +254,15 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       std::string const& name, std::vector<std::string> const& delegates,
-      std::string const& payload, Options options = {});
+      std::string const& payload, Options opts = {});
 
   ///
   /// Signs a blob using a service account's system-managed private key.
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::SignBlobRequest,google/iam/credentials/v1/common.proto#L81}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignBlobResponse,google/iam/credentials/v1/common.proto#L109}
   ///
@@ -268,7 +273,7 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::SignBlobResponse> SignBlob(
       google::iam::credentials::v1::SignBlobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Signs a JWT using a service account's system-managed private key.
@@ -292,7 +297,8 @@ class IAMCredentialsClient {
   ///  invalid.
   /// @param payload  Required. The JWT payload to sign: a JSON object that
   /// contains a JWT Claims Set.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
@@ -303,14 +309,15 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       std::string const& name, std::vector<std::string> const& delegates,
-      std::string const& payload, Options options = {});
+      std::string const& payload, Options opts = {});
 
   ///
   /// Signs a JWT using a service account's system-managed private key.
   ///
   /// @param request
   /// @googleapis_link{google::iam::credentials::v1::SignJwtRequest,google/iam/credentials/v1/common.proto#L117}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::credentials::v1::SignJwtResponse,google/iam/credentials/v1/common.proto#L145}
   ///
@@ -321,7 +328,7 @@ class IAMCredentialsClient {
   ///
   StatusOr<google::iam::credentials::v1::SignJwtResponse> SignJwt(
       google::iam::credentials::v1::SignJwtRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<IAMCredentialsConnection> connection_;

--- a/google/cloud/iap/identity_aware_proxy_admin_client.cc
+++ b/google/cloud/iap/identity_aware_proxy_admin_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IdentityAwareProxyAdminServiceClient::IdentityAwareProxyAdminServiceClient(
     std::shared_ptr<IdentityAwareProxyAdminServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           iap_internal::IdentityAwareProxyAdminServiceDefaultOptions(
               connection_->options()))) {}
 IdentityAwareProxyAdminServiceClient::~IdentityAwareProxyAdminServiceClient() =
@@ -38,44 +38,38 @@ IdentityAwareProxyAdminServiceClient::~IdentityAwareProxyAdminServiceClient() =
 
 StatusOr<google::iam::v1::Policy>
 IdentityAwareProxyAdminServiceClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy>
 IdentityAwareProxyAdminServiceClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 IdentityAwareProxyAdminServiceClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StatusOr<google::cloud::iap::v1::IapSettings>
 IdentityAwareProxyAdminServiceClient::GetIapSettings(
     google::cloud::iap::v1::GetIapSettingsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIapSettings(request);
 }
 
 StatusOr<google::cloud::iap::v1::IapSettings>
 IdentityAwareProxyAdminServiceClient::UpdateIapSettings(
     google::cloud::iap::v1::UpdateIapSettingsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateIapSettings(request);
 }
 

--- a/google/cloud/iap/identity_aware_proxy_admin_client.h
+++ b/google/cloud/iap/identity_aware_proxy_admin_client.h
@@ -62,7 +62,7 @@ class IdentityAwareProxyAdminServiceClient {
  public:
   explicit IdentityAwareProxyAdminServiceClient(
       std::shared_ptr<IdentityAwareProxyAdminServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~IdentityAwareProxyAdminServiceClient();
 
   //@{
@@ -97,7 +97,8 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -107,8 +108,7 @@ class IdentityAwareProxyAdminServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for an Identity-Aware Proxy protected
@@ -118,7 +118,8 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -128,8 +129,7 @@ class IdentityAwareProxyAdminServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the Identity-Aware Proxy
@@ -139,7 +139,8 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -150,14 +151,15 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the IAP settings on a particular IAP protected resource.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::GetIapSettingsRequest,google/cloud/iap/v1/service.proto#L91}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::IapSettings,google/cloud/iap/v1/service.proto#L112}
   ///
@@ -168,7 +170,7 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   StatusOr<google::cloud::iap::v1::IapSettings> GetIapSettings(
       google::cloud::iap::v1::GetIapSettingsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the IAP settings on a particular IAP protected resource. It
@@ -176,7 +178,8 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::UpdateIapSettingsRequest,google/cloud/iap/v1/service.proto#L99}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::IapSettings,google/cloud/iap/v1/service.proto#L112}
   ///
@@ -187,7 +190,7 @@ class IdentityAwareProxyAdminServiceClient {
   ///
   StatusOr<google::cloud::iap::v1::IapSettings> UpdateIapSettings(
       google::cloud::iap::v1::UpdateIapSettingsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<IdentityAwareProxyAdminServiceConnection> connection_;

--- a/google/cloud/iap/identity_aware_proxy_o_auth_client.cc
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IdentityAwareProxyOAuthServiceClient::IdentityAwareProxyOAuthServiceClient(
     std::shared_ptr<IdentityAwareProxyOAuthServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           iap_internal::IdentityAwareProxyOAuthServiceDefaultOptions(
               connection_->options()))) {}
 IdentityAwareProxyOAuthServiceClient::~IdentityAwareProxyOAuthServiceClient() =
@@ -38,26 +38,22 @@ IdentityAwareProxyOAuthServiceClient::~IdentityAwareProxyOAuthServiceClient() =
 
 StatusOr<google::cloud::iap::v1::ListBrandsResponse>
 IdentityAwareProxyOAuthServiceClient::ListBrands(
-    google::cloud::iap::v1::ListBrandsRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iap::v1::ListBrandsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBrands(request);
 }
 
 StatusOr<google::cloud::iap::v1::Brand>
 IdentityAwareProxyOAuthServiceClient::CreateBrand(
-    google::cloud::iap::v1::CreateBrandRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iap::v1::CreateBrandRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBrand(request);
 }
 
 StatusOr<google::cloud::iap::v1::Brand>
 IdentityAwareProxyOAuthServiceClient::GetBrand(
-    google::cloud::iap::v1::GetBrandRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iap::v1::GetBrandRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBrand(request);
 }
 
@@ -65,27 +61,24 @@ StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>
 IdentityAwareProxyOAuthServiceClient::CreateIdentityAwareProxyClient(
     google::cloud::iap::v1::CreateIdentityAwareProxyClientRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateIdentityAwareProxyClient(request);
 }
 
 StreamRange<google::cloud::iap::v1::IdentityAwareProxyClient>
 IdentityAwareProxyOAuthServiceClient::ListIdentityAwareProxyClients(
     google::cloud::iap::v1::ListIdentityAwareProxyClientsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListIdentityAwareProxyClients(std::move(request));
 }
 
 StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>
 IdentityAwareProxyOAuthServiceClient::GetIdentityAwareProxyClient(
     google::cloud::iap::v1::GetIdentityAwareProxyClientRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIdentityAwareProxyClient(request);
 }
 
@@ -93,18 +86,16 @@ StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>
 IdentityAwareProxyOAuthServiceClient::ResetIdentityAwareProxyClientSecret(
     google::cloud::iap::v1::ResetIdentityAwareProxyClientSecretRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResetIdentityAwareProxyClientSecret(request);
 }
 
 Status IdentityAwareProxyOAuthServiceClient::DeleteIdentityAwareProxyClient(
     google::cloud::iap::v1::DeleteIdentityAwareProxyClientRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteIdentityAwareProxyClient(request);
 }
 

--- a/google/cloud/iap/identity_aware_proxy_o_auth_client.h
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_client.h
@@ -64,7 +64,7 @@ class IdentityAwareProxyOAuthServiceClient {
  public:
   explicit IdentityAwareProxyOAuthServiceClient(
       std::shared_ptr<IdentityAwareProxyOAuthServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~IdentityAwareProxyOAuthServiceClient();
 
   //@{
@@ -96,7 +96,8 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::ListBrandsRequest,google/cloud/iap/v1/service.proto#L286}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::ListBrandsResponse,google/cloud/iap/v1/service.proto#L293}
   ///
@@ -107,7 +108,7 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   StatusOr<google::cloud::iap::v1::ListBrandsResponse> ListBrands(
       google::cloud::iap::v1::ListBrandsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Constructs a new OAuth brand for the project if one does not exist.
@@ -120,7 +121,8 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::CreateBrandRequest,google/cloud/iap/v1/service.proto#L299}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::Brand,google/cloud/iap/v1/service.proto#L384}
   ///
@@ -131,14 +133,15 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   StatusOr<google::cloud::iap::v1::Brand> CreateBrand(
       google::cloud::iap::v1::CreateBrandRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves the OAuth brand of the project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::GetBrandRequest,google/cloud/iap/v1/service.proto#L309}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::Brand,google/cloud/iap/v1/service.proto#L384}
   ///
@@ -149,7 +152,7 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   StatusOr<google::cloud::iap::v1::Brand> GetBrand(
       google::cloud::iap::v1::GetBrandRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an Identity Aware Proxy (IAP) OAuth client. The client is owned
@@ -158,7 +161,8 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::CreateIdentityAwareProxyClientRequest,google/cloud/iap/v1/service.proto#L347}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::IdentityAwareProxyClient,google/cloud/iap/v1/service.proto#L402}
   ///
@@ -171,14 +175,15 @@ class IdentityAwareProxyOAuthServiceClient {
   CreateIdentityAwareProxyClient(
       google::cloud::iap::v1::CreateIdentityAwareProxyClientRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the existing clients for the brand.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::ListIdentityAwareProxyClientsRequest,google/cloud/iap/v1/service.proto#L316}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::IdentityAwareProxyClient,google/cloud/iap/v1/service.proto#L402}
   ///
@@ -190,7 +195,7 @@ class IdentityAwareProxyOAuthServiceClient {
   StreamRange<google::cloud::iap::v1::IdentityAwareProxyClient>
   ListIdentityAwareProxyClients(
       google::cloud::iap::v1::ListIdentityAwareProxyClientsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves an Identity Aware Proxy (IAP) OAuth client.
@@ -198,7 +203,8 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::GetIdentityAwareProxyClientRequest,google/cloud/iap/v1/service.proto#L359}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::IdentityAwareProxyClient,google/cloud/iap/v1/service.proto#L402}
   ///
@@ -210,7 +216,7 @@ class IdentityAwareProxyOAuthServiceClient {
   StatusOr<google::cloud::iap::v1::IdentityAwareProxyClient>
   GetIdentityAwareProxyClient(
       google::cloud::iap::v1::GetIdentityAwareProxyClientRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resets an Identity Aware Proxy (IAP) OAuth client secret. Useful if the
@@ -218,7 +224,8 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::ResetIdentityAwareProxyClientSecretRequest,google/cloud/iap/v1/service.proto#L367}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iap::v1::IdentityAwareProxyClient,google/cloud/iap/v1/service.proto#L402}
   ///
@@ -231,7 +238,7 @@ class IdentityAwareProxyOAuthServiceClient {
   ResetIdentityAwareProxyClientSecret(
       google::cloud::iap::v1::ResetIdentityAwareProxyClientSecretRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an Identity Aware Proxy (IAP) OAuth client. Useful for removing
@@ -240,7 +247,8 @@ class IdentityAwareProxyOAuthServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iap::v1::DeleteIdentityAwareProxyClientRequest,google/cloud/iap/v1/service.proto#L375}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.iap.v1.DeleteIdentityAwareProxyClientRequest]:
   /// @googleapis_reference_link{google/cloud/iap/v1/service.proto#L375}
@@ -248,7 +256,7 @@ class IdentityAwareProxyOAuthServiceClient {
   Status DeleteIdentityAwareProxyClient(
       google::cloud::iap::v1::DeleteIdentityAwareProxyClientRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<IdentityAwareProxyOAuthServiceConnection> connection_;

--- a/google/cloud/ids/ids_client.cc
+++ b/google/cloud/ids/ids_client.cc
@@ -25,51 +25,45 @@ namespace cloud {
 namespace ids {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-IDSClient::IDSClient(std::shared_ptr<IDSConnection> connection, Options options)
+IDSClient::IDSClient(std::shared_ptr<IDSConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           ids_internal::IDSDefaultOptions(connection_->options()))) {}
 IDSClient::~IDSClient() = default;
 
 StreamRange<google::cloud::ids::v1::Endpoint> IDSClient::ListEndpoints(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::ids::v1::ListEndpointsRequest request;
   request.set_parent(parent);
   return connection_->ListEndpoints(request);
 }
 
 StreamRange<google::cloud::ids::v1::Endpoint> IDSClient::ListEndpoints(
-    google::cloud::ids::v1::ListEndpointsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::ids::v1::ListEndpointsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEndpoints(std::move(request));
 }
 
 StatusOr<google::cloud::ids::v1::Endpoint> IDSClient::GetEndpoint(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::ids::v1::GetEndpointRequest request;
   request.set_name(name);
   return connection_->GetEndpoint(request);
 }
 
 StatusOr<google::cloud::ids::v1::Endpoint> IDSClient::GetEndpoint(
-    google::cloud::ids::v1::GetEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::ids::v1::GetEndpointRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEndpoint(request);
 }
 
 future<StatusOr<google::cloud::ids::v1::Endpoint>> IDSClient::CreateEndpoint(
     std::string const& parent, google::cloud::ids::v1::Endpoint const& endpoint,
-    std::string const& endpoint_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& endpoint_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::ids::v1::CreateEndpointRequest request;
   request.set_parent(parent);
   *request.mutable_endpoint() = endpoint;
@@ -79,16 +73,14 @@ future<StatusOr<google::cloud::ids::v1::Endpoint>> IDSClient::CreateEndpoint(
 
 future<StatusOr<google::cloud::ids::v1::Endpoint>> IDSClient::CreateEndpoint(
     google::cloud::ids::v1::CreateEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEndpoint(request);
 }
 
 future<StatusOr<google::cloud::ids::v1::OperationMetadata>>
-IDSClient::DeleteEndpoint(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+IDSClient::DeleteEndpoint(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::ids::v1::DeleteEndpointRequest request;
   request.set_name(name);
   return connection_->DeleteEndpoint(request);
@@ -97,9 +89,8 @@ IDSClient::DeleteEndpoint(std::string const& name, Options options) {
 future<StatusOr<google::cloud::ids::v1::OperationMetadata>>
 IDSClient::DeleteEndpoint(
     google::cloud::ids::v1::DeleteEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteEndpoint(request);
 }
 

--- a/google/cloud/ids/ids_client.h
+++ b/google/cloud/ids/ids_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IDSClient {
  public:
   explicit IDSClient(std::shared_ptr<IDSConnection> connection,
-                     Options options = {});
+                     Options opts = {});
   ~IDSClient();
 
   //@{
@@ -89,7 +89,8 @@ class IDSClient {
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// endpoints.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::Endpoint,google/cloud/ids/v1/ids.proto#L82}
   ///
@@ -99,14 +100,15 @@ class IDSClient {
   /// @googleapis_reference_link{google/cloud/ids/v1/ids.proto#L82}
   ///
   StreamRange<google::cloud::ids::v1::Endpoint> ListEndpoints(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Endpoints in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::ids::v1::ListEndpointsRequest,google/cloud/ids/v1/ids.proto#L159}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::Endpoint,google/cloud/ids/v1/ids.proto#L82}
   ///
@@ -116,15 +118,15 @@ class IDSClient {
   /// @googleapis_reference_link{google/cloud/ids/v1/ids.proto#L82}
   ///
   StreamRange<google::cloud::ids::v1::Endpoint> ListEndpoints(
-      google::cloud::ids::v1::ListEndpointsRequest request,
-      Options options = {});
+      google::cloud::ids::v1::ListEndpointsRequest request, Options opts = {});
 
   ///
   /// Gets details of a single Endpoint.
   ///
   /// @param name  Required. The name of the endpoint to retrieve.
   ///  Format: `projects/{project}/locations/{location}/endpoints/{endpoint}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::Endpoint,google/cloud/ids/v1/ids.proto#L82}
   ///
@@ -134,14 +136,15 @@ class IDSClient {
   /// @googleapis_reference_link{google/cloud/ids/v1/ids.proto#L82}
   ///
   StatusOr<google::cloud::ids::v1::Endpoint> GetEndpoint(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Endpoint.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::ids::v1::GetEndpointRequest,google/cloud/ids/v1/ids.proto#L200}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::Endpoint,google/cloud/ids/v1/ids.proto#L82}
   ///
@@ -152,7 +155,7 @@ class IDSClient {
   ///
   StatusOr<google::cloud::ids::v1::Endpoint> GetEndpoint(
       google::cloud::ids::v1::GetEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Endpoint in a given project and location.
@@ -166,7 +169,8 @@ class IDSClient {
   ///  lowercase letters, numbers, or hyphens, and cannot end with a hyphen.
   ///  Values that do not match this pattern will trigger an INVALID_ARGUMENT
   ///  error.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::Endpoint,google/cloud/ids/v1/ids.proto#L82}
   ///
@@ -178,14 +182,15 @@ class IDSClient {
   future<StatusOr<google::cloud::ids::v1::Endpoint>> CreateEndpoint(
       std::string const& parent,
       google::cloud::ids::v1::Endpoint const& endpoint,
-      std::string const& endpoint_id, Options options = {});
+      std::string const& endpoint_id, Options opts = {});
 
   ///
   /// Creates a new Endpoint in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::ids::v1::CreateEndpointRequest,google/cloud/ids/v1/ids.proto#L211}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::Endpoint,google/cloud/ids/v1/ids.proto#L82}
   ///
@@ -196,13 +201,14 @@ class IDSClient {
   ///
   future<StatusOr<google::cloud::ids::v1::Endpoint>> CreateEndpoint(
       google::cloud::ids::v1::CreateEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Endpoint.
   ///
   /// @param name  Required. The name of the endpoint to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::OperationMetadata,google/cloud/ids/v1/ids.proto#L273}
   ///
@@ -212,14 +218,15 @@ class IDSClient {
   /// @googleapis_reference_link{google/cloud/ids/v1/ids.proto#L273}
   ///
   future<StatusOr<google::cloud::ids::v1::OperationMetadata>> DeleteEndpoint(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Endpoint.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::ids::v1::DeleteEndpointRequest,google/cloud/ids/v1/ids.proto#L247}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::ids::v1::OperationMetadata,google/cloud/ids/v1/ids.proto#L273}
   ///
@@ -230,7 +237,7 @@ class IDSClient {
   ///
   future<StatusOr<google::cloud::ids::v1::OperationMetadata>> DeleteEndpoint(
       google::cloud::ids::v1::DeleteEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<IDSConnection> connection_;

--- a/google/cloud/iot/device_manager_client.cc
+++ b/google/cloud/iot/device_manager_client.cc
@@ -28,10 +28,10 @@ namespace iot {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DeviceManagerClient::DeviceManagerClient(
-    std::shared_ptr<DeviceManagerConnection> connection, Options options)
+    std::shared_ptr<DeviceManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           iot_internal::DeviceManagerDefaultOptions(connection_->options()))) {}
 DeviceManagerClient::~DeviceManagerClient() = default;
 
@@ -39,9 +39,8 @@ StatusOr<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::CreateDeviceRegistry(
     std::string const& parent,
     google::cloud::iot::v1::DeviceRegistry const& device_registry,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::CreateDeviceRegistryRequest request;
   request.set_parent(parent);
   *request.mutable_device_registry() = device_registry;
@@ -51,17 +50,14 @@ DeviceManagerClient::CreateDeviceRegistry(
 StatusOr<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::CreateDeviceRegistry(
     google::cloud::iot::v1::CreateDeviceRegistryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDeviceRegistry(request);
 }
 
 StatusOr<google::cloud::iot::v1::DeviceRegistry>
-DeviceManagerClient::GetDeviceRegistry(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DeviceManagerClient::GetDeviceRegistry(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::GetDeviceRegistryRequest request;
   request.set_name(name);
   return connection_->GetDeviceRegistry(request);
@@ -70,18 +66,16 @@ DeviceManagerClient::GetDeviceRegistry(std::string const& name,
 StatusOr<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::GetDeviceRegistry(
     google::cloud::iot::v1::GetDeviceRegistryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDeviceRegistry(request);
 }
 
 StatusOr<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::UpdateDeviceRegistry(
     google::cloud::iot::v1::DeviceRegistry const& device_registry,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::UpdateDeviceRegistryRequest request;
   *request.mutable_device_registry() = device_registry;
   *request.mutable_update_mask() = update_mask;
@@ -91,16 +85,14 @@ DeviceManagerClient::UpdateDeviceRegistry(
 StatusOr<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::UpdateDeviceRegistry(
     google::cloud::iot::v1::UpdateDeviceRegistryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDeviceRegistry(request);
 }
 
 Status DeviceManagerClient::DeleteDeviceRegistry(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::DeleteDeviceRegistryRequest request;
   request.set_name(name);
   return connection_->DeleteDeviceRegistry(request);
@@ -108,17 +100,15 @@ Status DeviceManagerClient::DeleteDeviceRegistry(std::string const& name,
 
 Status DeviceManagerClient::DeleteDeviceRegistry(
     google::cloud::iot::v1::DeleteDeviceRegistryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDeviceRegistry(request);
 }
 
 StreamRange<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::ListDeviceRegistries(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::ListDeviceRegistriesRequest request;
   request.set_parent(parent);
   return connection_->ListDeviceRegistries(request);
@@ -126,18 +116,15 @@ DeviceManagerClient::ListDeviceRegistries(std::string const& parent,
 
 StreamRange<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerClient::ListDeviceRegistries(
-    google::cloud::iot::v1::ListDeviceRegistriesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iot::v1::ListDeviceRegistriesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDeviceRegistries(std::move(request));
 }
 
 StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::CreateDevice(
     std::string const& parent, google::cloud::iot::v1::Device const& device,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::CreateDeviceRequest request;
   request.set_parent(parent);
   *request.mutable_device() = device;
@@ -145,34 +132,29 @@ StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::CreateDevice(
 }
 
 StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::CreateDevice(
-    google::cloud::iot::v1::CreateDeviceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iot::v1::CreateDeviceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDevice(request);
 }
 
 StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::GetDevice(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::GetDeviceRequest request;
   request.set_name(name);
   return connection_->GetDevice(request);
 }
 
 StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::GetDevice(
-    google::cloud::iot::v1::GetDeviceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iot::v1::GetDeviceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDevice(request);
 }
 
 StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::UpdateDevice(
     google::cloud::iot::v1::Device const& device,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::UpdateDeviceRequest request;
   *request.mutable_device() = device;
   *request.mutable_update_mask() = update_mask;
@@ -180,52 +162,44 @@ StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::UpdateDevice(
 }
 
 StatusOr<google::cloud::iot::v1::Device> DeviceManagerClient::UpdateDevice(
-    google::cloud::iot::v1::UpdateDeviceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iot::v1::UpdateDeviceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDevice(request);
 }
 
 Status DeviceManagerClient::DeleteDevice(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::DeleteDeviceRequest request;
   request.set_name(name);
   return connection_->DeleteDevice(request);
 }
 
 Status DeviceManagerClient::DeleteDevice(
-    google::cloud::iot::v1::DeleteDeviceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iot::v1::DeleteDeviceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDevice(request);
 }
 
 StreamRange<google::cloud::iot::v1::Device> DeviceManagerClient::ListDevices(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::ListDevicesRequest request;
   request.set_parent(parent);
   return connection_->ListDevices(request);
 }
 
 StreamRange<google::cloud::iot::v1::Device> DeviceManagerClient::ListDevices(
-    google::cloud::iot::v1::ListDevicesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::iot::v1::ListDevicesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDevices(std::move(request));
 }
 
 StatusOr<google::cloud::iot::v1::DeviceConfig>
 DeviceManagerClient::ModifyCloudToDeviceConfig(std::string const& name,
                                                std::string const& binary_data,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest request;
   request.set_name(name);
   request.set_binary_data(binary_data);
@@ -235,17 +209,15 @@ DeviceManagerClient::ModifyCloudToDeviceConfig(std::string const& name,
 StatusOr<google::cloud::iot::v1::DeviceConfig>
 DeviceManagerClient::ModifyCloudToDeviceConfig(
     google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ModifyCloudToDeviceConfig(request);
 }
 
 StatusOr<google::cloud::iot::v1::ListDeviceConfigVersionsResponse>
 DeviceManagerClient::ListDeviceConfigVersions(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::ListDeviceConfigVersionsRequest request;
   request.set_name(name);
   return connection_->ListDeviceConfigVersions(request);
@@ -254,17 +226,14 @@ DeviceManagerClient::ListDeviceConfigVersions(std::string const& name,
 StatusOr<google::cloud::iot::v1::ListDeviceConfigVersionsResponse>
 DeviceManagerClient::ListDeviceConfigVersions(
     google::cloud::iot::v1::ListDeviceConfigVersionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDeviceConfigVersions(request);
 }
 
 StatusOr<google::cloud::iot::v1::ListDeviceStatesResponse>
-DeviceManagerClient::ListDeviceStates(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DeviceManagerClient::ListDeviceStates(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::ListDeviceStatesRequest request;
   request.set_name(name);
   return connection_->ListDeviceStates(request);
@@ -273,17 +242,15 @@ DeviceManagerClient::ListDeviceStates(std::string const& name,
 StatusOr<google::cloud::iot::v1::ListDeviceStatesResponse>
 DeviceManagerClient::ListDeviceStates(
     google::cloud::iot::v1::ListDeviceStatesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDeviceStates(request);
 }
 
 StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -291,11 +258,10 @@ StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<DeviceManagerBackoffPolicyOption>(options,
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<DeviceManagerBackoffPolicyOption>(opts,
                                                                    __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -322,34 +288,30 @@ StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DeviceManagerClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DeviceManagerClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DeviceManagerClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -358,19 +320,16 @@ DeviceManagerClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DeviceManagerClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StatusOr<google::cloud::iot::v1::SendCommandToDeviceResponse>
 DeviceManagerClient::SendCommandToDevice(std::string const& name,
                                          std::string const& binary_data,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::SendCommandToDeviceRequest request;
   request.set_name(name);
   request.set_binary_data(binary_data);
@@ -381,9 +340,8 @@ StatusOr<google::cloud::iot::v1::SendCommandToDeviceResponse>
 DeviceManagerClient::SendCommandToDevice(std::string const& name,
                                          std::string const& binary_data,
                                          std::string const& subfolder,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::SendCommandToDeviceRequest request;
   request.set_name(name);
   request.set_binary_data(binary_data);
@@ -394,9 +352,8 @@ DeviceManagerClient::SendCommandToDevice(std::string const& name,
 StatusOr<google::cloud::iot::v1::SendCommandToDeviceResponse>
 DeviceManagerClient::SendCommandToDevice(
     google::cloud::iot::v1::SendCommandToDeviceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SendCommandToDevice(request);
 }
 
@@ -404,9 +361,8 @@ StatusOr<google::cloud::iot::v1::BindDeviceToGatewayResponse>
 DeviceManagerClient::BindDeviceToGateway(std::string const& parent,
                                          std::string const& gateway_id,
                                          std::string const& device_id,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::BindDeviceToGatewayRequest request;
   request.set_parent(parent);
   request.set_gateway_id(gateway_id);
@@ -417,9 +373,8 @@ DeviceManagerClient::BindDeviceToGateway(std::string const& parent,
 StatusOr<google::cloud::iot::v1::BindDeviceToGatewayResponse>
 DeviceManagerClient::BindDeviceToGateway(
     google::cloud::iot::v1::BindDeviceToGatewayRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BindDeviceToGateway(request);
 }
 
@@ -427,9 +382,8 @@ StatusOr<google::cloud::iot::v1::UnbindDeviceFromGatewayResponse>
 DeviceManagerClient::UnbindDeviceFromGateway(std::string const& parent,
                                              std::string const& gateway_id,
                                              std::string const& device_id,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::iot::v1::UnbindDeviceFromGatewayRequest request;
   request.set_parent(parent);
   request.set_gateway_id(gateway_id);
@@ -440,9 +394,8 @@ DeviceManagerClient::UnbindDeviceFromGateway(std::string const& parent,
 StatusOr<google::cloud::iot::v1::UnbindDeviceFromGatewayResponse>
 DeviceManagerClient::UnbindDeviceFromGateway(
     google::cloud::iot::v1::UnbindDeviceFromGatewayRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UnbindDeviceFromGateway(request);
 }
 

--- a/google/cloud/iot/device_manager_client.h
+++ b/google/cloud/iot/device_manager_client.h
@@ -63,8 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DeviceManagerClient {
  public:
   explicit DeviceManagerClient(
-      std::shared_ptr<DeviceManagerConnection> connection,
-      Options options = {});
+      std::shared_ptr<DeviceManagerConnection> connection, Options opts = {});
   ~DeviceManagerClient();
 
   //@{
@@ -97,7 +96,8 @@ class DeviceManagerClient {
   /// must be empty. The server will
   ///  generate that field from the device registry `id` provided and the
   ///  `parent` field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -109,14 +109,15 @@ class DeviceManagerClient {
   StatusOr<google::cloud::iot::v1::DeviceRegistry> CreateDeviceRegistry(
       std::string const& parent,
       google::cloud::iot::v1::DeviceRegistry const& device_registry,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a device registry that contains devices.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::CreateDeviceRegistryRequest,google/cloud/iot/v1/device_manager.proto#L274}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -127,14 +128,15 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::DeviceRegistry> CreateDeviceRegistry(
       google::cloud::iot::v1::CreateDeviceRegistryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a device registry configuration.
   ///
   /// @param name  Required. The name of the device registry. For example,
   ///  `projects/example-project/locations/us-central1/registries/my-registry`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -144,14 +146,15 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/resources.proto#L155}
   ///
   StatusOr<google::cloud::iot::v1::DeviceRegistry> GetDeviceRegistry(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a device registry configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::GetDeviceRegistryRequest,google/cloud/iot/v1/device_manager.proto#L291}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -162,7 +165,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::DeviceRegistry> GetDeviceRegistry(
       google::cloud::iot::v1::GetDeviceRegistryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a device registry configuration.
@@ -177,7 +180,8 @@ class DeviceManagerClient {
   ///  are immutable or only set by the server.
   ///  Mutable top-level fields: `event_notification_config`, `http_config`,
   ///  `mqtt_config`, and `state_notification_config`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -188,14 +192,15 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::DeviceRegistry> UpdateDeviceRegistry(
       google::cloud::iot::v1::DeviceRegistry const& device_registry,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a device registry configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::UpdateDeviceRegistryRequest,google/cloud/iot/v1/device_manager.proto#L315}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -206,40 +211,43 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::DeviceRegistry> UpdateDeviceRegistry(
       google::cloud::iot::v1::UpdateDeviceRegistryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a device registry configuration.
   ///
   /// @param name  Required. The name of the device registry. For example,
   ///  `projects/example-project/locations/us-central1/registries/my-registry`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.iot.v1.DeleteDeviceRegistryRequest]:
   /// @googleapis_reference_link{google/cloud/iot/v1/device_manager.proto#L303}
   ///
-  Status DeleteDeviceRegistry(std::string const& name, Options options = {});
+  Status DeleteDeviceRegistry(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a device registry configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::DeleteDeviceRegistryRequest,google/cloud/iot/v1/device_manager.proto#L303}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.iot.v1.DeleteDeviceRegistryRequest]:
   /// @googleapis_reference_link{google/cloud/iot/v1/device_manager.proto#L303}
   ///
   Status DeleteDeviceRegistry(
       google::cloud::iot::v1::DeleteDeviceRegistryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists device registries.
   ///
   /// @param parent  Required. The project and cloud region path. For example,
   ///  `projects/example-project/locations/us-central1`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -249,14 +257,15 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/resources.proto#L155}
   ///
   StreamRange<google::cloud::iot::v1::DeviceRegistry> ListDeviceRegistries(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists device registries.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceRegistriesRequest,google/cloud/iot/v1/device_manager.proto#L330}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceRegistry,google/cloud/iot/v1/resources.proto#L155}
   ///
@@ -267,7 +276,7 @@ class DeviceManagerClient {
   ///
   StreamRange<google::cloud::iot::v1::DeviceRegistry> ListDeviceRegistries(
       google::cloud::iot::v1::ListDeviceRegistriesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a device in a device registry.
@@ -280,7 +289,8 @@ class DeviceManagerClient {
   /// must be empty. The server
   ///  generates `name` from the device registry `id` and the
   ///  `parent` field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -291,14 +301,15 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::Device> CreateDevice(
       std::string const& parent, google::cloud::iot::v1::Device const& device,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a device in a device registry.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::CreateDeviceRequest,google/cloud/iot/v1/device_manager.proto#L364}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -309,7 +320,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::Device> CreateDevice(
       google::cloud::iot::v1::CreateDeviceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details about a device.
@@ -318,7 +329,8 @@ class DeviceManagerClient {
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/device0`
   ///  or
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -328,14 +340,15 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/resources.proto#L30}
   ///
   StatusOr<google::cloud::iot::v1::Device> GetDevice(std::string const& name,
-                                                     Options options = {});
+                                                     Options opts = {});
 
   ///
   /// Gets details about a device.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::GetDeviceRequest,google/cloud/iot/v1/device_manager.proto#L382}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -346,7 +359,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::Device> GetDevice(
       google::cloud::iot::v1::GetDeviceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a device.
@@ -361,7 +374,8 @@ class DeviceManagerClient {
   ///  The field mask must not be empty, and it must not contain fields that
   ///  are immutable or only set by the server.
   ///  Mutable top-level fields: `credentials`, `blocked`, and `metadata`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -372,14 +386,15 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::Device> UpdateDevice(
       google::cloud::iot::v1::Device const& device,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a device.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::UpdateDeviceRequest,google/cloud/iot/v1/device_manager.proto#L400}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -390,7 +405,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::Device> UpdateDevice(
       google::cloud::iot::v1::UpdateDeviceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a device.
@@ -399,33 +414,36 @@ class DeviceManagerClient {
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/device0`
   ///  or
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.iot.v1.DeleteDeviceRequest]:
   /// @googleapis_reference_link{google/cloud/iot/v1/device_manager.proto#L415}
   ///
-  Status DeleteDevice(std::string const& name, Options options = {});
+  Status DeleteDevice(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a device.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::DeleteDeviceRequest,google/cloud/iot/v1/device_manager.proto#L415}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.iot.v1.DeleteDeviceRequest]:
   /// @googleapis_reference_link{google/cloud/iot/v1/device_manager.proto#L415}
   ///
   Status DeleteDevice(
       google::cloud::iot::v1::DeleteDeviceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List devices in a device registry.
   ///
   /// @param parent  Required. The device registry path. Required. For example,
   ///  `projects/my-project/locations/us-central1/registries/my-registry`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -435,14 +453,15 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/resources.proto#L30}
   ///
   StreamRange<google::cloud::iot::v1::Device> ListDevices(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// List devices in a device registry.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::ListDevicesRequest,google/cloud/iot/v1/device_manager.proto#L428}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::Device,google/cloud/iot/v1/resources.proto#L30}
   ///
@@ -452,7 +471,7 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/resources.proto#L30}
   ///
   StreamRange<google::cloud::iot::v1::Device> ListDevices(
-      google::cloud::iot::v1::ListDevicesRequest request, Options options = {});
+      google::cloud::iot::v1::ListDevicesRequest request, Options opts = {});
 
   ///
   /// Modifies the configuration for the device, which is eventually sent from
@@ -464,7 +483,8 @@ class DeviceManagerClient {
   ///  or
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
   /// @param binary_data  Required. The configuration data for the device.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceConfig,google/cloud/iot/v1/resources.proto#L449}
   ///
@@ -475,7 +495,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::DeviceConfig> ModifyCloudToDeviceConfig(
       std::string const& name, std::string const& binary_data,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Modifies the configuration for the device, which is eventually sent from
@@ -484,7 +504,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest,google/cloud/iot/v1/device_manager.proto#L502}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::DeviceConfig,google/cloud/iot/v1/resources.proto#L449}
   ///
@@ -495,7 +516,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::DeviceConfig> ModifyCloudToDeviceConfig(
       google::cloud::iot::v1::ModifyCloudToDeviceConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the last few versions of the device configuration in descending
@@ -505,7 +526,8 @@ class DeviceManagerClient {
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/device0`
   ///  or
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceConfigVersionsResponse,google/cloud/iot/v1/device_manager.proto#L543}
   ///
@@ -515,7 +537,7 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/device_manager.proto#L543}
   ///
   StatusOr<google::cloud::iot::v1::ListDeviceConfigVersionsResponse>
-  ListDeviceConfigVersions(std::string const& name, Options options = {});
+  ListDeviceConfigVersions(std::string const& name, Options opts = {});
 
   ///
   /// Lists the last few versions of the device configuration in descending
@@ -523,7 +545,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceConfigVersionsRequest,google/cloud/iot/v1/device_manager.proto#L525}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceConfigVersionsResponse,google/cloud/iot/v1/device_manager.proto#L543}
   ///
@@ -535,7 +558,7 @@ class DeviceManagerClient {
   StatusOr<google::cloud::iot::v1::ListDeviceConfigVersionsResponse>
   ListDeviceConfigVersions(
       google::cloud::iot::v1::ListDeviceConfigVersionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the last few versions of the device state in descending order (i.e.:
@@ -545,7 +568,8 @@ class DeviceManagerClient {
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/device0`
   ///  or
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceStatesResponse,google/cloud/iot/v1/device_manager.proto#L568}
   ///
@@ -555,7 +579,7 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/cloud/iot/v1/device_manager.proto#L568}
   ///
   StatusOr<google::cloud::iot::v1::ListDeviceStatesResponse> ListDeviceStates(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Lists the last few versions of the device state in descending order (i.e.:
@@ -563,7 +587,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceStatesRequest,google/cloud/iot/v1/device_manager.proto#L550}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::ListDeviceStatesResponse,google/cloud/iot/v1/device_manager.proto#L568}
   ///
@@ -574,7 +599,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::ListDeviceStatesResponse> ListDeviceStates(
       google::cloud::iot::v1::ListDeviceStatesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the access control policy on the specified resource. Replaces any
@@ -588,7 +613,8 @@ class DeviceManagerClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -599,7 +625,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -617,14 +643,13 @@ class DeviceManagerClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `DeviceManagerBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on the specified resource. Replaces any
@@ -632,7 +657,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -642,8 +668,7 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for a resource.
@@ -653,7 +678,8 @@ class DeviceManagerClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -663,7 +689,7 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a resource.
@@ -672,7 +698,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -682,8 +709,7 @@ class DeviceManagerClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the specified resource.
@@ -698,7 +724,8 @@ class DeviceManagerClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -709,7 +736,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the specified resource.
@@ -718,7 +745,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -729,7 +757,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sends a command to the specified device. In order for a device to be able
@@ -752,7 +780,8 @@ class DeviceManagerClient {
   ///  or
   ///  `projects/p0/locations/us-central1/registries/registry0/devices/{num_id}`.
   /// @param binary_data  Required. The command data to send to the device.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::SendCommandToDeviceResponse,google/cloud/iot/v1/device_manager.proto#L598}
   ///
@@ -763,7 +792,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::SendCommandToDeviceResponse>
   SendCommandToDevice(std::string const& name, std::string const& binary_data,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Sends a command to the specified device. In order for a device to be able
@@ -793,7 +822,8 @@ class DeviceManagerClient {
   ///  Multi-level subfolders are allowed. This field must not have more than
   ///  256 characters, and must not contain any MQTT wildcards ("+" or "#") or
   ///  null characters.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::SendCommandToDeviceResponse,google/cloud/iot/v1/device_manager.proto#L598}
   ///
@@ -804,7 +834,7 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::SendCommandToDeviceResponse>
   SendCommandToDevice(std::string const& name, std::string const& binary_data,
-                      std::string const& subfolder, Options options = {});
+                      std::string const& subfolder, Options opts = {});
 
   ///
   /// Sends a command to the specified device. In order for a device to be able
@@ -824,7 +854,8 @@ class DeviceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::SendCommandToDeviceRequest,google/cloud/iot/v1/device_manager.proto#L575}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::SendCommandToDeviceResponse,google/cloud/iot/v1/device_manager.proto#L598}
   ///
@@ -836,7 +867,7 @@ class DeviceManagerClient {
   StatusOr<google::cloud::iot::v1::SendCommandToDeviceResponse>
   SendCommandToDevice(
       google::cloud::iot::v1::SendCommandToDeviceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Associates the device with the gateway.
@@ -850,7 +881,8 @@ class DeviceManagerClient {
   /// gateway. The value of
   ///  `device_id` can be either the device numeric ID or the user-defined
   ///  device identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::BindDeviceToGatewayResponse,google/cloud/iot/v1/device_manager.proto#L624}
   ///
@@ -861,14 +893,15 @@ class DeviceManagerClient {
   ///
   StatusOr<google::cloud::iot::v1::BindDeviceToGatewayResponse>
   BindDeviceToGateway(std::string const& parent, std::string const& gateway_id,
-                      std::string const& device_id, Options options = {});
+                      std::string const& device_id, Options opts = {});
 
   ///
   /// Associates the device with the gateway.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::BindDeviceToGatewayRequest,google/cloud/iot/v1/device_manager.proto#L603}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::BindDeviceToGatewayResponse,google/cloud/iot/v1/device_manager.proto#L624}
   ///
@@ -880,7 +913,7 @@ class DeviceManagerClient {
   StatusOr<google::cloud::iot::v1::BindDeviceToGatewayResponse>
   BindDeviceToGateway(
       google::cloud::iot::v1::BindDeviceToGatewayRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the association between the device and the gateway.
@@ -894,7 +927,8 @@ class DeviceManagerClient {
   /// gateway. The value of
   ///  `device_id` can be either the device numeric ID or the user-defined
   ///  device identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::UnbindDeviceFromGatewayResponse,google/cloud/iot/v1/device_manager.proto#L650}
   ///
@@ -906,14 +940,15 @@ class DeviceManagerClient {
   StatusOr<google::cloud::iot::v1::UnbindDeviceFromGatewayResponse>
   UnbindDeviceFromGateway(std::string const& parent,
                           std::string const& gateway_id,
-                          std::string const& device_id, Options options = {});
+                          std::string const& device_id, Options opts = {});
 
   ///
   /// Deletes the association between the device and the gateway.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::iot::v1::UnbindDeviceFromGatewayRequest,google/cloud/iot/v1/device_manager.proto#L629}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::iot::v1::UnbindDeviceFromGatewayResponse,google/cloud/iot/v1/device_manager.proto#L650}
   ///
@@ -925,7 +960,7 @@ class DeviceManagerClient {
   StatusOr<google::cloud::iot::v1::UnbindDeviceFromGatewayResponse>
   UnbindDeviceFromGateway(
       google::cloud::iot::v1::UnbindDeviceFromGatewayRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DeviceManagerConnection> connection_;

--- a/google/cloud/iot/device_manager_client.h
+++ b/google/cloud/iot/device_manager_client.h
@@ -643,8 +643,8 @@ class DeviceManagerClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/kms/key_management_client.cc
+++ b/google/cloud/kms/key_management_client.cc
@@ -26,18 +26,17 @@ namespace kms {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 KeyManagementServiceClient::KeyManagementServiceClient(
-    std::shared_ptr<KeyManagementServiceConnection> connection, Options options)
+    std::shared_ptr<KeyManagementServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), kms_internal::KeyManagementServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), kms_internal::KeyManagementServiceDefaultOptions(
+                               connection_->options()))) {}
 KeyManagementServiceClient::~KeyManagementServiceClient() = default;
 
 StreamRange<google::cloud::kms::v1::KeyRing>
 KeyManagementServiceClient::ListKeyRings(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::ListKeyRingsRequest request;
   request.set_parent(parent);
   return connection_->ListKeyRings(request);
@@ -45,17 +44,15 @@ KeyManagementServiceClient::ListKeyRings(std::string const& parent,
 
 StreamRange<google::cloud::kms::v1::KeyRing>
 KeyManagementServiceClient::ListKeyRings(
-    google::cloud::kms::v1::ListKeyRingsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::ListKeyRingsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListKeyRings(std::move(request));
 }
 
 StreamRange<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::ListCryptoKeys(std::string const& parent,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::ListCryptoKeysRequest request;
   request.set_parent(parent);
   return connection_->ListCryptoKeys(request);
@@ -63,17 +60,15 @@ KeyManagementServiceClient::ListCryptoKeys(std::string const& parent,
 
 StreamRange<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::ListCryptoKeys(
-    google::cloud::kms::v1::ListCryptoKeysRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::ListCryptoKeysRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCryptoKeys(std::move(request));
 }
 
 StreamRange<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::ListCryptoKeyVersions(std::string const& parent,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::ListCryptoKeyVersionsRequest request;
   request.set_parent(parent);
   return connection_->ListCryptoKeyVersions(request);
@@ -82,17 +77,15 @@ KeyManagementServiceClient::ListCryptoKeyVersions(std::string const& parent,
 StreamRange<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::ListCryptoKeyVersions(
     google::cloud::kms::v1::ListCryptoKeyVersionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCryptoKeyVersions(std::move(request));
 }
 
 StreamRange<google::cloud::kms::v1::ImportJob>
 KeyManagementServiceClient::ListImportJobs(std::string const& parent,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::ListImportJobsRequest request;
   request.set_parent(parent);
   return connection_->ListImportJobs(request);
@@ -100,17 +93,14 @@ KeyManagementServiceClient::ListImportJobs(std::string const& parent,
 
 StreamRange<google::cloud::kms::v1::ImportJob>
 KeyManagementServiceClient::ListImportJobs(
-    google::cloud::kms::v1::ListImportJobsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::ListImportJobsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListImportJobs(std::move(request));
 }
 
 StatusOr<google::cloud::kms::v1::KeyRing>
-KeyManagementServiceClient::GetKeyRing(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+KeyManagementServiceClient::GetKeyRing(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::GetKeyRingRequest request;
   request.set_name(name);
   return connection_->GetKeyRing(request);
@@ -118,17 +108,15 @@ KeyManagementServiceClient::GetKeyRing(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::KeyRing>
 KeyManagementServiceClient::GetKeyRing(
-    google::cloud::kms::v1::GetKeyRingRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::GetKeyRingRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetKeyRing(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::GetCryptoKey(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::GetCryptoKeyRequest request;
   request.set_name(name);
   return connection_->GetCryptoKey(request);
@@ -136,18 +124,15 @@ KeyManagementServiceClient::GetCryptoKey(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::GetCryptoKey(
-    google::cloud::kms::v1::GetCryptoKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::GetCryptoKeyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCryptoKey(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::GetCryptoKeyVersion(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::GetCryptoKeyVersionRequest request;
   request.set_name(name);
   return connection_->GetCryptoKeyVersion(request);
@@ -156,17 +141,15 @@ KeyManagementServiceClient::GetCryptoKeyVersion(std::string const& name,
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::GetCryptoKeyVersion(
     google::cloud::kms::v1::GetCryptoKeyVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCryptoKeyVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::PublicKey>
 KeyManagementServiceClient::GetPublicKey(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::GetPublicKeyRequest request;
   request.set_name(name);
   return connection_->GetPublicKey(request);
@@ -174,18 +157,15 @@ KeyManagementServiceClient::GetPublicKey(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::PublicKey>
 KeyManagementServiceClient::GetPublicKey(
-    google::cloud::kms::v1::GetPublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::GetPublicKeyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPublicKey(request);
 }
 
 StatusOr<google::cloud::kms::v1::ImportJob>
 KeyManagementServiceClient::GetImportJob(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::GetImportJobRequest request;
   request.set_name(name);
   return connection_->GetImportJob(request);
@@ -193,19 +173,16 @@ KeyManagementServiceClient::GetImportJob(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::ImportJob>
 KeyManagementServiceClient::GetImportJob(
-    google::cloud::kms::v1::GetImportJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::GetImportJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetImportJob(request);
 }
 
 StatusOr<google::cloud::kms::v1::KeyRing>
 KeyManagementServiceClient::CreateKeyRing(
     std::string const& parent, std::string const& key_ring_id,
-    google::cloud::kms::v1::KeyRing const& key_ring, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::KeyRing const& key_ring, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::CreateKeyRingRequest request;
   request.set_parent(parent);
   request.set_key_ring_id(key_ring_id);
@@ -215,19 +192,16 @@ KeyManagementServiceClient::CreateKeyRing(
 
 StatusOr<google::cloud::kms::v1::KeyRing>
 KeyManagementServiceClient::CreateKeyRing(
-    google::cloud::kms::v1::CreateKeyRingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::CreateKeyRingRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateKeyRing(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::CreateCryptoKey(
     std::string const& parent, std::string const& crypto_key_id,
-    google::cloud::kms::v1::CryptoKey const& crypto_key, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::CryptoKey const& crypto_key, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::CreateCryptoKeyRequest request;
   request.set_parent(parent);
   request.set_crypto_key_id(crypto_key_id);
@@ -238,9 +212,8 @@ KeyManagementServiceClient::CreateCryptoKey(
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::CreateCryptoKey(
     google::cloud::kms::v1::CreateCryptoKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCryptoKey(request);
 }
 
@@ -248,9 +221,8 @@ StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::CreateCryptoKeyVersion(
     std::string const& parent,
     google::cloud::kms::v1::CryptoKeyVersion const& crypto_key_version,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::CreateCryptoKeyVersionRequest request;
   request.set_parent(parent);
   *request.mutable_crypto_key_version() = crypto_key_version;
@@ -260,27 +232,24 @@ KeyManagementServiceClient::CreateCryptoKeyVersion(
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::CreateCryptoKeyVersion(
     google::cloud::kms::v1::CreateCryptoKeyVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCryptoKeyVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::ImportCryptoKeyVersion(
     google::cloud::kms::v1::ImportCryptoKeyVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportCryptoKeyVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::ImportJob>
 KeyManagementServiceClient::CreateImportJob(
     std::string const& parent, std::string const& import_job_id,
-    google::cloud::kms::v1::ImportJob const& import_job, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::ImportJob const& import_job, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::CreateImportJobRequest request;
   request.set_parent(parent);
   request.set_import_job_id(import_job_id);
@@ -291,18 +260,16 @@ KeyManagementServiceClient::CreateImportJob(
 StatusOr<google::cloud::kms::v1::ImportJob>
 KeyManagementServiceClient::CreateImportJob(
     google::cloud::kms::v1::CreateImportJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateImportJob(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::UpdateCryptoKey(
     google::cloud::kms::v1::CryptoKey const& crypto_key,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::UpdateCryptoKeyRequest request;
   *request.mutable_crypto_key() = crypto_key;
   *request.mutable_update_mask() = update_mask;
@@ -312,18 +279,16 @@ KeyManagementServiceClient::UpdateCryptoKey(
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::UpdateCryptoKey(
     google::cloud::kms::v1::UpdateCryptoKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCryptoKey(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::UpdateCryptoKeyVersion(
     google::cloud::kms::v1::CryptoKeyVersion const& crypto_key_version,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::UpdateCryptoKeyVersionRequest request;
   *request.mutable_crypto_key_version() = crypto_key_version;
   *request.mutable_update_mask() = update_mask;
@@ -333,18 +298,16 @@ KeyManagementServiceClient::UpdateCryptoKeyVersion(
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::UpdateCryptoKeyVersion(
     google::cloud::kms::v1::UpdateCryptoKeyVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCryptoKeyVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::UpdateCryptoKeyPrimaryVersion(
     std::string const& name, std::string const& crypto_key_version_id,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest request;
   request.set_name(name);
   request.set_crypto_key_version_id(crypto_key_version_id);
@@ -354,17 +317,15 @@ KeyManagementServiceClient::UpdateCryptoKeyPrimaryVersion(
 StatusOr<google::cloud::kms::v1::CryptoKey>
 KeyManagementServiceClient::UpdateCryptoKeyPrimaryVersion(
     google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCryptoKeyPrimaryVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::DestroyCryptoKeyVersion(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::DestroyCryptoKeyVersionRequest request;
   request.set_name(name);
   return connection_->DestroyCryptoKeyVersion(request);
@@ -373,17 +334,15 @@ KeyManagementServiceClient::DestroyCryptoKeyVersion(std::string const& name,
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::DestroyCryptoKeyVersion(
     google::cloud::kms::v1::DestroyCryptoKeyVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DestroyCryptoKeyVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::RestoreCryptoKeyVersion(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::RestoreCryptoKeyVersionRequest request;
   request.set_name(name);
   return connection_->RestoreCryptoKeyVersion(request);
@@ -392,18 +351,16 @@ KeyManagementServiceClient::RestoreCryptoKeyVersion(std::string const& name,
 StatusOr<google::cloud::kms::v1::CryptoKeyVersion>
 KeyManagementServiceClient::RestoreCryptoKeyVersion(
     google::cloud::kms::v1::RestoreCryptoKeyVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreCryptoKeyVersion(request);
 }
 
 StatusOr<google::cloud::kms::v1::EncryptResponse>
 KeyManagementServiceClient::Encrypt(std::string const& name,
                                     std::string const& plaintext,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::EncryptRequest request;
   request.set_name(name);
   request.set_plaintext(plaintext);
@@ -412,18 +369,16 @@ KeyManagementServiceClient::Encrypt(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::EncryptResponse>
 KeyManagementServiceClient::Encrypt(
-    google::cloud::kms::v1::EncryptRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::EncryptRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Encrypt(request);
 }
 
 StatusOr<google::cloud::kms::v1::DecryptResponse>
 KeyManagementServiceClient::Decrypt(std::string const& name,
                                     std::string const& ciphertext,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::DecryptRequest request;
   request.set_name(name);
   request.set_ciphertext(ciphertext);
@@ -432,18 +387,16 @@ KeyManagementServiceClient::Decrypt(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::DecryptResponse>
 KeyManagementServiceClient::Decrypt(
-    google::cloud::kms::v1::DecryptRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::DecryptRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Decrypt(request);
 }
 
 StatusOr<google::cloud::kms::v1::AsymmetricSignResponse>
 KeyManagementServiceClient::AsymmetricSign(
     std::string const& name, google::cloud::kms::v1::Digest const& digest,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::AsymmetricSignRequest request;
   request.set_name(name);
   *request.mutable_digest() = digest;
@@ -453,18 +406,16 @@ KeyManagementServiceClient::AsymmetricSign(
 StatusOr<google::cloud::kms::v1::AsymmetricSignResponse>
 KeyManagementServiceClient::AsymmetricSign(
     google::cloud::kms::v1::AsymmetricSignRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsymmetricSign(request);
 }
 
 StatusOr<google::cloud::kms::v1::AsymmetricDecryptResponse>
 KeyManagementServiceClient::AsymmetricDecrypt(std::string const& name,
                                               std::string const& ciphertext,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::AsymmetricDecryptRequest request;
   request.set_name(name);
   request.set_ciphertext(ciphertext);
@@ -474,17 +425,15 @@ KeyManagementServiceClient::AsymmetricDecrypt(std::string const& name,
 StatusOr<google::cloud::kms::v1::AsymmetricDecryptResponse>
 KeyManagementServiceClient::AsymmetricDecrypt(
     google::cloud::kms::v1::AsymmetricDecryptRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsymmetricDecrypt(request);
 }
 
 StatusOr<google::cloud::kms::v1::MacSignResponse>
 KeyManagementServiceClient::MacSign(std::string const& name,
-                                    std::string const& data, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    std::string const& data, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::MacSignRequest request;
   request.set_name(name);
   request.set_data(data);
@@ -493,18 +442,16 @@ KeyManagementServiceClient::MacSign(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::MacSignResponse>
 KeyManagementServiceClient::MacSign(
-    google::cloud::kms::v1::MacSignRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::MacSignRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MacSign(request);
 }
 
 StatusOr<google::cloud::kms::v1::MacVerifyResponse>
 KeyManagementServiceClient::MacVerify(std::string const& name,
                                       std::string const& data,
-                                      std::string const& mac, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                      std::string const& mac, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::MacVerifyRequest request;
   request.set_name(name);
   request.set_data(data);
@@ -514,18 +461,16 @@ KeyManagementServiceClient::MacVerify(std::string const& name,
 
 StatusOr<google::cloud::kms::v1::MacVerifyResponse>
 KeyManagementServiceClient::MacVerify(
-    google::cloud::kms::v1::MacVerifyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::MacVerifyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MacVerify(request);
 }
 
 StatusOr<google::cloud::kms::v1::GenerateRandomBytesResponse>
 KeyManagementServiceClient::GenerateRandomBytes(
     std::string const& location, std::int32_t length_bytes,
-    google::cloud::kms::v1::ProtectionLevel protection_level, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::kms::v1::ProtectionLevel protection_level, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::kms::v1::GenerateRandomBytesRequest request;
   request.set_location(location);
   request.set_length_bytes(length_bytes);
@@ -536,9 +481,8 @@ KeyManagementServiceClient::GenerateRandomBytes(
 StatusOr<google::cloud::kms::v1::GenerateRandomBytesResponse>
 KeyManagementServiceClient::GenerateRandomBytes(
     google::cloud::kms::v1::GenerateRandomBytesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateRandomBytes(request);
 }
 

--- a/google/cloud/kms/key_management_client.h
+++ b/google/cloud/kms/key_management_client.h
@@ -74,7 +74,7 @@ class KeyManagementServiceClient {
  public:
   explicit KeyManagementServiceClient(
       std::shared_ptr<KeyManagementServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~KeyManagementServiceClient();
 
   //@{
@@ -105,7 +105,8 @@ class KeyManagementServiceClient {
   /// the
   ///  [KeyRings][google.cloud.kms.v1.KeyRing], in the format
   ///  `projects/*/locations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::KeyRing,google/cloud/kms/v1/resources.proto#L35}
   ///
@@ -115,14 +116,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L35}
   ///
   StreamRange<google::cloud::kms::v1::KeyRing> ListKeyRings(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [KeyRings][google.cloud.kms.v1.KeyRing].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::ListKeyRingsRequest,google/cloud/kms/v1/service.proto#L337}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::KeyRing,google/cloud/kms/v1/resources.proto#L35}
   ///
@@ -132,8 +134,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L35}
   ///
   StreamRange<google::cloud::kms::v1::KeyRing> ListKeyRings(
-      google::cloud::kms::v1::ListKeyRingsRequest request,
-      Options options = {});
+      google::cloud::kms::v1::ListKeyRingsRequest request, Options opts = {});
 
   ///
   /// Lists [CryptoKeys][google.cloud.kms.v1.CryptoKey].
@@ -141,7 +142,8 @@ class KeyManagementServiceClient {
   /// @param parent  Required. The resource name of the
   /// [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format
   ///  `projects/*/locations/*/keyRings/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -151,14 +153,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L54}
   ///
   StreamRange<google::cloud::kms::v1::CryptoKey> ListCryptoKeys(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [CryptoKeys][google.cloud.kms.v1.CryptoKey].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::ListCryptoKeysRequest,google/cloud/kms/v1/service.proto#L371}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -168,8 +171,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L54}
   ///
   StreamRange<google::cloud::kms::v1::CryptoKey> ListCryptoKeys(
-      google::cloud::kms::v1::ListCryptoKeysRequest request,
-      Options options = {});
+      google::cloud::kms::v1::ListCryptoKeysRequest request, Options opts = {});
 
   ///
   /// Lists [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].
@@ -177,7 +179,8 @@ class KeyManagementServiceClient {
   /// @param parent  Required. The resource name of the
   /// [CryptoKey][google.cloud.kms.v1.CryptoKey] to list, in the format
   ///  `projects/*/locations/*/keyRings/*/cryptoKeys/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -187,14 +190,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L214}
   ///
   StreamRange<google::cloud::kms::v1::CryptoKeyVersion> ListCryptoKeyVersions(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [CryptoKeyVersions][google.cloud.kms.v1.CryptoKeyVersion].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::ListCryptoKeyVersionsRequest,google/cloud/kms/v1/service.proto#L408}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -205,7 +209,7 @@ class KeyManagementServiceClient {
   ///
   StreamRange<google::cloud::kms::v1::CryptoKeyVersion> ListCryptoKeyVersions(
       google::cloud::kms::v1::ListCryptoKeyVersionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists [ImportJobs][google.cloud.kms.v1.ImportJob].
@@ -213,7 +217,8 @@ class KeyManagementServiceClient {
   /// @param parent  Required. The resource name of the
   /// [KeyRing][google.cloud.kms.v1.KeyRing] to list, in the format
   ///  `projects/*/locations/*/keyRings/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::ImportJob,google/cloud/kms/v1/resources.proto#L528}
   ///
@@ -223,14 +228,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L528}
   ///
   StreamRange<google::cloud::kms::v1::ImportJob> ListImportJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [ImportJobs][google.cloud.kms.v1.ImportJob].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::ListImportJobsRequest,google/cloud/kms/v1/service.proto#L446}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::ImportJob,google/cloud/kms/v1/resources.proto#L528}
   ///
@@ -240,15 +246,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L528}
   ///
   StreamRange<google::cloud::kms::v1::ImportJob> ListImportJobs(
-      google::cloud::kms::v1::ListImportJobsRequest request,
-      Options options = {});
+      google::cloud::kms::v1::ListImportJobsRequest request, Options opts = {});
 
   ///
   /// Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].
   ///
   /// @param name  Required. The [name][google.cloud.kms.v1.KeyRing.name] of the
   /// [KeyRing][google.cloud.kms.v1.KeyRing] to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::KeyRing,google/cloud/kms/v1/resources.proto#L35}
   ///
@@ -258,14 +264,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L35}
   ///
   StatusOr<google::cloud::kms::v1::KeyRing> GetKeyRing(std::string const& name,
-                                                       Options options = {});
+                                                       Options opts = {});
 
   ///
   /// Returns metadata for a given [KeyRing][google.cloud.kms.v1.KeyRing].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::GetKeyRingRequest,google/cloud/kms/v1/service.proto#L534}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::KeyRing,google/cloud/kms/v1/resources.proto#L35}
   ///
@@ -276,7 +283,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::KeyRing> GetKeyRing(
       google::cloud::kms::v1::GetKeyRingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey],
@@ -285,7 +292,8 @@ class KeyManagementServiceClient {
   ///
   /// @param name  Required. The [name][google.cloud.kms.v1.CryptoKey.name] of
   /// the [CryptoKey][google.cloud.kms.v1.CryptoKey] to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -295,7 +303,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L54}
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> GetCryptoKey(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns metadata for a given [CryptoKey][google.cloud.kms.v1.CryptoKey],
@@ -304,7 +312,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::GetCryptoKeyRequest,google/cloud/kms/v1/service.proto#L545}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -315,7 +324,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> GetCryptoKey(
       google::cloud::kms::v1::GetCryptoKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns metadata for a given
@@ -324,7 +333,8 @@ class KeyManagementServiceClient {
   /// @param name  Required. The
   /// [name][google.cloud.kms.v1.CryptoKeyVersion.name] of the
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -334,7 +344,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L214}
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> GetCryptoKeyVersion(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns metadata for a given
@@ -342,7 +352,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::GetCryptoKeyVersionRequest,google/cloud/kms/v1/service.proto#L556}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -353,7 +364,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> GetCryptoKeyVersion(
       google::cloud::kms::v1::GetCryptoKeyVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the public key for the given
@@ -367,7 +378,8 @@ class KeyManagementServiceClient {
   /// [name][google.cloud.kms.v1.CryptoKeyVersion.name] of the
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] public key to
   ///  get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::PublicKey,google/cloud/kms/v1/resources.proto#L459}
   ///
@@ -377,7 +389,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L459}
   ///
   StatusOr<google::cloud::kms::v1::PublicKey> GetPublicKey(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns the public key for the given
@@ -389,7 +401,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::GetPublicKeyRequest,google/cloud/kms/v1/service.proto#L567}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::PublicKey,google/cloud/kms/v1/resources.proto#L459}
   ///
@@ -400,14 +413,15 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::PublicKey> GetPublicKey(
       google::cloud::kms::v1::GetPublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].
   ///
   /// @param name  Required. The [name][google.cloud.kms.v1.ImportJob.name] of
   /// the [ImportJob][google.cloud.kms.v1.ImportJob] to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::ImportJob,google/cloud/kms/v1/resources.proto#L528}
   ///
@@ -417,14 +431,15 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L528}
   ///
   StatusOr<google::cloud::kms::v1::ImportJob> GetImportJob(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns metadata for a given [ImportJob][google.cloud.kms.v1.ImportJob].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::GetImportJobRequest,google/cloud/kms/v1/service.proto#L579}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::ImportJob,google/cloud/kms/v1/resources.proto#L528}
   ///
@@ -435,7 +450,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::ImportJob> GetImportJob(
       google::cloud::kms::v1::GetImportJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and
@@ -450,7 +465,8 @@ class KeyManagementServiceClient {
   ///  expression `[a-zA-Z0-9_-]{1,63}`
   /// @param key_ring  Required. A [KeyRing][google.cloud.kms.v1.KeyRing] with
   /// initial field values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::KeyRing,google/cloud/kms/v1/resources.proto#L35}
   ///
@@ -461,7 +477,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::KeyRing> CreateKeyRing(
       std::string const& parent, std::string const& key_ring_id,
-      google::cloud::kms::v1::KeyRing const& key_ring, Options options = {});
+      google::cloud::kms::v1::KeyRing const& key_ring, Options opts = {});
 
   ///
   /// Create a new [KeyRing][google.cloud.kms.v1.KeyRing] in a given Project and
@@ -469,7 +485,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::CreateKeyRingRequest,google/cloud/kms/v1/service.proto#L590}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::KeyRing,google/cloud/kms/v1/resources.proto#L35}
   ///
@@ -480,7 +497,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::KeyRing> CreateKeyRing(
       google::cloud::kms::v1::CreateKeyRingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a
@@ -498,7 +515,8 @@ class KeyManagementServiceClient {
   ///  expression `[a-zA-Z0-9_-]{1,63}`
   /// @param crypto_key  Required. A [CryptoKey][google.cloud.kms.v1.CryptoKey]
   /// with initial field values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -509,8 +527,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> CreateCryptoKey(
       std::string const& parent, std::string const& crypto_key_id,
-      google::cloud::kms::v1::CryptoKey const& crypto_key,
-      Options options = {});
+      google::cloud::kms::v1::CryptoKey const& crypto_key, Options opts = {});
 
   ///
   /// Create a new [CryptoKey][google.cloud.kms.v1.CryptoKey] within a
@@ -522,7 +539,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::CreateCryptoKeyRequest,google/cloud/kms/v1/service.proto#L609}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -533,7 +551,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> CreateCryptoKey(
       google::cloud::kms::v1::CreateCryptoKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a
@@ -549,7 +567,8 @@ class KeyManagementServiceClient {
   /// @param crypto_key_version  Required. A
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] with initial
   /// field values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -561,7 +580,7 @@ class KeyManagementServiceClient {
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> CreateCryptoKeyVersion(
       std::string const& parent,
       google::cloud::kms::v1::CryptoKeyVersion const& crypto_key_version,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in a
@@ -573,7 +592,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::CreateCryptoKeyVersionRequest,google/cloud/kms/v1/service.proto#L635}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -584,7 +604,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> CreateCryptoKeyVersion(
       google::cloud::kms::v1::CreateCryptoKeyVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Import wrapped key material into a
@@ -599,7 +619,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::ImportCryptoKeyVersionRequest,google/cloud/kms/v1/service.proto#L650}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -610,7 +631,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> ImportCryptoKeyVersion(
       google::cloud::kms::v1::ImportCryptoKeyVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new [ImportJob][google.cloud.kms.v1.ImportJob] within a
@@ -627,7 +648,8 @@ class KeyManagementServiceClient {
   ///  expression `[a-zA-Z0-9_-]{1,63}`
   /// @param import_job  Required. An [ImportJob][google.cloud.kms.v1.ImportJob]
   /// with initial field values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::ImportJob,google/cloud/kms/v1/resources.proto#L528}
   ///
@@ -638,8 +660,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::ImportJob> CreateImportJob(
       std::string const& parent, std::string const& import_job_id,
-      google::cloud::kms::v1::ImportJob const& import_job,
-      Options options = {});
+      google::cloud::kms::v1::ImportJob const& import_job, Options opts = {});
 
   ///
   /// Create a new [ImportJob][google.cloud.kms.v1.ImportJob] within a
@@ -650,7 +671,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::CreateImportJobRequest,google/cloud/kms/v1/service.proto#L724}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::ImportJob,google/cloud/kms/v1/resources.proto#L528}
   ///
@@ -661,7 +683,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::ImportJob> CreateImportJob(
       google::cloud::kms::v1::CreateImportJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].
@@ -670,7 +692,8 @@ class KeyManagementServiceClient {
   /// with updated values.
   /// @param update_mask  Required. List of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -681,14 +704,15 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> UpdateCryptoKey(
       google::cloud::kms::v1::CryptoKey const& crypto_key,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a [CryptoKey][google.cloud.kms.v1.CryptoKey].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::UpdateCryptoKeyRequest,google/cloud/kms/v1/service.proto#L743}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -699,7 +723,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> UpdateCryptoKey(
       google::cloud::kms::v1::UpdateCryptoKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s
@@ -720,7 +744,8 @@ class KeyManagementServiceClient {
   /// values.
   /// @param update_mask  Required. List of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -731,7 +756,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> UpdateCryptoKeyVersion(
       google::cloud::kms::v1::CryptoKeyVersion const& crypto_key_version,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s
@@ -749,7 +774,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::UpdateCryptoKeyVersionRequest,google/cloud/kms/v1/service.proto#L752}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -760,7 +786,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> UpdateCryptoKeyVersion(
       google::cloud::kms::v1::UpdateCryptoKeyVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that
@@ -775,7 +801,8 @@ class KeyManagementServiceClient {
   /// @param crypto_key_version_id  Required. The id of the child
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to use as
   /// primary.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -786,7 +813,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKey> UpdateCryptoKeyPrimaryVersion(
       std::string const& name, std::string const& crypto_key_version_id,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update the version of a [CryptoKey][google.cloud.kms.v1.CryptoKey] that
@@ -798,7 +825,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest,google/cloud/kms/v1/service.proto#L761}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKey,google/cloud/kms/v1/resources.proto#L54}
   ///
@@ -810,7 +838,7 @@ class KeyManagementServiceClient {
   StatusOr<google::cloud::kms::v1::CryptoKey> UpdateCryptoKeyPrimaryVersion(
       google::cloud::kms::v1::UpdateCryptoKeyPrimaryVersionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for
@@ -837,7 +865,8 @@ class KeyManagementServiceClient {
   ///
   /// @param name  Required. The resource name of the
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to destroy.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -847,7 +876,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L214}
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> DestroyCryptoKeyVersion(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Schedule a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] for
@@ -874,7 +903,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::DestroyCryptoKeyVersionRequest,google/cloud/kms/v1/service.proto#L775}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -885,7 +915,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> DestroyCryptoKeyVersion(
       google::cloud::kms::v1::DestroyCryptoKeyVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Restore a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in the
@@ -900,7 +930,8 @@ class KeyManagementServiceClient {
   ///
   /// @param name  Required. The resource name of the
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] to restore.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -910,7 +941,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/resources.proto#L214}
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> RestoreCryptoKeyVersion(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Restore a [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion] in the
@@ -925,7 +956,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::RestoreCryptoKeyVersionRequest,google/cloud/kms/v1/service.proto#L786}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::CryptoKeyVersion,google/cloud/kms/v1/resources.proto#L214}
   ///
@@ -936,7 +968,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::CryptoKeyVersion> RestoreCryptoKeyVersion(
       google::cloud::kms::v1::RestoreCryptoKeyVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Encrypts data, so that it can only be recovered by a call to
@@ -959,7 +991,8 @@ class KeyManagementServiceClient {
   ///  [HSM][google.cloud.kms.v1.ProtectionLevel.HSM] keys, the combined length
   ///  of the plaintext and additional_authenticated_data fields must be no
   ///  larger than 8KiB.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::EncryptResponse,google/cloud/kms/v1/service.proto#L1090}
   ///
@@ -969,8 +1002,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1090}
   ///
   StatusOr<google::cloud::kms::v1::EncryptResponse> Encrypt(
-      std::string const& name, std::string const& plaintext,
-      Options options = {});
+      std::string const& name, std::string const& plaintext, Options opts = {});
 
   ///
   /// Encrypts data, so that it can only be recovered by a call to
@@ -980,7 +1012,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::EncryptRequest,google/cloud/kms/v1/service.proto#L797}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::EncryptResponse,google/cloud/kms/v1/service.proto#L1090}
   ///
@@ -990,8 +1023,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1090}
   ///
   StatusOr<google::cloud::kms::v1::EncryptResponse> Encrypt(
-      google::cloud::kms::v1::EncryptRequest const& request,
-      Options options = {});
+      google::cloud::kms::v1::EncryptRequest const& request, Options opts = {});
 
   ///
   /// Decrypts data that was protected by
@@ -1004,7 +1036,8 @@ class KeyManagementServiceClient {
   ///  The server will choose the appropriate version.
   /// @param ciphertext  Required. The encrypted data originally returned in
   ///  [EncryptResponse.ciphertext][google.cloud.kms.v1.EncryptResponse.ciphertext].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::DecryptResponse,google/cloud/kms/v1/service.proto#L1137}
   ///
@@ -1015,7 +1048,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::DecryptResponse> Decrypt(
       std::string const& name, std::string const& ciphertext,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Decrypts data that was protected by
@@ -1025,7 +1058,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::DecryptRequest,google/cloud/kms/v1/service.proto#L864}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::DecryptResponse,google/cloud/kms/v1/service.proto#L1137}
   ///
@@ -1035,8 +1069,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1137}
   ///
   StatusOr<google::cloud::kms::v1::DecryptResponse> Decrypt(
-      google::cloud::kms::v1::DecryptRequest const& request,
-      Options options = {});
+      google::cloud::kms::v1::DecryptRequest const& request, Options opts = {});
 
   ///
   /// Signs data using a
@@ -1053,7 +1086,8 @@ class KeyManagementServiceClient {
   /// be produced with
   ///  the same digest algorithm as specified by the key version's
   ///  [algorithm][google.cloud.kms.v1.CryptoKeyVersion.algorithm].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::AsymmetricSignResponse,google/cloud/kms/v1/service.proto#L1164}
   ///
@@ -1064,7 +1098,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::AsymmetricSignResponse> AsymmetricSign(
       std::string const& name, google::cloud::kms::v1::Digest const& digest,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Signs data using a
@@ -1076,7 +1110,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::AsymmetricSignRequest,google/cloud/kms/v1/service.proto#L915}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::AsymmetricSignResponse,google/cloud/kms/v1/service.proto#L1164}
   ///
@@ -1087,7 +1122,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::AsymmetricSignResponse> AsymmetricSign(
       google::cloud::kms::v1::AsymmetricSignRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Decrypts data that was encrypted with a public key retrieved from
@@ -1103,7 +1138,8 @@ class KeyManagementServiceClient {
   /// @param ciphertext  Required. The data encrypted with the named
   /// [CryptoKeyVersion][google.cloud.kms.v1.CryptoKeyVersion]'s public
   ///  key using OAEP.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::AsymmetricDecryptResponse,google/cloud/kms/v1/service.proto#L1210}
   ///
@@ -1114,7 +1150,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::AsymmetricDecryptResponse> AsymmetricDecrypt(
       std::string const& name, std::string const& ciphertext,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Decrypts data that was encrypted with a public key retrieved from
@@ -1126,7 +1162,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::AsymmetricDecryptRequest,google/cloud/kms/v1/service.proto#L966}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::AsymmetricDecryptResponse,google/cloud/kms/v1/service.proto#L1210}
   ///
@@ -1137,7 +1174,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::AsymmetricDecryptResponse> AsymmetricDecrypt(
       google::cloud::kms::v1::AsymmetricDecryptRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Signs data using a
@@ -1151,7 +1188,8 @@ class KeyManagementServiceClient {
   /// @param data  Required. The data to sign. The MAC tag is computed over this
   /// data field based on
   ///  the specific algorithm.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::MacSignResponse,google/cloud/kms/v1/service.proto#L1242}
   ///
@@ -1161,7 +1199,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1242}
   ///
   StatusOr<google::cloud::kms::v1::MacSignResponse> MacSign(
-      std::string const& name, std::string const& data, Options options = {});
+      std::string const& name, std::string const& data, Options opts = {});
 
   ///
   /// Signs data using a
@@ -1171,7 +1209,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::MacSignRequest,google/cloud/kms/v1/service.proto#L997}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::MacSignResponse,google/cloud/kms/v1/service.proto#L1242}
   ///
@@ -1181,8 +1220,7 @@ class KeyManagementServiceClient {
   /// @googleapis_reference_link{google/cloud/kms/v1/service.proto#L1242}
   ///
   StatusOr<google::cloud::kms::v1::MacSignResponse> MacSign(
-      google::cloud::kms::v1::MacSignRequest const& request,
-      Options options = {});
+      google::cloud::kms::v1::MacSignRequest const& request, Options opts = {});
 
   ///
   /// Verifies MAC tag using a
@@ -1199,7 +1237,8 @@ class KeyManagementServiceClient {
   /// the MAC
   ///  tag.
   /// @param mac  Required. The signature to verify.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::MacVerifyResponse,google/cloud/kms/v1/service.proto#L1278}
   ///
@@ -1210,7 +1249,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::MacVerifyResponse> MacVerify(
       std::string const& name, std::string const& data, std::string const& mac,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Verifies MAC tag using a
@@ -1221,7 +1260,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::MacVerifyRequest,google/cloud/kms/v1/service.proto#L1027}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::MacVerifyResponse,google/cloud/kms/v1/service.proto#L1278}
   ///
@@ -1232,7 +1272,7 @@ class KeyManagementServiceClient {
   ///
   StatusOr<google::cloud::kms::v1::MacVerifyResponse> MacVerify(
       google::cloud::kms::v1::MacVerifyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Generate random bytes using the Cloud KMS randomness source in the
@@ -1248,7 +1288,8 @@ class KeyManagementServiceClient {
   /// [ProtectionLevel][google.cloud.kms.v1.ProtectionLevel] to use when
   /// generating the random data. Defaults to
   ///  [SOFTWARE][google.cloud.kms.v1.ProtectionLevel.SOFTWARE].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::GenerateRandomBytesResponse,google/cloud/kms/v1/service.proto#L1319}
   ///
@@ -1260,7 +1301,7 @@ class KeyManagementServiceClient {
   StatusOr<google::cloud::kms::v1::GenerateRandomBytesResponse>
   GenerateRandomBytes(std::string const& location, std::int32_t length_bytes,
                       google::cloud::kms::v1::ProtectionLevel protection_level,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Generate random bytes using the Cloud KMS randomness source in the
@@ -1268,7 +1309,8 @@ class KeyManagementServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::kms::v1::GenerateRandomBytesRequest,google/cloud/kms/v1/service.proto#L1075}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::kms::v1::GenerateRandomBytesResponse,google/cloud/kms/v1/service.proto#L1319}
   ///
@@ -1280,7 +1322,7 @@ class KeyManagementServiceClient {
   StatusOr<google::cloud::kms::v1::GenerateRandomBytesResponse>
   GenerateRandomBytes(
       google::cloud::kms::v1::GenerateRandomBytesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<KeyManagementServiceConnection> connection_;

--- a/google/cloud/language/language_client.cc
+++ b/google/cloud/language/language_client.cc
@@ -26,19 +26,18 @@ namespace language {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LanguageServiceClient::LanguageServiceClient(
-    std::shared_ptr<LanguageServiceConnection> connection, Options options)
+    std::shared_ptr<LanguageServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), language_internal::LanguageServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), language_internal::LanguageServiceDefaultOptions(
+                               connection_->options()))) {}
 LanguageServiceClient::~LanguageServiceClient() = default;
 
 StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
 LanguageServiceClient::AnalyzeSentiment(
     google::cloud::language::v1::Document const& document,
-    google::cloud::language::v1::EncodingType encoding_type, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::EncodingType encoding_type, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeSentimentRequest request;
   *request.mutable_document() = document;
   request.set_encoding_type(encoding_type);
@@ -47,9 +46,8 @@ LanguageServiceClient::AnalyzeSentiment(
 
 StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
 LanguageServiceClient::AnalyzeSentiment(
-    google::cloud::language::v1::Document const& document, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::Document const& document, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeSentimentRequest request;
   *request.mutable_document() = document;
   return connection_->AnalyzeSentiment(request);
@@ -58,18 +56,16 @@ LanguageServiceClient::AnalyzeSentiment(
 StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
 LanguageServiceClient::AnalyzeSentiment(
     google::cloud::language::v1::AnalyzeSentimentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeSentiment(request);
 }
 
 StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>
 LanguageServiceClient::AnalyzeEntities(
     google::cloud::language::v1::Document const& document,
-    google::cloud::language::v1::EncodingType encoding_type, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::EncodingType encoding_type, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeEntitiesRequest request;
   *request.mutable_document() = document;
   request.set_encoding_type(encoding_type);
@@ -78,9 +74,8 @@ LanguageServiceClient::AnalyzeEntities(
 
 StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>
 LanguageServiceClient::AnalyzeEntities(
-    google::cloud::language::v1::Document const& document, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::Document const& document, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeEntitiesRequest request;
   *request.mutable_document() = document;
   return connection_->AnalyzeEntities(request);
@@ -89,18 +84,16 @@ LanguageServiceClient::AnalyzeEntities(
 StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>
 LanguageServiceClient::AnalyzeEntities(
     google::cloud::language::v1::AnalyzeEntitiesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeEntities(request);
 }
 
 StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>
 LanguageServiceClient::AnalyzeEntitySentiment(
     google::cloud::language::v1::Document const& document,
-    google::cloud::language::v1::EncodingType encoding_type, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::EncodingType encoding_type, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeEntitySentimentRequest request;
   *request.mutable_document() = document;
   request.set_encoding_type(encoding_type);
@@ -109,9 +102,8 @@ LanguageServiceClient::AnalyzeEntitySentiment(
 
 StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>
 LanguageServiceClient::AnalyzeEntitySentiment(
-    google::cloud::language::v1::Document const& document, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::Document const& document, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeEntitySentimentRequest request;
   *request.mutable_document() = document;
   return connection_->AnalyzeEntitySentiment(request);
@@ -120,18 +112,16 @@ LanguageServiceClient::AnalyzeEntitySentiment(
 StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>
 LanguageServiceClient::AnalyzeEntitySentiment(
     google::cloud::language::v1::AnalyzeEntitySentimentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeEntitySentiment(request);
 }
 
 StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse>
 LanguageServiceClient::AnalyzeSyntax(
     google::cloud::language::v1::Document const& document,
-    google::cloud::language::v1::EncodingType encoding_type, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::EncodingType encoding_type, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeSyntaxRequest request;
   *request.mutable_document() = document;
   request.set_encoding_type(encoding_type);
@@ -140,9 +130,8 @@ LanguageServiceClient::AnalyzeSyntax(
 
 StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse>
 LanguageServiceClient::AnalyzeSyntax(
-    google::cloud::language::v1::Document const& document, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::Document const& document, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnalyzeSyntaxRequest request;
   *request.mutable_document() = document;
   return connection_->AnalyzeSyntax(request);
@@ -151,17 +140,15 @@ LanguageServiceClient::AnalyzeSyntax(
 StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse>
 LanguageServiceClient::AnalyzeSyntax(
     google::cloud::language::v1::AnalyzeSyntaxRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnalyzeSyntax(request);
 }
 
 StatusOr<google::cloud::language::v1::ClassifyTextResponse>
 LanguageServiceClient::ClassifyText(
-    google::cloud::language::v1::Document const& document, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::Document const& document, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::ClassifyTextRequest request;
   *request.mutable_document() = document;
   return connection_->ClassifyText(request);
@@ -170,9 +157,8 @@ LanguageServiceClient::ClassifyText(
 StatusOr<google::cloud::language::v1::ClassifyTextResponse>
 LanguageServiceClient::ClassifyText(
     google::cloud::language::v1::ClassifyTextRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ClassifyText(request);
 }
 
@@ -180,9 +166,8 @@ StatusOr<google::cloud::language::v1::AnnotateTextResponse>
 LanguageServiceClient::AnnotateText(
     google::cloud::language::v1::Document const& document,
     google::cloud::language::v1::AnnotateTextRequest::Features const& features,
-    google::cloud::language::v1::EncodingType encoding_type, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::language::v1::EncodingType encoding_type, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnnotateTextRequest request;
   *request.mutable_document() = document;
   *request.mutable_features() = features;
@@ -194,9 +179,8 @@ StatusOr<google::cloud::language::v1::AnnotateTextResponse>
 LanguageServiceClient::AnnotateText(
     google::cloud::language::v1::Document const& document,
     google::cloud::language::v1::AnnotateTextRequest::Features const& features,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::language::v1::AnnotateTextRequest request;
   *request.mutable_document() = document;
   *request.mutable_features() = features;
@@ -206,9 +190,8 @@ LanguageServiceClient::AnnotateText(
 StatusOr<google::cloud::language::v1::AnnotateTextResponse>
 LanguageServiceClient::AnnotateText(
     google::cloud::language::v1::AnnotateTextRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnnotateText(request);
 }
 

--- a/google/cloud/language/language_client.h
+++ b/google/cloud/language/language_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LanguageServiceClient {
  public:
   explicit LanguageServiceClient(
-      std::shared_ptr<LanguageServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<LanguageServiceConnection> connection, Options opts = {});
   ~LanguageServiceClient();
 
   //@{
@@ -92,7 +91,8 @@ class LanguageServiceClient {
   /// @param document  Input document.
   /// @param encoding_type  The encoding type used by the API to calculate
   /// sentence offsets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSentimentResponse,google/cloud/language/v1/language_service.proto#L975}
   ///
@@ -104,13 +104,14 @@ class LanguageServiceClient {
   StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
   AnalyzeSentiment(google::cloud::language::v1::Document const& document,
                    google::cloud::language::v1::EncodingType encoding_type,
-                   Options options = {});
+                   Options opts = {});
 
   ///
   /// Analyzes the sentiment of the provided text.
   ///
   /// @param document  Input document.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSentimentResponse,google/cloud/language/v1/language_service.proto#L975}
   ///
@@ -121,14 +122,15 @@ class LanguageServiceClient {
   ///
   StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
   AnalyzeSentiment(google::cloud::language::v1::Document const& document,
-                   Options options = {});
+                   Options opts = {});
 
   ///
   /// Analyzes the sentiment of the provided text.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSentimentRequest,google/cloud/language/v1/language_service.proto#L966}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSentimentResponse,google/cloud/language/v1/language_service.proto#L975}
   ///
@@ -140,7 +142,7 @@ class LanguageServiceClient {
   StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
   AnalyzeSentiment(
       google::cloud::language::v1::AnalyzeSentimentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Finds named entities (currently proper names and common nouns) in the text
@@ -150,7 +152,8 @@ class LanguageServiceClient {
   /// @param document  Input document.
   /// @param encoding_type  The encoding type used by the API to calculate
   /// offsets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitiesResponse,google/cloud/language/v1/language_service.proto#L1018}
   ///
@@ -162,7 +165,7 @@ class LanguageServiceClient {
   StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>
   AnalyzeEntities(google::cloud::language::v1::Document const& document,
                   google::cloud::language::v1::EncodingType encoding_type,
-                  Options options = {});
+                  Options opts = {});
 
   ///
   /// Finds named entities (currently proper names and common nouns) in the text
@@ -170,7 +173,8 @@ class LanguageServiceClient {
   /// other properties.
   ///
   /// @param document  Input document.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitiesResponse,google/cloud/language/v1/language_service.proto#L1018}
   ///
@@ -181,7 +185,7 @@ class LanguageServiceClient {
   ///
   StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>
   AnalyzeEntities(google::cloud::language::v1::Document const& document,
-                  Options options = {});
+                  Options opts = {});
 
   ///
   /// Finds named entities (currently proper names and common nouns) in the text
@@ -190,7 +194,8 @@ class LanguageServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitiesRequest,google/cloud/language/v1/language_service.proto#L1009}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitiesResponse,google/cloud/language/v1/language_service.proto#L1018}
   ///
@@ -202,7 +207,7 @@ class LanguageServiceClient {
   StatusOr<google::cloud::language::v1::AnalyzeEntitiesResponse>
   AnalyzeEntities(
       google::cloud::language::v1::AnalyzeEntitiesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Finds entities, similar to
@@ -213,7 +218,8 @@ class LanguageServiceClient {
   /// @param document  Input document.
   /// @param encoding_type  The encoding type used by the API to calculate
   /// offsets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitySentimentResponse,google/cloud/language/v1/language_service.proto#L998}
   ///
@@ -226,7 +232,7 @@ class LanguageServiceClient {
   AnalyzeEntitySentiment(
       google::cloud::language::v1::Document const& document,
       google::cloud::language::v1::EncodingType encoding_type,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Finds entities, similar to
@@ -235,7 +241,8 @@ class LanguageServiceClient {
   /// mentions.
   ///
   /// @param document  Input document.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitySentimentResponse,google/cloud/language/v1/language_service.proto#L998}
   ///
@@ -246,7 +253,7 @@ class LanguageServiceClient {
   ///
   StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>
   AnalyzeEntitySentiment(google::cloud::language::v1::Document const& document,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Finds entities, similar to
@@ -256,7 +263,8 @@ class LanguageServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitySentimentRequest,google/cloud/language/v1/language_service.proto#L989}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeEntitySentimentResponse,google/cloud/language/v1/language_service.proto#L998}
   ///
@@ -268,7 +276,7 @@ class LanguageServiceClient {
   StatusOr<google::cloud::language::v1::AnalyzeEntitySentimentResponse>
   AnalyzeEntitySentiment(
       google::cloud::language::v1::AnalyzeEntitySentimentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Analyzes the syntax of the text and provides sentence boundaries and
@@ -278,7 +286,8 @@ class LanguageServiceClient {
   /// @param document  Input document.
   /// @param encoding_type  The encoding type used by the API to calculate
   /// offsets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSyntaxResponse,google/cloud/language/v1/language_service.proto#L1038}
   ///
@@ -290,7 +299,7 @@ class LanguageServiceClient {
   StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse> AnalyzeSyntax(
       google::cloud::language::v1::Document const& document,
       google::cloud::language::v1::EncodingType encoding_type,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Analyzes the syntax of the text and provides sentence boundaries and
@@ -298,7 +307,8 @@ class LanguageServiceClient {
   /// properties.
   ///
   /// @param document  Input document.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSyntaxResponse,google/cloud/language/v1/language_service.proto#L1038}
   ///
@@ -308,8 +318,7 @@ class LanguageServiceClient {
   /// @googleapis_reference_link{google/cloud/language/v1/language_service.proto#L1038}
   ///
   StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse> AnalyzeSyntax(
-      google::cloud::language::v1::Document const& document,
-      Options options = {});
+      google::cloud::language::v1::Document const& document, Options opts = {});
 
   ///
   /// Analyzes the syntax of the text and provides sentence boundaries and
@@ -318,7 +327,8 @@ class LanguageServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSyntaxRequest,google/cloud/language/v1/language_service.proto#L1029}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnalyzeSyntaxResponse,google/cloud/language/v1/language_service.proto#L1038}
   ///
@@ -329,13 +339,14 @@ class LanguageServiceClient {
   ///
   StatusOr<google::cloud::language::v1::AnalyzeSyntaxResponse> AnalyzeSyntax(
       google::cloud::language::v1::AnalyzeSyntaxRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Classifies a document into categories.
   ///
   /// @param document  Input document.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::ClassifyTextResponse,google/cloud/language/v1/language_service.proto#L1058}
   ///
@@ -345,15 +356,15 @@ class LanguageServiceClient {
   /// @googleapis_reference_link{google/cloud/language/v1/language_service.proto#L1058}
   ///
   StatusOr<google::cloud::language::v1::ClassifyTextResponse> ClassifyText(
-      google::cloud::language::v1::Document const& document,
-      Options options = {});
+      google::cloud::language::v1::Document const& document, Options opts = {});
 
   ///
   /// Classifies a document into categories.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::language::v1::ClassifyTextRequest,google/cloud/language/v1/language_service.proto#L1052}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::ClassifyTextResponse,google/cloud/language/v1/language_service.proto#L1058}
   ///
@@ -364,7 +375,7 @@ class LanguageServiceClient {
   ///
   StatusOr<google::cloud::language::v1::ClassifyTextResponse> ClassifyText(
       google::cloud::language::v1::ClassifyTextRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// A convenience method that provides all the features that analyzeSentiment,
@@ -374,7 +385,8 @@ class LanguageServiceClient {
   /// @param features  The enabled features.
   /// @param encoding_type  The encoding type used by the API to calculate
   /// offsets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnnotateTextResponse,google/cloud/language/v1/language_service.proto#L1096}
   ///
@@ -388,7 +400,7 @@ class LanguageServiceClient {
       google::cloud::language::v1::AnnotateTextRequest::Features const&
           features,
       google::cloud::language::v1::EncodingType encoding_type,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// A convenience method that provides all the features that analyzeSentiment,
@@ -396,7 +408,8 @@ class LanguageServiceClient {
   ///
   /// @param document  Input document.
   /// @param features  The enabled features.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnnotateTextResponse,google/cloud/language/v1/language_service.proto#L1096}
   ///
@@ -409,7 +422,7 @@ class LanguageServiceClient {
       google::cloud::language::v1::Document const& document,
       google::cloud::language::v1::AnnotateTextRequest::Features const&
           features,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// A convenience method that provides all the features that analyzeSentiment,
@@ -417,7 +430,8 @@ class LanguageServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::language::v1::AnnotateTextRequest,google/cloud/language/v1/language_service.proto#L1065}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::language::v1::AnnotateTextResponse,google/cloud/language/v1/language_service.proto#L1096}
   ///
@@ -428,7 +442,7 @@ class LanguageServiceClient {
   ///
   StatusOr<google::cloud::language::v1::AnnotateTextResponse> AnnotateText(
       google::cloud::language::v1::AnnotateTextRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<LanguageServiceConnection> connection_;

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -26,26 +26,24 @@ namespace logging {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LoggingServiceV2Client::LoggingServiceV2Client(
-    std::shared_ptr<LoggingServiceV2Connection> connection, Options options)
+    std::shared_ptr<LoggingServiceV2Connection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), logging_internal::LoggingServiceV2DefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), logging_internal::LoggingServiceV2DefaultOptions(
+                               connection_->options()))) {}
 LoggingServiceV2Client::~LoggingServiceV2Client() = default;
 
 Status LoggingServiceV2Client::DeleteLog(std::string const& log_name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::logging::v2::DeleteLogRequest request;
   request.set_log_name(log_name);
   return connection_->DeleteLog(request);
 }
 
 Status LoggingServiceV2Client::DeleteLog(
-    google::logging::v2::DeleteLogRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::logging::v2::DeleteLogRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteLog(request);
 }
 
@@ -53,10 +51,8 @@ StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
     std::string const& log_name, google::api::MonitoredResource const& resource,
     std::map<std::string, std::string> const& labels,
-    std::vector<google::logging::v2::LogEntry> const& entries,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<google::logging::v2::LogEntry> const& entries, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::logging::v2::WriteLogEntriesRequest request;
   request.set_log_name(log_name);
   *request.mutable_resource() = resource;
@@ -67,19 +63,16 @@ LoggingServiceV2Client::WriteLogEntries(
 
 StatusOr<google::logging::v2::WriteLogEntriesResponse>
 LoggingServiceV2Client::WriteLogEntries(
-    google::logging::v2::WriteLogEntriesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::logging::v2::WriteLogEntriesRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->WriteLogEntries(request);
 }
 
 StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
     std::vector<std::string> const& resource_names, std::string const& filter,
-    std::string const& order_by, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& order_by, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::logging::v2::ListLogEntriesRequest request;
   *request.mutable_resource_names() = {resource_names.begin(),
                                        resource_names.end()};
@@ -90,43 +83,38 @@ LoggingServiceV2Client::ListLogEntries(
 
 StreamRange<google::logging::v2::LogEntry>
 LoggingServiceV2Client::ListLogEntries(
-    google::logging::v2::ListLogEntriesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::logging::v2::ListLogEntriesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListLogEntries(std::move(request));
 }
 
 StreamRange<google::api::MonitoredResourceDescriptor>
 LoggingServiceV2Client::ListMonitoredResourceDescriptors(
     google::logging::v2::ListMonitoredResourceDescriptorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMonitoredResourceDescriptors(std::move(request));
 }
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::logging::v2::ListLogsRequest request;
   request.set_parent(parent);
   return connection_->ListLogs(request);
 }
 
 StreamRange<std::string> LoggingServiceV2Client::ListLogs(
-    google::logging::v2::ListLogsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::logging::v2::ListLogsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListLogs(std::move(request));
 }
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::logging::v2::TailLogEntriesRequest,
     google::logging::v2::TailLogEntriesResponse>>
-LoggingServiceV2Client::AsyncTailLogEntries(Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+LoggingServiceV2Client::AsyncTailLogEntries(Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncTailLogEntries();
 }
 

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -63,7 +63,7 @@ class LoggingServiceV2Client {
  public:
   explicit LoggingServiceV2Client(
       std::shared_ptr<LoggingServiceV2Connection> connection,
-      Options options = {});
+      Options opts = {});
   ~LoggingServiceV2Client();
 
   //@{
@@ -102,12 +102,13 @@ class LoggingServiceV2Client {
   ///  `"organizations/1234567890/logs/cloudresourcemanager.googleapis.com%2Factivity"`.
   ///  For more information about log names, see
   ///  [LogEntry][google.logging.v2.LogEntry].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
   ///
-  Status DeleteLog(std::string const& log_name, Options options = {});
+  Status DeleteLog(std::string const& log_name, Options opts = {});
 
   ///
   /// Deletes all the log entries in a log. The log reappears if it receives new
@@ -117,13 +118,14 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::DeleteLogRequest,google/logging/v2/logging.proto#L140}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.logging.v2.DeleteLogRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L140}
   ///
   Status DeleteLog(google::logging::v2::DeleteLogRequest const& request,
-                   Options options = {});
+                   Options opts = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -182,7 +184,8 @@ class LoggingServiceV2Client {
   ///  [quota limit](https://cloud.google.com/logging/quota-policy) for calls to
   ///  `entries.write`, you should try to include several log entries in this
   ///  list, rather than calling this method for each individual log entry.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
@@ -196,7 +199,7 @@ class LoggingServiceV2Client {
       google::api::MonitoredResource const& resource,
       std::map<std::string, std::string> const& labels,
       std::vector<google::logging::v2::LogEntry> const& entries,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Writes log entries to Logging. This API method is the
@@ -209,7 +212,8 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::WriteLogEntriesRequest,google/logging/v2/logging.proto#L162}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::logging::v2::WriteLogEntriesResponse,google/logging/v2/logging.proto#L243}
   ///
@@ -220,7 +224,7 @@ class LoggingServiceV2Client {
   ///
   StatusOr<google::logging::v2::WriteLogEntriesResponse> WriteLogEntries(
       google::logging::v2::WriteLogEntriesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists log entries.  Use this method to retrieve log entries that
@@ -257,7 +261,8 @@ class LoggingServiceV2Client {
   ///  `LogEntry.timestamp` (oldest first), and the second option returns
   ///  entries in order of decreasing timestamps (newest first).  Entries with
   ///  equal timestamps are returned in order of their `insert_id` values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
@@ -268,7 +273,7 @@ class LoggingServiceV2Client {
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
       std::vector<std::string> const& resource_names, std::string const& filter,
-      std::string const& order_by, Options options = {});
+      std::string const& order_by, Options opts = {});
 
   ///
   /// Lists log entries.  Use this method to retrieve log entries that
@@ -278,7 +283,8 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::ListLogEntriesRequest,google/logging/v2/logging.proto#L257}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::logging::v2::LogEntry,google/logging/v2/log_entry.proto#L42}
   ///
@@ -288,14 +294,15 @@ class LoggingServiceV2Client {
   /// @googleapis_reference_link{google/logging/v2/log_entry.proto#L42}
   ///
   StreamRange<google::logging::v2::LogEntry> ListLogEntries(
-      google::logging::v2::ListLogEntriesRequest request, Options options = {});
+      google::logging::v2::ListLogEntriesRequest request, Options opts = {});
 
   ///
   /// Lists the descriptors for monitored resource types used by Logging.
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::ListMonitoredResourceDescriptorsRequest,google/logging/v2/logging.proto#L331}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
@@ -307,7 +314,7 @@ class LoggingServiceV2Client {
   StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
       google::logging::v2::ListMonitoredResourceDescriptorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -318,14 +325,15 @@ class LoggingServiceV2Client {
   ///      "organizations/[ORGANIZATION_ID]"
   ///      "billingAccounts/[BILLING_ACCOUNT_ID]"
   ///      "folders/[FOLDER_ID]"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.logging.v2.ListLogsRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
   ///
   StreamRange<std::string> ListLogs(std::string const& parent,
-                                    Options options = {});
+                                    Options opts = {});
 
   ///
   /// Lists the logs in projects, organizations, folders, or billing accounts.
@@ -333,19 +341,20 @@ class LoggingServiceV2Client {
   ///
   /// @param request
   /// @googleapis_link{google::logging::v2::ListLogsRequest,google/logging/v2/logging.proto#L356}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.logging.v2.ListLogsRequest]:
   /// @googleapis_reference_link{google/logging/v2/logging.proto#L356}
   ///
   StreamRange<std::string> ListLogs(
-      google::logging::v2::ListLogsRequest request, Options options = {});
+      google::logging::v2::ListLogsRequest request, Options opts = {});
 
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::logging::v2::TailLogEntriesRequest,
       google::logging::v2::TailLogEntriesResponse>>
-  AsyncTailLogEntries(Options options = {});
+  AsyncTailLogEntries(Options opts = {});
 
  private:
   std::shared_ptr<LoggingServiceV2Connection> connection_;

--- a/google/cloud/managedidentities/managed_identities_client.cc
+++ b/google/cloud/managedidentities/managed_identities_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ManagedIdentitiesServiceClient::ManagedIdentitiesServiceClient(
     std::shared_ptr<ManagedIdentitiesServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           managedidentities_internal::ManagedIdentitiesServiceDefaultOptions(
               connection_->options()))) {}
 ManagedIdentitiesServiceClient::~ManagedIdentitiesServiceClient() = default;
@@ -38,10 +38,8 @@ ManagedIdentitiesServiceClient::~ManagedIdentitiesServiceClient() = default;
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::CreateMicrosoftAdDomain(
     std::string const& parent, std::string const& domain_name,
-    google::cloud::managedidentities::v1::Domain const& domain,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::managedidentities::v1::Domain const& domain, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::CreateMicrosoftAdDomainRequest request;
   request.set_parent(parent);
   request.set_domain_name(domain_name);
@@ -53,17 +51,15 @@ future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::CreateMicrosoftAdDomain(
     google::cloud::managedidentities::v1::CreateMicrosoftAdDomainRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMicrosoftAdDomain(request);
 }
 
 StatusOr<google::cloud::managedidentities::v1::ResetAdminPasswordResponse>
 ManagedIdentitiesServiceClient::ResetAdminPassword(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::ResetAdminPasswordRequest request;
   request.set_name(name);
   return connection_->ResetAdminPassword(request);
@@ -73,17 +69,15 @@ StatusOr<google::cloud::managedidentities::v1::ResetAdminPasswordResponse>
 ManagedIdentitiesServiceClient::ResetAdminPassword(
     google::cloud::managedidentities::v1::ResetAdminPasswordRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResetAdminPassword(request);
 }
 
 StreamRange<google::cloud::managedidentities::v1::Domain>
 ManagedIdentitiesServiceClient::ListDomains(std::string const& parent,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::ListDomainsRequest request;
   request.set_parent(parent);
   return connection_->ListDomains(request);
@@ -92,17 +86,15 @@ ManagedIdentitiesServiceClient::ListDomains(std::string const& parent,
 StreamRange<google::cloud::managedidentities::v1::Domain>
 ManagedIdentitiesServiceClient::ListDomains(
     google::cloud::managedidentities::v1::ListDomainsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDomains(std::move(request));
 }
 
 StatusOr<google::cloud::managedidentities::v1::Domain>
 ManagedIdentitiesServiceClient::GetDomain(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::GetDomainRequest request;
   request.set_name(name);
   return connection_->GetDomain(request);
@@ -111,18 +103,16 @@ ManagedIdentitiesServiceClient::GetDomain(std::string const& name,
 StatusOr<google::cloud::managedidentities::v1::Domain>
 ManagedIdentitiesServiceClient::GetDomain(
     google::cloud::managedidentities::v1::GetDomainRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDomain(request);
 }
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::UpdateDomain(
     google::cloud::managedidentities::v1::Domain const& domain,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::UpdateDomainRequest request;
   *request.mutable_domain() = domain;
   *request.mutable_update_mask() = update_mask;
@@ -132,17 +122,15 @@ ManagedIdentitiesServiceClient::UpdateDomain(
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::UpdateDomain(
     google::cloud::managedidentities::v1::UpdateDomainRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDomain(request);
 }
 
 future<StatusOr<google::cloud::managedidentities::v1::OpMetadata>>
 ManagedIdentitiesServiceClient::DeleteDomain(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::DeleteDomainRequest request;
   request.set_name(name);
   return connection_->DeleteDomain(request);
@@ -151,18 +139,16 @@ ManagedIdentitiesServiceClient::DeleteDomain(std::string const& name,
 future<StatusOr<google::cloud::managedidentities::v1::OpMetadata>>
 ManagedIdentitiesServiceClient::DeleteDomain(
     google::cloud::managedidentities::v1::DeleteDomainRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDomain(request);
 }
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::AttachTrust(
     std::string const& name,
-    google::cloud::managedidentities::v1::Trust const& trust, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::managedidentities::v1::Trust const& trust, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::AttachTrustRequest request;
   request.set_name(name);
   *request.mutable_trust() = trust;
@@ -172,18 +158,16 @@ ManagedIdentitiesServiceClient::AttachTrust(
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::AttachTrust(
     google::cloud::managedidentities::v1::AttachTrustRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AttachTrust(request);
 }
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::ReconfigureTrust(
     std::string const& name, std::string const& target_domain_name,
-    std::vector<std::string> const& target_dns_ip_addresses, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<std::string> const& target_dns_ip_addresses, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::ReconfigureTrustRequest request;
   request.set_name(name);
   request.set_target_domain_name(target_domain_name);
@@ -196,18 +180,16 @@ future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::ReconfigureTrust(
     google::cloud::managedidentities::v1::ReconfigureTrustRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReconfigureTrust(request);
 }
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::DetachTrust(
     std::string const& name,
-    google::cloud::managedidentities::v1::Trust const& trust, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::managedidentities::v1::Trust const& trust, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::DetachTrustRequest request;
   request.set_name(name);
   *request.mutable_trust() = trust;
@@ -217,18 +199,16 @@ ManagedIdentitiesServiceClient::DetachTrust(
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::DetachTrust(
     google::cloud::managedidentities::v1::DetachTrustRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DetachTrust(request);
 }
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::ValidateTrust(
     std::string const& name,
-    google::cloud::managedidentities::v1::Trust const& trust, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::managedidentities::v1::Trust const& trust, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::managedidentities::v1::ValidateTrustRequest request;
   request.set_name(name);
   *request.mutable_trust() = trust;
@@ -238,9 +218,8 @@ ManagedIdentitiesServiceClient::ValidateTrust(
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceClient::ValidateTrust(
     google::cloud::managedidentities::v1::ValidateTrustRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ValidateTrust(request);
 }
 

--- a/google/cloud/managedidentities/managed_identities_client.h
+++ b/google/cloud/managedidentities/managed_identities_client.h
@@ -96,7 +96,7 @@ class ManagedIdentitiesServiceClient {
  public:
   explicit ManagedIdentitiesServiceClient(
       std::shared_ptr<ManagedIdentitiesServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ManagedIdentitiesServiceClient();
 
   //@{
@@ -140,7 +140,8 @@ class ManagedIdentitiesServiceClient {
   ///   * The last segment cannot be fully numeric.
   ///   * Must be unique within the customer project.
   /// @param domain  Required. A Managed Identity domain resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -153,14 +154,15 @@ class ManagedIdentitiesServiceClient {
   CreateMicrosoftAdDomain(
       std::string const& parent, std::string const& domain_name,
       google::cloud::managedidentities::v1::Domain const& domain,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Microsoft AD domain.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::CreateMicrosoftAdDomainRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L217}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -172,14 +174,15 @@ class ManagedIdentitiesServiceClient {
   future<StatusOr<google::cloud::managedidentities::v1::Domain>>
   CreateMicrosoftAdDomain(google::cloud::managedidentities::v1::
                               CreateMicrosoftAdDomainRequest const& request,
-                          Options options = {});
+                          Options opts = {});
 
   ///
   /// Resets a domain's administrator password.
   ///
   /// @param name  Required. The domain resource name using the form:
   ///  `projects/{project_id}/locations/global/domains/{domain_name}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::ResetAdminPasswordResponse,google/cloud/managedidentities/v1/managed_identities_service.proto#L260}
   ///
@@ -189,14 +192,15 @@ class ManagedIdentitiesServiceClient {
   /// @googleapis_reference_link{google/cloud/managedidentities/v1/managed_identities_service.proto#L260}
   ///
   StatusOr<google::cloud::managedidentities::v1::ResetAdminPasswordResponse>
-  ResetAdminPassword(std::string const& name, Options options = {});
+  ResetAdminPassword(std::string const& name, Options opts = {});
 
   ///
   /// Resets a domain's administrator password.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::ResetAdminPasswordRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L247}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::ResetAdminPasswordResponse,google/cloud/managedidentities/v1/managed_identities_service.proto#L260}
   ///
@@ -209,7 +213,7 @@ class ManagedIdentitiesServiceClient {
   ResetAdminPassword(
       google::cloud::managedidentities::v1::ResetAdminPasswordRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists domains in a project.
@@ -217,7 +221,8 @@ class ManagedIdentitiesServiceClient {
   /// @param parent  Required. The resource name of the domain location using
   /// the form:
   ///  `projects/{project_id}/locations/global`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -227,14 +232,15 @@ class ManagedIdentitiesServiceClient {
   /// @googleapis_reference_link{google/cloud/managedidentities/v1/resource.proto#L34}
   ///
   StreamRange<google::cloud::managedidentities::v1::Domain> ListDomains(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists domains in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::ListDomainsRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L267}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -245,14 +251,15 @@ class ManagedIdentitiesServiceClient {
   ///
   StreamRange<google::cloud::managedidentities::v1::Domain> ListDomains(
       google::cloud::managedidentities::v1::ListDomainsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information about a domain.
   ///
   /// @param name  Required. The domain resource name using the form:
   ///  `projects/{project_id}/locations/global/domains/{domain_name}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -262,14 +269,15 @@ class ManagedIdentitiesServiceClient {
   /// @googleapis_reference_link{google/cloud/managedidentities/v1/resource.proto#L34}
   ///
   StatusOr<google::cloud::managedidentities::v1::Domain> GetDomain(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information about a domain.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::GetDomainRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L315}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -280,7 +288,7 @@ class ManagedIdentitiesServiceClient {
   ///
   StatusOr<google::cloud::managedidentities::v1::Domain> GetDomain(
       google::cloud::managedidentities::v1::GetDomainRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the metadata and configuration of a domain.
@@ -295,7 +303,8 @@ class ManagedIdentitiesServiceClient {
   ///   * `labels`
   ///   * `locations`
   ///   * `authorized_networks`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -306,14 +315,15 @@ class ManagedIdentitiesServiceClient {
   ///
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> UpdateDomain(
       google::cloud::managedidentities::v1::Domain const& domain,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the metadata and configuration of a domain.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::UpdateDomainRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L328}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -324,14 +334,15 @@ class ManagedIdentitiesServiceClient {
   ///
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> UpdateDomain(
       google::cloud::managedidentities::v1::UpdateDomainRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a domain.
   ///
   /// @param name  Required. The domain resource name using the form:
   ///  `projects/{project_id}/locations/global/domains/{domain_name}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::OpMetadata,google/cloud/managedidentities/v1/managed_identities_service.proto#L192}
   ///
@@ -341,14 +352,15 @@ class ManagedIdentitiesServiceClient {
   /// @googleapis_reference_link{google/cloud/managedidentities/v1/managed_identities_service.proto#L192}
   ///
   future<StatusOr<google::cloud::managedidentities::v1::OpMetadata>>
-  DeleteDomain(std::string const& name, Options options = {});
+  DeleteDomain(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a domain.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::DeleteDomainRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L344}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::OpMetadata,google/cloud/managedidentities/v1/managed_identities_service.proto#L192}
   ///
@@ -360,7 +372,7 @@ class ManagedIdentitiesServiceClient {
   future<StatusOr<google::cloud::managedidentities::v1::OpMetadata>>
   DeleteDomain(
       google::cloud::managedidentities::v1::DeleteDomainRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds an AD trust to a domain.
@@ -369,7 +381,8 @@ class ManagedIdentitiesServiceClient {
   /// using the form:
   ///  `projects/{project_id}/locations/global/domains/{domain_name}`
   /// @param trust  Required. The domain trust resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -381,14 +394,15 @@ class ManagedIdentitiesServiceClient {
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> AttachTrust(
       std::string const& name,
       google::cloud::managedidentities::v1::Trust const& trust,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds an AD trust to a domain.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::AttachTrustRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L357}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -399,7 +413,7 @@ class ManagedIdentitiesServiceClient {
   ///
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> AttachTrust(
       google::cloud::managedidentities::v1::AttachTrustRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the DNS conditional forwarder.
@@ -413,7 +427,8 @@ class ManagedIdentitiesServiceClient {
   /// @param target_dns_ip_addresses  Required. The target DNS server IP
   /// addresses to resolve the remote domain involved
   ///  in the trust.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -426,14 +441,15 @@ class ManagedIdentitiesServiceClient {
   ReconfigureTrust(std::string const& name,
                    std::string const& target_domain_name,
                    std::vector<std::string> const& target_dns_ip_addresses,
-                   Options options = {});
+                   Options opts = {});
 
   ///
   /// Updates the DNS conditional forwarder.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::ReconfigureTrustRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L373}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -446,7 +462,7 @@ class ManagedIdentitiesServiceClient {
   ReconfigureTrust(
       google::cloud::managedidentities::v1::ReconfigureTrustRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes an AD trust.
@@ -455,7 +471,8 @@ class ManagedIdentitiesServiceClient {
   /// location using the form:
   ///  `projects/{project_id}/locations/global/domains/{domain_name}`
   /// @param trust  Required. The domain trust resource to removed.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -467,14 +484,15 @@ class ManagedIdentitiesServiceClient {
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> DetachTrust(
       std::string const& name,
       google::cloud::managedidentities::v1::Trust const& trust,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes an AD trust.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::DetachTrustRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L394}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -485,7 +503,7 @@ class ManagedIdentitiesServiceClient {
   ///
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> DetachTrust(
       google::cloud::managedidentities::v1::DetachTrustRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Validates a trust state, that the target domain is reachable, and that the
@@ -495,7 +513,8 @@ class ManagedIdentitiesServiceClient {
   /// location using the form:
   ///  `projects/{project_id}/locations/global/domains/{domain_name}`
   /// @param trust  Required. The domain trust to validate trust state for.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -507,7 +526,7 @@ class ManagedIdentitiesServiceClient {
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> ValidateTrust(
       std::string const& name,
       google::cloud::managedidentities::v1::Trust const& trust,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Validates a trust state, that the target domain is reachable, and that the
@@ -515,7 +534,8 @@ class ManagedIdentitiesServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::managedidentities::v1::ValidateTrustRequest,google/cloud/managedidentities/v1/managed_identities_service.proto#L410}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::managedidentities::v1::Domain,google/cloud/managedidentities/v1/resource.proto#L34}
   ///
@@ -526,7 +546,7 @@ class ManagedIdentitiesServiceClient {
   ///
   future<StatusOr<google::cloud::managedidentities::v1::Domain>> ValidateTrust(
       google::cloud::managedidentities::v1::ValidateTrustRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ManagedIdentitiesServiceConnection> connection_;

--- a/google/cloud/memcache/cloud_memcache_client.cc
+++ b/google/cloud/memcache/cloud_memcache_client.cc
@@ -26,17 +26,16 @@ namespace memcache {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudMemcacheClient::CloudMemcacheClient(
-    std::shared_ptr<CloudMemcacheConnection> connection, Options options)
+    std::shared_ptr<CloudMemcacheConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), memcache_internal::CloudMemcacheDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), memcache_internal::CloudMemcacheDefaultOptions(
+                               connection_->options()))) {}
 CloudMemcacheClient::~CloudMemcacheClient() = default;
 
 StreamRange<google::cloud::memcache::v1::Instance>
-CloudMemcacheClient::ListInstances(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudMemcacheClient::ListInstances(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
@@ -44,17 +43,14 @@ CloudMemcacheClient::ListInstances(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::memcache::v1::Instance>
 CloudMemcacheClient::ListInstances(
-    google::cloud::memcache::v1::ListInstancesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::memcache::v1::ListInstancesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::cloud::memcache::v1::Instance>
-CloudMemcacheClient::GetInstance(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudMemcacheClient::GetInstance(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -63,9 +59,8 @@ CloudMemcacheClient::GetInstance(std::string const& name, Options options) {
 StatusOr<google::cloud::memcache::v1::Instance>
 CloudMemcacheClient::GetInstance(
     google::cloud::memcache::v1::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
@@ -73,9 +68,8 @@ future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::CreateInstance(
     std::string const& parent,
     google::cloud::memcache::v1::Instance const& instance,
-    std::string const& instance_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& instance_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::CreateInstanceRequest request;
   request.set_parent(parent);
   *request.mutable_instance() = instance;
@@ -86,18 +80,16 @@ CloudMemcacheClient::CreateInstance(
 future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::CreateInstance(
     google::cloud::memcache::v1::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
 future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::UpdateInstance(
     google::cloud::memcache::v1::Instance const& instance,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::UpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_update_mask() = update_mask;
@@ -107,9 +99,8 @@ CloudMemcacheClient::UpdateInstance(
 future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::UpdateInstance(
     google::cloud::memcache::v1::UpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstance(request);
 }
 
@@ -117,9 +108,8 @@ future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::UpdateParameters(
     std::string const& name, google::protobuf::FieldMask const& update_mask,
     google::cloud::memcache::v1::MemcacheParameters const& parameters,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::UpdateParametersRequest request;
   request.set_name(name);
   *request.mutable_update_mask() = update_mask;
@@ -130,16 +120,14 @@ CloudMemcacheClient::UpdateParameters(
 future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::UpdateParameters(
     google::cloud::memcache::v1::UpdateParametersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateParameters(request);
 }
 
 future<StatusOr<google::cloud::memcache::v1::OperationMetadata>>
-CloudMemcacheClient::DeleteInstance(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudMemcacheClient::DeleteInstance(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -148,18 +136,16 @@ CloudMemcacheClient::DeleteInstance(std::string const& name, Options options) {
 future<StatusOr<google::cloud::memcache::v1::OperationMetadata>>
 CloudMemcacheClient::DeleteInstance(
     google::cloud::memcache::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
 future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::ApplyParameters(std::string const& name,
                                      std::vector<std::string> const& node_ids,
-                                     bool apply_all, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                     bool apply_all, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::memcache::v1::ApplyParametersRequest request;
   request.set_name(name);
   *request.mutable_node_ids() = {node_ids.begin(), node_ids.end()};
@@ -170,9 +156,8 @@ CloudMemcacheClient::ApplyParameters(std::string const& name,
 future<StatusOr<google::cloud::memcache::v1::Instance>>
 CloudMemcacheClient::ApplyParameters(
     google::cloud::memcache::v1::ApplyParametersRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ApplyParameters(request);
 }
 

--- a/google/cloud/memcache/cloud_memcache_client.h
+++ b/google/cloud/memcache/cloud_memcache_client.h
@@ -79,8 +79,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudMemcacheClient {
  public:
   explicit CloudMemcacheClient(
-      std::shared_ptr<CloudMemcacheConnection> connection,
-      Options options = {});
+      std::shared_ptr<CloudMemcacheConnection> connection, Options opts = {});
   ~CloudMemcacheClient();
 
   //@{
@@ -110,7 +109,8 @@ class CloudMemcacheClient {
   /// the form:
   ///      `projects/{project_id}/locations/{location_id}`
   ///  where `location_id` refers to a GCP region
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -120,14 +120,15 @@ class CloudMemcacheClient {
   /// @googleapis_reference_link{google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
   StreamRange<google::cloud::memcache::v1::Instance> ListInstances(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Instances in a given location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::ListInstancesRequest,google/cloud/memcache/v1/cloud_memcache.proto#L299}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -138,7 +139,7 @@ class CloudMemcacheClient {
   ///
   StreamRange<google::cloud::memcache::v1::Instance> ListInstances(
       google::cloud::memcache::v1::ListInstancesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Instance.
@@ -146,7 +147,8 @@ class CloudMemcacheClient {
   /// @param name  Required. Memcached instance resource name in the format:
   ///      `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
   ///  where `location_id` refers to a GCP region
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -156,14 +158,15 @@ class CloudMemcacheClient {
   /// @googleapis_reference_link{google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
   StatusOr<google::cloud::memcache::v1::Instance> GetInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::GetInstanceRequest,google/cloud/memcache/v1/cloud_memcache.proto#L349}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -174,7 +177,7 @@ class CloudMemcacheClient {
   ///
   StatusOr<google::cloud::memcache::v1::Instance> GetInstance(
       google::cloud::memcache::v1::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Instance in a given location.
@@ -193,7 +196,8 @@ class CloudMemcacheClient {
   ///  * Must end with a number or a letter.
   ///  * Must be unique within the user project / location
   ///  If any of the above are not met, will raise an invalid argument error.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -205,14 +209,15 @@ class CloudMemcacheClient {
   future<StatusOr<google::cloud::memcache::v1::Instance>> CreateInstance(
       std::string const& parent,
       google::cloud::memcache::v1::Instance const& instance,
-      std::string const& instance_id, Options options = {});
+      std::string const& instance_id, Options opts = {});
 
   ///
   /// Creates a new Instance in a given location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::CreateInstanceRequest,google/cloud/memcache/v1/cloud_memcache.proto#L362}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -223,7 +228,7 @@ class CloudMemcacheClient {
   ///
   future<StatusOr<google::cloud::memcache::v1::Instance>> CreateInstance(
       google::cloud::memcache::v1::CreateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing Instance in a given project and location.
@@ -232,7 +237,8 @@ class CloudMemcacheClient {
   ///  Only fields specified in update_mask are updated.
   /// @param update_mask  Required. Mask of fields to update.
   ///   *   `displayName`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -243,14 +249,15 @@ class CloudMemcacheClient {
   ///
   future<StatusOr<google::cloud::memcache::v1::Instance>> UpdateInstance(
       google::cloud::memcache::v1::Instance const& instance,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing Instance in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::UpdateInstanceRequest,google/cloud/memcache/v1/cloud_memcache.proto#L390}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -261,7 +268,7 @@ class CloudMemcacheClient {
   ///
   future<StatusOr<google::cloud::memcache::v1::Instance>> UpdateInstance(
       google::cloud::memcache::v1::UpdateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the defined Memcached Parameters for an existing Instance.
@@ -274,7 +281,8 @@ class CloudMemcacheClient {
   ///  updated.
   /// @param update_mask  Required. Mask of fields to update.
   /// @param parameters  The parameters to apply to the instance.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -286,7 +294,7 @@ class CloudMemcacheClient {
   future<StatusOr<google::cloud::memcache::v1::Instance>> UpdateParameters(
       std::string const& name, google::protobuf::FieldMask const& update_mask,
       google::cloud::memcache::v1::MemcacheParameters const& parameters,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the defined Memcached Parameters for an existing Instance.
@@ -296,7 +304,8 @@ class CloudMemcacheClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::UpdateParametersRequest,google/cloud/memcache/v1/cloud_memcache.proto#L434}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -307,7 +316,7 @@ class CloudMemcacheClient {
   ///
   future<StatusOr<google::cloud::memcache::v1::Instance>> UpdateParameters(
       google::cloud::memcache::v1::UpdateParametersRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Instance.
@@ -315,7 +324,8 @@ class CloudMemcacheClient {
   /// @param name  Required. Memcached instance resource name in the format:
   ///      `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
   ///  where `location_id` refers to a GCP region
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::OperationMetadata,google/cloud/memcache/v1/cloud_memcache.proto#L463}
   ///
@@ -325,14 +335,15 @@ class CloudMemcacheClient {
   /// @googleapis_reference_link{google/cloud/memcache/v1/cloud_memcache.proto#L463}
   ///
   future<StatusOr<google::cloud::memcache::v1::OperationMetadata>>
-  DeleteInstance(std::string const& name, Options options = {});
+  DeleteInstance(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::DeleteInstanceRequest,google/cloud/memcache/v1/cloud_memcache.proto#L401}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::OperationMetadata,google/cloud/memcache/v1/cloud_memcache.proto#L463}
   ///
@@ -344,7 +355,7 @@ class CloudMemcacheClient {
   future<StatusOr<google::cloud::memcache::v1::OperationMetadata>>
   DeleteInstance(
       google::cloud::memcache::v1::DeleteInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// ApplyParameters will restart the set of specified nodes in order to update
@@ -359,7 +370,8 @@ class CloudMemcacheClient {
   /// nodes. If set to
   ///  true, will explicitly restrict users from specifying any nodes, and apply
   ///  parameter group updates to all nodes within the instance.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -370,7 +382,7 @@ class CloudMemcacheClient {
   ///
   future<StatusOr<google::cloud::memcache::v1::Instance>> ApplyParameters(
       std::string const& name, std::vector<std::string> const& node_ids,
-      bool apply_all, Options options = {});
+      bool apply_all, Options opts = {});
 
   ///
   /// ApplyParameters will restart the set of specified nodes in order to update
@@ -378,7 +390,8 @@ class CloudMemcacheClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::memcache::v1::ApplyParametersRequest,google/cloud/memcache/v1/cloud_memcache.proto#L414}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::memcache::v1::Instance,google/cloud/memcache/v1/cloud_memcache.proto#L135}
   ///
@@ -389,7 +402,7 @@ class CloudMemcacheClient {
   ///
   future<StatusOr<google::cloud::memcache::v1::Instance>> ApplyParameters(
       google::cloud::memcache::v1::ApplyParametersRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudMemcacheConnection> connection_;

--- a/google/cloud/monitoring/alert_policy_client.cc
+++ b/google/cloud/monitoring/alert_policy_client.cc
@@ -26,19 +26,18 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AlertPolicyServiceClient::AlertPolicyServiceClient(
-    std::shared_ptr<AlertPolicyServiceConnection> connection, Options options)
+    std::shared_ptr<AlertPolicyServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           monitoring_internal::AlertPolicyServiceDefaultOptions(
               connection_->options()))) {}
 AlertPolicyServiceClient::~AlertPolicyServiceClient() = default;
 
 StreamRange<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::ListAlertPolicies(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListAlertPoliciesRequest request;
   request.set_name(name);
   return connection_->ListAlertPolicies(request);
@@ -46,17 +45,15 @@ AlertPolicyServiceClient::ListAlertPolicies(std::string const& name,
 
 StreamRange<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::ListAlertPolicies(
-    google::monitoring::v3::ListAlertPoliciesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::ListAlertPoliciesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAlertPolicies(std::move(request));
 }
 
 StatusOr<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::GetAlertPolicy(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetAlertPolicyRequest request;
   request.set_name(name);
   return connection_->GetAlertPolicy(request);
@@ -65,18 +62,16 @@ AlertPolicyServiceClient::GetAlertPolicy(std::string const& name,
 StatusOr<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::GetAlertPolicy(
     google::monitoring::v3::GetAlertPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAlertPolicy(request);
 }
 
 StatusOr<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::CreateAlertPolicy(
     std::string const& name,
-    google::monitoring::v3::AlertPolicy const& alert_policy, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::AlertPolicy const& alert_policy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateAlertPolicyRequest request;
   request.set_name(name);
   *request.mutable_alert_policy() = alert_policy;
@@ -86,16 +81,14 @@ AlertPolicyServiceClient::CreateAlertPolicy(
 StatusOr<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::CreateAlertPolicy(
     google::monitoring::v3::CreateAlertPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateAlertPolicy(request);
 }
 
 Status AlertPolicyServiceClient::DeleteAlertPolicy(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteAlertPolicyRequest request;
   request.set_name(name);
   return connection_->DeleteAlertPolicy(request);
@@ -103,18 +96,16 @@ Status AlertPolicyServiceClient::DeleteAlertPolicy(std::string const& name,
 
 Status AlertPolicyServiceClient::DeleteAlertPolicy(
     google::monitoring::v3::DeleteAlertPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteAlertPolicy(request);
 }
 
 StatusOr<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::UpdateAlertPolicy(
     google::protobuf::FieldMask const& update_mask,
-    google::monitoring::v3::AlertPolicy const& alert_policy, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::AlertPolicy const& alert_policy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::UpdateAlertPolicyRequest request;
   *request.mutable_update_mask() = update_mask;
   *request.mutable_alert_policy() = alert_policy;
@@ -124,9 +115,8 @@ AlertPolicyServiceClient::UpdateAlertPolicy(
 StatusOr<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceClient::UpdateAlertPolicy(
     google::monitoring::v3::UpdateAlertPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateAlertPolicy(request);
 }
 

--- a/google/cloud/monitoring/alert_policy_client.h
+++ b/google/cloud/monitoring/alert_policy_client.h
@@ -71,7 +71,7 @@ class AlertPolicyServiceClient {
  public:
   explicit AlertPolicyServiceClient(
       std::shared_ptr<AlertPolicyServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AlertPolicyServiceClient();
 
   //@{
@@ -107,7 +107,8 @@ class AlertPolicyServiceClient {
   ///  by name, use the
   ///  [GetAlertPolicy][google.monitoring.v3.AlertPolicyService.GetAlertPolicy]
   ///  operation, instead.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -117,14 +118,15 @@ class AlertPolicyServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/alert.proto#L39}
   ///
   StreamRange<google::monitoring::v3::AlertPolicy> ListAlertPolicies(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Lists the existing alerting policies for the workspace.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListAlertPoliciesRequest,google/monitoring/v3/alert_service.proto#L138}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -135,14 +137,15 @@ class AlertPolicyServiceClient {
   ///
   StreamRange<google::monitoring::v3::AlertPolicy> ListAlertPolicies(
       google::monitoring::v3::ListAlertPoliciesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single alerting policy.
   ///
   /// @param name  Required. The alerting policy to retrieve. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -152,14 +155,15 @@ class AlertPolicyServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/alert.proto#L39}
   ///
   StatusOr<google::monitoring::v3::AlertPolicy> GetAlertPolicy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a single alerting policy.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetAlertPolicyRequest,google/monitoring/v3/alert_service.proto#L125}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -170,7 +174,7 @@ class AlertPolicyServiceClient {
   ///
   StatusOr<google::monitoring::v3::AlertPolicy> GetAlertPolicy(
       google::monitoring::v3::GetAlertPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new alerting policy.
@@ -190,7 +194,8 @@ class AlertPolicyServiceClient {
   /// omit the `name` field in this
   ///  policy. The name will be returned in the new policy, including
   ///  a new `[ALERT_POLICY_ID]` value.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -202,14 +207,15 @@ class AlertPolicyServiceClient {
   StatusOr<google::monitoring::v3::AlertPolicy> CreateAlertPolicy(
       std::string const& name,
       google::monitoring::v3::AlertPolicy const& alert_policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new alerting policy.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateAlertPolicyRequest,google/monitoring/v3/alert_service.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -220,7 +226,7 @@ class AlertPolicyServiceClient {
   ///
   StatusOr<google::monitoring::v3::AlertPolicy> CreateAlertPolicy(
       google::monitoring::v3::CreateAlertPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an alerting policy.
@@ -229,26 +235,28 @@ class AlertPolicyServiceClient {
   ///      projects/[PROJECT_ID_OR_NUMBER]/alertPolicies/[ALERT_POLICY_ID]
   ///  For more information, see
   ///  [AlertPolicy][google.monitoring.v3.AlertPolicy].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteAlertPolicyRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/alert_service.proto#L228}
   ///
-  Status DeleteAlertPolicy(std::string const& name, Options options = {});
+  Status DeleteAlertPolicy(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an alerting policy.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteAlertPolicyRequest,google/monitoring/v3/alert_service.proto#L228}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteAlertPolicyRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/alert_service.proto#L228}
   ///
   Status DeleteAlertPolicy(
       google::monitoring::v3::DeleteAlertPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an alerting policy. You can either replace the entire policy with
@@ -281,7 +289,8 @@ class AlertPolicyServiceClient {
   ///  fields listed in `update_mask`.
   ///  If `update_mask` is not empty, any fields in this policy that are
   ///  not in `update_mask` are ignored.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -293,7 +302,7 @@ class AlertPolicyServiceClient {
   StatusOr<google::monitoring::v3::AlertPolicy> UpdateAlertPolicy(
       google::protobuf::FieldMask const& update_mask,
       google::monitoring::v3::AlertPolicy const& alert_policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an alerting policy. You can either replace the entire policy with
@@ -303,7 +312,8 @@ class AlertPolicyServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::UpdateAlertPolicyRequest,google/monitoring/v3/alert_service.proto#L196}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::AlertPolicy,google/monitoring/v3/alert.proto#L39}
   ///
@@ -314,7 +324,7 @@ class AlertPolicyServiceClient {
   ///
   StatusOr<google::monitoring::v3::AlertPolicy> UpdateAlertPolicy(
       google::monitoring::v3::UpdateAlertPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AlertPolicyServiceConnection> connection_;

--- a/google/cloud/monitoring/dashboards_client.cc
+++ b/google/cloud/monitoring/dashboards_client.cc
@@ -26,55 +26,49 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DashboardsServiceClient::DashboardsServiceClient(
-    std::shared_ptr<DashboardsServiceConnection> connection, Options options)
+    std::shared_ptr<DashboardsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          monitoring_internal::DashboardsServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), monitoring_internal::DashboardsServiceDefaultOptions(
+                               connection_->options()))) {}
 DashboardsServiceClient::~DashboardsServiceClient() = default;
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>
 DashboardsServiceClient::CreateDashboard(
     google::monitoring::dashboard::v1::CreateDashboardRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDashboard(request);
 }
 
 StreamRange<google::monitoring::dashboard::v1::Dashboard>
 DashboardsServiceClient::ListDashboards(
     google::monitoring::dashboard::v1::ListDashboardsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDashboards(std::move(request));
 }
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>
 DashboardsServiceClient::GetDashboard(
     google::monitoring::dashboard::v1::GetDashboardRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDashboard(request);
 }
 
 Status DashboardsServiceClient::DeleteDashboard(
     google::monitoring::dashboard::v1::DeleteDashboardRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDashboard(request);
 }
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>
 DashboardsServiceClient::UpdateDashboard(
     google::monitoring::dashboard::v1::UpdateDashboardRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDashboard(request);
 }
 

--- a/google/cloud/monitoring/dashboards_client.h
+++ b/google/cloud/monitoring/dashboards_client.h
@@ -63,7 +63,7 @@ class DashboardsServiceClient {
  public:
   explicit DashboardsServiceClient(
       std::shared_ptr<DashboardsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~DashboardsServiceClient();
 
   //@{
@@ -96,7 +96,8 @@ class DashboardsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::dashboard::v1::CreateDashboardRequest,google/monitoring/dashboard/v1/dashboards_service.proto#L101}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::dashboard::v1::Dashboard,google/monitoring/dashboard/v1/dashboard.proto#L33}
   ///
@@ -107,7 +108,7 @@ class DashboardsServiceClient {
   ///
   StatusOr<google::monitoring::dashboard::v1::Dashboard> CreateDashboard(
       google::monitoring::dashboard::v1::CreateDashboardRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the existing dashboards.
@@ -118,7 +119,8 @@ class DashboardsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::dashboard::v1::ListDashboardsRequest,google/monitoring/dashboard/v1/dashboards_service.proto#L118}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::dashboard::v1::Dashboard,google/monitoring/dashboard/v1/dashboard.proto#L33}
   ///
@@ -129,7 +131,7 @@ class DashboardsServiceClient {
   ///
   StreamRange<google::monitoring::dashboard::v1::Dashboard> ListDashboards(
       google::monitoring::dashboard::v1::ListDashboardsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Fetches a specific dashboard.
@@ -140,7 +142,8 @@ class DashboardsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::dashboard::v1::GetDashboardRequest,google/monitoring/dashboard/v1/dashboards_service.proto#L151}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::dashboard::v1::Dashboard,google/monitoring/dashboard/v1/dashboard.proto#L33}
   ///
@@ -151,7 +154,7 @@ class DashboardsServiceClient {
   ///
   StatusOr<google::monitoring::dashboard::v1::Dashboard> GetDashboard(
       google::monitoring::dashboard::v1::GetDashboardRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an existing custom dashboard.
@@ -162,14 +165,15 @@ class DashboardsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::dashboard::v1::DeleteDashboardRequest,google/monitoring/dashboard/v1/dashboards_service.proto#L166}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.dashboard.v1.DeleteDashboardRequest]:
   /// @googleapis_reference_link{google/monitoring/dashboard/v1/dashboards_service.proto#L166}
   ///
   Status DeleteDashboard(
       google::monitoring::dashboard::v1::DeleteDashboardRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Replaces an existing custom dashboard with a new definition.
@@ -180,7 +184,8 @@ class DashboardsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::dashboard::v1::UpdateDashboardRequest,google/monitoring/dashboard/v1/dashboards_service.proto#L179}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::dashboard::v1::Dashboard,google/monitoring/dashboard/v1/dashboard.proto#L33}
   ///
@@ -191,7 +196,7 @@ class DashboardsServiceClient {
   ///
   StatusOr<google::monitoring::dashboard::v1::Dashboard> UpdateDashboard(
       google::monitoring::dashboard::v1::UpdateDashboardRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DashboardsServiceConnection> connection_;

--- a/google/cloud/monitoring/group_client.cc
+++ b/google/cloud/monitoring/group_client.cc
@@ -26,50 +26,45 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 GroupServiceClient::GroupServiceClient(
-    std::shared_ptr<GroupServiceConnection> connection, Options options)
+    std::shared_ptr<GroupServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::GroupServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), monitoring_internal::GroupServiceDefaultOptions(
+                               connection_->options()))) {}
 GroupServiceClient::~GroupServiceClient() = default;
 
 StreamRange<google::monitoring::v3::Group> GroupServiceClient::ListGroups(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListGroupsRequest request;
   request.set_name(name);
   return connection_->ListGroups(request);
 }
 
 StreamRange<google::monitoring::v3::Group> GroupServiceClient::ListGroups(
-    google::monitoring::v3::ListGroupsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::ListGroupsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGroups(std::move(request));
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceClient::GetGroup(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetGroupRequest request;
   request.set_name(name);
   return connection_->GetGroup(request);
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceClient::GetGroup(
-    google::monitoring::v3::GetGroupRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::GetGroupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGroup(request);
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceClient::CreateGroup(
     std::string const& name, google::monitoring::v3::Group const& group,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateGroupRequest request;
   request.set_name(name);
   *request.mutable_group() = group;
@@ -77,51 +72,41 @@ StatusOr<google::monitoring::v3::Group> GroupServiceClient::CreateGroup(
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceClient::CreateGroup(
-    google::monitoring::v3::CreateGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::CreateGroupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGroup(request);
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceClient::UpdateGroup(
-    google::monitoring::v3::Group const& group, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::Group const& group, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::UpdateGroupRequest request;
   *request.mutable_group() = group;
   return connection_->UpdateGroup(request);
 }
 
 StatusOr<google::monitoring::v3::Group> GroupServiceClient::UpdateGroup(
-    google::monitoring::v3::UpdateGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::UpdateGroupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGroup(request);
 }
 
-Status GroupServiceClient::DeleteGroup(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status GroupServiceClient::DeleteGroup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteGroupRequest request;
   request.set_name(name);
   return connection_->DeleteGroup(request);
 }
 
 Status GroupServiceClient::DeleteGroup(
-    google::monitoring::v3::DeleteGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::DeleteGroupRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGroup(request);
 }
 
 StreamRange<google::api::MonitoredResource>
-GroupServiceClient::ListGroupMembers(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+GroupServiceClient::ListGroupMembers(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListGroupMembersRequest request;
   request.set_name(name);
   return connection_->ListGroupMembers(request);
@@ -129,9 +114,8 @@ GroupServiceClient::ListGroupMembers(std::string const& name, Options options) {
 
 StreamRange<google::api::MonitoredResource>
 GroupServiceClient::ListGroupMembers(
-    google::monitoring::v3::ListGroupMembersRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::ListGroupMembersRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGroupMembers(std::move(request));
 }
 

--- a/google/cloud/monitoring/group_client.h
+++ b/google/cloud/monitoring/group_client.h
@@ -72,7 +72,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class GroupServiceClient {
  public:
   explicit GroupServiceClient(
-      std::shared_ptr<GroupServiceConnection> connection, Options options = {});
+      std::shared_ptr<GroupServiceConnection> connection, Options opts = {});
   ~GroupServiceClient();
 
   //@{
@@ -102,7 +102,8 @@ class GroupServiceClient {
   /// [project](https://cloud.google.com/monitoring/api/v3#project_name)
   ///  whose groups are to be listed. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -112,14 +113,15 @@ class GroupServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/group.proto#L55}
   ///
   StreamRange<google::monitoring::v3::Group> ListGroups(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Lists the existing groups.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListGroupsRequest,google/monitoring/v3/group_service.proto#L108}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -129,14 +131,15 @@ class GroupServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/group.proto#L55}
   ///
   StreamRange<google::monitoring::v3::Group> ListGroups(
-      google::monitoring::v3::ListGroupsRequest request, Options options = {});
+      google::monitoring::v3::ListGroupsRequest request, Options opts = {});
 
   ///
   /// Gets a single group.
   ///
   /// @param name  Required. The group to retrieve. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -146,14 +149,15 @@ class GroupServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/group.proto#L55}
   ///
   StatusOr<google::monitoring::v3::Group> GetGroup(std::string const& name,
-                                                   Options options = {});
+                                                   Options opts = {});
 
   ///
   /// Gets a single group.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetGroupRequest,google/monitoring/v3/group_service.proto#L179}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -164,7 +168,7 @@ class GroupServiceClient {
   ///
   StatusOr<google::monitoring::v3::Group> GetGroup(
       google::monitoring::v3::GetGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new group.
@@ -176,7 +180,8 @@ class GroupServiceClient {
   /// @param group  Required. A group definition. It is an error to define the
   /// `name` field because
   ///  the system assigns the name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -187,14 +192,15 @@ class GroupServiceClient {
   ///
   StatusOr<google::monitoring::v3::Group> CreateGroup(
       std::string const& name, google::monitoring::v3::Group const& group,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new group.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateGroupRequest,google/monitoring/v3/group_service.proto#L192}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -205,7 +211,7 @@ class GroupServiceClient {
   ///
   StatusOr<google::monitoring::v3::Group> CreateGroup(
       google::monitoring::v3::CreateGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing group.
@@ -215,7 +221,8 @@ class GroupServiceClient {
   /// the existing group,
   ///  excepting `name`, are replaced with the corresponding fields of this
   ///  group.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -225,7 +232,7 @@ class GroupServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/group.proto#L55}
   ///
   StatusOr<google::monitoring::v3::Group> UpdateGroup(
-      google::monitoring::v3::Group const& group, Options options = {});
+      google::monitoring::v3::Group const& group, Options opts = {});
 
   ///
   /// Updates an existing group.
@@ -233,7 +240,8 @@ class GroupServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::UpdateGroupRequest,google/monitoring/v3/group_service.proto#L213}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Group,google/monitoring/v3/group.proto#L55}
   ///
@@ -244,39 +252,42 @@ class GroupServiceClient {
   ///
   StatusOr<google::monitoring::v3::Group> UpdateGroup(
       google::monitoring::v3::UpdateGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an existing group.
   ///
   /// @param name  Required. The group to delete. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteGroupRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/group_service.proto#L224}
   ///
-  Status DeleteGroup(std::string const& name, Options options = {});
+  Status DeleteGroup(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an existing group.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteGroupRequest,google/monitoring/v3/group_service.proto#L224}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteGroupRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/group_service.proto#L224}
   ///
   Status DeleteGroup(google::monitoring::v3::DeleteGroupRequest const& request,
-                     Options options = {});
+                     Options opts = {});
 
   ///
   /// Lists the monitored resources that are members of a group.
   ///
   /// @param name  Required. The group whose members are listed. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/groups/[GROUP_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResource,google/api/monitored_resource.proto#L85}
   ///
@@ -286,14 +297,15 @@ class GroupServiceClient {
   /// @googleapis_reference_link{google/api/monitored_resource.proto#L85}
   ///
   StreamRange<google::api::MonitoredResource> ListGroupMembers(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Lists the monitored resources that are members of a group.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListGroupMembersRequest,google/monitoring/v3/group_service.proto#L242}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResource,google/api/monitored_resource.proto#L85}
   ///
@@ -304,7 +316,7 @@ class GroupServiceClient {
   ///
   StreamRange<google::api::MonitoredResource> ListGroupMembers(
       google::monitoring::v3::ListGroupMembersRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<GroupServiceConnection> connection_;

--- a/google/cloud/monitoring/metric_client.cc
+++ b/google/cloud/monitoring/metric_client.cc
@@ -26,18 +26,17 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 MetricServiceClient::MetricServiceClient(
-    std::shared_ptr<MetricServiceConnection> connection, Options options)
+    std::shared_ptr<MetricServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::MetricServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), monitoring_internal::MetricServiceDefaultOptions(
+                               connection_->options()))) {}
 MetricServiceClient::~MetricServiceClient() = default;
 
 StreamRange<google::api::MonitoredResourceDescriptor>
 MetricServiceClient::ListMonitoredResourceDescriptors(std::string const& name,
-                                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                      Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListMonitoredResourceDescriptorsRequest request;
   request.set_name(name);
   return connection_->ListMonitoredResourceDescriptors(request);
@@ -46,17 +45,15 @@ MetricServiceClient::ListMonitoredResourceDescriptors(std::string const& name,
 StreamRange<google::api::MonitoredResourceDescriptor>
 MetricServiceClient::ListMonitoredResourceDescriptors(
     google::monitoring::v3::ListMonitoredResourceDescriptorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMonitoredResourceDescriptors(std::move(request));
 }
 
 StatusOr<google::api::MonitoredResourceDescriptor>
 MetricServiceClient::GetMonitoredResourceDescriptor(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetMonitoredResourceDescriptorRequest request;
   request.set_name(name);
   return connection_->GetMonitoredResourceDescriptor(request);
@@ -66,17 +63,15 @@ StatusOr<google::api::MonitoredResourceDescriptor>
 MetricServiceClient::GetMonitoredResourceDescriptor(
     google::monitoring::v3::GetMonitoredResourceDescriptorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMonitoredResourceDescriptor(request);
 }
 
 StreamRange<google::api::MetricDescriptor>
 MetricServiceClient::ListMetricDescriptors(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListMetricDescriptorsRequest request;
   request.set_name(name);
   return connection_->ListMetricDescriptors(request);
@@ -85,17 +80,15 @@ MetricServiceClient::ListMetricDescriptors(std::string const& name,
 StreamRange<google::api::MetricDescriptor>
 MetricServiceClient::ListMetricDescriptors(
     google::monitoring::v3::ListMetricDescriptorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMetricDescriptors(std::move(request));
 }
 
 StatusOr<google::api::MetricDescriptor>
 MetricServiceClient::GetMetricDescriptor(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetMetricDescriptorRequest request;
   request.set_name(name);
   return connection_->GetMetricDescriptor(request);
@@ -104,18 +97,16 @@ MetricServiceClient::GetMetricDescriptor(std::string const& name,
 StatusOr<google::api::MetricDescriptor>
 MetricServiceClient::GetMetricDescriptor(
     google::monitoring::v3::GetMetricDescriptorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMetricDescriptor(request);
 }
 
 StatusOr<google::api::MetricDescriptor>
 MetricServiceClient::CreateMetricDescriptor(
     std::string const& name,
-    google::api::MetricDescriptor const& metric_descriptor, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::api::MetricDescriptor const& metric_descriptor, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateMetricDescriptorRequest request;
   request.set_name(name);
   *request.mutable_metric_descriptor() = metric_descriptor;
@@ -125,16 +116,14 @@ MetricServiceClient::CreateMetricDescriptor(
 StatusOr<google::api::MetricDescriptor>
 MetricServiceClient::CreateMetricDescriptor(
     google::monitoring::v3::CreateMetricDescriptorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMetricDescriptor(request);
 }
 
 Status MetricServiceClient::DeleteMetricDescriptor(std::string const& name,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteMetricDescriptorRequest request;
   request.set_name(name);
   return connection_->DeleteMetricDescriptor(request);
@@ -142,9 +131,8 @@ Status MetricServiceClient::DeleteMetricDescriptor(std::string const& name,
 
 Status MetricServiceClient::DeleteMetricDescriptor(
     google::monitoring::v3::DeleteMetricDescriptorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMetricDescriptor(request);
 }
 
@@ -153,9 +141,8 @@ MetricServiceClient::ListTimeSeries(
     std::string const& name, std::string const& filter,
     google::monitoring::v3::TimeInterval const& interval,
     google::monitoring::v3::ListTimeSeriesRequest::TimeSeriesView view,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListTimeSeriesRequest request;
   request.set_name(name);
   request.set_filter(filter);
@@ -166,18 +153,16 @@ MetricServiceClient::ListTimeSeries(
 
 StreamRange<google::monitoring::v3::TimeSeries>
 MetricServiceClient::ListTimeSeries(
-    google::monitoring::v3::ListTimeSeriesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::ListTimeSeriesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTimeSeries(std::move(request));
 }
 
 Status MetricServiceClient::CreateTimeSeries(
     std::string const& name,
     std::vector<google::monitoring::v3::TimeSeries> const& time_series,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateTimeSeriesRequest request;
   request.set_name(name);
   *request.mutable_time_series() = {time_series.begin(), time_series.end()};
@@ -186,18 +171,16 @@ Status MetricServiceClient::CreateTimeSeries(
 
 Status MetricServiceClient::CreateTimeSeries(
     google::monitoring::v3::CreateTimeSeriesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTimeSeries(request);
 }
 
 Status MetricServiceClient::CreateServiceTimeSeries(
     std::string const& name,
     std::vector<google::monitoring::v3::TimeSeries> const& time_series,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateTimeSeriesRequest request;
   request.set_name(name);
   *request.mutable_time_series() = {time_series.begin(), time_series.end()};
@@ -206,9 +189,8 @@ Status MetricServiceClient::CreateServiceTimeSeries(
 
 Status MetricServiceClient::CreateServiceTimeSeries(
     google::monitoring::v3::CreateTimeSeriesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServiceTimeSeries(request);
 }
 

--- a/google/cloud/monitoring/metric_client.h
+++ b/google/cloud/monitoring/metric_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetricServiceClient {
  public:
   explicit MetricServiceClient(
-      std::shared_ptr<MetricServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<MetricServiceConnection> connection, Options opts = {});
   ~MetricServiceClient();
 
   //@{
@@ -94,7 +93,8 @@ class MetricServiceClient {
   /// [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
@@ -104,8 +104,7 @@ class MetricServiceClient {
   /// @googleapis_reference_link{google/api/monitored_resource.proto#L40}
   ///
   StreamRange<google::api::MonitoredResourceDescriptor>
-  ListMonitoredResourceDescriptors(std::string const& name,
-                                   Options options = {});
+  ListMonitoredResourceDescriptors(std::string const& name, Options opts = {});
 
   ///
   /// Lists monitored resource descriptors that match a filter. This method does
@@ -113,7 +112,8 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListMonitoredResourceDescriptorsRequest,google/monitoring/v3/metric_service.proto#L177}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
@@ -125,7 +125,7 @@ class MetricServiceClient {
   StreamRange<google::api::MonitoredResourceDescriptor>
   ListMonitoredResourceDescriptors(
       google::monitoring::v3::ListMonitoredResourceDescriptorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single monitored resource descriptor. This method does not require
@@ -136,7 +136,8 @@ class MetricServiceClient {
   ///      projects/[PROJECT_ID_OR_NUMBER]/monitoredResourceDescriptors/[RESOURCE_TYPE]
   ///  The `[RESOURCE_TYPE]` is a predefined type, such as
   ///  `cloudsql_database`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
@@ -146,7 +147,7 @@ class MetricServiceClient {
   /// @googleapis_reference_link{google/api/monitored_resource.proto#L40}
   ///
   StatusOr<google::api::MonitoredResourceDescriptor>
-  GetMonitoredResourceDescriptor(std::string const& name, Options options = {});
+  GetMonitoredResourceDescriptor(std::string const& name, Options opts = {});
 
   ///
   /// Gets a single monitored resource descriptor. This method does not require
@@ -154,7 +155,8 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetMonitoredResourceDescriptorRequest,google/monitoring/v3/metric_service.proto#L219}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MonitoredResourceDescriptor,google/api/monitored_resource.proto#L40}
   ///
@@ -167,7 +169,7 @@ class MetricServiceClient {
   GetMonitoredResourceDescriptor(
       google::monitoring::v3::GetMonitoredResourceDescriptorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists metric descriptors that match a filter. This method does not require
@@ -177,7 +179,8 @@ class MetricServiceClient {
   /// [project](https://cloud.google.com/monitoring/api/v3#project_name) on
   ///  which to execute the request. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MetricDescriptor,google/api/metric.proto#L33}
   ///
@@ -187,7 +190,7 @@ class MetricServiceClient {
   /// @googleapis_reference_link{google/api/metric.proto#L33}
   ///
   StreamRange<google::api::MetricDescriptor> ListMetricDescriptors(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Lists metric descriptors that match a filter. This method does not require
@@ -195,7 +198,8 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListMetricDescriptorsRequest,google/monitoring/v3/metric_service.proto#L235}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MetricDescriptor,google/api/metric.proto#L33}
   ///
@@ -206,7 +210,7 @@ class MetricServiceClient {
   ///
   StreamRange<google::api::MetricDescriptor> ListMetricDescriptors(
       google::monitoring::v3::ListMetricDescriptorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single metric descriptor. This method does not require a Workspace.
@@ -216,7 +220,8 @@ class MetricServiceClient {
   ///      projects/[PROJECT_ID_OR_NUMBER]/metricDescriptors/[METRIC_ID]
   ///  An example value of `[METRIC_ID]` is
   ///  `"compute.googleapis.com/instance/disk/read_bytes_count"`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MetricDescriptor,google/api/metric.proto#L33}
   ///
@@ -226,14 +231,15 @@ class MetricServiceClient {
   /// @googleapis_reference_link{google/api/metric.proto#L33}
   ///
   StatusOr<google::api::MetricDescriptor> GetMetricDescriptor(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a single metric descriptor. This method does not require a Workspace.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetMetricDescriptorRequest,google/monitoring/v3/metric_service.proto#L279}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MetricDescriptor,google/api/metric.proto#L33}
   ///
@@ -244,7 +250,7 @@ class MetricServiceClient {
   ///
   StatusOr<google::api::MetricDescriptor> GetMetricDescriptor(
       google::monitoring::v3::GetMetricDescriptorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new metric descriptor.
@@ -261,7 +267,8 @@ class MetricServiceClient {
   /// @param metric_descriptor  Required. The new [custom
   /// metric](https://cloud.google.com/monitoring/custom-metrics)
   ///  descriptor.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MetricDescriptor,google/api/metric.proto#L33}
   ///
@@ -273,7 +280,7 @@ class MetricServiceClient {
   StatusOr<google::api::MetricDescriptor> CreateMetricDescriptor(
       std::string const& name,
       google::api::MetricDescriptor const& metric_descriptor,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new metric descriptor.
@@ -284,7 +291,8 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateMetricDescriptorRequest,google/monitoring/v3/metric_service.proto#L295}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::MetricDescriptor,google/api/metric.proto#L33}
   ///
@@ -295,7 +303,7 @@ class MetricServiceClient {
   ///
   StatusOr<google::api::MetricDescriptor> CreateMetricDescriptor(
       google::monitoring::v3::CreateMetricDescriptorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a metric descriptor. Only user-created
@@ -307,12 +315,13 @@ class MetricServiceClient {
   ///      projects/[PROJECT_ID_OR_NUMBER]/metricDescriptors/[METRIC_ID]
   ///  An example of `[METRIC_ID]` is:
   ///  `"custom.googleapis.com/my_test_metric"`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteMetricDescriptorRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L313}
   ///
-  Status DeleteMetricDescriptor(std::string const& name, Options options = {});
+  Status DeleteMetricDescriptor(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a metric descriptor. Only user-created
@@ -321,14 +330,15 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteMetricDescriptorRequest,google/monitoring/v3/metric_service.proto#L313}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteMetricDescriptorRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L313}
   ///
   Status DeleteMetricDescriptor(
       google::monitoring::v3::DeleteMetricDescriptorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists time series that match a filter. This method does not require a
@@ -353,7 +363,8 @@ class MetricServiceClient {
   ///  in the response.
   /// @param view  Required. Specifies which information is returned about the
   /// time series.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::TimeSeries,google/monitoring/v3/metric.proto#L55}
   ///
@@ -366,7 +377,7 @@ class MetricServiceClient {
       std::string const& name, std::string const& filter,
       google::monitoring::v3::TimeInterval const& interval,
       google::monitoring::v3::ListTimeSeriesRequest::TimeSeriesView view,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists time series that match a filter. This method does not require a
@@ -374,7 +385,8 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListTimeSeriesRequest,google/monitoring/v3/metric_service.proto#L329}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::TimeSeries,google/monitoring/v3/metric.proto#L55}
   ///
@@ -384,8 +396,7 @@ class MetricServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/metric.proto#L55}
   ///
   StreamRange<google::monitoring::v3::TimeSeries> ListTimeSeries(
-      google::monitoring::v3::ListTimeSeriesRequest request,
-      Options options = {});
+      google::monitoring::v3::ListTimeSeriesRequest request, Options opts = {});
 
   ///
   /// Creates or adds data to one or more time series.
@@ -404,7 +415,8 @@ class MetricServiceClient {
   ///  `TimeSeries` value must fully specify a unique time series by supplying
   ///  all label values for the metric and the monitored resource.
   ///  The maximum number of `TimeSeries` objects per `Create` request is 200.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.CreateTimeSeriesRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L423}
@@ -412,7 +424,7 @@ class MetricServiceClient {
   Status CreateTimeSeries(
       std::string const& name,
       std::vector<google::monitoring::v3::TimeSeries> const& time_series,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or adds data to one or more time series.
@@ -422,14 +434,15 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateTimeSeriesRequest,google/monitoring/v3/metric_service.proto#L423}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.CreateTimeSeriesRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L423}
   ///
   Status CreateTimeSeries(
       google::monitoring::v3::CreateTimeSeriesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or adds data to one or more service time series. A service time
@@ -453,7 +466,8 @@ class MetricServiceClient {
   ///  `TimeSeries` value must fully specify a unique time series by supplying
   ///  all label values for the metric and the monitored resource.
   ///  The maximum number of `TimeSeries` objects per `Create` request is 200.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.CreateTimeSeriesRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L423}
@@ -461,7 +475,7 @@ class MetricServiceClient {
   Status CreateServiceTimeSeries(
       std::string const& name,
       std::vector<google::monitoring::v3::TimeSeries> const& time_series,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or adds data to one or more service time series. A service time
@@ -476,14 +490,15 @@ class MetricServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateTimeSeriesRequest,google/monitoring/v3/metric_service.proto#L423}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.CreateTimeSeriesRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L423}
   ///
   Status CreateServiceTimeSeries(
       google::monitoring::v3::CreateTimeSeriesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<MetricServiceConnection> connection_;

--- a/google/cloud/monitoring/metrics_scopes_client.cc
+++ b/google/cloud/monitoring/metrics_scopes_client.cc
@@ -26,17 +26,16 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 MetricsScopesClient::MetricsScopesClient(
-    std::shared_ptr<MetricsScopesConnection> connection, Options options)
+    std::shared_ptr<MetricsScopesConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::MetricsScopesDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), monitoring_internal::MetricsScopesDefaultOptions(
+                               connection_->options()))) {}
 MetricsScopesClient::~MetricsScopesClient() = default;
 
 StatusOr<google::monitoring::metricsscope::v1::MetricsScope>
-MetricsScopesClient::GetMetricsScope(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+MetricsScopesClient::GetMetricsScope(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::metricsscope::v1::GetMetricsScopeRequest request;
   request.set_name(name);
   return connection_->GetMetricsScope(request);
@@ -45,9 +44,8 @@ MetricsScopesClient::GetMetricsScope(std::string const& name, Options options) {
 StatusOr<google::monitoring::metricsscope::v1::MetricsScope>
 MetricsScopesClient::GetMetricsScope(
     google::monitoring::metricsscope::v1::GetMetricsScopeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMetricsScope(request);
 }
 
@@ -56,9 +54,8 @@ StatusOr<google::monitoring::metricsscope::v1::
 MetricsScopesClient::ListMetricsScopesByMonitoredProject(
     google::monitoring::metricsscope::v1::
         ListMetricsScopesByMonitoredProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMetricsScopesByMonitoredProject(request);
 }
 
@@ -67,9 +64,8 @@ MetricsScopesClient::CreateMonitoredProject(
     std::string const& parent,
     google::monitoring::metricsscope::v1::MonitoredProject const&
         monitored_project,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::metricsscope::v1::CreateMonitoredProjectRequest request;
   request.set_parent(parent);
   *request.mutable_monitored_project() = monitored_project;
@@ -80,17 +76,15 @@ future<StatusOr<google::monitoring::metricsscope::v1::MonitoredProject>>
 MetricsScopesClient::CreateMonitoredProject(
     google::monitoring::metricsscope::v1::CreateMonitoredProjectRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMonitoredProject(request);
 }
 
 future<StatusOr<google::monitoring::metricsscope::v1::OperationMetadata>>
 MetricsScopesClient::DeleteMonitoredProject(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::metricsscope::v1::DeleteMonitoredProjectRequest request;
   request.set_name(name);
   return connection_->DeleteMonitoredProject(request);
@@ -100,9 +94,8 @@ future<StatusOr<google::monitoring::metricsscope::v1::OperationMetadata>>
 MetricsScopesClient::DeleteMonitoredProject(
     google::monitoring::metricsscope::v1::DeleteMonitoredProjectRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMonitoredProject(request);
 }
 

--- a/google/cloud/monitoring/metrics_scopes_client.h
+++ b/google/cloud/monitoring/metrics_scopes_client.h
@@ -63,8 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class MetricsScopesClient {
  public:
   explicit MetricsScopesClient(
-      std::shared_ptr<MetricsScopesConnection> connection,
-      Options options = {});
+      std::shared_ptr<MetricsScopesConnection> connection, Options opts = {});
   ~MetricsScopesClient();
 
   //@{
@@ -93,7 +92,8 @@ class MetricsScopesClient {
   /// @param name  Required. The resource name of the `Metrics Scope`.
   ///  Example:
   ///  `locations/global/metricsScopes/{SCOPING_PROJECT_ID_OR_NUMBER}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::MetricsScope,google/monitoring/metricsscope/v1/metrics_scope.proto#L35}
   ///
@@ -103,14 +103,15 @@ class MetricsScopesClient {
   /// @googleapis_reference_link{google/monitoring/metricsscope/v1/metrics_scope.proto#L35}
   ///
   StatusOr<google::monitoring::metricsscope::v1::MetricsScope> GetMetricsScope(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns a specific `Metrics Scope`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::metricsscope::v1::GetMetricsScopeRequest,google/monitoring/metricsscope/v1/metrics_scopes.proto#L90}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::MetricsScope,google/monitoring/metricsscope/v1/metrics_scope.proto#L35}
   ///
@@ -122,7 +123,7 @@ class MetricsScopesClient {
   StatusOr<google::monitoring::metricsscope::v1::MetricsScope> GetMetricsScope(
       google::monitoring::metricsscope::v1::GetMetricsScopeRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a list of every `Metrics Scope` that a specific `MonitoredProject`
@@ -131,7 +132,8 @@ class MetricsScopesClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::metricsscope::v1::ListMetricsScopesByMonitoredProjectRequest,google/monitoring/metricsscope/v1/metrics_scopes.proto#L103}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::ListMetricsScopesByMonitoredProjectResponse,google/monitoring/metricsscope/v1/metrics_scopes.proto#L111}
   ///
@@ -145,7 +147,7 @@ class MetricsScopesClient {
   ListMetricsScopesByMonitoredProject(
       google::monitoring::metricsscope::v1::
           ListMetricsScopesByMonitoredProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds a `MonitoredProject` with the given project ID
@@ -161,7 +163,8 @@ class MetricsScopesClient {
   ///  Specify only the `monitored_project.name` field. All other fields are
   ///  ignored. The `monitored_project.name` must be in the format:
   ///  `locations/global/metricsScopes/{SCOPING_PROJECT_ID_OR_NUMBER}/projects/{MONITORED_PROJECT_ID_OR_NUMBER}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::MonitoredProject,google/monitoring/metricsscope/v1/metrics_scope.proto#L62}
   ///
@@ -175,7 +178,7 @@ class MetricsScopesClient {
       std::string const& parent,
       google::monitoring::metricsscope::v1::MonitoredProject const&
           monitored_project,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds a `MonitoredProject` with the given project ID
@@ -183,7 +186,8 @@ class MetricsScopesClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::metricsscope::v1::CreateMonitoredProjectRequest,google/monitoring/metricsscope/v1/metrics_scopes.proto#L118}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::MonitoredProject,google/monitoring/metricsscope/v1/metrics_scope.proto#L62}
   ///
@@ -196,7 +200,7 @@ class MetricsScopesClient {
   CreateMonitoredProject(
       google::monitoring::metricsscope::v1::CreateMonitoredProjectRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a `MonitoredProject` from the specified `Metrics Scope`.
@@ -207,7 +211,8 @@ class MetricsScopesClient {
   ///  Authorization requires the following [Google
   ///  IAM](https://cloud.google.com/iam) permissions on both the `Metrics
   ///  Scope` and on the `MonitoredProject`: `monitoring.metricsScopes.link`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::OperationMetadata,google/monitoring/metricsscope/v1/metrics_scopes.proto#L156}
   ///
@@ -217,14 +222,15 @@ class MetricsScopesClient {
   /// @googleapis_reference_link{google/monitoring/metricsscope/v1/metrics_scopes.proto#L156}
   ///
   future<StatusOr<google::monitoring::metricsscope::v1::OperationMetadata>>
-  DeleteMonitoredProject(std::string const& name, Options options = {});
+  DeleteMonitoredProject(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a `MonitoredProject` from the specified `Metrics Scope`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::metricsscope::v1::DeleteMonitoredProjectRequest,google/monitoring/metricsscope/v1/metrics_scopes.proto#L138}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::metricsscope::v1::OperationMetadata,google/monitoring/metricsscope/v1/metrics_scopes.proto#L156}
   ///
@@ -237,7 +243,7 @@ class MetricsScopesClient {
   DeleteMonitoredProject(
       google::monitoring::metricsscope::v1::DeleteMonitoredProjectRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<MetricsScopesConnection> connection_;

--- a/google/cloud/monitoring/notification_channel_client.cc
+++ b/google/cloud/monitoring/notification_channel_client.cc
@@ -27,19 +27,18 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 NotificationChannelServiceClient::NotificationChannelServiceClient(
     std::shared_ptr<NotificationChannelServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           monitoring_internal::NotificationChannelServiceDefaultOptions(
               connection_->options()))) {}
 NotificationChannelServiceClient::~NotificationChannelServiceClient() = default;
 
 StreamRange<google::monitoring::v3::NotificationChannelDescriptor>
 NotificationChannelServiceClient::ListNotificationChannelDescriptors(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListNotificationChannelDescriptorsRequest request;
   request.set_name(name);
   return connection_->ListNotificationChannelDescriptors(request);
@@ -48,17 +47,15 @@ NotificationChannelServiceClient::ListNotificationChannelDescriptors(
 StreamRange<google::monitoring::v3::NotificationChannelDescriptor>
 NotificationChannelServiceClient::ListNotificationChannelDescriptors(
     google::monitoring::v3::ListNotificationChannelDescriptorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNotificationChannelDescriptors(std::move(request));
 }
 
 StatusOr<google::monitoring::v3::NotificationChannelDescriptor>
 NotificationChannelServiceClient::GetNotificationChannelDescriptor(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetNotificationChannelDescriptorRequest request;
   request.set_name(name);
   return connection_->GetNotificationChannelDescriptor(request);
@@ -68,17 +65,15 @@ StatusOr<google::monitoring::v3::NotificationChannelDescriptor>
 NotificationChannelServiceClient::GetNotificationChannelDescriptor(
     google::monitoring::v3::GetNotificationChannelDescriptorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNotificationChannelDescriptor(request);
 }
 
 StreamRange<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::ListNotificationChannels(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListNotificationChannelsRequest request;
   request.set_name(name);
   return connection_->ListNotificationChannels(request);
@@ -87,17 +82,15 @@ NotificationChannelServiceClient::ListNotificationChannels(
 StreamRange<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::ListNotificationChannels(
     google::monitoring::v3::ListNotificationChannelsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNotificationChannels(std::move(request));
 }
 
 StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::GetNotificationChannel(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetNotificationChannelRequest request;
   request.set_name(name);
   return connection_->GetNotificationChannel(request);
@@ -106,9 +99,8 @@ NotificationChannelServiceClient::GetNotificationChannel(
 StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::GetNotificationChannel(
     google::monitoring::v3::GetNotificationChannelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNotificationChannel(request);
 }
 
@@ -116,9 +108,8 @@ StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::CreateNotificationChannel(
     std::string const& name,
     google::monitoring::v3::NotificationChannel const& notification_channel,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateNotificationChannelRequest request;
   request.set_name(name);
   *request.mutable_notification_channel() = notification_channel;
@@ -128,9 +119,8 @@ NotificationChannelServiceClient::CreateNotificationChannel(
 StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::CreateNotificationChannel(
     google::monitoring::v3::CreateNotificationChannelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateNotificationChannel(request);
 }
 
@@ -138,9 +128,8 @@ StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::UpdateNotificationChannel(
     google::protobuf::FieldMask const& update_mask,
     google::monitoring::v3::NotificationChannel const& notification_channel,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::UpdateNotificationChannelRequest request;
   *request.mutable_update_mask() = update_mask;
   *request.mutable_notification_channel() = notification_channel;
@@ -150,16 +139,14 @@ NotificationChannelServiceClient::UpdateNotificationChannel(
 StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::UpdateNotificationChannel(
     google::monitoring::v3::UpdateNotificationChannelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateNotificationChannel(request);
 }
 
 Status NotificationChannelServiceClient::DeleteNotificationChannel(
-    std::string const& name, bool force, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, bool force, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteNotificationChannelRequest request;
   request.set_name(name);
   request.set_force(force);
@@ -168,17 +155,15 @@ Status NotificationChannelServiceClient::DeleteNotificationChannel(
 
 Status NotificationChannelServiceClient::DeleteNotificationChannel(
     google::monitoring::v3::DeleteNotificationChannelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteNotificationChannel(request);
 }
 
 Status
 NotificationChannelServiceClient::SendNotificationChannelVerificationCode(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::SendNotificationChannelVerificationCodeRequest
       request;
   request.set_name(name);
@@ -189,17 +174,15 @@ Status
 NotificationChannelServiceClient::SendNotificationChannelVerificationCode(
     google::monitoring::v3::
         SendNotificationChannelVerificationCodeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SendNotificationChannelVerificationCode(request);
 }
 
 StatusOr<google::monitoring::v3::GetNotificationChannelVerificationCodeResponse>
 NotificationChannelServiceClient::GetNotificationChannelVerificationCode(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetNotificationChannelVerificationCodeRequest request;
   request.set_name(name);
   return connection_->GetNotificationChannelVerificationCode(request);
@@ -209,17 +192,15 @@ StatusOr<google::monitoring::v3::GetNotificationChannelVerificationCodeResponse>
 NotificationChannelServiceClient::GetNotificationChannelVerificationCode(
     google::monitoring::v3::GetNotificationChannelVerificationCodeRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNotificationChannelVerificationCode(request);
 }
 
 StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::VerifyNotificationChannel(
-    std::string const& name, std::string const& code, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, std::string const& code, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::VerifyNotificationChannelRequest request;
   request.set_name(name);
   request.set_code(code);
@@ -229,9 +210,8 @@ NotificationChannelServiceClient::VerifyNotificationChannel(
 StatusOr<google::monitoring::v3::NotificationChannel>
 NotificationChannelServiceClient::VerifyNotificationChannel(
     google::monitoring::v3::VerifyNotificationChannelRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->VerifyNotificationChannel(request);
 }
 

--- a/google/cloud/monitoring/notification_channel_client.h
+++ b/google/cloud/monitoring/notification_channel_client.h
@@ -64,7 +64,7 @@ class NotificationChannelServiceClient {
  public:
   explicit NotificationChannelServiceClient(
       std::shared_ptr<NotificationChannelServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~NotificationChannelServiceClient();
 
   //@{
@@ -105,7 +105,8 @@ class NotificationChannelServiceClient {
   ///  single descriptor by name, use the
   ///  [GetNotificationChannelDescriptor][google.monitoring.v3.NotificationChannelService.GetNotificationChannelDescriptor]
   ///  operation, instead.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannelDescriptor,google/monitoring/v3/notification.proto#L37}
   ///
@@ -116,7 +117,7 @@ class NotificationChannelServiceClient {
   ///
   StreamRange<google::monitoring::v3::NotificationChannelDescriptor>
   ListNotificationChannelDescriptors(std::string const& name,
-                                     Options options = {});
+                                     Options opts = {});
 
   ///
   /// Lists the descriptors for supported channel types. The use of descriptors
@@ -124,7 +125,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListNotificationChannelDescriptorsRequest,google/monitoring/v3/notification_service.proto#L164}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannelDescriptor,google/monitoring/v3/notification.proto#L37}
   ///
@@ -136,7 +138,7 @@ class NotificationChannelServiceClient {
   StreamRange<google::monitoring::v3::NotificationChannelDescriptor>
   ListNotificationChannelDescriptors(
       google::monitoring::v3::ListNotificationChannelDescriptorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single channel descriptor. The descriptor indicates which fields
@@ -145,7 +147,8 @@ class NotificationChannelServiceClient {
   /// @param name  Required. The channel type for which to execute the request.
   /// The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/notificationChannelDescriptors/[CHANNEL_TYPE]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannelDescriptor,google/monitoring/v3/notification.proto#L37}
   ///
@@ -155,8 +158,7 @@ class NotificationChannelServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/notification.proto#L37}
   ///
   StatusOr<google::monitoring::v3::NotificationChannelDescriptor>
-  GetNotificationChannelDescriptor(std::string const& name,
-                                   Options options = {});
+  GetNotificationChannelDescriptor(std::string const& name, Options opts = {});
 
   ///
   /// Gets a single channel descriptor. The descriptor indicates which fields
@@ -164,7 +166,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetNotificationChannelDescriptorRequest,google/monitoring/v3/notification_service.proto#L208}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannelDescriptor,google/monitoring/v3/notification.proto#L37}
   ///
@@ -177,7 +180,7 @@ class NotificationChannelServiceClient {
   GetNotificationChannelDescriptor(
       google::monitoring::v3::GetNotificationChannelDescriptorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the notification channels that have been created for the project.
@@ -192,7 +195,8 @@ class NotificationChannelServiceClient {
   ///  the
   ///  [`GetNotificationChannel`][google.monitoring.v3.NotificationChannelService.GetNotificationChannel]
   ///  operation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -202,14 +206,15 @@ class NotificationChannelServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/notification.proto#L87}
   ///
   StreamRange<google::monitoring::v3::NotificationChannel>
-  ListNotificationChannels(std::string const& name, Options options = {});
+  ListNotificationChannels(std::string const& name, Options opts = {});
 
   ///
   /// Lists the notification channels that have been created for the project.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListNotificationChannelsRequest,google/monitoring/v3/notification_service.proto#L243}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -221,7 +226,7 @@ class NotificationChannelServiceClient {
   StreamRange<google::monitoring::v3::NotificationChannel>
   ListNotificationChannels(
       google::monitoring::v3::ListNotificationChannelsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single notification channel. The channel includes the relevant
@@ -233,7 +238,8 @@ class NotificationChannelServiceClient {
   /// @param name  Required. The channel for which to execute the request. The
   /// format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/notificationChannels/[CHANNEL_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -243,7 +249,7 @@ class NotificationChannelServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/notification.proto#L87}
   ///
   StatusOr<google::monitoring::v3::NotificationChannel> GetNotificationChannel(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a single notification channel. The channel includes the relevant
@@ -254,7 +260,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetNotificationChannelRequest,google/monitoring/v3/notification_service.proto#L305}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -265,7 +272,7 @@ class NotificationChannelServiceClient {
   ///
   StatusOr<google::monitoring::v3::NotificationChannel> GetNotificationChannel(
       google::monitoring::v3::GetNotificationChannelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new notification channel, representing a single notification
@@ -282,7 +289,8 @@ class NotificationChannelServiceClient {
   ///  channel.
   /// @param notification_channel  Required. The definition of the
   /// `NotificationChannel` to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -295,7 +303,7 @@ class NotificationChannelServiceClient {
   CreateNotificationChannel(
       std::string const& name,
       google::monitoring::v3::NotificationChannel const& notification_channel,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new notification channel, representing a single notification
@@ -303,7 +311,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateNotificationChannelRequest,google/monitoring/v3/notification_service.proto#L221}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -315,7 +324,7 @@ class NotificationChannelServiceClient {
   StatusOr<google::monitoring::v3::NotificationChannel>
   CreateNotificationChannel(
       google::monitoring::v3::CreateNotificationChannelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a notification channel. Fields not specified in the field mask
@@ -327,7 +336,8 @@ class NotificationChannelServiceClient {
   ///  notification channel. The description must provide a definition for
   ///  fields to be updated; the names of these fields should also be
   ///  included in the `update_mask`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -340,7 +350,7 @@ class NotificationChannelServiceClient {
   UpdateNotificationChannel(
       google::protobuf::FieldMask const& update_mask,
       google::monitoring::v3::NotificationChannel const& notification_channel,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a notification channel. Fields not specified in the field mask
@@ -348,7 +358,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::UpdateNotificationChannelRequest,google/monitoring/v3/notification_service.proto#L318}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -360,7 +371,7 @@ class NotificationChannelServiceClient {
   StatusOr<google::monitoring::v3::NotificationChannel>
   UpdateNotificationChannel(
       google::monitoring::v3::UpdateNotificationChannelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a notification channel.
@@ -373,27 +384,29 @@ class NotificationChannelServiceClient {
   ///  use in alert policies (the policies will be updated to remove the
   ///  channel). If false, channels that are still referenced by an existing
   ///  alerting policy will fail to be deleted in a delete operation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteNotificationChannelRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/notification_service.proto#L330}
   ///
   Status DeleteNotificationChannel(std::string const& name, bool force,
-                                   Options options = {});
+                                   Options opts = {});
 
   ///
   /// Deletes a notification channel.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteNotificationChannelRequest,google/monitoring/v3/notification_service.proto#L330}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteNotificationChannelRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/notification_service.proto#L330}
   ///
   Status DeleteNotificationChannel(
       google::monitoring::v3::DeleteNotificationChannelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Causes a verification code to be delivered to the channel. The code
@@ -401,13 +414,14 @@ class NotificationChannelServiceClient {
   ///
   /// @param name  Required. The notification channel to which to send a
   /// verification code.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.SendNotificationChannelVerificationCodeRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/notification_service.proto#L349}
   ///
   Status SendNotificationChannelVerificationCode(std::string const& name,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Causes a verification code to be delivered to the channel. The code
@@ -415,7 +429,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::SendNotificationChannelVerificationCodeRequest,google/monitoring/v3/notification_service.proto#L349}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.SendNotificationChannelVerificationCodeRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/notification_service.proto#L349}
@@ -423,7 +438,7 @@ class NotificationChannelServiceClient {
   Status SendNotificationChannelVerificationCode(
       google::monitoring::v3::
           SendNotificationChannelVerificationCodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Requests a verification code for an already verified channel that can then
@@ -452,7 +467,8 @@ class NotificationChannelServiceClient {
   /// code is to be generated
   ///  and retrieved. This must name a channel that is already verified; if
   ///  the specified channel is not verified, the request will fail.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::GetNotificationChannelVerificationCodeResponse,google/monitoring/v3/notification_service.proto#L384}
   ///
@@ -464,7 +480,7 @@ class NotificationChannelServiceClient {
   StatusOr<
       google::monitoring::v3::GetNotificationChannelVerificationCodeResponse>
   GetNotificationChannelVerificationCode(std::string const& name,
-                                         Options options = {});
+                                         Options opts = {});
 
   ///
   /// Requests a verification code for an already verified channel that can then
@@ -491,7 +507,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetNotificationChannelVerificationCodeRequest,google/monitoring/v3/notification_service.proto#L360}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::GetNotificationChannelVerificationCodeResponse,google/monitoring/v3/notification_service.proto#L384}
   ///
@@ -505,7 +522,7 @@ class NotificationChannelServiceClient {
   GetNotificationChannelVerificationCode(
       google::monitoring::v3::
           GetNotificationChannelVerificationCodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Verifies a `NotificationChannel` by proving receipt of the code
@@ -521,7 +538,8 @@ class NotificationChannelServiceClient {
   ///  "G-123456" or "TKNZGhhd2EyN3I1MnRnMjRv" (in general, one is only
   ///  guaranteed that the code is valid UTF-8; one should not
   ///  make any assumptions regarding the structure or format of the code).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -532,7 +550,7 @@ class NotificationChannelServiceClient {
   ///
   StatusOr<google::monitoring::v3::NotificationChannel>
   VerifyNotificationChannel(std::string const& name, std::string const& code,
-                            Options options = {});
+                            Options opts = {});
 
   ///
   /// Verifies a `NotificationChannel` by proving receipt of the code
@@ -541,7 +559,8 @@ class NotificationChannelServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::VerifyNotificationChannelRequest,google/monitoring/v3/notification_service.proto#L398}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::NotificationChannel,google/monitoring/v3/notification.proto#L87}
   ///
@@ -553,7 +572,7 @@ class NotificationChannelServiceClient {
   StatusOr<google::monitoring::v3::NotificationChannel>
   VerifyNotificationChannel(
       google::monitoring::v3::VerifyNotificationChannelRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<NotificationChannelServiceConnection> connection_;

--- a/google/cloud/monitoring/query_client.cc
+++ b/google/cloud/monitoring/query_client.cc
@@ -26,18 +26,17 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 QueryServiceClient::QueryServiceClient(
-    std::shared_ptr<QueryServiceConnection> connection, Options options)
+    std::shared_ptr<QueryServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::QueryServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), monitoring_internal::QueryServiceDefaultOptions(
+                               connection_->options()))) {}
 QueryServiceClient::~QueryServiceClient() = default;
 
 StreamRange<google::monitoring::v3::TimeSeriesData>
 QueryServiceClient::QueryTimeSeries(
-    google::monitoring::v3::QueryTimeSeriesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::QueryTimeSeriesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->QueryTimeSeries(std::move(request));
 }
 

--- a/google/cloud/monitoring/query_client.h
+++ b/google/cloud/monitoring/query_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class QueryServiceClient {
  public:
   explicit QueryServiceClient(
-      std::shared_ptr<QueryServiceConnection> connection, Options options = {});
+      std::shared_ptr<QueryServiceConnection> connection, Options opts = {});
   ~QueryServiceClient();
 
   //@{
@@ -92,7 +92,8 @@ class QueryServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::QueryTimeSeriesRequest,google/monitoring/v3/metric_service.proto#L476}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::TimeSeriesData,google/monitoring/v3/metric.proto#L135}
   ///
@@ -103,7 +104,7 @@ class QueryServiceClient {
   ///
   StreamRange<google::monitoring::v3::TimeSeriesData> QueryTimeSeries(
       google::monitoring::v3::QueryTimeSeriesRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<QueryServiceConnection> connection_;

--- a/google/cloud/monitoring/service_monitoring_client.cc
+++ b/google/cloud/monitoring/service_monitoring_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceMonitoringServiceClient::ServiceMonitoringServiceClient(
     std::shared_ptr<ServiceMonitoringServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           monitoring_internal::ServiceMonitoringServiceDefaultOptions(
               connection_->options()))) {}
 ServiceMonitoringServiceClient::~ServiceMonitoringServiceClient() = default;
@@ -38,9 +38,8 @@ ServiceMonitoringServiceClient::~ServiceMonitoringServiceClient() = default;
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::CreateService(
     std::string const& parent, google::monitoring::v3::Service const& service,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateServiceRequest request;
   request.set_parent(parent);
   *request.mutable_service() = service;
@@ -49,18 +48,15 @@ ServiceMonitoringServiceClient::CreateService(
 
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::CreateService(
-    google::monitoring::v3::CreateServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::CreateServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateService(request);
 }
 
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::GetService(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetServiceRequest request;
   request.set_name(name);
   return connection_->GetService(request);
@@ -68,17 +64,15 @@ ServiceMonitoringServiceClient::GetService(std::string const& name,
 
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::GetService(
-    google::monitoring::v3::GetServiceRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::GetServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetService(request);
 }
 
 StreamRange<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::ListServices(std::string const& parent,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListServicesRequest request;
   request.set_parent(parent);
   return connection_->ListServices(request);
@@ -86,17 +80,15 @@ ServiceMonitoringServiceClient::ListServices(std::string const& parent,
 
 StreamRange<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::ListServices(
-    google::monitoring::v3::ListServicesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::ListServicesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServices(std::move(request));
 }
 
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::UpdateService(
-    google::monitoring::v3::Service const& service, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::Service const& service, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::UpdateServiceRequest request;
   *request.mutable_service() = service;
   return connection_->UpdateService(request);
@@ -104,27 +96,22 @@ ServiceMonitoringServiceClient::UpdateService(
 
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceClient::UpdateService(
-    google::monitoring::v3::UpdateServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::UpdateServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateService(request);
 }
 
 Status ServiceMonitoringServiceClient::DeleteService(std::string const& name,
-                                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteServiceRequest request;
   request.set_name(name);
   return connection_->DeleteService(request);
 }
 
 Status ServiceMonitoringServiceClient::DeleteService(
-    google::monitoring::v3::DeleteServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::DeleteServiceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteService(request);
 }
 
@@ -133,9 +120,8 @@ ServiceMonitoringServiceClient::CreateServiceLevelObjective(
     std::string const& parent,
     google::monitoring::v3::ServiceLevelObjective const&
         service_level_objective,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateServiceLevelObjectiveRequest request;
   request.set_parent(parent);
   *request.mutable_service_level_objective() = service_level_objective;
@@ -145,17 +131,15 @@ ServiceMonitoringServiceClient::CreateServiceLevelObjective(
 StatusOr<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::CreateServiceLevelObjective(
     google::monitoring::v3::CreateServiceLevelObjectiveRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServiceLevelObjective(request);
 }
 
 StatusOr<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::GetServiceLevelObjective(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetServiceLevelObjectiveRequest request;
   request.set_name(name);
   return connection_->GetServiceLevelObjective(request);
@@ -164,17 +148,15 @@ ServiceMonitoringServiceClient::GetServiceLevelObjective(
 StatusOr<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::GetServiceLevelObjective(
     google::monitoring::v3::GetServiceLevelObjectiveRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServiceLevelObjective(request);
 }
 
 StreamRange<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::ListServiceLevelObjectives(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListServiceLevelObjectivesRequest request;
   request.set_parent(parent);
   return connection_->ListServiceLevelObjectives(request);
@@ -183,9 +165,8 @@ ServiceMonitoringServiceClient::ListServiceLevelObjectives(
 StreamRange<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::ListServiceLevelObjectives(
     google::monitoring::v3::ListServiceLevelObjectivesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServiceLevelObjectives(std::move(request));
 }
 
@@ -193,9 +174,8 @@ StatusOr<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::UpdateServiceLevelObjective(
     google::monitoring::v3::ServiceLevelObjective const&
         service_level_objective,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::UpdateServiceLevelObjectiveRequest request;
   *request.mutable_service_level_objective() = service_level_objective;
   return connection_->UpdateServiceLevelObjective(request);
@@ -204,16 +184,14 @@ ServiceMonitoringServiceClient::UpdateServiceLevelObjective(
 StatusOr<google::monitoring::v3::ServiceLevelObjective>
 ServiceMonitoringServiceClient::UpdateServiceLevelObjective(
     google::monitoring::v3::UpdateServiceLevelObjectiveRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateServiceLevelObjective(request);
 }
 
 Status ServiceMonitoringServiceClient::DeleteServiceLevelObjective(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteServiceLevelObjectiveRequest request;
   request.set_name(name);
   return connection_->DeleteServiceLevelObjective(request);
@@ -221,9 +199,8 @@ Status ServiceMonitoringServiceClient::DeleteServiceLevelObjective(
 
 Status ServiceMonitoringServiceClient::DeleteServiceLevelObjective(
     google::monitoring::v3::DeleteServiceLevelObjectiveRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteServiceLevelObjective(request);
 }
 

--- a/google/cloud/monitoring/service_monitoring_client.h
+++ b/google/cloud/monitoring/service_monitoring_client.h
@@ -66,7 +66,7 @@ class ServiceMonitoringServiceClient {
  public:
   explicit ServiceMonitoringServiceClient(
       std::shared_ptr<ServiceMonitoringServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ServiceMonitoringServiceClient();
 
   //@{
@@ -100,7 +100,8 @@ class ServiceMonitoringServiceClient {
   ///  the parent workspace. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param service  Required. The `Service` to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -111,14 +112,15 @@ class ServiceMonitoringServiceClient {
   ///
   StatusOr<google::monitoring::v3::Service> CreateService(
       std::string const& parent, google::monitoring::v3::Service const& service,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a `Service`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateServiceRequest,google/monitoring/v3/service_service.proto#L132}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -129,14 +131,15 @@ class ServiceMonitoringServiceClient {
   ///
   StatusOr<google::monitoring::v3::Service> CreateService(
       google::monitoring::v3::CreateServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get the named `Service`.
   ///
   /// @param name  Required. Resource name of the `Service`. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -146,14 +149,15 @@ class ServiceMonitoringServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/service.proto#L38}
   ///
   StatusOr<google::monitoring::v3::Service> GetService(std::string const& name,
-                                                       Options options = {});
+                                                       Options opts = {});
 
   ///
   /// Get the named `Service`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetServiceRequest,google/monitoring/v3/service_service.proto#L153}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -164,7 +168,7 @@ class ServiceMonitoringServiceClient {
   ///
   StatusOr<google::monitoring::v3::Service> GetService(
       google::monitoring::v3::GetServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List `Service`s for this workspace.
@@ -175,7 +179,8 @@ class ServiceMonitoringServiceClient {
   ///  Monitoring Workspace. The formats are:
   ///      projects/[PROJECT_ID_OR_NUMBER]
   ///      workspaces/[HOST_PROJECT_ID_OR_NUMBER]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -185,14 +190,15 @@ class ServiceMonitoringServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/service.proto#L38}
   ///
   StreamRange<google::monitoring::v3::Service> ListServices(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// List `Service`s for this workspace.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListServicesRequest,google/monitoring/v3/service_service.proto#L166}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -202,15 +208,15 @@ class ServiceMonitoringServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/service.proto#L38}
   ///
   StreamRange<google::monitoring::v3::Service> ListServices(
-      google::monitoring::v3::ListServicesRequest request,
-      Options options = {});
+      google::monitoring::v3::ListServicesRequest request, Options opts = {});
 
   ///
   /// Update this `Service`.
   ///
   /// @param service  Required. The `Service` to draw updates from.
   ///  The given `name` specifies the resource to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -220,14 +226,15 @@ class ServiceMonitoringServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/service.proto#L38}
   ///
   StatusOr<google::monitoring::v3::Service> UpdateService(
-      google::monitoring::v3::Service const& service, Options options = {});
+      google::monitoring::v3::Service const& service, Options opts = {});
 
   ///
   /// Update this `Service`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::UpdateServiceRequest,google/monitoring/v3/service_service.proto#L223}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::Service,google/monitoring/v3/service.proto#L38}
   ///
@@ -238,7 +245,7 @@ class ServiceMonitoringServiceClient {
   ///
   StatusOr<google::monitoring::v3::Service> UpdateService(
       google::monitoring::v3::UpdateServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Soft delete this `Service`.
@@ -246,26 +253,28 @@ class ServiceMonitoringServiceClient {
   /// @param name  Required. Resource name of the `Service` to delete. The
   /// format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteServiceRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/service_service.proto#L233}
   ///
-  Status DeleteService(std::string const& name, Options options = {});
+  Status DeleteService(std::string const& name, Options opts = {});
 
   ///
   /// Soft delete this `Service`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteServiceRequest,google/monitoring/v3/service_service.proto#L233}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteServiceRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/service_service.proto#L233}
   ///
   Status DeleteService(
       google::monitoring::v3::DeleteServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a `ServiceLevelObjective` for the given `Service`.
@@ -277,7 +286,8 @@ class ServiceMonitoringServiceClient {
   /// create.
   ///  The provided `name` will be respected if no `ServiceLevelObjective`
   ///  exists with this name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -291,14 +301,15 @@ class ServiceMonitoringServiceClient {
       std::string const& parent,
       google::monitoring::v3::ServiceLevelObjective const&
           service_level_objective,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a `ServiceLevelObjective` for the given `Service`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateServiceLevelObjectiveRequest,google/monitoring/v3/service_service.proto#L246}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -310,7 +321,7 @@ class ServiceMonitoringServiceClient {
   StatusOr<google::monitoring::v3::ServiceLevelObjective>
   CreateServiceLevelObjective(
       google::monitoring::v3::CreateServiceLevelObjectiveRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get a `ServiceLevelObjective` by name.
@@ -318,7 +329,8 @@ class ServiceMonitoringServiceClient {
   /// @param name  Required. Resource name of the `ServiceLevelObjective` to
   /// get. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]/serviceLevelObjectives/[SLO_NAME]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -328,14 +340,15 @@ class ServiceMonitoringServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/service.proto#L185}
   ///
   StatusOr<google::monitoring::v3::ServiceLevelObjective>
-  GetServiceLevelObjective(std::string const& name, Options options = {});
+  GetServiceLevelObjective(std::string const& name, Options opts = {});
 
   ///
   /// Get a `ServiceLevelObjective` by name.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetServiceLevelObjectiveRequest,google/monitoring/v3/service_service.proto#L269}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -347,7 +360,7 @@ class ServiceMonitoringServiceClient {
   StatusOr<google::monitoring::v3::ServiceLevelObjective>
   GetServiceLevelObjective(
       google::monitoring::v3::GetServiceLevelObjectiveRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List the `ServiceLevelObjective`s for the given `Service`.
@@ -357,7 +370,8 @@ class ServiceMonitoringServiceClient {
   ///  project or a Monitoring Workspace. The formats are:
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]
   ///      workspaces/[HOST_PROJECT_ID_OR_NUMBER]/services/-
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -367,14 +381,15 @@ class ServiceMonitoringServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/service.proto#L185}
   ///
   StreamRange<google::monitoring::v3::ServiceLevelObjective>
-  ListServiceLevelObjectives(std::string const& parent, Options options = {});
+  ListServiceLevelObjectives(std::string const& parent, Options opts = {});
 
   ///
   /// List the `ServiceLevelObjective`s for the given `Service`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListServiceLevelObjectivesRequest,google/monitoring/v3/service_service.proto#L288}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -386,7 +401,7 @@ class ServiceMonitoringServiceClient {
   StreamRange<google::monitoring::v3::ServiceLevelObjective>
   ListServiceLevelObjectives(
       google::monitoring::v3::ListServiceLevelObjectivesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update the given `ServiceLevelObjective`.
@@ -394,7 +409,8 @@ class ServiceMonitoringServiceClient {
   /// @param service_level_objective  Required. The `ServiceLevelObjective` to
   /// draw updates from.
   ///  The given `name` specifies the resource to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -407,14 +423,15 @@ class ServiceMonitoringServiceClient {
   UpdateServiceLevelObjective(
       google::monitoring::v3::ServiceLevelObjective const&
           service_level_objective,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update the given `ServiceLevelObjective`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::UpdateServiceLevelObjectiveRequest,google/monitoring/v3/service_service.proto#L332}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::ServiceLevelObjective,google/monitoring/v3/service.proto#L185}
   ///
@@ -426,7 +443,7 @@ class ServiceMonitoringServiceClient {
   StatusOr<google::monitoring::v3::ServiceLevelObjective>
   UpdateServiceLevelObjective(
       google::monitoring::v3::UpdateServiceLevelObjectiveRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Delete the given `ServiceLevelObjective`.
@@ -434,27 +451,29 @@ class ServiceMonitoringServiceClient {
   /// @param name  Required. Resource name of the `ServiceLevelObjective` to
   /// delete. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/services/[SERVICE_ID]/serviceLevelObjectives/[SLO_NAME]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteServiceLevelObjectiveRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/service_service.proto#L342}
   ///
   Status DeleteServiceLevelObjective(std::string const& name,
-                                     Options options = {});
+                                     Options opts = {});
 
   ///
   /// Delete the given `ServiceLevelObjective`.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteServiceLevelObjectiveRequest,google/monitoring/v3/service_service.proto#L342}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteServiceLevelObjectiveRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/service_service.proto#L342}
   ///
   Status DeleteServiceLevelObjective(
       google::monitoring::v3::DeleteServiceLevelObjectiveRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ServiceMonitoringServiceConnection> connection_;

--- a/google/cloud/monitoring/uptime_check_client.cc
+++ b/google/cloud/monitoring/uptime_check_client.cc
@@ -26,19 +26,18 @@ namespace monitoring {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 UptimeCheckServiceClient::UptimeCheckServiceClient(
-    std::shared_ptr<UptimeCheckServiceConnection> connection, Options options)
+    std::shared_ptr<UptimeCheckServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           monitoring_internal::UptimeCheckServiceDefaultOptions(
               connection_->options()))) {}
 UptimeCheckServiceClient::~UptimeCheckServiceClient() = default;
 
 StreamRange<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::ListUptimeCheckConfigs(std::string const& parent,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::ListUptimeCheckConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListUptimeCheckConfigs(request);
@@ -47,17 +46,15 @@ UptimeCheckServiceClient::ListUptimeCheckConfigs(std::string const& parent,
 StreamRange<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::ListUptimeCheckConfigs(
     google::monitoring::v3::ListUptimeCheckConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListUptimeCheckConfigs(std::move(request));
 }
 
 StatusOr<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::GetUptimeCheckConfig(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::GetUptimeCheckConfigRequest request;
   request.set_name(name);
   return connection_->GetUptimeCheckConfig(request);
@@ -66,9 +63,8 @@ UptimeCheckServiceClient::GetUptimeCheckConfig(std::string const& name,
 StatusOr<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::GetUptimeCheckConfig(
     google::monitoring::v3::GetUptimeCheckConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetUptimeCheckConfig(request);
 }
 
@@ -76,9 +72,8 @@ StatusOr<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::CreateUptimeCheckConfig(
     std::string const& parent,
     google::monitoring::v3::UptimeCheckConfig const& uptime_check_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::CreateUptimeCheckConfigRequest request;
   request.set_parent(parent);
   *request.mutable_uptime_check_config() = uptime_check_config;
@@ -88,18 +83,16 @@ UptimeCheckServiceClient::CreateUptimeCheckConfig(
 StatusOr<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::CreateUptimeCheckConfig(
     google::monitoring::v3::CreateUptimeCheckConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateUptimeCheckConfig(request);
 }
 
 StatusOr<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::UpdateUptimeCheckConfig(
     google::monitoring::v3::UptimeCheckConfig const& uptime_check_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::UpdateUptimeCheckConfigRequest request;
   *request.mutable_uptime_check_config() = uptime_check_config;
   return connection_->UpdateUptimeCheckConfig(request);
@@ -108,16 +101,14 @@ UptimeCheckServiceClient::UpdateUptimeCheckConfig(
 StatusOr<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceClient::UpdateUptimeCheckConfig(
     google::monitoring::v3::UpdateUptimeCheckConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateUptimeCheckConfig(request);
 }
 
 Status UptimeCheckServiceClient::DeleteUptimeCheckConfig(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::monitoring::v3::DeleteUptimeCheckConfigRequest request;
   request.set_name(name);
   return connection_->DeleteUptimeCheckConfig(request);
@@ -125,18 +116,15 @@ Status UptimeCheckServiceClient::DeleteUptimeCheckConfig(
 
 Status UptimeCheckServiceClient::DeleteUptimeCheckConfig(
     google::monitoring::v3::DeleteUptimeCheckConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteUptimeCheckConfig(request);
 }
 
 StreamRange<google::monitoring::v3::UptimeCheckIp>
 UptimeCheckServiceClient::ListUptimeCheckIps(
-    google::monitoring::v3::ListUptimeCheckIpsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::monitoring::v3::ListUptimeCheckIpsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListUptimeCheckIps(std::move(request));
 }
 

--- a/google/cloud/monitoring/uptime_check_client.h
+++ b/google/cloud/monitoring/uptime_check_client.h
@@ -69,7 +69,7 @@ class UptimeCheckServiceClient {
  public:
   explicit UptimeCheckServiceClient(
       std::shared_ptr<UptimeCheckServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~UptimeCheckServiceClient();
 
   //@{
@@ -101,7 +101,8 @@ class UptimeCheckServiceClient {
   /// [project](https://cloud.google.com/monitoring/api/v3#project_name)
   ///  whose Uptime check configurations are listed. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -111,7 +112,7 @@ class UptimeCheckServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/uptime.proto#L110}
   ///
   StreamRange<google::monitoring::v3::UptimeCheckConfig> ListUptimeCheckConfigs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists the existing valid Uptime check configurations for the project
@@ -119,7 +120,8 @@ class UptimeCheckServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListUptimeCheckConfigsRequest,google/monitoring/v3/uptime_service.proto#L109}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -130,7 +132,7 @@ class UptimeCheckServiceClient {
   ///
   StreamRange<google::monitoring::v3::UptimeCheckConfig> ListUptimeCheckConfigs(
       google::monitoring::v3::ListUptimeCheckConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single Uptime check configuration.
@@ -138,7 +140,8 @@ class UptimeCheckServiceClient {
   /// @param name  Required. The Uptime check configuration to retrieve. The
   /// format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/uptimeCheckConfigs/[UPTIME_CHECK_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -148,14 +151,15 @@ class UptimeCheckServiceClient {
   /// @googleapis_reference_link{google/monitoring/v3/uptime.proto#L110}
   ///
   StatusOr<google::monitoring::v3::UptimeCheckConfig> GetUptimeCheckConfig(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a single Uptime check configuration.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::GetUptimeCheckConfigRequest,google/monitoring/v3/uptime_service.proto#L151}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -166,7 +170,7 @@ class UptimeCheckServiceClient {
   ///
   StatusOr<google::monitoring::v3::UptimeCheckConfig> GetUptimeCheckConfig(
       google::monitoring::v3::GetUptimeCheckConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Uptime check configuration.
@@ -176,7 +180,8 @@ class UptimeCheckServiceClient {
   ///  which to create the Uptime check. The format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]
   /// @param uptime_check_config  Required. The new Uptime check configuration.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -188,14 +193,15 @@ class UptimeCheckServiceClient {
   StatusOr<google::monitoring::v3::UptimeCheckConfig> CreateUptimeCheckConfig(
       std::string const& parent,
       google::monitoring::v3::UptimeCheckConfig const& uptime_check_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Uptime check configuration.
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::CreateUptimeCheckConfigRequest,google/monitoring/v3/uptime_service.proto#L164}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -206,7 +212,7 @@ class UptimeCheckServiceClient {
   ///
   StatusOr<google::monitoring::v3::UptimeCheckConfig> CreateUptimeCheckConfig(
       google::monitoring::v3::CreateUptimeCheckConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an Uptime check configuration. You can either replace the entire
@@ -225,7 +231,8 @@ class UptimeCheckServiceClient {
   ///  The following fields can be updated: `display_name`,
   ///  `http_check`, `tcp_check`, `timeout`, `content_matchers`, and
   ///  `selected_regions`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -236,7 +243,7 @@ class UptimeCheckServiceClient {
   ///
   StatusOr<google::monitoring::v3::UptimeCheckConfig> UpdateUptimeCheckConfig(
       google::monitoring::v3::UptimeCheckConfig const& uptime_check_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an Uptime check configuration. You can either replace the entire
@@ -246,7 +253,8 @@ class UptimeCheckServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::UpdateUptimeCheckConfigRequest,google/monitoring/v3/uptime_service.proto#L181}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckConfig,google/monitoring/v3/uptime.proto#L110}
   ///
@@ -257,7 +265,7 @@ class UptimeCheckServiceClient {
   ///
   StatusOr<google::monitoring::v3::UptimeCheckConfig> UpdateUptimeCheckConfig(
       google::monitoring::v3::UpdateUptimeCheckConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an Uptime check configuration. Note that this method will fail
@@ -267,12 +275,13 @@ class UptimeCheckServiceClient {
   /// @param name  Required. The Uptime check configuration to delete. The
   /// format is:
   ///      projects/[PROJECT_ID_OR_NUMBER]/uptimeCheckConfigs/[UPTIME_CHECK_ID]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteUptimeCheckConfigRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/uptime_service.proto#L203}
   ///
-  Status DeleteUptimeCheckConfig(std::string const& name, Options options = {});
+  Status DeleteUptimeCheckConfig(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an Uptime check configuration. Note that this method will fail
@@ -281,21 +290,23 @@ class UptimeCheckServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::DeleteUptimeCheckConfigRequest,google/monitoring/v3/uptime_service.proto#L203}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.monitoring.v3.DeleteUptimeCheckConfigRequest]:
   /// @googleapis_reference_link{google/monitoring/v3/uptime_service.proto#L203}
   ///
   Status DeleteUptimeCheckConfig(
       google::monitoring::v3::DeleteUptimeCheckConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the list of IP addresses that checkers run from
   ///
   /// @param request
   /// @googleapis_link{google::monitoring::v3::ListUptimeCheckIpsRequest,google/monitoring/v3/uptime_service.proto#L216}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::monitoring::v3::UptimeCheckIp,google/monitoring/v3/uptime.proto#L371}
   ///
@@ -306,7 +317,7 @@ class UptimeCheckServiceClient {
   ///
   StreamRange<google::monitoring::v3::UptimeCheckIp> ListUptimeCheckIps(
       google::monitoring::v3::ListUptimeCheckIpsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<UptimeCheckServiceConnection> connection_;

--- a/google/cloud/networkmanagement/reachability_client.cc
+++ b/google/cloud/networkmanagement/reachability_client.cc
@@ -26,19 +26,18 @@ namespace networkmanagement {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ReachabilityServiceClient::ReachabilityServiceClient(
-    std::shared_ptr<ReachabilityServiceConnection> connection, Options options)
+    std::shared_ptr<ReachabilityServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           networkmanagement_internal::ReachabilityServiceDefaultOptions(
               connection_->options()))) {}
 ReachabilityServiceClient::~ReachabilityServiceClient() = default;
 
 StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>
 ReachabilityServiceClient::ListConnectivityTests(std::string const& parent,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::networkmanagement::v1::ListConnectivityTestsRequest request;
   request.set_parent(parent);
   return connection_->ListConnectivityTests(request);
@@ -47,17 +46,15 @@ ReachabilityServiceClient::ListConnectivityTests(std::string const& parent,
 StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>
 ReachabilityServiceClient::ListConnectivityTests(
     google::cloud::networkmanagement::v1::ListConnectivityTestsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListConnectivityTests(std::move(request));
 }
 
 StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>
 ReachabilityServiceClient::GetConnectivityTest(std::string const& name,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::networkmanagement::v1::GetConnectivityTestRequest request;
   request.set_name(name);
   return connection_->GetConnectivityTest(request);
@@ -67,9 +64,8 @@ StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>
 ReachabilityServiceClient::GetConnectivityTest(
     google::cloud::networkmanagement::v1::GetConnectivityTestRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetConnectivityTest(request);
 }
 
@@ -77,9 +73,8 @@ future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>
 ReachabilityServiceClient::CreateConnectivityTest(
     std::string const& parent, std::string const& test_id,
     google::cloud::networkmanagement::v1::ConnectivityTest const& resource,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::networkmanagement::v1::CreateConnectivityTestRequest request;
   request.set_parent(parent);
   request.set_test_id(test_id);
@@ -91,9 +86,8 @@ future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>
 ReachabilityServiceClient::CreateConnectivityTest(
     google::cloud::networkmanagement::v1::CreateConnectivityTestRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateConnectivityTest(request);
 }
 
@@ -101,9 +95,8 @@ future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>
 ReachabilityServiceClient::UpdateConnectivityTest(
     google::protobuf::FieldMask const& update_mask,
     google::cloud::networkmanagement::v1::ConnectivityTest const& resource,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::networkmanagement::v1::UpdateConnectivityTestRequest request;
   *request.mutable_update_mask() = update_mask;
   *request.mutable_resource() = resource;
@@ -114,9 +107,8 @@ future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>
 ReachabilityServiceClient::UpdateConnectivityTest(
     google::cloud::networkmanagement::v1::UpdateConnectivityTestRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateConnectivityTest(request);
 }
 
@@ -124,17 +116,15 @@ future<StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>>
 ReachabilityServiceClient::RerunConnectivityTest(
     google::cloud::networkmanagement::v1::RerunConnectivityTestRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RerunConnectivityTest(request);
 }
 
 future<StatusOr<google::cloud::networkmanagement::v1::OperationMetadata>>
 ReachabilityServiceClient::DeleteConnectivityTest(std::string const& name,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::networkmanagement::v1::DeleteConnectivityTestRequest request;
   request.set_name(name);
   return connection_->DeleteConnectivityTest(request);
@@ -144,9 +134,8 @@ future<StatusOr<google::cloud::networkmanagement::v1::OperationMetadata>>
 ReachabilityServiceClient::DeleteConnectivityTest(
     google::cloud::networkmanagement::v1::DeleteConnectivityTestRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteConnectivityTest(request);
 }
 

--- a/google/cloud/networkmanagement/reachability_client.h
+++ b/google/cloud/networkmanagement/reachability_client.h
@@ -71,7 +71,7 @@ class ReachabilityServiceClient {
  public:
   explicit ReachabilityServiceClient(
       std::shared_ptr<ReachabilityServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ReachabilityServiceClient();
 
   //@{
@@ -100,7 +100,8 @@ class ReachabilityServiceClient {
   ///
   /// @param parent  Required. The parent resource of the Connectivity Tests:
   ///      `projects/{project_id}/locations/global`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -110,14 +111,15 @@ class ReachabilityServiceClient {
   /// @googleapis_reference_link{google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
   StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>
-  ListConnectivityTests(std::string const& parent, Options options = {});
+  ListConnectivityTests(std::string const& parent, Options opts = {});
 
   ///
   /// Lists all Connectivity Tests owned by a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::networkmanagement::v1::ListConnectivityTestsRequest,google/cloud/networkmanagement/v1/reachability.proto#L154}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -130,14 +132,15 @@ class ReachabilityServiceClient {
   ListConnectivityTests(
       google::cloud::networkmanagement::v1::ListConnectivityTestsRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the details of a specific Connectivity Test.
   ///
   /// @param name  Required. `ConnectivityTest` resource name using the form:
   ///      `projects/{project_id}/locations/global/connectivityTests/{test_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -147,14 +150,15 @@ class ReachabilityServiceClient {
   /// @googleapis_reference_link{google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
   StatusOr<google::cloud::networkmanagement::v1::ConnectivityTest>
-  GetConnectivityTest(std::string const& name, Options options = {});
+  GetConnectivityTest(std::string const& name, Options opts = {});
 
   ///
   /// Gets the details of a specific Connectivity Test.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::networkmanagement::v1::GetConnectivityTestRequest,google/cloud/networkmanagement/v1/reachability.proto#L202}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -167,7 +171,7 @@ class ReachabilityServiceClient {
   GetConnectivityTest(
       google::cloud::networkmanagement::v1::GetConnectivityTestRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Connectivity Test.
@@ -197,7 +201,8 @@ class ReachabilityServiceClient {
   ///  * Must end with a number or a letter.
   ///  * Must be unique within the customer project
   /// @param resource  Required. A `ConnectivityTest` resource
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -210,7 +215,7 @@ class ReachabilityServiceClient {
   CreateConnectivityTest(
       std::string const& parent, std::string const& test_id,
       google::cloud::networkmanagement::v1::ConnectivityTest const& resource,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Connectivity Test.
@@ -230,7 +235,8 @@ class ReachabilityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::networkmanagement::v1::CreateConnectivityTestRequest,google/cloud/networkmanagement/v1/reachability.proto#L209}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -243,7 +249,7 @@ class ReachabilityServiceClient {
   CreateConnectivityTest(
       google::cloud::networkmanagement::v1::CreateConnectivityTestRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the configuration of an existing `ConnectivityTest`.
@@ -267,7 +273,8 @@ class ReachabilityServiceClient {
   ///  this field.
   /// @param resource  Required. Only fields specified in update_mask are
   /// updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -280,7 +287,7 @@ class ReachabilityServiceClient {
   UpdateConnectivityTest(
       google::protobuf::FieldMask const& update_mask,
       google::cloud::networkmanagement::v1::ConnectivityTest const& resource,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the configuration of an existing `ConnectivityTest`.
@@ -301,7 +308,8 @@ class ReachabilityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::networkmanagement::v1::UpdateConnectivityTestRequest,google/cloud/networkmanagement/v1/reachability.proto#L229}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -314,7 +322,7 @@ class ReachabilityServiceClient {
   UpdateConnectivityTest(
       google::cloud::networkmanagement::v1::UpdateConnectivityTestRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Rerun an existing `ConnectivityTest`.
@@ -332,7 +340,8 @@ class ReachabilityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::networkmanagement::v1::RerunConnectivityTestRequest,google/cloud/networkmanagement/v1/reachability.proto#L246}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::ConnectivityTest,google/cloud/networkmanagement/v1/connectivity_test.proto#L35}
   ///
@@ -345,14 +354,15 @@ class ReachabilityServiceClient {
   RerunConnectivityTest(
       google::cloud::networkmanagement::v1::RerunConnectivityTestRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a specific `ConnectivityTest`.
   ///
   /// @param name  Required. Connectivity Test resource name using the form:
   ///      `projects/{project_id}/locations/global/connectivityTests/{test_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::OperationMetadata,google/cloud/networkmanagement/v1/reachability.proto#L253}
   ///
@@ -362,14 +372,15 @@ class ReachabilityServiceClient {
   /// @googleapis_reference_link{google/cloud/networkmanagement/v1/reachability.proto#L253}
   ///
   future<StatusOr<google::cloud::networkmanagement::v1::OperationMetadata>>
-  DeleteConnectivityTest(std::string const& name, Options options = {});
+  DeleteConnectivityTest(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a specific `ConnectivityTest`.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::networkmanagement::v1::DeleteConnectivityTestRequest,google/cloud/networkmanagement/v1/reachability.proto#L239}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::networkmanagement::v1::OperationMetadata,google/cloud/networkmanagement/v1/reachability.proto#L253}
   ///
@@ -382,7 +393,7 @@ class ReachabilityServiceClient {
   DeleteConnectivityTest(
       google::cloud::networkmanagement::v1::DeleteConnectivityTestRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ReachabilityServiceConnection> connection_;

--- a/google/cloud/notebooks/managed_notebook_client.cc
+++ b/google/cloud/notebooks/managed_notebook_client.cc
@@ -26,20 +26,18 @@ namespace notebooks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ManagedNotebookServiceClient::ManagedNotebookServiceClient(
-    std::shared_ptr<ManagedNotebookServiceConnection> connection,
-    Options options)
+    std::shared_ptr<ManagedNotebookServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           notebooks_internal::ManagedNotebookServiceDefaultOptions(
               connection_->options()))) {}
 ManagedNotebookServiceClient::~ManagedNotebookServiceClient() = default;
 
 StreamRange<google::cloud::notebooks::v1::Runtime>
 ManagedNotebookServiceClient::ListRuntimes(std::string const& parent,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ListRuntimesRequest request;
   request.set_parent(parent);
   return connection_->ListRuntimes(request);
@@ -47,18 +45,15 @@ ManagedNotebookServiceClient::ListRuntimes(std::string const& parent,
 
 StreamRange<google::cloud::notebooks::v1::Runtime>
 ManagedNotebookServiceClient::ListRuntimes(
-    google::cloud::notebooks::v1::ListRuntimesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::notebooks::v1::ListRuntimesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListRuntimes(std::move(request));
 }
 
 StatusOr<google::cloud::notebooks::v1::Runtime>
 ManagedNotebookServiceClient::GetRuntime(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::GetRuntimeRequest request;
   request.set_name(name);
   return connection_->GetRuntime(request);
@@ -67,18 +62,16 @@ ManagedNotebookServiceClient::GetRuntime(std::string const& name,
 StatusOr<google::cloud::notebooks::v1::Runtime>
 ManagedNotebookServiceClient::GetRuntime(
     google::cloud::notebooks::v1::GetRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::CreateRuntime(
     std::string const& parent, std::string const& runtime_id,
-    google::cloud::notebooks::v1::Runtime const& runtime, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::notebooks::v1::Runtime const& runtime, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::CreateRuntimeRequest request;
   request.set_parent(parent);
   request.set_runtime_id(runtime_id);
@@ -89,17 +82,15 @@ ManagedNotebookServiceClient::CreateRuntime(
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::CreateRuntime(
     google::cloud::notebooks::v1::CreateRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 ManagedNotebookServiceClient::DeleteRuntime(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::DeleteRuntimeRequest request;
   request.set_name(name);
   return connection_->DeleteRuntime(request);
@@ -108,17 +99,15 @@ ManagedNotebookServiceClient::DeleteRuntime(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 ManagedNotebookServiceClient::DeleteRuntime(
     google::cloud::notebooks::v1::DeleteRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::StartRuntime(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::StartRuntimeRequest request;
   request.set_name(name);
   return connection_->StartRuntime(request);
@@ -127,17 +116,15 @@ ManagedNotebookServiceClient::StartRuntime(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::StartRuntime(
     google::cloud::notebooks::v1::StartRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::StopRuntime(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::StopRuntimeRequest request;
   request.set_name(name);
   return connection_->StopRuntime(request);
@@ -146,17 +133,15 @@ ManagedNotebookServiceClient::StopRuntime(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::StopRuntime(
     google::cloud::notebooks::v1::StopRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StopRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::SwitchRuntime(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::SwitchRuntimeRequest request;
   request.set_name(name);
   return connection_->SwitchRuntime(request);
@@ -165,17 +150,15 @@ ManagedNotebookServiceClient::SwitchRuntime(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::SwitchRuntime(
     google::cloud::notebooks::v1::SwitchRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SwitchRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::ResetRuntime(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ResetRuntimeRequest request;
   request.set_name(name);
   return connection_->ResetRuntime(request);
@@ -184,17 +167,15 @@ ManagedNotebookServiceClient::ResetRuntime(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::ResetRuntime(
     google::cloud::notebooks::v1::ResetRuntimeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResetRuntime(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::ReportRuntimeEvent(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ReportRuntimeEventRequest request;
   request.set_name(name);
   return connection_->ReportRuntimeEvent(request);
@@ -203,9 +184,8 @@ ManagedNotebookServiceClient::ReportRuntimeEvent(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::Runtime>>
 ManagedNotebookServiceClient::ReportRuntimeEvent(
     google::cloud::notebooks::v1::ReportRuntimeEventRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReportRuntimeEvent(request);
 }
 

--- a/google/cloud/notebooks/managed_notebook_client.h
+++ b/google/cloud/notebooks/managed_notebook_client.h
@@ -63,7 +63,7 @@ class ManagedNotebookServiceClient {
  public:
   explicit ManagedNotebookServiceClient(
       std::shared_ptr<ManagedNotebookServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ManagedNotebookServiceClient();
 
   //@{
@@ -93,7 +93,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param parent  Required. Format:
   ///  `parent=projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -103,14 +104,15 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   StreamRange<google::cloud::notebooks::v1::Runtime> ListRuntimes(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Runtimes in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ListRuntimesRequest,google/cloud/notebooks/v1/managed_service.proto#L157}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -121,7 +123,7 @@ class ManagedNotebookServiceClient {
   ///
   StreamRange<google::cloud::notebooks::v1::Runtime> ListRuntimes(
       google::cloud::notebooks::v1::ListRuntimesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Runtime. The location must be a regional endpoint
@@ -129,7 +131,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -139,7 +142,7 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   StatusOr<google::cloud::notebooks::v1::Runtime> GetRuntime(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Runtime. The location must be a regional endpoint
@@ -147,7 +150,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::GetRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L191}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -158,7 +162,7 @@ class ManagedNotebookServiceClient {
   ///
   StatusOr<google::cloud::notebooks::v1::Runtime> GetRuntime(
       google::cloud::notebooks::v1::GetRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Runtime in a given project and location.
@@ -167,7 +171,8 @@ class ManagedNotebookServiceClient {
   ///  `parent=projects/{project_id}/locations/{location}`
   /// @param runtime_id  Required. User-defined unique ID of this Runtime.
   /// @param runtime  Required. The Runtime to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -178,15 +183,15 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> CreateRuntime(
       std::string const& parent, std::string const& runtime_id,
-      google::cloud::notebooks::v1::Runtime const& runtime,
-      Options options = {});
+      google::cloud::notebooks::v1::Runtime const& runtime, Options opts = {});
 
   ///
   /// Creates a new Runtime in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::CreateRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L203}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -197,14 +202,15 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> CreateRuntime(
       google::cloud::notebooks::v1::CreateRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Runtime.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -214,14 +220,15 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/service.proto#L400}
   ///
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-  DeleteRuntime(std::string const& name, Options options = {});
+  DeleteRuntime(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Runtime.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::DeleteRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L221}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -233,7 +240,7 @@ class ManagedNotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
   DeleteRuntime(
       google::cloud::notebooks::v1::DeleteRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts a Managed Notebook Runtime.
@@ -244,7 +251,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -254,7 +262,7 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> StartRuntime(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Starts a Managed Notebook Runtime.
@@ -265,7 +273,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::StartRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L233}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -276,7 +285,7 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> StartRuntime(
       google::cloud::notebooks::v1::StartRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a Managed Notebook Runtime.
@@ -287,7 +296,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -297,7 +307,7 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> StopRuntime(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Stops a Managed Notebook Runtime.
@@ -308,7 +318,8 @@ class ManagedNotebookServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::StopRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L240}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -319,14 +330,15 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> StopRuntime(
       google::cloud::notebooks::v1::StopRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Switch a Managed Notebook Runtime.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -336,14 +348,15 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> SwitchRuntime(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Switch a Managed Notebook Runtime.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::SwitchRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L247}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -354,14 +367,15 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> SwitchRuntime(
       google::cloud::notebooks::v1::SwitchRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resets a Managed Notebook Runtime.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -371,14 +385,15 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> ResetRuntime(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Resets a Managed Notebook Runtime.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ResetRuntimeRequest,google/cloud/notebooks/v1/managed_service.proto#L260}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -389,14 +404,15 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> ResetRuntime(
       google::cloud::notebooks::v1::ResetRuntimeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Report and process a runtime event.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/runtimes/{runtime_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -406,14 +422,15 @@ class ManagedNotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/runtime.proto#L33}
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> ReportRuntimeEvent(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Report and process a runtime event.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ReportRuntimeEventRequest,google/cloud/notebooks/v1/managed_service.proto#L267}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Runtime,google/cloud/notebooks/v1/runtime.proto#L33}
   ///
@@ -424,7 +441,7 @@ class ManagedNotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Runtime>> ReportRuntimeEvent(
       google::cloud::notebooks::v1::ReportRuntimeEventRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ManagedNotebookServiceConnection> connection_;

--- a/google/cloud/notebooks/notebook_client.cc
+++ b/google/cloud/notebooks/notebook_client.cc
@@ -26,18 +26,16 @@ namespace notebooks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 NotebookServiceClient::NotebookServiceClient(
-    std::shared_ptr<NotebookServiceConnection> connection, Options options)
+    std::shared_ptr<NotebookServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), notebooks_internal::NotebookServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), notebooks_internal::NotebookServiceDefaultOptions(
+                               connection_->options()))) {}
 NotebookServiceClient::~NotebookServiceClient() = default;
 
 StreamRange<google::cloud::notebooks::v1::Instance>
-NotebookServiceClient::ListInstances(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::ListInstances(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
@@ -45,17 +43,14 @@ NotebookServiceClient::ListInstances(std::string const& parent,
 
 StreamRange<google::cloud::notebooks::v1::Instance>
 NotebookServiceClient::ListInstances(
-    google::cloud::notebooks::v1::ListInstancesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::notebooks::v1::ListInstancesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::cloud::notebooks::v1::Instance>
-NotebookServiceClient::GetInstance(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::GetInstance(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -64,9 +59,8 @@ NotebookServiceClient::GetInstance(std::string const& name, Options options) {
 StatusOr<google::cloud::notebooks::v1::Instance>
 NotebookServiceClient::GetInstance(
     google::cloud::notebooks::v1::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
@@ -74,9 +68,8 @@ future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::CreateInstance(
     std::string const& parent,
     google::cloud::notebooks::v1::Instance const& instance,
-    std::string const& instance_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& instance_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::CreateInstanceRequest request;
   request.set_parent(parent);
   *request.mutable_instance() = instance;
@@ -87,45 +80,40 @@ NotebookServiceClient::CreateInstance(
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::CreateInstance(
     google::cloud::notebooks::v1::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::RegisterInstance(
     google::cloud::notebooks::v1::RegisterInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RegisterInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::SetInstanceAccelerator(
     google::cloud::notebooks::v1::SetInstanceAcceleratorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetInstanceAccelerator(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::SetInstanceMachineType(
     google::cloud::notebooks::v1::SetInstanceMachineTypeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetInstanceMachineType(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::UpdateInstanceConfig(
     google::cloud::notebooks::v1::UpdateInstanceConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstanceConfig(request);
 }
 
@@ -133,26 +121,22 @@ future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::UpdateShieldedInstanceConfig(
     google::cloud::notebooks::v1::UpdateShieldedInstanceConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateShieldedInstanceConfig(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::SetInstanceLabels(
     google::cloud::notebooks::v1::SetInstanceLabelsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetInstanceLabels(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-NotebookServiceClient::DeleteInstance(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::DeleteInstance(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -161,62 +145,55 @@ NotebookServiceClient::DeleteInstance(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 NotebookServiceClient::DeleteInstance(
     google::cloud::notebooks::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::StartInstance(
     google::cloud::notebooks::v1::StartInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::StopInstance(
     google::cloud::notebooks::v1::StopInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StopInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::ResetInstance(
     google::cloud::notebooks::v1::ResetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResetInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::ReportInstanceInfo(
     google::cloud::notebooks::v1::ReportInstanceInfoRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReportInstanceInfo(request);
 }
 
 StatusOr<google::cloud::notebooks::v1::IsInstanceUpgradeableResponse>
 NotebookServiceClient::IsInstanceUpgradeable(
     google::cloud::notebooks::v1::IsInstanceUpgradeableRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->IsInstanceUpgradeable(request);
 }
 
 StatusOr<google::cloud::notebooks::v1::GetInstanceHealthResponse>
 NotebookServiceClient::GetInstanceHealth(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::GetInstanceHealthRequest request;
   request.set_name(name);
   return connection_->GetInstanceHealth(request);
@@ -225,44 +202,39 @@ NotebookServiceClient::GetInstanceHealth(std::string const& name,
 StatusOr<google::cloud::notebooks::v1::GetInstanceHealthResponse>
 NotebookServiceClient::GetInstanceHealth(
     google::cloud::notebooks::v1::GetInstanceHealthRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstanceHealth(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::UpgradeInstance(
     google::cloud::notebooks::v1::UpgradeInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpgradeInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::RollbackInstance(
     google::cloud::notebooks::v1::RollbackInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RollbackInstance(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Instance>>
 NotebookServiceClient::UpgradeInstanceInternal(
     google::cloud::notebooks::v1::UpgradeInstanceInternalRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpgradeInstanceInternal(request);
 }
 
 StreamRange<google::cloud::notebooks::v1::Environment>
 NotebookServiceClient::ListEnvironments(std::string const& parent,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ListEnvironmentsRequest request;
   request.set_parent(parent);
   return connection_->ListEnvironments(request);
@@ -271,17 +243,14 @@ NotebookServiceClient::ListEnvironments(std::string const& parent,
 StreamRange<google::cloud::notebooks::v1::Environment>
 NotebookServiceClient::ListEnvironments(
     google::cloud::notebooks::v1::ListEnvironmentsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEnvironments(std::move(request));
 }
 
 StatusOr<google::cloud::notebooks::v1::Environment>
-NotebookServiceClient::GetEnvironment(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::GetEnvironment(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::GetEnvironmentRequest request;
   request.set_name(name);
   return connection_->GetEnvironment(request);
@@ -290,9 +259,8 @@ NotebookServiceClient::GetEnvironment(std::string const& name,
 StatusOr<google::cloud::notebooks::v1::Environment>
 NotebookServiceClient::GetEnvironment(
     google::cloud::notebooks::v1::GetEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEnvironment(request);
 }
 
@@ -300,9 +268,8 @@ future<StatusOr<google::cloud::notebooks::v1::Environment>>
 NotebookServiceClient::CreateEnvironment(
     std::string const& parent,
     google::cloud::notebooks::v1::Environment const& environment,
-    std::string const& environment_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& environment_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::CreateEnvironmentRequest request;
   request.set_parent(parent);
   *request.mutable_environment() = environment;
@@ -313,17 +280,15 @@ NotebookServiceClient::CreateEnvironment(
 future<StatusOr<google::cloud::notebooks::v1::Environment>>
 NotebookServiceClient::CreateEnvironment(
     google::cloud::notebooks::v1::CreateEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEnvironment(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 NotebookServiceClient::DeleteEnvironment(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::DeleteEnvironmentRequest request;
   request.set_name(name);
   return connection_->DeleteEnvironment(request);
@@ -332,17 +297,14 @@ NotebookServiceClient::DeleteEnvironment(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 NotebookServiceClient::DeleteEnvironment(
     google::cloud::notebooks::v1::DeleteEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteEnvironment(request);
 }
 
 StreamRange<google::cloud::notebooks::v1::Schedule>
-NotebookServiceClient::ListSchedules(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::ListSchedules(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ListSchedulesRequest request;
   request.set_parent(parent);
   return connection_->ListSchedules(request);
@@ -350,17 +312,14 @@ NotebookServiceClient::ListSchedules(std::string const& parent,
 
 StreamRange<google::cloud::notebooks::v1::Schedule>
 NotebookServiceClient::ListSchedules(
-    google::cloud::notebooks::v1::ListSchedulesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::notebooks::v1::ListSchedulesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSchedules(std::move(request));
 }
 
 StatusOr<google::cloud::notebooks::v1::Schedule>
-NotebookServiceClient::GetSchedule(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::GetSchedule(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::GetScheduleRequest request;
   request.set_name(name);
   return connection_->GetSchedule(request);
@@ -369,17 +328,14 @@ NotebookServiceClient::GetSchedule(std::string const& name, Options options) {
 StatusOr<google::cloud::notebooks::v1::Schedule>
 NotebookServiceClient::GetSchedule(
     google::cloud::notebooks::v1::GetScheduleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSchedule(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-NotebookServiceClient::DeleteSchedule(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::DeleteSchedule(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::DeleteScheduleRequest request;
   request.set_name(name);
   return connection_->DeleteSchedule(request);
@@ -388,9 +344,8 @@ NotebookServiceClient::DeleteSchedule(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 NotebookServiceClient::DeleteSchedule(
     google::cloud::notebooks::v1::DeleteScheduleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteSchedule(request);
 }
 
@@ -398,9 +353,8 @@ future<StatusOr<google::cloud::notebooks::v1::Schedule>>
 NotebookServiceClient::CreateSchedule(
     std::string const& parent,
     google::cloud::notebooks::v1::Schedule const& schedule,
-    std::string const& schedule_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& schedule_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::CreateScheduleRequest request;
   request.set_parent(parent);
   *request.mutable_schedule() = schedule;
@@ -411,26 +365,22 @@ NotebookServiceClient::CreateSchedule(
 future<StatusOr<google::cloud::notebooks::v1::Schedule>>
 NotebookServiceClient::CreateSchedule(
     google::cloud::notebooks::v1::CreateScheduleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSchedule(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::Schedule>>
 NotebookServiceClient::TriggerSchedule(
     google::cloud::notebooks::v1::TriggerScheduleRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TriggerSchedule(request);
 }
 
 StreamRange<google::cloud::notebooks::v1::Execution>
-NotebookServiceClient::ListExecutions(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::ListExecutions(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::ListExecutionsRequest request;
   request.set_parent(parent);
   return connection_->ListExecutions(request);
@@ -438,17 +388,14 @@ NotebookServiceClient::ListExecutions(std::string const& parent,
 
 StreamRange<google::cloud::notebooks::v1::Execution>
 NotebookServiceClient::ListExecutions(
-    google::cloud::notebooks::v1::ListExecutionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::notebooks::v1::ListExecutionsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListExecutions(std::move(request));
 }
 
 StatusOr<google::cloud::notebooks::v1::Execution>
-NotebookServiceClient::GetExecution(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::GetExecution(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::GetExecutionRequest request;
   request.set_name(name);
   return connection_->GetExecution(request);
@@ -457,17 +404,14 @@ NotebookServiceClient::GetExecution(std::string const& name, Options options) {
 StatusOr<google::cloud::notebooks::v1::Execution>
 NotebookServiceClient::GetExecution(
     google::cloud::notebooks::v1::GetExecutionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetExecution(request);
 }
 
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-NotebookServiceClient::DeleteExecution(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+NotebookServiceClient::DeleteExecution(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::DeleteExecutionRequest request;
   request.set_name(name);
   return connection_->DeleteExecution(request);
@@ -476,9 +420,8 @@ NotebookServiceClient::DeleteExecution(std::string const& name,
 future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
 NotebookServiceClient::DeleteExecution(
     google::cloud::notebooks::v1::DeleteExecutionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteExecution(request);
 }
 
@@ -486,9 +429,8 @@ future<StatusOr<google::cloud::notebooks::v1::Execution>>
 NotebookServiceClient::CreateExecution(
     std::string const& parent,
     google::cloud::notebooks::v1::Execution const& execution,
-    std::string const& execution_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& execution_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::notebooks::v1::CreateExecutionRequest request;
   request.set_parent(parent);
   *request.mutable_execution() = execution;
@@ -499,9 +441,8 @@ NotebookServiceClient::CreateExecution(
 future<StatusOr<google::cloud::notebooks::v1::Execution>>
 NotebookServiceClient::CreateExecution(
     google::cloud::notebooks::v1::CreateExecutionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateExecution(request);
 }
 

--- a/google/cloud/notebooks/notebook_client.h
+++ b/google/cloud/notebooks/notebook_client.h
@@ -63,8 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class NotebookServiceClient {
  public:
   explicit NotebookServiceClient(
-      std::shared_ptr<NotebookServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<NotebookServiceConnection> connection, Options opts = {});
   ~NotebookServiceClient();
 
   //@{
@@ -92,7 +91,8 @@ class NotebookServiceClient {
   ///
   /// @param parent  Required. Format:
   ///  `parent=projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -102,14 +102,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/instance.proto#L61}
   ///
   StreamRange<google::cloud::notebooks::v1::Instance> ListInstances(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists instances in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ListInstancesRequest,google/cloud/notebooks/v1/service.proto#L430}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -120,14 +121,15 @@ class NotebookServiceClient {
   ///
   StreamRange<google::cloud::notebooks::v1::Instance> ListInstances(
       google::cloud::notebooks::v1::ListInstancesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Instance.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/instances/{instance_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -137,14 +139,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/instance.proto#L61}
   ///
   StatusOr<google::cloud::notebooks::v1::Instance> GetInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::GetInstanceRequest,google/cloud/notebooks/v1/service.proto#L459}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -155,7 +158,7 @@ class NotebookServiceClient {
   ///
   StatusOr<google::cloud::notebooks::v1::Instance> GetInstance(
       google::cloud::notebooks::v1::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Instance in a given project and location.
@@ -164,7 +167,8 @@ class NotebookServiceClient {
   ///  `parent=projects/{project_id}/locations/{location}`
   /// @param instance  Required. The instance to be created.
   /// @param instance_id  Required. User-defined unique ID of this instance.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -176,14 +180,15 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::Instance>> CreateInstance(
       std::string const& parent,
       google::cloud::notebooks::v1::Instance const& instance,
-      std::string const& instance_id, Options options = {});
+      std::string const& instance_id, Options opts = {});
 
   ///
   /// Creates a new Instance in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::CreateInstanceRequest,google/cloud/notebooks/v1/service.proto#L466}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -194,7 +199,7 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> CreateInstance(
       google::cloud::notebooks::v1::CreateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Registers an existing legacy notebook instance to the Notebooks API
@@ -204,7 +209,8 @@ class NotebookServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::RegisterInstanceRequest,google/cloud/notebooks/v1/service.proto#L479}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -215,14 +221,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> RegisterInstance(
       google::cloud::notebooks::v1::RegisterInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the guest accelerators of a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::SetInstanceAcceleratorRequest,google/cloud/notebooks/v1/service.proto#L492}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -235,14 +242,15 @@ class NotebookServiceClient {
   SetInstanceAccelerator(
       google::cloud::notebooks::v1::SetInstanceAcceleratorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the machine type of a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::SetInstanceMachineTypeRequest,google/cloud/notebooks/v1/service.proto#L508}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -255,14 +263,15 @@ class NotebookServiceClient {
   SetInstanceMachineType(
       google::cloud::notebooks::v1::SetInstanceMachineTypeRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update Notebook Instance configurations.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::UpdateInstanceConfigRequest,google/cloud/notebooks/v1/service.proto#L519}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -273,14 +282,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> UpdateInstanceConfig(
       google::cloud::notebooks::v1::UpdateInstanceConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the Shielded instance configuration of a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::UpdateShieldedInstanceConfigRequest,google/cloud/notebooks/v1/service.proto#L541}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -293,14 +303,15 @@ class NotebookServiceClient {
   UpdateShieldedInstanceConfig(
       google::cloud::notebooks::v1::UpdateShieldedInstanceConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Replaces all the labels of an Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::SetInstanceLabelsRequest,google/cloud/notebooks/v1/service.proto#L529}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -311,14 +322,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> SetInstanceLabels(
       google::cloud::notebooks::v1::SetInstanceLabelsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Instance.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/instances/{instance_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -328,14 +340,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/service.proto#L400}
   ///
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-  DeleteInstance(std::string const& name, Options options = {});
+  DeleteInstance(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::DeleteInstanceRequest,google/cloud/notebooks/v1/service.proto#L551}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -347,14 +360,15 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
   DeleteInstance(
       google::cloud::notebooks::v1::DeleteInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts a notebook instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::StartInstanceRequest,google/cloud/notebooks/v1/service.proto#L558}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -365,14 +379,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> StartInstance(
       google::cloud::notebooks::v1::StartInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a notebook instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::StopInstanceRequest,google/cloud/notebooks/v1/service.proto#L565}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -383,14 +398,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> StopInstance(
       google::cloud::notebooks::v1::StopInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resets a notebook instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ResetInstanceRequest,google/cloud/notebooks/v1/service.proto#L572}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -401,7 +417,7 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> ResetInstance(
       google::cloud::notebooks::v1::ResetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Allows notebook instances to
@@ -411,7 +427,8 @@ class NotebookServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ReportInstanceInfoRequest,google/cloud/notebooks/v1/service.proto#L579}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -422,14 +439,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> ReportInstanceInfo(
       google::cloud::notebooks::v1::ReportInstanceInfoRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Check if a notebook instance is upgradable.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::IsInstanceUpgradeableRequest,google/cloud/notebooks/v1/service.proto#L594}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::IsInstanceUpgradeableResponse,google/cloud/notebooks/v1/service.proto#L601}
   ///
@@ -441,14 +459,15 @@ class NotebookServiceClient {
   StatusOr<google::cloud::notebooks::v1::IsInstanceUpgradeableResponse>
   IsInstanceUpgradeable(
       google::cloud::notebooks::v1::IsInstanceUpgradeableRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Check if a notebook instance is healthy.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/instances/{instance_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::GetInstanceHealthResponse,google/cloud/notebooks/v1/service.proto#L631}
   ///
@@ -458,14 +477,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/service.proto#L631}
   ///
   StatusOr<google::cloud::notebooks::v1::GetInstanceHealthResponse>
-  GetInstanceHealth(std::string const& name, Options options = {});
+  GetInstanceHealth(std::string const& name, Options opts = {});
 
   ///
   /// Check if a notebook instance is healthy.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::GetInstanceHealthRequest,google/cloud/notebooks/v1/service.proto#L619}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::GetInstanceHealthResponse,google/cloud/notebooks/v1/service.proto#L631}
   ///
@@ -477,14 +497,15 @@ class NotebookServiceClient {
   StatusOr<google::cloud::notebooks::v1::GetInstanceHealthResponse>
   GetInstanceHealth(
       google::cloud::notebooks::v1::GetInstanceHealthRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Upgrades a notebook instance to the latest version.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::UpgradeInstanceRequest,google/cloud/notebooks/v1/service.proto#L672}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -495,14 +516,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> UpgradeInstance(
       google::cloud::notebooks::v1::UpgradeInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Rollbacks a notebook instance to the previous version.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::RollbackInstanceRequest,google/cloud/notebooks/v1/service.proto#L679}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -513,7 +535,7 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Instance>> RollbackInstance(
       google::cloud::notebooks::v1::RollbackInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Allows notebook instances to
@@ -521,7 +543,8 @@ class NotebookServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::UpgradeInstanceInternalRequest,google/cloud/notebooks/v1/service.proto#L690}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Instance,google/cloud/notebooks/v1/instance.proto#L61}
   ///
@@ -534,14 +557,15 @@ class NotebookServiceClient {
   UpgradeInstanceInternal(
       google::cloud::notebooks::v1::UpgradeInstanceInternalRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists environments in a project.
   ///
   /// @param parent  Required. Format:
   /// `projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Environment,google/cloud/notebooks/v1/environment.proto#L33}
   ///
@@ -551,14 +575,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/environment.proto#L33}
   ///
   StreamRange<google::cloud::notebooks::v1::Environment> ListEnvironments(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists environments in a project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ListEnvironmentsRequest,google/cloud/notebooks/v1/service.proto#L701}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Environment,google/cloud/notebooks/v1/environment.proto#L33}
   ///
@@ -569,14 +594,15 @@ class NotebookServiceClient {
   ///
   StreamRange<google::cloud::notebooks::v1::Environment> ListEnvironments(
       google::cloud::notebooks::v1::ListEnvironmentsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Environment.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/environments/{environment_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Environment,google/cloud/notebooks/v1/environment.proto#L33}
   ///
@@ -586,14 +612,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/environment.proto#L33}
   ///
   StatusOr<google::cloud::notebooks::v1::Environment> GetEnvironment(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::GetEnvironmentRequest,google/cloud/notebooks/v1/service.proto#L727}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Environment,google/cloud/notebooks/v1/environment.proto#L33}
   ///
@@ -604,7 +631,7 @@ class NotebookServiceClient {
   ///
   StatusOr<google::cloud::notebooks::v1::Environment> GetEnvironment(
       google::cloud::notebooks::v1::GetEnvironmentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Environment.
@@ -617,7 +644,8 @@ class NotebookServiceClient {
   ///  be 1 to 63 characters long and contain only lowercase letters,
   ///  numeric characters, and dashes. The first character must be a lowercase
   ///  letter and the last character cannot be a dash.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Environment,google/cloud/notebooks/v1/environment.proto#L33}
   ///
@@ -629,14 +657,15 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::Environment>> CreateEnvironment(
       std::string const& parent,
       google::cloud::notebooks::v1::Environment const& environment,
-      std::string const& environment_id, Options options = {});
+      std::string const& environment_id, Options opts = {});
 
   ///
   /// Creates a new Environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::CreateEnvironmentRequest,google/cloud/notebooks/v1/service.proto#L734}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Environment,google/cloud/notebooks/v1/environment.proto#L33}
   ///
@@ -647,14 +676,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Environment>> CreateEnvironment(
       google::cloud::notebooks::v1::CreateEnvironmentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Environment.
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/environments/{environment_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -664,14 +694,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/service.proto#L400}
   ///
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-  DeleteEnvironment(std::string const& name, Options options = {});
+  DeleteEnvironment(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Environment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::DeleteEnvironmentRequest,google/cloud/notebooks/v1/service.proto#L749}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -683,14 +714,15 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
   DeleteEnvironment(
       google::cloud::notebooks::v1::DeleteEnvironmentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists schedules in a given project and location.
   ///
   /// @param parent  Required. Format:
   ///  `parent=projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -700,14 +732,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/schedule.proto#L30}
   ///
   StreamRange<google::cloud::notebooks::v1::Schedule> ListSchedules(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists schedules in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ListSchedulesRequest,google/cloud/notebooks/v1/service.proto#L756}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -718,14 +751,15 @@ class NotebookServiceClient {
   ///
   StreamRange<google::cloud::notebooks::v1::Schedule> ListSchedules(
       google::cloud::notebooks::v1::ListSchedulesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of schedule
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/schedules/{schedule_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -735,14 +769,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/schedule.proto#L30}
   ///
   StatusOr<google::cloud::notebooks::v1::Schedule> GetSchedule(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of schedule
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::GetScheduleRequest,google/cloud/notebooks/v1/service.proto#L797}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -753,14 +788,15 @@ class NotebookServiceClient {
   ///
   StatusOr<google::cloud::notebooks::v1::Schedule> GetSchedule(
       google::cloud::notebooks::v1::GetScheduleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes schedule and all underlying jobs
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/schedules/{schedule_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -770,14 +806,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/service.proto#L400}
   ///
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-  DeleteSchedule(std::string const& name, Options options = {});
+  DeleteSchedule(std::string const& name, Options opts = {});
 
   ///
   /// Deletes schedule and all underlying jobs
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::DeleteScheduleRequest,google/cloud/notebooks/v1/service.proto#L809}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -789,7 +826,7 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
   DeleteSchedule(
       google::cloud::notebooks::v1::DeleteScheduleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Scheduled Notebook in a given project and location.
@@ -798,7 +835,8 @@ class NotebookServiceClient {
   ///  `parent=projects/{project_id}/locations/{location}`
   /// @param schedule  Required. The schedule to be created.
   /// @param schedule_id  Required. User-defined unique ID of this schedule.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -810,14 +848,15 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::Schedule>> CreateSchedule(
       std::string const& parent,
       google::cloud::notebooks::v1::Schedule const& schedule,
-      std::string const& schedule_id, Options options = {});
+      std::string const& schedule_id, Options opts = {});
 
   ///
   /// Creates a new Scheduled Notebook in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::CreateScheduleRequest,google/cloud/notebooks/v1/service.proto#L821}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -828,14 +867,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Schedule>> CreateSchedule(
       google::cloud::notebooks::v1::CreateScheduleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Triggers execution of an existing schedule.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::TriggerScheduleRequest,google/cloud/notebooks/v1/service.proto#L839}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Schedule,google/cloud/notebooks/v1/schedule.proto#L30}
   ///
@@ -846,14 +886,15 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Schedule>> TriggerSchedule(
       google::cloud::notebooks::v1::TriggerScheduleRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists executions in a given project and location
   ///
   /// @param parent  Required. Format:
   ///  `parent=projects/{project_id}/locations/{location}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Execution,google/cloud/notebooks/v1/execution.proto#L250}
   ///
@@ -863,14 +904,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/execution.proto#L250}
   ///
   StreamRange<google::cloud::notebooks::v1::Execution> ListExecutions(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists executions in a given project and location
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::ListExecutionsRequest,google/cloud/notebooks/v1/service.proto#L851}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Execution,google/cloud/notebooks/v1/execution.proto#L250}
   ///
@@ -881,14 +923,15 @@ class NotebookServiceClient {
   ///
   StreamRange<google::cloud::notebooks::v1::Execution> ListExecutions(
       google::cloud::notebooks::v1::ListExecutionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of executions
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/executions/{execution_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Execution,google/cloud/notebooks/v1/execution.proto#L250}
   ///
@@ -898,14 +941,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/execution.proto#L250}
   ///
   StatusOr<google::cloud::notebooks::v1::Execution> GetExecution(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of executions
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::GetExecutionRequest,google/cloud/notebooks/v1/service.proto#L894}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Execution,google/cloud/notebooks/v1/execution.proto#L250}
   ///
@@ -916,14 +960,15 @@ class NotebookServiceClient {
   ///
   StatusOr<google::cloud::notebooks::v1::Execution> GetExecution(
       google::cloud::notebooks::v1::GetExecutionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes execution
   ///
   /// @param name  Required. Format:
   ///  `projects/{project_id}/locations/{location}/executions/{execution_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -933,14 +978,15 @@ class NotebookServiceClient {
   /// @googleapis_reference_link{google/cloud/notebooks/v1/service.proto#L400}
   ///
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
-  DeleteExecution(std::string const& name, Options options = {});
+  DeleteExecution(std::string const& name, Options opts = {});
 
   ///
   /// Deletes execution
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::DeleteExecutionRequest,google/cloud/notebooks/v1/service.proto#L906}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::OperationMetadata,google/cloud/notebooks/v1/service.proto#L400}
   ///
@@ -952,7 +998,7 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::OperationMetadata>>
   DeleteExecution(
       google::cloud::notebooks::v1::DeleteExecutionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Scheduled Notebook in a given project and location.
@@ -961,7 +1007,8 @@ class NotebookServiceClient {
   ///  `parent=projects/{project_id}/locations/{location}`
   /// @param execution  Required. The execution to be created.
   /// @param execution_id  Required. User-defined unique ID of this execution.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Execution,google/cloud/notebooks/v1/execution.proto#L250}
   ///
@@ -973,14 +1020,15 @@ class NotebookServiceClient {
   future<StatusOr<google::cloud::notebooks::v1::Execution>> CreateExecution(
       std::string const& parent,
       google::cloud::notebooks::v1::Execution const& execution,
-      std::string const& execution_id, Options options = {});
+      std::string const& execution_id, Options opts = {});
 
   ///
   /// Creates a new Scheduled Notebook in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::notebooks::v1::CreateExecutionRequest,google/cloud/notebooks/v1/service.proto#L918}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::notebooks::v1::Execution,google/cloud/notebooks/v1/execution.proto#L250}
   ///
@@ -991,7 +1039,7 @@ class NotebookServiceClient {
   ///
   future<StatusOr<google::cloud::notebooks::v1::Execution>> CreateExecution(
       google::cloud::notebooks::v1::CreateExecutionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<NotebookServiceConnection> connection_;

--- a/google/cloud/orgpolicy/org_policy_client.cc
+++ b/google/cloud/orgpolicy/org_policy_client.cc
@@ -26,17 +26,16 @@ namespace orgpolicy {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OrgPolicyClient::OrgPolicyClient(
-    std::shared_ptr<OrgPolicyConnection> connection, Options options)
+    std::shared_ptr<OrgPolicyConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), orgpolicy_internal::OrgPolicyDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), orgpolicy_internal::OrgPolicyDefaultOptions(
+                               connection_->options()))) {}
 OrgPolicyClient::~OrgPolicyClient() = default;
 
 StreamRange<google::cloud::orgpolicy::v2::Constraint>
-OrgPolicyClient::ListConstraints(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OrgPolicyClient::ListConstraints(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::ListConstraintsRequest request;
   request.set_parent(parent);
   return connection_->ListConstraints(request);
@@ -45,33 +44,28 @@ OrgPolicyClient::ListConstraints(std::string const& parent, Options options) {
 StreamRange<google::cloud::orgpolicy::v2::Constraint>
 OrgPolicyClient::ListConstraints(
     google::cloud::orgpolicy::v2::ListConstraintsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListConstraints(std::move(request));
 }
 
 StreamRange<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::ListPolicies(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::ListPoliciesRequest request;
   request.set_parent(parent);
   return connection_->ListPolicies(request);
 }
 
 StreamRange<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::ListPolicies(
-    google::cloud::orgpolicy::v2::ListPoliciesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::orgpolicy::v2::ListPoliciesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPolicies(std::move(request));
 }
 
 StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::GetPolicy(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::GetPolicyRequest request;
   request.set_name(name);
   return connection_->GetPolicy(request);
@@ -79,16 +73,14 @@ StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::GetPolicy(
 
 StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::GetPolicy(
     google::cloud::orgpolicy::v2::GetPolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPolicy(request);
 }
 
 StatusOr<google::cloud::orgpolicy::v2::Policy>
-OrgPolicyClient::GetEffectivePolicy(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OrgPolicyClient::GetEffectivePolicy(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::GetEffectivePolicyRequest request;
   request.set_name(name);
   return connection_->GetEffectivePolicy(request);
@@ -97,17 +89,15 @@ OrgPolicyClient::GetEffectivePolicy(std::string const& name, Options options) {
 StatusOr<google::cloud::orgpolicy::v2::Policy>
 OrgPolicyClient::GetEffectivePolicy(
     google::cloud::orgpolicy::v2::GetEffectivePolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEffectivePolicy(request);
 }
 
 StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::CreatePolicy(
     std::string const& parent,
-    google::cloud::orgpolicy::v2::Policy const& policy, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::orgpolicy::v2::Policy const& policy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::CreatePolicyRequest request;
   request.set_parent(parent);
   *request.mutable_policy() = policy;
@@ -116,16 +106,14 @@ StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::CreatePolicy(
 
 StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::CreatePolicy(
     google::cloud::orgpolicy::v2::CreatePolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreatePolicy(request);
 }
 
 StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::UpdatePolicy(
-    google::cloud::orgpolicy::v2::Policy const& policy, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::orgpolicy::v2::Policy const& policy, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::UpdatePolicyRequest request;
   *request.mutable_policy() = policy;
   return connection_->UpdatePolicy(request);
@@ -133,15 +121,13 @@ StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::UpdatePolicy(
 
 StatusOr<google::cloud::orgpolicy::v2::Policy> OrgPolicyClient::UpdatePolicy(
     google::cloud::orgpolicy::v2::UpdatePolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdatePolicy(request);
 }
 
-Status OrgPolicyClient::DeletePolicy(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status OrgPolicyClient::DeletePolicy(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::orgpolicy::v2::DeletePolicyRequest request;
   request.set_name(name);
   return connection_->DeletePolicy(request);
@@ -149,9 +135,8 @@ Status OrgPolicyClient::DeletePolicy(std::string const& name, Options options) {
 
 Status OrgPolicyClient::DeletePolicy(
     google::cloud::orgpolicy::v2::DeletePolicyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeletePolicy(request);
 }
 

--- a/google/cloud/orgpolicy/org_policy_client.h
+++ b/google/cloud/orgpolicy/org_policy_client.h
@@ -80,7 +80,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OrgPolicyClient {
  public:
   explicit OrgPolicyClient(std::shared_ptr<OrgPolicyConnection> connection,
-                           Options options = {});
+                           Options opts = {});
   ~OrgPolicyClient();
 
   //@{
@@ -111,7 +111,8 @@ class OrgPolicyClient {
   ///  * `projects/{project_id}`
   ///  * `folders/{folder_id}`
   ///  * `organizations/{organization_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Constraint,google/cloud/orgpolicy/v2/constraint.proto#L44}
   ///
@@ -121,14 +122,15 @@ class OrgPolicyClient {
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/constraint.proto#L44}
   ///
   StreamRange<google::cloud::orgpolicy::v2::Constraint> ListConstraints(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists `Constraints` that could be applied on the specified resource.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::ListConstraintsRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L343}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Constraint,google/cloud/orgpolicy/v2/constraint.proto#L44}
   ///
@@ -139,7 +141,7 @@ class OrgPolicyClient {
   ///
   StreamRange<google::cloud::orgpolicy::v2::Constraint> ListConstraints(
       google::cloud::orgpolicy::v2::ListConstraintsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves all of the `Policies` that exist on a particular resource.
@@ -152,7 +154,8 @@ class OrgPolicyClient {
   ///  * `projects/{project_id}`
   ///  * `folders/{folder_id}`
   ///  * `organizations/{organization_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -162,14 +165,15 @@ class OrgPolicyClient {
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
   StreamRange<google::cloud::orgpolicy::v2::Policy> ListPolicies(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Retrieves all of the `Policies` that exist on a particular resource.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::ListPoliciesRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L379}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -180,7 +184,7 @@ class OrgPolicyClient {
   ///
   StreamRange<google::cloud::orgpolicy::v2::Policy> ListPolicies(
       google::cloud::orgpolicy::v2::ListPoliciesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a `Policy` on a resource.
@@ -191,7 +195,8 @@ class OrgPolicyClient {
   ///
   /// @param name  Required. Resource name of the policy. See `Policy` for
   /// naming requirements.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -201,7 +206,7 @@ class OrgPolicyClient {
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> GetPolicy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a `Policy` on a resource.
@@ -212,7 +217,8 @@ class OrgPolicyClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::GetPolicyRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L419}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -223,7 +229,7 @@ class OrgPolicyClient {
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> GetPolicy(
       google::cloud::orgpolicy::v2::GetPolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the effective `Policy` on a resource. This is the result of merging
@@ -235,7 +241,8 @@ class OrgPolicyClient {
   ///
   /// @param name  Required. The effective policy to compute. See `Policy` for
   /// naming rules.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -245,7 +252,7 @@ class OrgPolicyClient {
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> GetEffectivePolicy(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the effective `Policy` on a resource. This is the result of merging
@@ -257,7 +264,8 @@ class OrgPolicyClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::GetEffectivePolicyRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L431}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -268,7 +276,7 @@ class OrgPolicyClient {
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> GetEffectivePolicy(
       google::cloud::orgpolicy::v2::GetEffectivePolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Policy.
@@ -286,7 +294,8 @@ class OrgPolicyClient {
   ///  * `folders/{folder_id}`
   ///  * `organizations/{organization_id}`
   /// @param policy  Required. `Policy` to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -297,7 +306,7 @@ class OrgPolicyClient {
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> CreatePolicy(
       std::string const& parent,
-      google::cloud::orgpolicy::v2::Policy const& policy, Options options = {});
+      google::cloud::orgpolicy::v2::Policy const& policy, Options opts = {});
 
   ///
   /// Creates a Policy.
@@ -309,7 +318,8 @@ class OrgPolicyClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::CreatePolicyRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L443}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -320,7 +330,7 @@ class OrgPolicyClient {
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> CreatePolicy(
       google::cloud::orgpolicy::v2::CreatePolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a Policy.
@@ -334,7 +344,8 @@ class OrgPolicyClient {
   /// fields.
   ///
   /// @param policy  Required. `Policy` to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -344,7 +355,7 @@ class OrgPolicyClient {
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> UpdatePolicy(
-      google::cloud::orgpolicy::v2::Policy const& policy, Options options = {});
+      google::cloud::orgpolicy::v2::Policy const& policy, Options opts = {});
 
   ///
   /// Updates a Policy.
@@ -359,7 +370,8 @@ class OrgPolicyClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::UpdatePolicyRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L463}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::orgpolicy::v2::Policy,google/cloud/orgpolicy/v2/orgpolicy.proto#L192}
   ///
@@ -370,7 +382,7 @@ class OrgPolicyClient {
   ///
   StatusOr<google::cloud::orgpolicy::v2::Policy> UpdatePolicy(
       google::cloud::orgpolicy::v2::UpdatePolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a Policy.
@@ -380,12 +392,13 @@ class OrgPolicyClient {
   ///
   /// @param name  Required. Name of the policy to delete.
   ///  See `Policy` for naming rules.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.orgpolicy.v2.DeletePolicyRequest]:
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/orgpolicy.proto#L470}
   ///
-  Status DeletePolicy(std::string const& name, Options options = {});
+  Status DeletePolicy(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a Policy.
@@ -395,14 +408,15 @@ class OrgPolicyClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::orgpolicy::v2::DeletePolicyRequest,google/cloud/orgpolicy/v2/orgpolicy.proto#L470}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.orgpolicy.v2.DeletePolicyRequest]:
   /// @googleapis_reference_link{google/cloud/orgpolicy/v2/orgpolicy.proto#L470}
   ///
   Status DeletePolicy(
       google::cloud::orgpolicy::v2::DeletePolicyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<OrgPolicyConnection> connection_;

--- a/google/cloud/osconfig/agent_endpoint_client.cc
+++ b/google/cloud/osconfig/agent_endpoint_client.cc
@@ -26,10 +26,10 @@ namespace osconfig {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AgentEndpointServiceClient::AgentEndpointServiceClient(
-    std::shared_ptr<AgentEndpointServiceConnection> connection, Options options)
+    std::shared_ptr<AgentEndpointServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           osconfig_internal::AgentEndpointServiceDefaultOptions(
               connection_->options()))) {}
 AgentEndpointServiceClient::~AgentEndpointServiceClient() = default;
@@ -38,9 +38,8 @@ StreamRange<
     google::cloud::osconfig::agentendpoint::v1::ReceiveTaskNotificationResponse>
 AgentEndpointServiceClient::ReceiveTaskNotification(
     std::string const& instance_id_token, std::string const& agent_version,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::agentendpoint::v1::ReceiveTaskNotificationRequest
       request;
   request.set_instance_id_token(instance_id_token);
@@ -53,17 +52,15 @@ StreamRange<
 AgentEndpointServiceClient::ReceiveTaskNotification(
     google::cloud::osconfig::agentendpoint::v1::
         ReceiveTaskNotificationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReceiveTaskNotification(request);
 }
 
 StatusOr<google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>
 AgentEndpointServiceClient::StartNextTask(std::string const& instance_id_token,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::agentendpoint::v1::StartNextTaskRequest request;
   request.set_instance_id_token(instance_id_token);
   return connection_->StartNextTask(request);
@@ -73,9 +70,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>
 AgentEndpointServiceClient::StartNextTask(
     google::cloud::osconfig::agentendpoint::v1::StartNextTaskRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartNextTask(request);
 }
 
@@ -83,9 +79,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressResponse>
 AgentEndpointServiceClient::ReportTaskProgress(
     std::string const& instance_id_token, std::string const& task_id,
     google::cloud::osconfig::agentendpoint::v1::TaskType task_type,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressRequest request;
   request.set_instance_id_token(instance_id_token);
   request.set_task_id(task_id);
@@ -97,9 +92,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressResponse>
 AgentEndpointServiceClient::ReportTaskProgress(
     google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReportTaskProgress(request);
 }
 
@@ -107,9 +101,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteResponse>
 AgentEndpointServiceClient::ReportTaskComplete(
     std::string const& instance_id_token, std::string const& task_id,
     google::cloud::osconfig::agentendpoint::v1::TaskType task_type,
-    std::string const& error_message, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& error_message, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteRequest request;
   request.set_instance_id_token(instance_id_token);
   request.set_task_id(task_id);
@@ -122,18 +115,16 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteResponse>
 AgentEndpointServiceClient::ReportTaskComplete(
     google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReportTaskComplete(request);
 }
 
 StatusOr<google::cloud::osconfig::agentendpoint::v1::RegisterAgentResponse>
 AgentEndpointServiceClient::RegisterAgent(
     std::string const& instance_id_token, std::string const& agent_version,
-    std::vector<std::string> const& supported_capabilities, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<std::string> const& supported_capabilities, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::agentendpoint::v1::RegisterAgentRequest request;
   request.set_instance_id_token(instance_id_token);
   request.set_agent_version(agent_version);
@@ -146,9 +137,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::RegisterAgentResponse>
 AgentEndpointServiceClient::RegisterAgent(
     google::cloud::osconfig::agentendpoint::v1::RegisterAgentRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RegisterAgent(request);
 }
 
@@ -156,9 +146,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::ReportInventoryResponse>
 AgentEndpointServiceClient::ReportInventory(
     std::string const& instance_id_token, std::string const& inventory_checksum,
     google::cloud::osconfig::agentendpoint::v1::Inventory const& inventory,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::agentendpoint::v1::ReportInventoryRequest request;
   request.set_instance_id_token(instance_id_token);
   request.set_inventory_checksum(inventory_checksum);
@@ -170,9 +159,8 @@ StatusOr<google::cloud::osconfig::agentendpoint::v1::ReportInventoryResponse>
 AgentEndpointServiceClient::ReportInventory(
     google::cloud::osconfig::agentendpoint::v1::ReportInventoryRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReportInventory(request);
 }
 

--- a/google/cloud/osconfig/agent_endpoint_client.h
+++ b/google/cloud/osconfig/agent_endpoint_client.h
@@ -62,7 +62,7 @@ class AgentEndpointServiceClient {
  public:
   explicit AgentEndpointServiceClient(
       std::shared_ptr<AgentEndpointServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~AgentEndpointServiceClient();
 
   //@{
@@ -95,7 +95,8 @@ class AgentEndpointServiceClient {
   ///  where the audience is 'osconfig.googleapis.com' and the format is 'full'.
   /// @param agent_version  Required. The version of the agent making the
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReceiveTaskNotificationResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L86}
   ///
@@ -107,15 +108,15 @@ class AgentEndpointServiceClient {
   StreamRange<google::cloud::osconfig::agentendpoint::v1::
                   ReceiveTaskNotificationResponse>
   ReceiveTaskNotification(std::string const& instance_id_token,
-                          std::string const& agent_version,
-                          Options options = {});
+                          std::string const& agent_version, Options opts = {});
 
   ///
   /// Stream established by client to receive Task notifications.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReceiveTaskNotificationRequest,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L74}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReceiveTaskNotificationResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L86}
   ///
@@ -128,7 +129,7 @@ class AgentEndpointServiceClient {
                   ReceiveTaskNotificationResponse>
   ReceiveTaskNotification(google::cloud::osconfig::agentendpoint::v1::
                               ReceiveTaskNotificationRequest const& request,
-                          Options options = {});
+                          Options opts = {});
 
   ///
   /// Signals the start of a task execution and returns the task info.
@@ -137,7 +138,8 @@ class AgentEndpointServiceClient {
   /// identity token described in
   ///  https://cloud.google.com/compute/docs/instances/verifying-instance-identity
   ///  where the audience is 'osconfig.googleapis.com' and the format is 'full'.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L97}
   ///
@@ -147,14 +149,15 @@ class AgentEndpointServiceClient {
   /// @googleapis_reference_link{google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L97}
   ///
   StatusOr<google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse>
-  StartNextTask(std::string const& instance_id_token, Options options = {});
+  StartNextTask(std::string const& instance_id_token, Options opts = {});
 
   ///
   /// Signals the start of a task execution and returns the task info.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::StartNextTaskRequest,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L89}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::StartNextTaskResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L97}
   ///
@@ -167,7 +170,7 @@ class AgentEndpointServiceClient {
   StartNextTask(
       google::cloud::osconfig::agentendpoint::v1::StartNextTaskRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Signals an intermediary progress checkpoint in task execution.
@@ -183,7 +186,8 @@ class AgentEndpointServiceClient {
   ///  APPLY_PATCHES = ApplyPatchesTaskProgress
   ///  EXEC_STEP = Progress not supported for this type.
   ///  APPLY_CONFIG_TASK = ApplyConfigTaskProgress
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L136}
   ///
@@ -197,14 +201,15 @@ class AgentEndpointServiceClient {
   ReportTaskProgress(
       std::string const& instance_id_token, std::string const& task_id,
       google::cloud::osconfig::agentendpoint::v1::TaskType task_type,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Signals an intermediary progress checkpoint in task execution.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressRequest,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L104}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L136}
   ///
@@ -217,7 +222,7 @@ class AgentEndpointServiceClient {
       google::cloud::osconfig::agentendpoint::v1::ReportTaskProgressResponse>
   ReportTaskProgress(google::cloud::osconfig::agentendpoint::v1::
                          ReportTaskProgressRequest const& request,
-                     Options options = {});
+                     Options opts = {});
 
   ///
   /// Signals that the task execution is complete and optionally returns the
@@ -236,7 +241,8 @@ class AgentEndpointServiceClient {
   ///  APPLY_CONFIG_TASK = ApplyConfigTaskOutput
   /// @param error_message  Descriptive error message if the task execution
   /// ended in error.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L177}
   ///
@@ -250,7 +256,7 @@ class AgentEndpointServiceClient {
   ReportTaskComplete(
       std::string const& instance_id_token, std::string const& task_id,
       google::cloud::osconfig::agentendpoint::v1::TaskType task_type,
-      std::string const& error_message, Options options = {});
+      std::string const& error_message, Options opts = {});
 
   ///
   /// Signals that the task execution is complete and optionally returns the
@@ -258,7 +264,8 @@ class AgentEndpointServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteRequest,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L142}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L177}
   ///
@@ -271,7 +278,7 @@ class AgentEndpointServiceClient {
       google::cloud::osconfig::agentendpoint::v1::ReportTaskCompleteResponse>
   ReportTaskComplete(google::cloud::osconfig::agentendpoint::v1::
                          ReportTaskCompleteRequest const& request,
-                     Options options = {});
+                     Options opts = {});
 
   ///
   /// Registers the agent running on the VM.
@@ -286,7 +293,8 @@ class AgentEndpointServiceClient {
   ///  PATCH_GA
   ///  GUEST_POLICY_BETA
   ///  CONFIG_V1
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::RegisterAgentResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L212}
   ///
@@ -299,14 +307,15 @@ class AgentEndpointServiceClient {
   RegisterAgent(std::string const& instance_id_token,
                 std::string const& agent_version,
                 std::vector<std::string> const& supported_capabilities,
-                Options options = {});
+                Options opts = {});
 
   ///
   /// Registers the agent running on the VM.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::RegisterAgentRequest,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L180}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::RegisterAgentResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L212}
   ///
@@ -319,7 +328,7 @@ class AgentEndpointServiceClient {
   RegisterAgent(
       google::cloud::osconfig::agentendpoint::v1::RegisterAgentRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Reports the VMs current inventory.
@@ -336,7 +345,8 @@ class AgentEndpointServiceClient {
   /// only be provided if
   ///  the inventory has changed since the last report, or if instructed by the
   ///  service to provide full inventory.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportInventoryResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L233}
   ///
@@ -350,14 +360,15 @@ class AgentEndpointServiceClient {
       std::string const& instance_id_token,
       std::string const& inventory_checksum,
       google::cloud::osconfig::agentendpoint::v1::Inventory const& inventory,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Reports the VMs current inventory.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportInventoryRequest,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L215}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::agentendpoint::v1::ReportInventoryResponse,google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto#L233}
   ///
@@ -370,7 +381,7 @@ class AgentEndpointServiceClient {
   ReportInventory(
       google::cloud::osconfig::agentendpoint::v1::ReportInventoryRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AgentEndpointServiceConnection> connection_;

--- a/google/cloud/osconfig/os_config_client.cc
+++ b/google/cloud/osconfig/os_config_client.cc
@@ -26,26 +26,24 @@ namespace osconfig {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OsConfigServiceClient::OsConfigServiceClient(
-    std::shared_ptr<OsConfigServiceConnection> connection, Options options)
+    std::shared_ptr<OsConfigServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), osconfig_internal::OsConfigServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), osconfig_internal::OsConfigServiceDefaultOptions(
+                               connection_->options()))) {}
 OsConfigServiceClient::~OsConfigServiceClient() = default;
 
 StatusOr<google::cloud::osconfig::v1::PatchJob>
 OsConfigServiceClient::ExecutePatchJob(
     google::cloud::osconfig::v1::ExecutePatchJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExecutePatchJob(request);
 }
 
 StatusOr<google::cloud::osconfig::v1::PatchJob>
-OsConfigServiceClient::GetPatchJob(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OsConfigServiceClient::GetPatchJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::GetPatchJobRequest request;
   request.set_name(name);
   return connection_->GetPatchJob(request);
@@ -54,26 +52,22 @@ OsConfigServiceClient::GetPatchJob(std::string const& name, Options options) {
 StatusOr<google::cloud::osconfig::v1::PatchJob>
 OsConfigServiceClient::GetPatchJob(
     google::cloud::osconfig::v1::GetPatchJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPatchJob(request);
 }
 
 StatusOr<google::cloud::osconfig::v1::PatchJob>
 OsConfigServiceClient::CancelPatchJob(
     google::cloud::osconfig::v1::CancelPatchJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelPatchJob(request);
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchJob>
-OsConfigServiceClient::ListPatchJobs(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OsConfigServiceClient::ListPatchJobs(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::ListPatchJobsRequest request;
   request.set_parent(parent);
   return connection_->ListPatchJobs(request);
@@ -81,18 +75,15 @@ OsConfigServiceClient::ListPatchJobs(std::string const& parent,
 
 StreamRange<google::cloud::osconfig::v1::PatchJob>
 OsConfigServiceClient::ListPatchJobs(
-    google::cloud::osconfig::v1::ListPatchJobsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::osconfig::v1::ListPatchJobsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPatchJobs(std::move(request));
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>
 OsConfigServiceClient::ListPatchJobInstanceDetails(std::string const& parent,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::ListPatchJobInstanceDetailsRequest request;
   request.set_parent(parent);
   return connection_->ListPatchJobInstanceDetails(request);
@@ -101,9 +92,8 @@ OsConfigServiceClient::ListPatchJobInstanceDetails(std::string const& parent,
 StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>
 OsConfigServiceClient::ListPatchJobInstanceDetails(
     google::cloud::osconfig::v1::ListPatchJobInstanceDetailsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPatchJobInstanceDetails(std::move(request));
 }
 
@@ -111,9 +101,8 @@ StatusOr<google::cloud::osconfig::v1::PatchDeployment>
 OsConfigServiceClient::CreatePatchDeployment(
     std::string const& parent,
     google::cloud::osconfig::v1::PatchDeployment const& patch_deployment,
-    std::string const& patch_deployment_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& patch_deployment_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::CreatePatchDeploymentRequest request;
   request.set_parent(parent);
   *request.mutable_patch_deployment() = patch_deployment;
@@ -124,17 +113,15 @@ OsConfigServiceClient::CreatePatchDeployment(
 StatusOr<google::cloud::osconfig::v1::PatchDeployment>
 OsConfigServiceClient::CreatePatchDeployment(
     google::cloud::osconfig::v1::CreatePatchDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreatePatchDeployment(request);
 }
 
 StatusOr<google::cloud::osconfig::v1::PatchDeployment>
 OsConfigServiceClient::GetPatchDeployment(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::GetPatchDeploymentRequest request;
   request.set_name(name);
   return connection_->GetPatchDeployment(request);
@@ -143,17 +130,15 @@ OsConfigServiceClient::GetPatchDeployment(std::string const& name,
 StatusOr<google::cloud::osconfig::v1::PatchDeployment>
 OsConfigServiceClient::GetPatchDeployment(
     google::cloud::osconfig::v1::GetPatchDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetPatchDeployment(request);
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchDeployment>
 OsConfigServiceClient::ListPatchDeployments(std::string const& parent,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::ListPatchDeploymentsRequest request;
   request.set_parent(parent);
   return connection_->ListPatchDeployments(request);
@@ -162,16 +147,14 @@ OsConfigServiceClient::ListPatchDeployments(std::string const& parent,
 StreamRange<google::cloud::osconfig::v1::PatchDeployment>
 OsConfigServiceClient::ListPatchDeployments(
     google::cloud::osconfig::v1::ListPatchDeploymentsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListPatchDeployments(std::move(request));
 }
 
 Status OsConfigServiceClient::DeletePatchDeployment(std::string const& name,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::osconfig::v1::DeletePatchDeploymentRequest request;
   request.set_name(name);
   return connection_->DeletePatchDeployment(request);
@@ -179,9 +162,8 @@ Status OsConfigServiceClient::DeletePatchDeployment(std::string const& name,
 
 Status OsConfigServiceClient::DeletePatchDeployment(
     google::cloud::osconfig::v1::DeletePatchDeploymentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeletePatchDeployment(request);
 }
 

--- a/google/cloud/osconfig/os_config_client.h
+++ b/google/cloud/osconfig/os_config_client.h
@@ -64,8 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OsConfigServiceClient {
  public:
   explicit OsConfigServiceClient(
-      std::shared_ptr<OsConfigServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<OsConfigServiceConnection> connection, Options opts = {});
   ~OsConfigServiceClient();
 
   //@{
@@ -93,7 +92,8 @@ class OsConfigServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::ExecutePatchJobRequest,google/cloud/osconfig/v1/patch_jobs.proto#L34}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJob,google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
@@ -104,7 +104,7 @@ class OsConfigServiceClient {
   ///
   StatusOr<google::cloud::osconfig::v1::PatchJob> ExecutePatchJob(
       google::cloud::osconfig::v1::ExecutePatchJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get the patch job. This can be used to track the progress of an
@@ -112,7 +112,8 @@ class OsConfigServiceClient {
   ///
   /// @param name  Required. Name of the patch in the form
   /// `projects/*/patchJobs/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJob,google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
@@ -122,7 +123,7 @@ class OsConfigServiceClient {
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
   StatusOr<google::cloud::osconfig::v1::PatchJob> GetPatchJob(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Get the patch job. This can be used to track the progress of an
@@ -130,7 +131,8 @@ class OsConfigServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::GetPatchJobRequest,google/cloud/osconfig/v1/patch_jobs.proto#L72}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJob,google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
@@ -141,7 +143,7 @@ class OsConfigServiceClient {
   ///
   StatusOr<google::cloud::osconfig::v1::PatchJob> GetPatchJob(
       google::cloud::osconfig::v1::GetPatchJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Cancel a patch job. The patch job must be active. Canceled patch jobs
@@ -149,7 +151,8 @@ class OsConfigServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::CancelPatchJobRequest,google/cloud/osconfig/v1/patch_jobs.proto#L431}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJob,google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
@@ -160,13 +163,14 @@ class OsConfigServiceClient {
   ///
   StatusOr<google::cloud::osconfig::v1::PatchJob> CancelPatchJob(
       google::cloud::osconfig::v1::CancelPatchJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get a list of patch jobs.
   ///
   /// @param parent  Required. In the form of `projects/*`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJob,google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
@@ -176,14 +180,15 @@ class OsConfigServiceClient {
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
   StreamRange<google::cloud::osconfig::v1::PatchJob> ListPatchJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Get a list of patch jobs.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::ListPatchJobsRequest,google/cloud/osconfig/v1/patch_jobs.proto#L140}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJob,google/cloud/osconfig/v1/patch_jobs.proto#L180}
   ///
@@ -194,14 +199,15 @@ class OsConfigServiceClient {
   ///
   StreamRange<google::cloud::osconfig::v1::PatchJob> ListPatchJobs(
       google::cloud::osconfig::v1::ListPatchJobsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get a list of instance details for a given patch job.
   ///
   /// @param parent  Required. The parent for the instances are in the form of
   ///  `projects/*/patchJobs/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJobInstanceDetails,google/cloud/osconfig/v1/patch_jobs.proto#L119}
   ///
@@ -211,14 +217,15 @@ class OsConfigServiceClient {
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_jobs.proto#L119}
   ///
   StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>
-  ListPatchJobInstanceDetails(std::string const& parent, Options options = {});
+  ListPatchJobInstanceDetails(std::string const& parent, Options opts = {});
 
   ///
   /// Get a list of instance details for a given patch job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::ListPatchJobInstanceDetailsRequest,google/cloud/osconfig/v1/patch_jobs.proto#L83}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchJobInstanceDetails,google/cloud/osconfig/v1/patch_jobs.proto#L119}
   ///
@@ -230,7 +237,7 @@ class OsConfigServiceClient {
   StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>
   ListPatchJobInstanceDetails(
       google::cloud::osconfig::v1::ListPatchJobInstanceDetailsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create an OS Config patch deployment.
@@ -247,7 +254,8 @@ class OsConfigServiceClient {
   ///  * Must be between 1-63 characters.
   ///  * Must end with a number or a letter.
   ///  * Must be unique within the project.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchDeployment,google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
@@ -259,14 +267,15 @@ class OsConfigServiceClient {
   StatusOr<google::cloud::osconfig::v1::PatchDeployment> CreatePatchDeployment(
       std::string const& parent,
       google::cloud::osconfig::v1::PatchDeployment const& patch_deployment,
-      std::string const& patch_deployment_id, Options options = {});
+      std::string const& patch_deployment_id, Options opts = {});
 
   ///
   /// Create an OS Config patch deployment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::CreatePatchDeploymentRequest,google/cloud/osconfig/v1/patch_deployments.proto#L203}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchDeployment,google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
@@ -277,7 +286,7 @@ class OsConfigServiceClient {
   ///
   StatusOr<google::cloud::osconfig::v1::PatchDeployment> CreatePatchDeployment(
       google::cloud::osconfig::v1::CreatePatchDeploymentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get an OS Config patch deployment.
@@ -285,7 +294,8 @@ class OsConfigServiceClient {
   /// @param name  Required. The resource name of the patch deployment in the
   /// form
   ///  `projects/*/patchDeployments/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchDeployment,google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
@@ -295,14 +305,15 @@ class OsConfigServiceClient {
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
   StatusOr<google::cloud::osconfig::v1::PatchDeployment> GetPatchDeployment(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Get an OS Config patch deployment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::GetPatchDeploymentRequest,google/cloud/osconfig/v1/patch_deployments.proto#L227}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchDeployment,google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
@@ -313,14 +324,15 @@ class OsConfigServiceClient {
   ///
   StatusOr<google::cloud::osconfig::v1::PatchDeployment> GetPatchDeployment(
       google::cloud::osconfig::v1::GetPatchDeploymentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get a page of OS Config patch deployments.
   ///
   /// @param parent  Required. The resource name of the parent in the form
   /// `projects/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchDeployment,google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
@@ -330,14 +342,15 @@ class OsConfigServiceClient {
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
   StreamRange<google::cloud::osconfig::v1::PatchDeployment>
-  ListPatchDeployments(std::string const& parent, Options options = {});
+  ListPatchDeployments(std::string const& parent, Options opts = {});
 
   ///
   /// Get a page of OS Config patch deployments.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::ListPatchDeploymentsRequest,google/cloud/osconfig/v1/patch_deployments.proto#L239}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::osconfig::v1::PatchDeployment,google/cloud/osconfig/v1/patch_deployments.proto#L40}
   ///
@@ -349,7 +362,7 @@ class OsConfigServiceClient {
   StreamRange<google::cloud::osconfig::v1::PatchDeployment>
   ListPatchDeployments(
       google::cloud::osconfig::v1::ListPatchDeploymentsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Delete an OS Config patch deployment.
@@ -357,26 +370,28 @@ class OsConfigServiceClient {
   /// @param name  Required. The resource name of the patch deployment in the
   /// form
   ///  `projects/*/patchDeployments/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.osconfig.v1.DeletePatchDeploymentRequest]:
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_deployments.proto#L269}
   ///
-  Status DeletePatchDeployment(std::string const& name, Options options = {});
+  Status DeletePatchDeployment(std::string const& name, Options opts = {});
 
   ///
   /// Delete an OS Config patch deployment.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::osconfig::v1::DeletePatchDeploymentRequest,google/cloud/osconfig/v1/patch_deployments.proto#L269}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.osconfig.v1.DeletePatchDeploymentRequest]:
   /// @googleapis_reference_link{google/cloud/osconfig/v1/patch_deployments.proto#L269}
   ///
   Status DeletePatchDeployment(
       google::cloud::osconfig::v1::DeletePatchDeploymentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<OsConfigServiceConnection> connection_;

--- a/google/cloud/oslogin/os_login_client.cc
+++ b/google/cloud/oslogin/os_login_client.cc
@@ -26,17 +26,16 @@ namespace oslogin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OsLoginServiceClient::OsLoginServiceClient(
-    std::shared_ptr<OsLoginServiceConnection> connection, Options options)
+    std::shared_ptr<OsLoginServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), oslogin_internal::OsLoginServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), oslogin_internal::OsLoginServiceDefaultOptions(
+                               connection_->options()))) {}
 OsLoginServiceClient::~OsLoginServiceClient() = default;
 
 Status OsLoginServiceClient::DeletePosixAccount(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::DeletePosixAccountRequest request;
   request.set_name(name);
   return connection_->DeletePosixAccount(request);
@@ -44,16 +43,14 @@ Status OsLoginServiceClient::DeletePosixAccount(std::string const& name,
 
 Status OsLoginServiceClient::DeletePosixAccount(
     google::cloud::oslogin::v1::DeletePosixAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeletePosixAccount(request);
 }
 
 Status OsLoginServiceClient::DeleteSshPublicKey(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::DeleteSshPublicKeyRequest request;
   request.set_name(name);
   return connection_->DeleteSshPublicKey(request);
@@ -61,17 +58,14 @@ Status OsLoginServiceClient::DeleteSshPublicKey(std::string const& name,
 
 Status OsLoginServiceClient::DeleteSshPublicKey(
     google::cloud::oslogin::v1::DeleteSshPublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteSshPublicKey(request);
 }
 
 StatusOr<google::cloud::oslogin::v1::LoginProfile>
-OsLoginServiceClient::GetLoginProfile(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OsLoginServiceClient::GetLoginProfile(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::GetLoginProfileRequest request;
   request.set_name(name);
   return connection_->GetLoginProfile(request);
@@ -80,17 +74,14 @@ OsLoginServiceClient::GetLoginProfile(std::string const& name,
 StatusOr<google::cloud::oslogin::v1::LoginProfile>
 OsLoginServiceClient::GetLoginProfile(
     google::cloud::oslogin::v1::GetLoginProfileRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetLoginProfile(request);
 }
 
 StatusOr<google::cloud::oslogin::common::SshPublicKey>
-OsLoginServiceClient::GetSshPublicKey(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OsLoginServiceClient::GetSshPublicKey(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::GetSshPublicKeyRequest request;
   request.set_name(name);
   return connection_->GetSshPublicKey(request);
@@ -99,9 +90,8 @@ OsLoginServiceClient::GetSshPublicKey(std::string const& name,
 StatusOr<google::cloud::oslogin::common::SshPublicKey>
 OsLoginServiceClient::GetSshPublicKey(
     google::cloud::oslogin::v1::GetSshPublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSshPublicKey(request);
 }
 
@@ -109,9 +99,8 @@ StatusOr<google::cloud::oslogin::v1::ImportSshPublicKeyResponse>
 OsLoginServiceClient::ImportSshPublicKey(
     std::string const& parent,
     google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::ImportSshPublicKeyRequest request;
   request.set_parent(parent);
   *request.mutable_ssh_public_key() = ssh_public_key;
@@ -122,9 +111,8 @@ StatusOr<google::cloud::oslogin::v1::ImportSshPublicKeyResponse>
 OsLoginServiceClient::ImportSshPublicKey(
     std::string const& parent,
     google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-    std::string const& project_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& project_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::ImportSshPublicKeyRequest request;
   request.set_parent(parent);
   *request.mutable_ssh_public_key() = ssh_public_key;
@@ -135,9 +123,8 @@ OsLoginServiceClient::ImportSshPublicKey(
 StatusOr<google::cloud::oslogin::v1::ImportSshPublicKeyResponse>
 OsLoginServiceClient::ImportSshPublicKey(
     google::cloud::oslogin::v1::ImportSshPublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportSshPublicKey(request);
 }
 
@@ -145,9 +132,8 @@ StatusOr<google::cloud::oslogin::common::SshPublicKey>
 OsLoginServiceClient::UpdateSshPublicKey(
     std::string const& name,
     google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::UpdateSshPublicKeyRequest request;
   request.set_name(name);
   *request.mutable_ssh_public_key() = ssh_public_key;
@@ -158,9 +144,8 @@ StatusOr<google::cloud::oslogin::common::SshPublicKey>
 OsLoginServiceClient::UpdateSshPublicKey(
     std::string const& name,
     google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::oslogin::v1::UpdateSshPublicKeyRequest request;
   request.set_name(name);
   *request.mutable_ssh_public_key() = ssh_public_key;
@@ -171,9 +156,8 @@ OsLoginServiceClient::UpdateSshPublicKey(
 StatusOr<google::cloud::oslogin::common::SshPublicKey>
 OsLoginServiceClient::UpdateSshPublicKey(
     google::cloud::oslogin::v1::UpdateSshPublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSshPublicKey(request);
 }
 

--- a/google/cloud/oslogin/os_login_client.h
+++ b/google/cloud/oslogin/os_login_client.h
@@ -65,8 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OsLoginServiceClient {
  public:
   explicit OsLoginServiceClient(
-      std::shared_ptr<OsLoginServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<OsLoginServiceConnection> connection, Options opts = {});
   ~OsLoginServiceClient();
 
   //@{
@@ -96,26 +95,28 @@ class OsLoginServiceClient {
   /// accounts are identified
   ///  by the project ID they are associated with. A reference to the POSIX
   ///  account is in format `users/{user}/projects/{project}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.oslogin.v1.DeletePosixAccountRequest]:
   /// @googleapis_reference_link{google/cloud/oslogin/v1/oslogin.proto#L117}
   ///
-  Status DeletePosixAccount(std::string const& name, Options options = {});
+  Status DeletePosixAccount(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a POSIX account.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::oslogin::v1::DeletePosixAccountRequest,google/cloud/oslogin/v1/oslogin.proto#L117}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.oslogin.v1.DeletePosixAccountRequest]:
   /// @googleapis_reference_link{google/cloud/oslogin/v1/oslogin.proto#L117}
   ///
   Status DeletePosixAccount(
       google::cloud::oslogin::v1::DeletePosixAccountRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an SSH public key.
@@ -124,26 +125,28 @@ class OsLoginServiceClient {
   /// keys are identified by
   ///  their SHA-256 fingerprint. The fingerprint of the public key is in format
   ///  `users/{user}/sshPublicKeys/{fingerprint}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.oslogin.v1.DeleteSshPublicKeyRequest]:
   /// @googleapis_reference_link{google/cloud/oslogin/v1/oslogin.proto#L130}
   ///
-  Status DeleteSshPublicKey(std::string const& name, Options options = {});
+  Status DeleteSshPublicKey(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an SSH public key.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::oslogin::v1::DeleteSshPublicKeyRequest,google/cloud/oslogin/v1/oslogin.proto#L130}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.oslogin.v1.DeleteSshPublicKeyRequest]:
   /// @googleapis_reference_link{google/cloud/oslogin/v1/oslogin.proto#L130}
   ///
   Status DeleteSshPublicKey(
       google::cloud::oslogin::v1::DeleteSshPublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves the profile information used for logging in to a virtual machine
@@ -151,7 +154,8 @@ class OsLoginServiceClient {
   ///
   /// @param name  Required. The unique ID for the user in format
   /// `users/{user}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::v1::LoginProfile,google/cloud/oslogin/v1/oslogin.proto#L105}
   ///
@@ -161,7 +165,7 @@ class OsLoginServiceClient {
   /// @googleapis_reference_link{google/cloud/oslogin/v1/oslogin.proto#L105}
   ///
   StatusOr<google::cloud::oslogin::v1::LoginProfile> GetLoginProfile(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves the profile information used for logging in to a virtual machine
@@ -169,7 +173,8 @@ class OsLoginServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::oslogin::v1::GetLoginProfileRequest,google/cloud/oslogin/v1/oslogin.proto#L143}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::v1::LoginProfile,google/cloud/oslogin/v1/oslogin.proto#L105}
   ///
@@ -180,7 +185,7 @@ class OsLoginServiceClient {
   ///
   StatusOr<google::cloud::oslogin::v1::LoginProfile> GetLoginProfile(
       google::cloud::oslogin::v1::GetLoginProfileRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves an SSH public key.
@@ -189,7 +194,8 @@ class OsLoginServiceClient {
   /// Public keys are identified
   ///  by their SHA-256 fingerprint. The fingerprint of the public key is in
   ///  format `users/{user}/sshPublicKeys/{fingerprint}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::common::SshPublicKey,google/cloud/oslogin/common/common.proto#L92}
   ///
@@ -199,14 +205,15 @@ class OsLoginServiceClient {
   /// @googleapis_reference_link{google/cloud/oslogin/common/common.proto#L92}
   ///
   StatusOr<google::cloud::oslogin::common::SshPublicKey> GetSshPublicKey(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves an SSH public key.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::oslogin::v1::GetSshPublicKeyRequest,google/cloud/oslogin/v1/oslogin.proto#L160}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::common::SshPublicKey,google/cloud/oslogin/common/common.proto#L92}
   ///
@@ -217,7 +224,7 @@ class OsLoginServiceClient {
   ///
   StatusOr<google::cloud::oslogin::common::SshPublicKey> GetSshPublicKey(
       google::cloud::oslogin::v1::GetSshPublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds an SSH public key and returns the profile information. Default POSIX
@@ -227,7 +234,8 @@ class OsLoginServiceClient {
   /// @param parent  Required. The unique ID for the user in format
   /// `users/{user}`.
   /// @param ssh_public_key  Optional. The SSH public key and expiration time.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::v1::ImportSshPublicKeyResponse,google/cloud/oslogin/v1/oslogin.proto#L190}
   ///
@@ -240,7 +248,7 @@ class OsLoginServiceClient {
   ImportSshPublicKey(
       std::string const& parent,
       google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds an SSH public key and returns the profile information. Default POSIX
@@ -251,7 +259,8 @@ class OsLoginServiceClient {
   /// `users/{user}`.
   /// @param ssh_public_key  Optional. The SSH public key and expiration time.
   /// @param project_id  The project ID of the Google Cloud Platform project.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::v1::ImportSshPublicKeyResponse,google/cloud/oslogin/v1/oslogin.proto#L190}
   ///
@@ -264,7 +273,7 @@ class OsLoginServiceClient {
   ImportSshPublicKey(
       std::string const& parent,
       google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-      std::string const& project_id, Options options = {});
+      std::string const& project_id, Options opts = {});
 
   ///
   /// Adds an SSH public key and returns the profile information. Default POSIX
@@ -273,7 +282,8 @@ class OsLoginServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::oslogin::v1::ImportSshPublicKeyRequest,google/cloud/oslogin/v1/oslogin.proto#L173}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::v1::ImportSshPublicKeyResponse,google/cloud/oslogin/v1/oslogin.proto#L190}
   ///
@@ -285,7 +295,7 @@ class OsLoginServiceClient {
   StatusOr<google::cloud::oslogin::v1::ImportSshPublicKeyResponse>
   ImportSshPublicKey(
       google::cloud::oslogin::v1::ImportSshPublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an SSH public key and returns the profile information. This method
@@ -296,7 +306,8 @@ class OsLoginServiceClient {
   ///  their SHA-256 fingerprint. The fingerprint of the public key is in format
   ///  `users/{user}/sshPublicKeys/{fingerprint}`.
   /// @param ssh_public_key  Required. The SSH public key and expiration time.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::common::SshPublicKey,google/cloud/oslogin/common/common.proto#L92}
   ///
@@ -308,7 +319,7 @@ class OsLoginServiceClient {
   StatusOr<google::cloud::oslogin::common::SshPublicKey> UpdateSshPublicKey(
       std::string const& name,
       google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an SSH public key and returns the profile information. This method
@@ -321,7 +332,8 @@ class OsLoginServiceClient {
   /// @param ssh_public_key  Required. The SSH public key and expiration time.
   /// @param update_mask  Mask to control which fields get updated. Updates all
   /// if not present.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::common::SshPublicKey,google/cloud/oslogin/common/common.proto#L92}
   ///
@@ -333,7 +345,7 @@ class OsLoginServiceClient {
   StatusOr<google::cloud::oslogin::common::SshPublicKey> UpdateSshPublicKey(
       std::string const& name,
       google::cloud::oslogin::common::SshPublicKey const& ssh_public_key,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an SSH public key and returns the profile information. This method
@@ -341,7 +353,8 @@ class OsLoginServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::oslogin::v1::UpdateSshPublicKeyRequest,google/cloud/oslogin/v1/oslogin.proto#L196}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::oslogin::common::SshPublicKey,google/cloud/oslogin/common/common.proto#L92}
   ///
@@ -352,7 +365,7 @@ class OsLoginServiceClient {
   ///
   StatusOr<google::cloud::oslogin::common::SshPublicKey> UpdateSshPublicKey(
       google::cloud::oslogin::v1::UpdateSshPublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<OsLoginServiceConnection> connection_;

--- a/google/cloud/policytroubleshooter/iam_checker_client.cc
+++ b/google/cloud/policytroubleshooter/iam_checker_client.cc
@@ -26,10 +26,10 @@ namespace policytroubleshooter {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IamCheckerClient::IamCheckerClient(
-    std::shared_ptr<IamCheckerConnection> connection, Options options)
+    std::shared_ptr<IamCheckerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           policytroubleshooter_internal::IamCheckerDefaultOptions(
               connection_->options()))) {}
 IamCheckerClient::~IamCheckerClient() = default;
@@ -38,9 +38,8 @@ StatusOr<google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>
 IamCheckerClient::TroubleshootIamPolicy(
     google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TroubleshootIamPolicy(request);
 }
 

--- a/google/cloud/policytroubleshooter/iam_checker_client.h
+++ b/google/cloud/policytroubleshooter/iam_checker_client.h
@@ -64,7 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class IamCheckerClient {
  public:
   explicit IamCheckerClient(std::shared_ptr<IamCheckerConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~IamCheckerClient();
 
   //@{
@@ -91,7 +91,8 @@ class IamCheckerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyRequest,google/cloud/policytroubleshooter/v1/checker.proto#L51}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse,google/cloud/policytroubleshooter/v1/checker.proto#L58}
   ///
@@ -104,7 +105,7 @@ class IamCheckerClient {
       google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>
   TroubleshootIamPolicy(google::cloud::policytroubleshooter::v1::
                             TroubleshootIamPolicyRequest const& request,
-                        Options options = {});
+                        Options opts = {});
 
  private:
   std::shared_ptr<IamCheckerConnection> connection_;

--- a/google/cloud/privateca/certificate_authority_client.cc
+++ b/google/cloud/privateca/certificate_authority_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CertificateAuthorityServiceClient::CertificateAuthorityServiceClient(
     std::shared_ptr<CertificateAuthorityServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           privateca_internal::CertificateAuthorityServiceDefaultOptions(
               connection_->options()))) {}
 CertificateAuthorityServiceClient::~CertificateAuthorityServiceClient() =
@@ -40,9 +40,8 @@ StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::CreateCertificate(
     std::string const& parent,
     google::cloud::security::privateca::v1::Certificate const& certificate,
-    std::string const& certificate_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& certificate_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::CreateCertificateRequest request;
   request.set_parent(parent);
   *request.mutable_certificate() = certificate;
@@ -54,17 +53,15 @@ StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::CreateCertificate(
     google::cloud::security::privateca::v1::CreateCertificateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCertificate(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::GetCertificate(std::string const& name,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::GetCertificateRequest request;
   request.set_name(name);
   return connection_->GetCertificate(request);
@@ -74,17 +71,15 @@ StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::GetCertificate(
     google::cloud::security::privateca::v1::GetCertificateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCertificate(request);
 }
 
 StreamRange<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::ListCertificates(std::string const& parent,
-                                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::ListCertificatesRequest request;
   request.set_parent(parent);
   return connection_->ListCertificates(request);
@@ -93,17 +88,15 @@ CertificateAuthorityServiceClient::ListCertificates(std::string const& parent,
 StreamRange<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::ListCertificates(
     google::cloud::security::privateca::v1::ListCertificatesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCertificates(std::move(request));
 }
 
 StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::RevokeCertificate(std::string const& name,
-                                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::RevokeCertificateRequest request;
   request.set_name(name);
   return connection_->RevokeCertificate(request);
@@ -113,18 +106,16 @@ StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::RevokeCertificate(
     google::cloud::security::privateca::v1::RevokeCertificateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RevokeCertificate(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::UpdateCertificate(
     google::cloud::security::privateca::v1::Certificate const& certificate,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::UpdateCertificateRequest request;
   *request.mutable_certificate() = certificate;
   *request.mutable_update_mask() = update_mask;
@@ -135,17 +126,15 @@ StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceClient::UpdateCertificate(
     google::cloud::security::privateca::v1::UpdateCertificateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCertificate(request);
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::ActivateCertificateAuthority(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::ActivateCertificateAuthorityRequest
       request;
   request.set_name(name);
@@ -156,9 +145,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::ActivateCertificateAuthority(
     google::cloud::security::privateca::v1::
         ActivateCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ActivateCertificateAuthority(request);
 }
 
@@ -167,9 +155,8 @@ CertificateAuthorityServiceClient::CreateCertificateAuthority(
     std::string const& parent,
     google::cloud::security::privateca::v1::CertificateAuthority const&
         certificate_authority,
-    std::string const& certificate_authority_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& certificate_authority_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::CreateCertificateAuthorityRequest
       request;
   request.set_parent(parent);
@@ -182,17 +169,15 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::CreateCertificateAuthority(
     google::cloud::security::privateca::v1::
         CreateCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCertificateAuthority(request);
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::DisableCertificateAuthority(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::DisableCertificateAuthorityRequest
       request;
   request.set_name(name);
@@ -203,17 +188,15 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::DisableCertificateAuthority(
     google::cloud::security::privateca::v1::
         DisableCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DisableCertificateAuthority(request);
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::EnableCertificateAuthority(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::EnableCertificateAuthorityRequest
       request;
   request.set_name(name);
@@ -224,18 +207,16 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::EnableCertificateAuthority(
     google::cloud::security::privateca::v1::
         EnableCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->EnableCertificateAuthority(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::
              FetchCertificateAuthorityCsrResponse>
 CertificateAuthorityServiceClient::FetchCertificateAuthorityCsr(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::FetchCertificateAuthorityCsrRequest
       request;
   request.set_name(name);
@@ -247,17 +228,15 @@ StatusOr<google::cloud::security::privateca::v1::
 CertificateAuthorityServiceClient::FetchCertificateAuthorityCsr(
     google::cloud::security::privateca::v1::
         FetchCertificateAuthorityCsrRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FetchCertificateAuthorityCsr(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>
 CertificateAuthorityServiceClient::GetCertificateAuthority(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::GetCertificateAuthorityRequest
       request;
   request.set_name(name);
@@ -268,17 +247,15 @@ StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>
 CertificateAuthorityServiceClient::GetCertificateAuthority(
     google::cloud::security::privateca::v1::
         GetCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCertificateAuthority(request);
 }
 
 StreamRange<google::cloud::security::privateca::v1::CertificateAuthority>
 CertificateAuthorityServiceClient::ListCertificateAuthorities(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::ListCertificateAuthoritiesRequest
       request;
   request.set_parent(parent);
@@ -289,17 +266,15 @@ StreamRange<google::cloud::security::privateca::v1::CertificateAuthority>
 CertificateAuthorityServiceClient::ListCertificateAuthorities(
     google::cloud::security::privateca::v1::ListCertificateAuthoritiesRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCertificateAuthorities(std::move(request));
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::UndeleteCertificateAuthority(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::UndeleteCertificateAuthorityRequest
       request;
   request.set_name(name);
@@ -310,17 +285,15 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::UndeleteCertificateAuthority(
     google::cloud::security::privateca::v1::
         UndeleteCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteCertificateAuthority(request);
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::DeleteCertificateAuthority(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::DeleteCertificateAuthorityRequest
       request;
   request.set_name(name);
@@ -331,9 +304,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::DeleteCertificateAuthority(
     google::cloud::security::privateca::v1::
         DeleteCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCertificateAuthority(request);
 }
 
@@ -341,9 +313,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::UpdateCertificateAuthority(
     google::cloud::security::privateca::v1::CertificateAuthority const&
         certificate_authority,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::UpdateCertificateAuthorityRequest
       request;
   *request.mutable_certificate_authority() = certificate_authority;
@@ -355,9 +326,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
 CertificateAuthorityServiceClient::UpdateCertificateAuthority(
     google::cloud::security::privateca::v1::
         UpdateCertificateAuthorityRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCertificateAuthority(request);
 }
 
@@ -365,9 +335,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CaPool>>
 CertificateAuthorityServiceClient::CreateCaPool(
     std::string const& parent,
     google::cloud::security::privateca::v1::CaPool const& ca_pool,
-    std::string const& ca_pool_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& ca_pool_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::CreateCaPoolRequest request;
   request.set_parent(parent);
   *request.mutable_ca_pool() = ca_pool;
@@ -378,18 +347,16 @@ CertificateAuthorityServiceClient::CreateCaPool(
 future<StatusOr<google::cloud::security::privateca::v1::CaPool>>
 CertificateAuthorityServiceClient::CreateCaPool(
     google::cloud::security::privateca::v1::CreateCaPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCaPool(request);
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::CaPool>>
 CertificateAuthorityServiceClient::UpdateCaPool(
     google::cloud::security::privateca::v1::CaPool const& ca_pool,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::UpdateCaPoolRequest request;
   *request.mutable_ca_pool() = ca_pool;
   *request.mutable_update_mask() = update_mask;
@@ -399,17 +366,15 @@ CertificateAuthorityServiceClient::UpdateCaPool(
 future<StatusOr<google::cloud::security::privateca::v1::CaPool>>
 CertificateAuthorityServiceClient::UpdateCaPool(
     google::cloud::security::privateca::v1::UpdateCaPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCaPool(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::CaPool>
 CertificateAuthorityServiceClient::GetCaPool(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::GetCaPoolRequest request;
   request.set_name(name);
   return connection_->GetCaPool(request);
@@ -418,17 +383,15 @@ CertificateAuthorityServiceClient::GetCaPool(std::string const& name,
 StatusOr<google::cloud::security::privateca::v1::CaPool>
 CertificateAuthorityServiceClient::GetCaPool(
     google::cloud::security::privateca::v1::GetCaPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCaPool(request);
 }
 
 StreamRange<google::cloud::security::privateca::v1::CaPool>
 CertificateAuthorityServiceClient::ListCaPools(std::string const& parent,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::ListCaPoolsRequest request;
   request.set_parent(parent);
   return connection_->ListCaPools(request);
@@ -437,17 +400,15 @@ CertificateAuthorityServiceClient::ListCaPools(std::string const& parent,
 StreamRange<google::cloud::security::privateca::v1::CaPool>
 CertificateAuthorityServiceClient::ListCaPools(
     google::cloud::security::privateca::v1::ListCaPoolsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCaPools(std::move(request));
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
 CertificateAuthorityServiceClient::DeleteCaPool(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::DeleteCaPoolRequest request;
   request.set_name(name);
   return connection_->DeleteCaPool(request);
@@ -456,17 +417,15 @@ CertificateAuthorityServiceClient::DeleteCaPool(std::string const& name,
 future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
 CertificateAuthorityServiceClient::DeleteCaPool(
     google::cloud::security::privateca::v1::DeleteCaPoolRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCaPool(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::FetchCaCertsResponse>
 CertificateAuthorityServiceClient::FetchCaCerts(std::string const& ca_pool,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::FetchCaCertsRequest request;
   request.set_ca_pool(ca_pool);
   return connection_->FetchCaCerts(request);
@@ -475,17 +434,15 @@ CertificateAuthorityServiceClient::FetchCaCerts(std::string const& ca_pool,
 StatusOr<google::cloud::security::privateca::v1::FetchCaCertsResponse>
 CertificateAuthorityServiceClient::FetchCaCerts(
     google::cloud::security::privateca::v1::FetchCaCertsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FetchCaCerts(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::CertificateRevocationList>
 CertificateAuthorityServiceClient::GetCertificateRevocationList(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::GetCertificateRevocationListRequest
       request;
   request.set_name(name);
@@ -496,17 +453,15 @@ StatusOr<google::cloud::security::privateca::v1::CertificateRevocationList>
 CertificateAuthorityServiceClient::GetCertificateRevocationList(
     google::cloud::security::privateca::v1::
         GetCertificateRevocationListRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCertificateRevocationList(request);
 }
 
 StreamRange<google::cloud::security::privateca::v1::CertificateRevocationList>
 CertificateAuthorityServiceClient::ListCertificateRevocationLists(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::ListCertificateRevocationListsRequest
       request;
   request.set_parent(parent);
@@ -517,9 +472,8 @@ StreamRange<google::cloud::security::privateca::v1::CertificateRevocationList>
 CertificateAuthorityServiceClient::ListCertificateRevocationLists(
     google::cloud::security::privateca::v1::
         ListCertificateRevocationListsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCertificateRevocationLists(std::move(request));
 }
 
@@ -528,9 +482,8 @@ future<
 CertificateAuthorityServiceClient::UpdateCertificateRevocationList(
     google::cloud::security::privateca::v1::CertificateRevocationList const&
         certificate_revocation_list,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::UpdateCertificateRevocationListRequest
       request;
   *request.mutable_certificate_revocation_list() = certificate_revocation_list;
@@ -543,9 +496,8 @@ future<
 CertificateAuthorityServiceClient::UpdateCertificateRevocationList(
     google::cloud::security::privateca::v1::
         UpdateCertificateRevocationListRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCertificateRevocationList(request);
 }
 
@@ -554,9 +506,8 @@ CertificateAuthorityServiceClient::CreateCertificateTemplate(
     std::string const& parent,
     google::cloud::security::privateca::v1::CertificateTemplate const&
         certificate_template,
-    std::string const& certificate_template_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& certificate_template_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::CreateCertificateTemplateRequest
       request;
   request.set_parent(parent);
@@ -569,17 +520,15 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>>
 CertificateAuthorityServiceClient::CreateCertificateTemplate(
     google::cloud::security::privateca::v1::
         CreateCertificateTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCertificateTemplate(request);
 }
 
 future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
 CertificateAuthorityServiceClient::DeleteCertificateTemplate(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::DeleteCertificateTemplateRequest
       request;
   request.set_name(name);
@@ -590,17 +539,15 @@ future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
 CertificateAuthorityServiceClient::DeleteCertificateTemplate(
     google::cloud::security::privateca::v1::
         DeleteCertificateTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCertificateTemplate(request);
 }
 
 StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>
 CertificateAuthorityServiceClient::GetCertificateTemplate(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::GetCertificateTemplateRequest request;
   request.set_name(name);
   return connection_->GetCertificateTemplate(request);
@@ -610,17 +557,15 @@ StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>
 CertificateAuthorityServiceClient::GetCertificateTemplate(
     google::cloud::security::privateca::v1::GetCertificateTemplateRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCertificateTemplate(request);
 }
 
 StreamRange<google::cloud::security::privateca::v1::CertificateTemplate>
 CertificateAuthorityServiceClient::ListCertificateTemplates(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::ListCertificateTemplatesRequest
       request;
   request.set_parent(parent);
@@ -631,9 +576,8 @@ StreamRange<google::cloud::security::privateca::v1::CertificateTemplate>
 CertificateAuthorityServiceClient::ListCertificateTemplates(
     google::cloud::security::privateca::v1::ListCertificateTemplatesRequest
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCertificateTemplates(std::move(request));
 }
 
@@ -641,9 +585,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>>
 CertificateAuthorityServiceClient::UpdateCertificateTemplate(
     google::cloud::security::privateca::v1::CertificateTemplate const&
         certificate_template,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::security::privateca::v1::UpdateCertificateTemplateRequest
       request;
   *request.mutable_certificate_template() = certificate_template;
@@ -655,9 +598,8 @@ future<StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>>
 CertificateAuthorityServiceClient::UpdateCertificateTemplate(
     google::cloud::security::privateca::v1::
         UpdateCertificateTemplateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCertificateTemplate(request);
 }
 

--- a/google/cloud/privateca/certificate_authority_client.h
+++ b/google/cloud/privateca/certificate_authority_client.h
@@ -66,7 +66,7 @@ class CertificateAuthorityServiceClient {
  public:
   explicit CertificateAuthorityServiceClient(
       std::shared_ptr<CertificateAuthorityServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~CertificateAuthorityServiceClient();
 
   //@{
@@ -111,7 +111,8 @@ class CertificateAuthorityServiceClient {
   ///  [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   ///  in the Enterprise [CertificateAuthority.Tier][], but is optional and its
   ///  value is ignored otherwise.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -124,7 +125,7 @@ class CertificateAuthorityServiceClient {
   CreateCertificate(
       std::string const& parent,
       google::cloud::security::privateca::v1::Certificate const& certificate,
-      std::string const& certificate_id, Options options = {});
+      std::string const& certificate_id, Options opts = {});
 
   ///
   /// Create a new [Certificate][google.cloud.security.privateca.v1.Certificate]
@@ -133,7 +134,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::CreateCertificateRequest,google/cloud/security/privateca/v1/service.proto#L364}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -146,7 +148,7 @@ class CertificateAuthorityServiceClient {
   CreateCertificate(
       google::cloud::security::privateca::v1::CreateCertificateRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a [Certificate][google.cloud.security.privateca.v1.Certificate].
@@ -154,7 +156,8 @@ class CertificateAuthorityServiceClient {
   /// @param name  Required. The
   /// [name][google.cloud.security.privateca.v1.Certificate.name] of the
   /// [Certificate][google.cloud.security.privateca.v1.Certificate] to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -164,14 +167,15 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L495}
   ///
   StatusOr<google::cloud::security::privateca::v1::Certificate> GetCertificate(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns a [Certificate][google.cloud.security.privateca.v1.Certificate].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::GetCertificateRequest,google/cloud/security/privateca/v1/service.proto#L419}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -183,7 +187,7 @@ class CertificateAuthorityServiceClient {
   StatusOr<google::cloud::security::privateca::v1::Certificate> GetCertificate(
       google::cloud::security::privateca::v1::GetCertificateRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists [Certificates][google.cloud.security.privateca.v1.Certificate].
@@ -192,7 +196,8 @@ class CertificateAuthorityServiceClient {
   /// the
   ///  [Certificates][google.cloud.security.privateca.v1.Certificate], in the
   ///  format `projects/*/locations/*/caPools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -202,14 +207,15 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L495}
   ///
   StreamRange<google::cloud::security::privateca::v1::Certificate>
-  ListCertificates(std::string const& parent, Options options = {});
+  ListCertificates(std::string const& parent, Options opts = {});
 
   ///
   /// Lists [Certificates][google.cloud.security.privateca.v1.Certificate].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::ListCertificatesRequest,google/cloud/security/privateca/v1/service.proto#L430}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -221,7 +227,7 @@ class CertificateAuthorityServiceClient {
   StreamRange<google::cloud::security::privateca::v1::Certificate>
   ListCertificates(
       google::cloud::security::privateca::v1::ListCertificatesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Revoke a [Certificate][google.cloud.security.privateca.v1.Certificate].
@@ -230,7 +236,8 @@ class CertificateAuthorityServiceClient {
   /// [Certificate][google.cloud.security.privateca.v1.Certificate] in the
   ///  format
   ///  `projects/*/locations/*/caPools/*/certificates/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -240,14 +247,15 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L495}
   ///
   StatusOr<google::cloud::security::privateca::v1::Certificate>
-  RevokeCertificate(std::string const& name, Options options = {});
+  RevokeCertificate(std::string const& name, Options opts = {});
 
   ///
   /// Revoke a [Certificate][google.cloud.security.privateca.v1.Certificate].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::RevokeCertificateRequest,google/cloud/security/privateca/v1/service.proto#L480}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -260,7 +268,7 @@ class CertificateAuthorityServiceClient {
   RevokeCertificate(
       google::cloud::security::privateca::v1::RevokeCertificateRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a [Certificate][google.cloud.security.privateca.v1.Certificate].
@@ -272,7 +280,8 @@ class CertificateAuthorityServiceClient {
   /// values.
   /// @param update_mask  Required. A list of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -284,7 +293,7 @@ class CertificateAuthorityServiceClient {
   StatusOr<google::cloud::security::privateca::v1::Certificate>
   UpdateCertificate(
       google::cloud::security::privateca::v1::Certificate const& certificate,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a [Certificate][google.cloud.security.privateca.v1.Certificate].
@@ -293,7 +302,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::UpdateCertificateRequest,google/cloud/security/privateca/v1/service.proto#L511}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::Certificate,google/cloud/security/privateca/v1/resources.proto#L495}
   ///
@@ -306,7 +316,7 @@ class CertificateAuthorityServiceClient {
   UpdateCertificate(
       google::cloud::security::privateca::v1::UpdateCertificateRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Activate a
@@ -324,7 +334,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// in the
   ///  format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -334,7 +345,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
-  ActivateCertificateAuthority(std::string const& name, Options options = {});
+  ActivateCertificateAuthority(std::string const& name, Options opts = {});
 
   ///
   /// Activate a
@@ -350,7 +361,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::ActivateCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L536}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -363,7 +375,7 @@ class CertificateAuthorityServiceClient {
   ActivateCertificateAuthority(
       google::cloud::security::privateca::v1::
           ActivateCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new
@@ -380,7 +392,8 @@ class CertificateAuthorityServiceClient {
   /// @param certificate_authority_id  Required. It must be unique within a
   /// location and match the regular
   ///  expression `[a-zA-Z0-9_-]{1,63}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -394,7 +407,7 @@ class CertificateAuthorityServiceClient {
       std::string const& parent,
       google::cloud::security::privateca::v1::CertificateAuthority const&
           certificate_authority,
-      std::string const& certificate_authority_id, Options options = {});
+      std::string const& certificate_authority_id, Options opts = {});
 
   ///
   /// Create a new
@@ -403,7 +416,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::CreateCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L572}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -416,7 +430,7 @@ class CertificateAuthorityServiceClient {
   CreateCertificateAuthority(
       google::cloud::security::privateca::v1::
           CreateCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Disable a
@@ -426,7 +440,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// in the
   ///  format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -436,7 +451,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
-  DisableCertificateAuthority(std::string const& name, Options options = {});
+  DisableCertificateAuthority(std::string const& name, Options opts = {});
 
   ///
   /// Disable a
@@ -444,7 +459,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::DisableCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L608}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -457,7 +473,7 @@ class CertificateAuthorityServiceClient {
   DisableCertificateAuthority(
       google::cloud::security::privateca::v1::
           DisableCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enable a
@@ -467,7 +483,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// in the
   ///  format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -477,7 +494,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
-  EnableCertificateAuthority(std::string const& name, Options options = {});
+  EnableCertificateAuthority(std::string const& name, Options opts = {});
 
   ///
   /// Enable a
@@ -485,7 +502,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::EnableCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L636}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -498,7 +516,7 @@ class CertificateAuthorityServiceClient {
   EnableCertificateAuthority(
       google::cloud::security::privateca::v1::
           EnableCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Fetch a certificate signing request (CSR) from a
@@ -517,7 +535,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// in the
   ///  format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::FetchCertificateAuthorityCsrResponse,google/cloud/security/privateca/v1/service.proto#L677}
   ///
@@ -528,7 +547,7 @@ class CertificateAuthorityServiceClient {
   ///
   StatusOr<google::cloud::security::privateca::v1::
                FetchCertificateAuthorityCsrResponse>
-  FetchCertificateAuthorityCsr(std::string const& name, Options options = {});
+  FetchCertificateAuthorityCsr(std::string const& name, Options opts = {});
 
   ///
   /// Fetch a certificate signing request (CSR) from a
@@ -545,7 +564,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::FetchCertificateAuthorityCsrRequest,google/cloud/security/privateca/v1/service.proto#L664}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::FetchCertificateAuthorityCsrResponse,google/cloud/security/privateca/v1/service.proto#L677}
   ///
@@ -559,7 +579,7 @@ class CertificateAuthorityServiceClient {
   FetchCertificateAuthorityCsr(
       google::cloud::security::privateca::v1::
           FetchCertificateAuthorityCsrRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a
@@ -571,7 +591,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// to
   ///  get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -581,7 +602,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>
-  GetCertificateAuthority(std::string const& name, Options options = {});
+  GetCertificateAuthority(std::string const& name, Options opts = {});
 
   ///
   /// Returns a
@@ -589,7 +610,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::GetCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L683}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -601,7 +623,7 @@ class CertificateAuthorityServiceClient {
   StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>
   GetCertificateAuthority(google::cloud::security::privateca::v1::
                               GetCertificateAuthorityRequest const& request,
-                          Options options = {});
+                          Options opts = {});
 
   ///
   /// Lists
@@ -611,7 +633,8 @@ class CertificateAuthorityServiceClient {
   /// [CaPool][google.cloud.security.privateca.v1.CaPool] associated with the
   ///  [CertificateAuthorities][google.cloud.security.privateca.v1.CertificateAuthority],
   ///  in the format `projects/*/locations/*/caPools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -621,7 +644,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   StreamRange<google::cloud::security::privateca::v1::CertificateAuthority>
-  ListCertificateAuthorities(std::string const& parent, Options options = {});
+  ListCertificateAuthorities(std::string const& parent, Options opts = {});
 
   ///
   /// Lists
@@ -629,7 +652,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::ListCertificateAuthoritiesRequest,google/cloud/security/privateca/v1/service.proto#L696}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -642,7 +666,7 @@ class CertificateAuthorityServiceClient {
   ListCertificateAuthorities(
       google::cloud::security::privateca::v1::ListCertificateAuthoritiesRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Undelete a
@@ -653,7 +677,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// in the
   ///  format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -663,7 +688,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
-  UndeleteCertificateAuthority(std::string const& name, Options options = {});
+  UndeleteCertificateAuthority(std::string const& name, Options opts = {});
 
   ///
   /// Undelete a
@@ -672,7 +697,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::UndeleteCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L743}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -685,7 +711,7 @@ class CertificateAuthorityServiceClient {
   UndeleteCertificateAuthority(
       google::cloud::security::privateca::v1::
           UndeleteCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Delete a
@@ -695,7 +721,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateAuthority][google.cloud.security.privateca.v1.CertificateAuthority]
   /// in the
   ///  format `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -705,7 +732,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L37}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::CertificateAuthority>>
-  DeleteCertificateAuthority(std::string const& name, Options options = {});
+  DeleteCertificateAuthority(std::string const& name, Options opts = {});
 
   ///
   /// Delete a
@@ -713,7 +740,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::DeleteCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L771}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -726,7 +754,7 @@ class CertificateAuthorityServiceClient {
   DeleteCertificateAuthority(
       google::cloud::security::privateca::v1::
           DeleteCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a
@@ -737,7 +765,8 @@ class CertificateAuthorityServiceClient {
   /// with updated values.
   /// @param update_mask  Required. A list of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -750,7 +779,7 @@ class CertificateAuthorityServiceClient {
   UpdateCertificateAuthority(
       google::cloud::security::privateca::v1::CertificateAuthority const&
           certificate_authority,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a
@@ -758,7 +787,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::UpdateCertificateAuthorityRequest,google/cloud/security/privateca/v1/service.proto#L803}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateAuthority,google/cloud/security/privateca/v1/resources.proto#L37}
   ///
@@ -771,7 +801,7 @@ class CertificateAuthorityServiceClient {
   UpdateCertificateAuthority(
       google::cloud::security::privateca::v1::
           UpdateCertificateAuthorityRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -786,7 +816,8 @@ class CertificateAuthorityServiceClient {
   /// @param ca_pool_id  Required. It must be unique within a location and match
   /// the regular
   ///  expression `[a-zA-Z0-9_-]{1,63}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -798,14 +829,15 @@ class CertificateAuthorityServiceClient {
   future<StatusOr<google::cloud::security::privateca::v1::CaPool>> CreateCaPool(
       std::string const& parent,
       google::cloud::security::privateca::v1::CaPool const& ca_pool,
-      std::string const& ca_pool_id, Options options = {});
+      std::string const& ca_pool_id, Options opts = {});
 
   ///
   /// Create a [CaPool][google.cloud.security.privateca.v1.CaPool].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::CreateCaPoolRequest,google/cloud/security/privateca/v1/service.proto#L828}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -817,7 +849,7 @@ class CertificateAuthorityServiceClient {
   future<StatusOr<google::cloud::security::privateca::v1::CaPool>> CreateCaPool(
       google::cloud::security::privateca::v1::CreateCaPoolRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -826,7 +858,8 @@ class CertificateAuthorityServiceClient {
   /// [CaPool][google.cloud.security.privateca.v1.CaPool] with updated values.
   /// @param update_mask  Required. A list of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -837,14 +870,15 @@ class CertificateAuthorityServiceClient {
   ///
   future<StatusOr<google::cloud::security::privateca::v1::CaPool>> UpdateCaPool(
       google::cloud::security::privateca::v1::CaPool const& ca_pool,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a [CaPool][google.cloud.security.privateca.v1.CaPool].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::UpdateCaPoolRequest,google/cloud/security/privateca/v1/service.proto#L863}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -856,7 +890,7 @@ class CertificateAuthorityServiceClient {
   future<StatusOr<google::cloud::security::privateca::v1::CaPool>> UpdateCaPool(
       google::cloud::security::privateca::v1::UpdateCaPoolRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -864,7 +898,8 @@ class CertificateAuthorityServiceClient {
   /// @param name  Required. The
   /// [name][google.cloud.security.privateca.v1.CaPool.name] of the
   /// [CaPool][google.cloud.security.privateca.v1.CaPool] to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -874,14 +909,15 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L243}
   ///
   StatusOr<google::cloud::security::privateca::v1::CaPool> GetCaPool(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns a [CaPool][google.cloud.security.privateca.v1.CaPool].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::GetCaPoolRequest,google/cloud/security/privateca/v1/service.proto#L957}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -892,7 +928,7 @@ class CertificateAuthorityServiceClient {
   ///
   StatusOr<google::cloud::security::privateca::v1::CaPool> GetCaPool(
       google::cloud::security::privateca::v1::GetCaPoolRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists [CaPools][google.cloud.security.privateca.v1.CaPool].
@@ -901,7 +937,8 @@ class CertificateAuthorityServiceClient {
   /// the
   ///  [CaPools][google.cloud.security.privateca.v1.CaPool], in the format
   ///  `projects/*/locations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -911,14 +948,15 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L243}
   ///
   StreamRange<google::cloud::security::privateca::v1::CaPool> ListCaPools(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [CaPools][google.cloud.security.privateca.v1.CaPool].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::ListCaPoolsRequest,google/cloud/security/privateca/v1/service.proto#L969}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CaPool,google/cloud/security/privateca/v1/resources.proto#L243}
   ///
@@ -929,7 +967,7 @@ class CertificateAuthorityServiceClient {
   ///
   StreamRange<google::cloud::security::privateca::v1::CaPool> ListCaPools(
       google::cloud::security::privateca::v1::ListCaPoolsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Delete a [CaPool][google.cloud.security.privateca.v1.CaPool].
@@ -937,7 +975,8 @@ class CertificateAuthorityServiceClient {
   /// @param name  Required. The resource name for this
   /// [CaPool][google.cloud.security.privateca.v1.CaPool] in the
   ///  format `projects/*/locations/*/caPools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::OperationMetadata,google/cloud/security/privateca/v1/service.proto#L1249}
   ///
@@ -947,14 +986,15 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L1249}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
-  DeleteCaPool(std::string const& name, Options options = {});
+  DeleteCaPool(std::string const& name, Options opts = {});
 
   ///
   /// Delete a [CaPool][google.cloud.security.privateca.v1.CaPool].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::DeleteCaPoolRequest,google/cloud/security/privateca/v1/service.proto#L888}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::OperationMetadata,google/cloud/security/privateca/v1/service.proto#L1249}
   ///
@@ -967,7 +1007,7 @@ class CertificateAuthorityServiceClient {
   DeleteCaPool(
       google::cloud::security::privateca::v1::DeleteCaPoolRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// FetchCaCerts returns the current trust anchor for the
@@ -979,7 +1019,8 @@ class CertificateAuthorityServiceClient {
   /// @param ca_pool  Required. The resource name for the
   /// [CaPool][google.cloud.security.privateca.v1.CaPool] in the
   ///  format `projects/*/locations/*/caPools/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::FetchCaCertsResponse,google/cloud/security/privateca/v1/service.proto#L944}
   ///
@@ -989,7 +1030,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L944}
   ///
   StatusOr<google::cloud::security::privateca::v1::FetchCaCertsResponse>
-  FetchCaCerts(std::string const& ca_pool, Options options = {});
+  FetchCaCerts(std::string const& ca_pool, Options opts = {});
 
   ///
   /// FetchCaCerts returns the current trust anchor for the
@@ -1000,7 +1041,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::FetchCaCertsRequest,google/cloud/security/privateca/v1/service.proto#L916}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::FetchCaCertsResponse,google/cloud/security/privateca/v1/service.proto#L944}
   ///
@@ -1013,7 +1055,7 @@ class CertificateAuthorityServiceClient {
   FetchCaCerts(
       google::cloud::security::privateca::v1::FetchCaCertsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a
@@ -1024,7 +1066,8 @@ class CertificateAuthorityServiceClient {
   /// of the
   ///  [CertificateRevocationList][google.cloud.security.privateca.v1.CertificateRevocationList]
   ///  to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateRevocationList,google/cloud/security/privateca/v1/resources.proto#L424}
   ///
@@ -1034,7 +1077,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L424}
   ///
   StatusOr<google::cloud::security::privateca::v1::CertificateRevocationList>
-  GetCertificateRevocationList(std::string const& name, Options options = {});
+  GetCertificateRevocationList(std::string const& name, Options opts = {});
 
   ///
   /// Returns a
@@ -1042,7 +1085,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::GetCertificateRevocationListRequest,google/cloud/security/privateca/v1/service.proto#L1016}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateRevocationList,google/cloud/security/privateca/v1/resources.proto#L424}
   ///
@@ -1055,7 +1099,7 @@ class CertificateAuthorityServiceClient {
   GetCertificateRevocationList(
       google::cloud::security::privateca::v1::
           GetCertificateRevocationListRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists
@@ -1066,7 +1110,8 @@ class CertificateAuthorityServiceClient {
   ///  [CertificateRevocationLists][google.cloud.security.privateca.v1.CertificateRevocationList],
   ///  in the format
   ///  `projects/*/locations/*/caPools/*/certificateAuthorities/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateRevocationList,google/cloud/security/privateca/v1/resources.proto#L424}
   ///
@@ -1076,8 +1121,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L424}
   ///
   StreamRange<google::cloud::security::privateca::v1::CertificateRevocationList>
-  ListCertificateRevocationLists(std::string const& parent,
-                                 Options options = {});
+  ListCertificateRevocationLists(std::string const& parent, Options opts = {});
 
   ///
   /// Lists
@@ -1085,7 +1129,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::ListCertificateRevocationListsRequest,google/cloud/security/privateca/v1/service.proto#L1029}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateRevocationList,google/cloud/security/privateca/v1/resources.proto#L424}
   ///
@@ -1098,7 +1143,7 @@ class CertificateAuthorityServiceClient {
   ListCertificateRevocationLists(
       google::cloud::security::privateca::v1::
           ListCertificateRevocationListsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a
@@ -1109,7 +1154,8 @@ class CertificateAuthorityServiceClient {
   /// with updated values.
   /// @param update_mask  Required. A list of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateRevocationList,google/cloud/security/privateca/v1/resources.proto#L424}
   ///
@@ -1123,7 +1169,7 @@ class CertificateAuthorityServiceClient {
   UpdateCertificateRevocationList(
       google::cloud::security::privateca::v1::CertificateRevocationList const&
           certificate_revocation_list,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a
@@ -1131,7 +1177,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::UpdateCertificateRevocationListRequest,google/cloud/security/privateca/v1/service.proto#L1076}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateRevocationList,google/cloud/security/privateca/v1/resources.proto#L424}
   ///
@@ -1145,7 +1192,7 @@ class CertificateAuthorityServiceClient {
   UpdateCertificateRevocationList(
       google::cloud::security::privateca::v1::
           UpdateCertificateRevocationListRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new
@@ -1162,7 +1209,8 @@ class CertificateAuthorityServiceClient {
   /// @param certificate_template_id  Required. It must be unique within a
   /// location and match the regular
   ///  expression `[a-zA-Z0-9_-]{1,63}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1176,7 +1224,7 @@ class CertificateAuthorityServiceClient {
       std::string const& parent,
       google::cloud::security::privateca::v1::CertificateTemplate const&
           certificate_template,
-      std::string const& certificate_template_id, Options options = {});
+      std::string const& certificate_template_id, Options opts = {});
 
   ///
   /// Create a new
@@ -1185,7 +1233,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::CreateCertificateTemplateRequest,google/cloud/security/privateca/v1/service.proto#L1101}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1197,7 +1246,7 @@ class CertificateAuthorityServiceClient {
   future<StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>>
   CreateCertificateTemplate(google::cloud::security::privateca::v1::
                                 CreateCertificateTemplateRequest const& request,
-                            Options options = {});
+                            Options opts = {});
 
   ///
   /// DeleteCertificateTemplate deletes a
@@ -1207,7 +1256,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateTemplate][google.cloud.security.privateca.v1.CertificateTemplate]
   /// in the format
   ///  `projects/*/locations/*/certificateTemplates/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::OperationMetadata,google/cloud/security/privateca/v1/service.proto#L1249}
   ///
@@ -1217,7 +1267,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/service.proto#L1249}
   ///
   future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
-  DeleteCertificateTemplate(std::string const& name, Options options = {});
+  DeleteCertificateTemplate(std::string const& name, Options opts = {});
 
   ///
   /// DeleteCertificateTemplate deletes a
@@ -1225,7 +1275,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::DeleteCertificateTemplateRequest,google/cloud/security/privateca/v1/service.proto#L1137}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::OperationMetadata,google/cloud/security/privateca/v1/service.proto#L1249}
   ///
@@ -1237,7 +1288,7 @@ class CertificateAuthorityServiceClient {
   future<StatusOr<google::cloud::security::privateca::v1::OperationMetadata>>
   DeleteCertificateTemplate(google::cloud::security::privateca::v1::
                                 DeleteCertificateTemplateRequest const& request,
-                            Options options = {});
+                            Options opts = {});
 
   ///
   /// Returns a
@@ -1248,7 +1299,8 @@ class CertificateAuthorityServiceClient {
   /// [CertificateTemplate][google.cloud.security.privateca.v1.CertificateTemplate]
   /// to
   ///  get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1258,7 +1310,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L590}
   ///
   StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>
-  GetCertificateTemplate(std::string const& name, Options options = {});
+  GetCertificateTemplate(std::string const& name, Options opts = {});
 
   ///
   /// Returns a
@@ -1266,7 +1318,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::GetCertificateTemplateRequest,google/cloud/security/privateca/v1/service.proto#L1165}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1278,7 +1331,7 @@ class CertificateAuthorityServiceClient {
   StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>
   GetCertificateTemplate(google::cloud::security::privateca::v1::
                              GetCertificateTemplateRequest const& request,
-                         Options options = {});
+                         Options opts = {});
 
   ///
   /// Lists
@@ -1288,7 +1341,8 @@ class CertificateAuthorityServiceClient {
   /// the
   ///  [CertificateTemplates][google.cloud.security.privateca.v1.CertificateTemplate],
   ///  in the format `projects/*/locations/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1298,7 +1352,7 @@ class CertificateAuthorityServiceClient {
   /// @googleapis_reference_link{google/cloud/security/privateca/v1/resources.proto#L590}
   ///
   StreamRange<google::cloud::security::privateca::v1::CertificateTemplate>
-  ListCertificateTemplates(std::string const& parent, Options options = {});
+  ListCertificateTemplates(std::string const& parent, Options opts = {});
 
   ///
   /// Lists
@@ -1306,7 +1360,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::ListCertificateTemplatesRequest,google/cloud/security/privateca/v1/service.proto#L1178}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1319,7 +1374,7 @@ class CertificateAuthorityServiceClient {
   ListCertificateTemplates(
       google::cloud::security::privateca::v1::ListCertificateTemplatesRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Update a
@@ -1330,7 +1385,8 @@ class CertificateAuthorityServiceClient {
   /// with updated values.
   /// @param update_mask  Required. A list of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1343,7 +1399,7 @@ class CertificateAuthorityServiceClient {
   UpdateCertificateTemplate(
       google::cloud::security::privateca::v1::CertificateTemplate const&
           certificate_template,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Update a
@@ -1351,7 +1407,8 @@ class CertificateAuthorityServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::security::privateca::v1::UpdateCertificateTemplateRequest,google/cloud/security/privateca/v1/service.proto#L1225}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::security::privateca::v1::CertificateTemplate,google/cloud/security/privateca/v1/resources.proto#L590}
   ///
@@ -1363,7 +1420,7 @@ class CertificateAuthorityServiceClient {
   future<StatusOr<google::cloud::security::privateca::v1::CertificateTemplate>>
   UpdateCertificateTemplate(google::cloud::security::privateca::v1::
                                 UpdateCertificateTemplateRequest const& request,
-                            Options options = {});
+                            Options opts = {});
 
  private:
   std::shared_ptr<CertificateAuthorityServiceConnection> connection_;

--- a/google/cloud/pubsublite/admin_client.cc
+++ b/google/cloud/pubsublite/admin_client.cc
@@ -26,19 +26,18 @@ namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AdminServiceClient::AdminServiceClient(
-    std::shared_ptr<AdminServiceConnection> connection, Options options)
+    std::shared_ptr<AdminServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), pubsublite_internal::AdminServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), pubsublite_internal::AdminServiceDefaultOptions(
+                               connection_->options()))) {}
 AdminServiceClient::~AdminServiceClient() = default;
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
     std::string const& parent,
     google::cloud::pubsublite::v1::Topic const& topic,
-    std::string const& topic_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& topic_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::CreateTopicRequest request;
   request.set_parent(parent);
   *request.mutable_topic() = topic;
@@ -48,16 +47,14 @@ StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(
     google::cloud::pubsublite::v1::CreateTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTopic(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::GetTopicRequest request;
   request.set_name(name);
   return connection_->GetTopic(request);
@@ -65,17 +62,14 @@ StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::GetTopic(
     google::cloud::pubsublite::v1::GetTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTopic(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::TopicPartitions>
-AdminServiceClient::GetTopicPartitions(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AdminServiceClient::GetTopicPartitions(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::GetTopicPartitionsRequest request;
   request.set_name(name);
   return connection_->GetTopicPartitions(request);
@@ -84,16 +78,14 @@ AdminServiceClient::GetTopicPartitions(std::string const& name,
 StatusOr<google::cloud::pubsublite::v1::TopicPartitions>
 AdminServiceClient::GetTopicPartitions(
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTopicPartitions(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Topic>
-AdminServiceClient::ListTopics(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AdminServiceClient::ListTopics(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::ListTopicsRequest request;
   request.set_parent(parent);
   return connection_->ListTopics(request);
@@ -101,17 +93,15 @@ AdminServiceClient::ListTopics(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::pubsublite::v1::Topic>
 AdminServiceClient::ListTopics(
-    google::cloud::pubsublite::v1::ListTopicsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::pubsublite::v1::ListTopicsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTopics(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
     google::cloud::pubsublite::v1::Topic const& topic,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::UpdateTopicRequest request;
   *request.mutable_topic() = topic;
   *request.mutable_update_mask() = update_mask;
@@ -120,16 +110,13 @@ StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::UpdateTopic(
     google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTopic(request);
 }
 
-Status AdminServiceClient::DeleteTopic(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status AdminServiceClient::DeleteTopic(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::DeleteTopicRequest request;
   request.set_name(name);
   return connection_->DeleteTopic(request);
@@ -137,16 +124,14 @@ Status AdminServiceClient::DeleteTopic(std::string const& name,
 
 Status AdminServiceClient::DeleteTopic(
     google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTopic(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request;
   request.set_name(name);
   return connection_->ListTopicSubscriptions(request);
@@ -154,9 +139,8 @@ StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
 
 StreamRange<std::string> AdminServiceClient::ListTopicSubscriptions(
     google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTopicSubscriptions(std::move(request));
 }
 
@@ -164,9 +148,8 @@ StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::CreateSubscription(
     std::string const& parent,
     google::cloud::pubsublite::v1::Subscription const& subscription,
-    std::string const& subscription_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& subscription_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::CreateSubscriptionRequest request;
   request.set_parent(parent);
   *request.mutable_subscription() = subscription;
@@ -177,16 +160,14 @@ AdminServiceClient::CreateSubscription(
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::CreateSubscription(
     google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSubscription(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::GetSubscription(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AdminServiceClient::GetSubscription(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::GetSubscriptionRequest request;
   request.set_name(name);
   return connection_->GetSubscription(request);
@@ -195,17 +176,14 @@ AdminServiceClient::GetSubscription(std::string const& name, Options options) {
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::GetSubscription(
     google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSubscription(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Subscription>
-AdminServiceClient::ListSubscriptions(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AdminServiceClient::ListSubscriptions(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::ListSubscriptionsRequest request;
   request.set_parent(parent);
   return connection_->ListSubscriptions(request);
@@ -214,18 +192,16 @@ AdminServiceClient::ListSubscriptions(std::string const& parent,
 StreamRange<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::ListSubscriptions(
     google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSubscriptions(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::UpdateSubscription(
     google::cloud::pubsublite::v1::Subscription const& subscription,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::UpdateSubscriptionRequest request;
   *request.mutable_subscription() = subscription;
   *request.mutable_update_mask() = update_mask;
@@ -235,16 +211,14 @@ AdminServiceClient::UpdateSubscription(
 StatusOr<google::cloud::pubsublite::v1::Subscription>
 AdminServiceClient::UpdateSubscription(
     google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSubscription(request);
 }
 
 Status AdminServiceClient::DeleteSubscription(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::DeleteSubscriptionRequest request;
   request.set_name(name);
   return connection_->DeleteSubscription(request);
@@ -252,18 +226,16 @@ Status AdminServiceClient::DeleteSubscription(std::string const& name,
 
 Status AdminServiceClient::DeleteSubscription(
     google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteSubscription(request);
 }
 
 future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
 AdminServiceClient::SeekSubscription(
     google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SeekSubscription(request);
 }
 
@@ -271,9 +243,8 @@ StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::CreateReservation(
     std::string const& parent,
     google::cloud::pubsublite::v1::Reservation const& reservation,
-    std::string const& reservation_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& reservation_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::CreateReservationRequest request;
   request.set_parent(parent);
   *request.mutable_reservation() = reservation;
@@ -284,16 +255,14 @@ AdminServiceClient::CreateReservation(
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::CreateReservation(
     google::cloud::pubsublite::v1::CreateReservationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateReservation(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::GetReservation(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AdminServiceClient::GetReservation(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::GetReservationRequest request;
   request.set_name(name);
   return connection_->GetReservation(request);
@@ -302,17 +271,14 @@ AdminServiceClient::GetReservation(std::string const& name, Options options) {
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::GetReservation(
     google::cloud::pubsublite::v1::GetReservationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetReservation(request);
 }
 
 StreamRange<google::cloud::pubsublite::v1::Reservation>
-AdminServiceClient::ListReservations(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+AdminServiceClient::ListReservations(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::ListReservationsRequest request;
   request.set_parent(parent);
   return connection_->ListReservations(request);
@@ -321,18 +287,16 @@ AdminServiceClient::ListReservations(std::string const& parent,
 StreamRange<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::ListReservations(
     google::cloud::pubsublite::v1::ListReservationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListReservations(std::move(request));
 }
 
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::UpdateReservation(
     google::cloud::pubsublite::v1::Reservation const& reservation,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::UpdateReservationRequest request;
   *request.mutable_reservation() = reservation;
   *request.mutable_update_mask() = update_mask;
@@ -342,16 +306,14 @@ AdminServiceClient::UpdateReservation(
 StatusOr<google::cloud::pubsublite::v1::Reservation>
 AdminServiceClient::UpdateReservation(
     google::cloud::pubsublite::v1::UpdateReservationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateReservation(request);
 }
 
 Status AdminServiceClient::DeleteReservation(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::DeleteReservationRequest request;
   request.set_name(name);
   return connection_->DeleteReservation(request);
@@ -359,16 +321,14 @@ Status AdminServiceClient::DeleteReservation(std::string const& name,
 
 Status AdminServiceClient::DeleteReservation(
     google::cloud::pubsublite::v1::DeleteReservationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteReservation(request);
 }
 
 StreamRange<std::string> AdminServiceClient::ListReservationTopics(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::pubsublite::v1::ListReservationTopicsRequest request;
   request.set_name(name);
   return connection_->ListReservationTopics(request);
@@ -376,9 +336,8 @@ StreamRange<std::string> AdminServiceClient::ListReservationTopics(
 
 StreamRange<std::string> AdminServiceClient::ListReservationTopics(
     google::cloud::pubsublite::v1::ListReservationTopicsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListReservationTopics(std::move(request));
 }
 

--- a/google/cloud/pubsublite/admin_client.h
+++ b/google/cloud/pubsublite/admin_client.h
@@ -64,7 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class AdminServiceClient {
  public:
   explicit AdminServiceClient(
-      std::shared_ptr<AdminServiceConnection> connection, Options options = {});
+      std::shared_ptr<AdminServiceConnection> connection, Options opts = {});
   ~AdminServiceClient();
 
   //@{
@@ -98,7 +98,8 @@ class AdminServiceClient {
   /// the final component of
   ///  the topic's name.
   ///  This value is structured like: `my-topic-name`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -110,14 +111,15 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       std::string const& parent,
       google::cloud::pubsublite::v1::Topic const& topic,
-      std::string const& topic_id, Options options = {});
+      std::string const& topic_id, Options opts = {});
 
   ///
   /// Creates a new topic.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L227}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -128,14 +130,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> CreateTopic(
       google::cloud::pubsublite::v1::CreateTopicRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the topic configuration.
   ///
   /// @param name  Required. The name of the topic whose configuration to
   /// return.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -145,14 +148,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns the topic configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicRequest,google/cloud/pubsublite/v1/admin.proto#L248}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -163,13 +167,14 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> GetTopic(
       google::cloud::pubsublite::v1::GetTopicRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the partition information for the requested topic.
   ///
   /// @param name  Required. The topic whose partition information to return.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
@@ -179,14 +184,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L270}
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns the partition information for the requested topic.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetTopicPartitionsRequest,google/cloud/pubsublite/v1/admin.proto#L259}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::TopicPartitions,google/cloud/pubsublite/v1/admin.proto#L270}
   ///
@@ -197,14 +203,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::TopicPartitions> GetTopicPartitions(
       google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the list of topics for the given project.
   ///
   /// @param parent  Required. The parent whose topics are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -214,14 +221,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L102}
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Returns the list of topics for the given project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L276}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -232,7 +240,7 @@ class AdminServiceClient {
   ///
   StreamRange<google::cloud::pubsublite::v1::Topic> ListTopics(
       google::cloud::pubsublite::v1::ListTopicsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates properties of the specified topic.
@@ -241,7 +249,8 @@ class AdminServiceClient {
   /// populated.
   /// @param update_mask  Required. A mask specifying the topic fields to
   /// change.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -252,14 +261,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::Topic const& topic,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates properties of the specified topic.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::UpdateTopicRequest,google/cloud/pubsublite/v1/admin.proto#L311}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Topic,google/cloud/pubsublite/v1/common.proto#L102}
   ///
@@ -270,52 +280,56 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Topic> UpdateTopic(
       google::cloud::pubsublite::v1::UpdateTopicRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified topic.
   ///
   /// @param name  Required. The name of the topic to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
-  Status DeleteTopic(std::string const& name, Options options = {});
+  Status DeleteTopic(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the specified topic.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteTopicRequest,google/cloud/pubsublite/v1/admin.proto#L320}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.pubsublite.v1.DeleteTopicRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L320}
   ///
   Status DeleteTopic(
       google::cloud::pubsublite::v1::DeleteTopicRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the subscriptions attached to the specified topic.
   ///
   /// @param name  Required. The name of the topic whose subscriptions to list.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L331}
   ///
   StreamRange<std::string> ListTopicSubscriptions(std::string const& name,
-                                                  Options options = {});
+                                                  Options opts = {});
 
   ///
   /// Lists the subscriptions attached to the specified topic.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L331}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListTopicSubscriptionsRequest]:
@@ -323,7 +337,7 @@ class AdminServiceClient {
   ///
   StreamRange<std::string> ListTopicSubscriptions(
       google::cloud::pubsublite::v1::ListTopicSubscriptionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new subscription.
@@ -337,7 +351,8 @@ class AdminServiceClient {
   /// which will become the final component
   ///  of the subscription's name.
   ///  This value is structured like: `my-sub-name`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -349,14 +364,15 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       std::string const& parent,
       google::cloud::pubsublite::v1::Subscription const& subscription,
-      std::string const& subscription_id, Options options = {});
+      std::string const& subscription_id, Options opts = {});
 
   ///
   /// Creates a new subscription.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L365}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -367,14 +383,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> CreateSubscription(
       google::cloud::pubsublite::v1::CreateSubscriptionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the subscription configuration.
   ///
   /// @param name  Required. The name of the subscription whose configuration to
   /// return.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -384,14 +401,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns the subscription configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L391}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -402,14 +420,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> GetSubscription(
       google::cloud::pubsublite::v1::GetSubscriptionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the list of subscriptions for the given project.
   ///
   /// @param parent  Required. The parent whose subscriptions are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -419,14 +438,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L186}
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Returns the list of subscriptions for the given project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListSubscriptionsRequest,google/cloud/pubsublite/v1/admin.proto#L402}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -437,7 +457,7 @@ class AdminServiceClient {
   ///
   StreamRange<google::cloud::pubsublite::v1::Subscription> ListSubscriptions(
       google::cloud::pubsublite::v1::ListSubscriptionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates properties of the specified subscription.
@@ -447,7 +467,8 @@ class AdminServiceClient {
   ///  Topic field must not be populated.
   /// @param update_mask  Required. A mask specifying the subscription fields to
   /// change.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -458,14 +479,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::Subscription const& subscription,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates properties of the specified subscription.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::UpdateSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L437}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Subscription,google/cloud/pubsublite/v1/common.proto#L186}
   ///
@@ -476,32 +498,34 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Subscription> UpdateSubscription(
       google::cloud::pubsublite::v1::UpdateSubscriptionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified subscription.
   ///
   /// @param name  Required. The name of the subscription to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
   ///
-  Status DeleteSubscription(std::string const& name, Options options = {});
+  Status DeleteSubscription(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the specified subscription.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L447}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.pubsublite.v1.DeleteSubscriptionRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L447}
   ///
   Status DeleteSubscription(
       google::cloud::pubsublite::v1::DeleteSubscriptionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Performs an out-of-band seek for a subscription to a specified target,
@@ -528,7 +552,8 @@ class AdminServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionRequest,google/cloud/pubsublite/v1/admin.proto#L458}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::SeekSubscriptionResponse,google/cloud/pubsublite/v1/admin.proto#L493}
   ///
@@ -540,7 +565,7 @@ class AdminServiceClient {
   future<StatusOr<google::cloud::pubsublite::v1::SeekSubscriptionResponse>>
   SeekSubscription(
       google::cloud::pubsublite::v1::SeekSubscriptionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new reservation.
@@ -554,7 +579,8 @@ class AdminServiceClient {
   /// will become the final component of
   ///  the reservation's name.
   ///  This value is structured like: `my-reservation-name`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -566,14 +592,15 @@ class AdminServiceClient {
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       std::string const& parent,
       google::cloud::pubsublite::v1::Reservation const& reservation,
-      std::string const& reservation_id, Options options = {});
+      std::string const& reservation_id, Options opts = {});
 
   ///
   /// Creates a new reservation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::CreateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L516}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -584,7 +611,7 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> CreateReservation(
       google::cloud::pubsublite::v1::CreateReservationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the reservation configuration.
@@ -593,7 +620,8 @@ class AdminServiceClient {
   /// return.
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -603,14 +631,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns the reservation configuration.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::GetReservationRequest,google/cloud/pubsublite/v1/admin.proto#L537}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -621,14 +650,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> GetReservation(
       google::cloud::pubsublite::v1::GetReservationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the list of reservations for the given project.
   ///
   /// @param parent  Required. The parent whose reservations are to be listed.
   ///  Structured like `projects/{project_number}/locations/{location}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -638,14 +668,15 @@ class AdminServiceClient {
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/common.proto#L80}
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Returns the list of reservations for the given project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationsRequest,google/cloud/pubsublite/v1/admin.proto#L550}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -656,7 +687,7 @@ class AdminServiceClient {
   ///
   StreamRange<google::cloud::pubsublite::v1::Reservation> ListReservations(
       google::cloud::pubsublite::v1::ListReservationsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates properties of the specified reservation.
@@ -665,7 +696,8 @@ class AdminServiceClient {
   /// must be populated.
   /// @param update_mask  Required. A mask specifying the reservation fields to
   /// change.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -676,14 +708,15 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::Reservation const& reservation,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates properties of the specified reservation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::UpdateReservationRequest,google/cloud/pubsublite/v1/admin.proto#L585}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::Reservation,google/cloud/pubsublite/v1/common.proto#L80}
   ///
@@ -694,7 +727,7 @@ class AdminServiceClient {
   ///
   StatusOr<google::cloud::pubsublite::v1::Reservation> UpdateReservation(
       google::cloud::pubsublite::v1::UpdateReservationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified reservation.
@@ -702,26 +735,28 @@ class AdminServiceClient {
   /// @param name  Required. The name of the reservation to delete.
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
   ///
-  Status DeleteReservation(std::string const& name, Options options = {});
+  Status DeleteReservation(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the specified reservation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::DeleteReservationRequest,google/cloud/pubsublite/v1/admin.proto#L594}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.pubsublite.v1.DeleteReservationRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L594}
   ///
   Status DeleteReservation(
       google::cloud::pubsublite::v1::DeleteReservationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the topics attached to the specified reservation.
@@ -729,21 +764,23 @@ class AdminServiceClient {
   /// @param name  Required. The name of the reservation whose topics to list.
   ///  Structured like:
   ///  projects/{project_number}/locations/{location}/reservations/{reservation_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
   /// @googleapis_reference_link{google/cloud/pubsublite/v1/admin.proto#L607}
   ///
   StreamRange<std::string> ListReservationTopics(std::string const& name,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Lists the topics attached to the specified reservation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ListReservationTopicsRequest,google/cloud/pubsublite/v1/admin.proto#L607}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return std::string
   ///
   /// [google.cloud.pubsublite.v1.ListReservationTopicsRequest]:
@@ -751,7 +788,7 @@ class AdminServiceClient {
   ///
   StreamRange<std::string> ListReservationTopics(
       google::cloud::pubsublite::v1::ListReservationTopicsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<AdminServiceConnection> connection_;

--- a/google/cloud/pubsublite/topic_stats_client.cc
+++ b/google/cloud/pubsublite/topic_stats_client.cc
@@ -26,38 +26,34 @@ namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TopicStatsServiceClient::TopicStatsServiceClient(
-    std::shared_ptr<TopicStatsServiceConnection> connection, Options options)
+    std::shared_ptr<TopicStatsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          pubsublite_internal::TopicStatsServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), pubsublite_internal::TopicStatsServiceDefaultOptions(
+                               connection_->options()))) {}
 TopicStatsServiceClient::~TopicStatsServiceClient() = default;
 
 StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>
 TopicStatsServiceClient::ComputeMessageStats(
     google::cloud::pubsublite::v1::ComputeMessageStatsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ComputeMessageStats(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::ComputeHeadCursorResponse>
 TopicStatsServiceClient::ComputeHeadCursor(
     google::cloud::pubsublite::v1::ComputeHeadCursorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ComputeHeadCursor(request);
 }
 
 StatusOr<google::cloud::pubsublite::v1::ComputeTimeCursorResponse>
 TopicStatsServiceClient::ComputeTimeCursor(
     google::cloud::pubsublite::v1::ComputeTimeCursorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ComputeTimeCursor(request);
 }
 

--- a/google/cloud/pubsublite/topic_stats_client.h
+++ b/google/cloud/pubsublite/topic_stats_client.h
@@ -62,7 +62,7 @@ class TopicStatsServiceClient {
  public:
   explicit TopicStatsServiceClient(
       std::shared_ptr<TopicStatsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~TopicStatsServiceClient();
 
   //@{
@@ -91,7 +91,8 @@ class TopicStatsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ComputeMessageStatsRequest,google/cloud/pubsublite/v1/topic_stats.proto#L72}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::ComputeMessageStatsResponse,google/cloud/pubsublite/v1/topic_stats.proto#L94}
   ///
@@ -103,7 +104,7 @@ class TopicStatsServiceClient {
   StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>
   ComputeMessageStats(
       google::cloud::pubsublite::v1::ComputeMessageStatsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Compute the head cursor for the partition.
@@ -115,7 +116,8 @@ class TopicStatsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ComputeHeadCursorRequest,google/cloud/pubsublite/v1/topic_stats.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::ComputeHeadCursorResponse,google/cloud/pubsublite/v1/topic_stats.proto#L127}
   ///
@@ -127,7 +129,7 @@ class TopicStatsServiceClient {
   StatusOr<google::cloud::pubsublite::v1::ComputeHeadCursorResponse>
   ComputeHeadCursor(
       google::cloud::pubsublite::v1::ComputeHeadCursorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Compute the corresponding cursor for a publish or event time in a topic
@@ -135,7 +137,8 @@ class TopicStatsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::pubsublite::v1::ComputeTimeCursorRequest,google/cloud/pubsublite/v1/topic_stats.proto#L134}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::pubsublite::v1::ComputeTimeCursorResponse,google/cloud/pubsublite/v1/topic_stats.proto#L153}
   ///
@@ -147,7 +150,7 @@ class TopicStatsServiceClient {
   StatusOr<google::cloud::pubsublite::v1::ComputeTimeCursorResponse>
   ComputeTimeCursor(
       google::cloud::pubsublite::v1::ComputeTimeCursorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<TopicStatsServiceConnection> connection_;

--- a/google/cloud/recommender/recommender_client.cc
+++ b/google/cloud/recommender/recommender_client.cc
@@ -26,17 +26,16 @@ namespace recommender {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 RecommenderClient::RecommenderClient(
-    std::shared_ptr<RecommenderConnection> connection, Options options)
+    std::shared_ptr<RecommenderConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), recommender_internal::RecommenderDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), recommender_internal::RecommenderDefaultOptions(
+                               connection_->options()))) {}
 RecommenderClient::~RecommenderClient() = default;
 
 StreamRange<google::cloud::recommender::v1::Insight>
-RecommenderClient::ListInsights(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+RecommenderClient::ListInsights(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::ListInsightsRequest request;
   request.set_parent(parent);
   return connection_->ListInsights(request);
@@ -44,17 +43,14 @@ RecommenderClient::ListInsights(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::recommender::v1::Insight>
 RecommenderClient::ListInsights(
-    google::cloud::recommender::v1::ListInsightsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::recommender::v1::ListInsightsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInsights(std::move(request));
 }
 
 StatusOr<google::cloud::recommender::v1::Insight> RecommenderClient::GetInsight(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::GetInsightRequest request;
   request.set_name(name);
   return connection_->GetInsight(request);
@@ -62,9 +58,8 @@ StatusOr<google::cloud::recommender::v1::Insight> RecommenderClient::GetInsight(
 
 StatusOr<google::cloud::recommender::v1::Insight> RecommenderClient::GetInsight(
     google::cloud::recommender::v1::GetInsightRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInsight(request);
 }
 
@@ -72,9 +67,8 @@ StatusOr<google::cloud::recommender::v1::Insight>
 RecommenderClient::MarkInsightAccepted(
     std::string const& name,
     std::map<std::string, std::string> const& state_metadata,
-    std::string const& etag, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& etag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::MarkInsightAcceptedRequest request;
   request.set_name(name);
   *request.mutable_state_metadata() = {state_metadata.begin(),
@@ -86,17 +80,15 @@ RecommenderClient::MarkInsightAccepted(
 StatusOr<google::cloud::recommender::v1::Insight>
 RecommenderClient::MarkInsightAccepted(
     google::cloud::recommender::v1::MarkInsightAcceptedRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MarkInsightAccepted(request);
 }
 
 StreamRange<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::ListRecommendations(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::ListRecommendationsRequest request;
   request.set_parent(parent);
   return connection_->ListRecommendations(request);
@@ -105,9 +97,8 @@ RecommenderClient::ListRecommendations(std::string const& parent,
 StreamRange<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::ListRecommendations(std::string const& parent,
                                        std::string const& filter,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::ListRecommendationsRequest request;
   request.set_parent(parent);
   request.set_filter(filter);
@@ -117,16 +108,14 @@ RecommenderClient::ListRecommendations(std::string const& parent,
 StreamRange<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::ListRecommendations(
     google::cloud::recommender::v1::ListRecommendationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListRecommendations(std::move(request));
 }
 
 StatusOr<google::cloud::recommender::v1::Recommendation>
-RecommenderClient::GetRecommendation(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+RecommenderClient::GetRecommendation(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::GetRecommendationRequest request;
   request.set_name(name);
   return connection_->GetRecommendation(request);
@@ -135,9 +124,8 @@ RecommenderClient::GetRecommendation(std::string const& name, Options options) {
 StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::GetRecommendation(
     google::cloud::recommender::v1::GetRecommendationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetRecommendation(request);
 }
 
@@ -145,9 +133,8 @@ StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::MarkRecommendationClaimed(
     std::string const& name,
     std::map<std::string, std::string> const& state_metadata,
-    std::string const& etag, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& etag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::MarkRecommendationClaimedRequest request;
   request.set_name(name);
   *request.mutable_state_metadata() = {state_metadata.begin(),
@@ -160,9 +147,8 @@ StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::MarkRecommendationClaimed(
     google::cloud::recommender::v1::MarkRecommendationClaimedRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MarkRecommendationClaimed(request);
 }
 
@@ -170,9 +156,8 @@ StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::MarkRecommendationSucceeded(
     std::string const& name,
     std::map<std::string, std::string> const& state_metadata,
-    std::string const& etag, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& etag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::MarkRecommendationSucceededRequest request;
   request.set_name(name);
   *request.mutable_state_metadata() = {state_metadata.begin(),
@@ -185,9 +170,8 @@ StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::MarkRecommendationSucceeded(
     google::cloud::recommender::v1::MarkRecommendationSucceededRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MarkRecommendationSucceeded(request);
 }
 
@@ -195,9 +179,8 @@ StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::MarkRecommendationFailed(
     std::string const& name,
     std::map<std::string, std::string> const& state_metadata,
-    std::string const& etag, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& etag, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::recommender::v1::MarkRecommendationFailedRequest request;
   request.set_name(name);
   *request.mutable_state_metadata() = {state_metadata.begin(),
@@ -210,9 +193,8 @@ StatusOr<google::cloud::recommender::v1::Recommendation>
 RecommenderClient::MarkRecommendationFailed(
     google::cloud::recommender::v1::MarkRecommendationFailedRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MarkRecommendationFailed(request);
 }
 

--- a/google/cloud/recommender/recommender_client.h
+++ b/google/cloud/recommender/recommender_client.h
@@ -65,7 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class RecommenderClient {
  public:
   explicit RecommenderClient(std::shared_ptr<RecommenderConnection> connection,
-                             Options options = {});
+                             Options opts = {});
   ~RecommenderClient();
 
   //@{
@@ -104,7 +104,8 @@ class RecommenderClient {
   ///  https://cloud.google.com/about/locations/
   ///  INSIGHT_TYPE_ID refers to supported insight types:
   ///  https://cloud.google.com/recommender/docs/insights/insight-types.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Insight,google/cloud/recommender/v1/insight.proto#L40}
   ///
@@ -114,7 +115,7 @@ class RecommenderClient {
   /// @googleapis_reference_link{google/cloud/recommender/v1/insight.proto#L40}
   ///
   StreamRange<google::cloud::recommender::v1::Insight> ListInsights(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists insights for the specified Cloud Resource. Requires the
@@ -122,7 +123,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::ListInsightsRequest,google/cloud/recommender/v1/recommender_service.proto#L234}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Insight,google/cloud/recommender/v1/insight.proto#L40}
   ///
@@ -133,14 +135,15 @@ class RecommenderClient {
   ///
   StreamRange<google::cloud::recommender::v1::Insight> ListInsights(
       google::cloud::recommender::v1::ListInsightsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the requested insight. Requires the recommender.*.get IAM permission
   /// for the specified insight type.
   ///
   /// @param name  Required. Name of the insight.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Insight,google/cloud/recommender/v1/insight.proto#L40}
   ///
@@ -150,7 +153,7 @@ class RecommenderClient {
   /// @googleapis_reference_link{google/cloud/recommender/v1/insight.proto#L40}
   ///
   StatusOr<google::cloud::recommender::v1::Insight> GetInsight(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the requested insight. Requires the recommender.*.get IAM permission
@@ -158,7 +161,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::GetInsightRequest,google/cloud/recommender/v1/recommender_service.proto#L305}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Insight,google/cloud/recommender/v1/insight.proto#L40}
   ///
@@ -169,7 +173,7 @@ class RecommenderClient {
   ///
   StatusOr<google::cloud::recommender::v1::Insight> GetInsight(
       google::cloud::recommender::v1::GetInsightRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Marks the Insight State as Accepted. Users can use this method to
@@ -185,7 +189,8 @@ class RecommenderClient {
   ///  current state_metadata.
   /// @param etag  Required. Fingerprint of the Insight. Provides optimistic
   /// locking.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Insight,google/cloud/recommender/v1/insight.proto#L40}
   ///
@@ -197,7 +202,7 @@ class RecommenderClient {
   StatusOr<google::cloud::recommender::v1::Insight> MarkInsightAccepted(
       std::string const& name,
       std::map<std::string, std::string> const& state_metadata,
-      std::string const& etag, Options options = {});
+      std::string const& etag, Options opts = {});
 
   ///
   /// Marks the Insight State as Accepted. Users can use this method to
@@ -209,7 +214,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::MarkInsightAcceptedRequest,google/cloud/recommender/v1/recommender_service.proto#L316}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Insight,google/cloud/recommender/v1/insight.proto#L40}
   ///
@@ -220,7 +226,7 @@ class RecommenderClient {
   ///
   StatusOr<google::cloud::recommender::v1::Insight> MarkInsightAccepted(
       google::cloud::recommender::v1::MarkInsightAcceptedRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists recommendations for the specified Cloud Resource. Requires the
@@ -238,7 +244,8 @@ class RecommenderClient {
   ///  https://cloud.google.com/about/locations/
   ///  RECOMMENDER_ID refers to supported recommenders:
   ///  https://cloud.google.com/recommender/docs/recommenders.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -248,7 +255,7 @@ class RecommenderClient {
   /// @googleapis_reference_link{google/cloud/recommender/v1/recommendation.proto#L40}
   ///
   StreamRange<google::cloud::recommender::v1::Recommendation>
-  ListRecommendations(std::string const& parent, Options options = {});
+  ListRecommendations(std::string const& parent, Options opts = {});
 
   ///
   /// Lists recommendations for the specified Cloud Resource. Requires the
@@ -279,7 +286,8 @@ class RecommenderClient {
   ///  * `stateInfo.state = ACTIVE AND (priority = P1 OR priority = P2)`
   ///  (These expressions are based on the filter language described at
   ///  https://google.aip.dev/160)
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -290,7 +298,7 @@ class RecommenderClient {
   ///
   StreamRange<google::cloud::recommender::v1::Recommendation>
   ListRecommendations(std::string const& parent, std::string const& filter,
-                      Options options = {});
+                      Options opts = {});
 
   ///
   /// Lists recommendations for the specified Cloud Resource. Requires the
@@ -298,7 +306,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::ListRecommendationsRequest,google/cloud/recommender/v1/recommender_service.proto#L334}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -310,14 +319,15 @@ class RecommenderClient {
   StreamRange<google::cloud::recommender::v1::Recommendation>
   ListRecommendations(
       google::cloud::recommender::v1::ListRecommendationsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the requested recommendation. Requires the recommender.*.get
   /// IAM permission for the specified recommender.
   ///
   /// @param name  Required. Name of the recommendation.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -327,7 +337,7 @@ class RecommenderClient {
   /// @googleapis_reference_link{google/cloud/recommender/v1/recommendation.proto#L40}
   ///
   StatusOr<google::cloud::recommender::v1::Recommendation> GetRecommendation(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the requested recommendation. Requires the recommender.*.get
@@ -335,7 +345,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::GetRecommendationRequest,google/cloud/recommender/v1/recommender_service.proto#L405}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -346,7 +357,7 @@ class RecommenderClient {
   ///
   StatusOr<google::cloud::recommender::v1::Recommendation> GetRecommendation(
       google::cloud::recommender::v1::GetRecommendationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Marks the Recommendation State as Claimed. Users can use this method to
@@ -369,7 +380,8 @@ class RecommenderClient {
   ///  Values must match the regex `/^[a-zA-Z0-9_./-]{0,255}$/`.
   /// @param etag  Required. Fingerprint of the Recommendation. Provides
   /// optimistic locking.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -382,7 +394,7 @@ class RecommenderClient {
   MarkRecommendationClaimed(
       std::string const& name,
       std::map<std::string, std::string> const& state_metadata,
-      std::string const& etag, Options options = {});
+      std::string const& etag, Options opts = {});
 
   ///
   /// Marks the Recommendation State as Claimed. Users can use this method to
@@ -399,7 +411,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::MarkRecommendationClaimedRequest,google/cloud/recommender/v1/recommender_service.proto#L416}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -412,7 +425,7 @@ class RecommenderClient {
   MarkRecommendationClaimed(
       google::cloud::recommender::v1::MarkRecommendationClaimedRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Marks the Recommendation State as Succeeded. Users can use this method to
@@ -435,7 +448,8 @@ class RecommenderClient {
   ///  Values must match the regex `/^[a-zA-Z0-9_./-]{0,255}$/`.
   /// @param etag  Required. Fingerprint of the Recommendation. Provides
   /// optimistic locking.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -448,7 +462,7 @@ class RecommenderClient {
   MarkRecommendationSucceeded(
       std::string const& name,
       std::map<std::string, std::string> const& state_metadata,
-      std::string const& etag, Options options = {});
+      std::string const& etag, Options opts = {});
 
   ///
   /// Marks the Recommendation State as Succeeded. Users can use this method to
@@ -465,7 +479,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::MarkRecommendationSucceededRequest,google/cloud/recommender/v1/recommender_service.proto#L436}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -478,7 +493,7 @@ class RecommenderClient {
   MarkRecommendationSucceeded(
       google::cloud::recommender::v1::MarkRecommendationSucceededRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Marks the Recommendation State as Failed. Users can use this method to
@@ -501,7 +516,8 @@ class RecommenderClient {
   ///  Values must match the regex `/^[a-zA-Z0-9_./-]{0,255}$/`.
   /// @param etag  Required. Fingerprint of the Recommendation. Provides
   /// optimistic locking.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -514,7 +530,7 @@ class RecommenderClient {
   MarkRecommendationFailed(
       std::string const& name,
       std::map<std::string, std::string> const& state_metadata,
-      std::string const& etag, Options options = {});
+      std::string const& etag, Options opts = {});
 
   ///
   /// Marks the Recommendation State as Failed. Users can use this method to
@@ -531,7 +547,8 @@ class RecommenderClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::recommender::v1::MarkRecommendationFailedRequest,google/cloud/recommender/v1/recommender_service.proto#L456}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::recommender::v1::Recommendation,google/cloud/recommender/v1/recommendation.proto#L40}
   ///
@@ -544,7 +561,7 @@ class RecommenderClient {
   MarkRecommendationFailed(
       google::cloud::recommender::v1::MarkRecommendationFailedRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<RecommenderConnection> connection_;

--- a/google/cloud/redis/cloud_redis_client.cc
+++ b/google/cloud/redis/cloud_redis_client.cc
@@ -26,52 +26,46 @@ namespace redis {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudRedisClient::CloudRedisClient(
-    std::shared_ptr<CloudRedisConnection> connection, Options options)
+    std::shared_ptr<CloudRedisConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           redis_internal::CloudRedisDefaultOptions(connection_->options()))) {}
 CloudRedisClient::~CloudRedisClient() = default;
 
 StreamRange<google::cloud::redis::v1::Instance> CloudRedisClient::ListInstances(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
 }
 
 StreamRange<google::cloud::redis::v1::Instance> CloudRedisClient::ListInstances(
-    google::cloud::redis::v1::ListInstancesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::redis::v1::ListInstancesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::cloud::redis::v1::Instance> CloudRedisClient::GetInstance(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
 }
 
 StatusOr<google::cloud::redis::v1::Instance> CloudRedisClient::GetInstance(
-    google::cloud::redis::v1::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::redis::v1::GetInstanceRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::CreateInstance(
     std::string const& parent, std::string const& instance_id,
-    google::cloud::redis::v1::Instance const& instance, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::redis::v1::Instance const& instance, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::CreateInstanceRequest request;
   request.set_parent(parent);
   request.set_instance_id(instance_id);
@@ -82,18 +76,16 @@ CloudRedisClient::CreateInstance(
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::CreateInstance(
     google::cloud::redis::v1::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::UpdateInstance(
     google::protobuf::FieldMask const& update_mask,
-    google::cloud::redis::v1::Instance const& instance, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::redis::v1::Instance const& instance, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::UpdateInstanceRequest request;
   *request.mutable_update_mask() = update_mask;
   *request.mutable_instance() = instance;
@@ -103,18 +95,16 @@ CloudRedisClient::UpdateInstance(
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::UpdateInstance(
     google::cloud::redis::v1::UpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstance(request);
 }
 
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::UpgradeInstance(std::string const& name,
                                   std::string const& redis_version,
-                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::UpgradeInstanceRequest request;
   request.set_name(name);
   request.set_redis_version(redis_version);
@@ -124,19 +114,16 @@ CloudRedisClient::UpgradeInstance(std::string const& name,
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::UpgradeInstance(
     google::cloud::redis::v1::UpgradeInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpgradeInstance(request);
 }
 
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::ImportInstance(
     std::string const& name,
-    google::cloud::redis::v1::InputConfig const& input_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::redis::v1::InputConfig const& input_config, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::ImportInstanceRequest request;
   request.set_name(name);
   *request.mutable_input_config() = input_config;
@@ -146,19 +133,16 @@ CloudRedisClient::ImportInstance(
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::ImportInstance(
     google::cloud::redis::v1::ImportInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportInstance(request);
 }
 
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::ExportInstance(
     std::string const& name,
-    google::cloud::redis::v1::OutputConfig const& output_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::redis::v1::OutputConfig const& output_config, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::ExportInstanceRequest request;
   request.set_name(name);
   *request.mutable_output_config() = output_config;
@@ -168,9 +152,8 @@ CloudRedisClient::ExportInstance(
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::ExportInstance(
     google::cloud::redis::v1::ExportInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ExportInstance(request);
 }
 
@@ -179,9 +162,8 @@ CloudRedisClient::FailoverInstance(
     std::string const& name,
     google::cloud::redis::v1::FailoverInstanceRequest::DataProtectionMode
         data_protection_mode,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::FailoverInstanceRequest request;
   request.set_name(name);
   request.set_data_protection_mode(data_protection_mode);
@@ -191,16 +173,14 @@ CloudRedisClient::FailoverInstance(
 future<StatusOr<google::cloud::redis::v1::Instance>>
 CloudRedisClient::FailoverInstance(
     google::cloud::redis::v1::FailoverInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FailoverInstance(request);
 }
 
 future<StatusOr<google::cloud::redis::v1::OperationMetadata>>
-CloudRedisClient::DeleteInstance(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudRedisClient::DeleteInstance(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::redis::v1::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -209,9 +189,8 @@ CloudRedisClient::DeleteInstance(std::string const& name, Options options) {
 future<StatusOr<google::cloud::redis::v1::OperationMetadata>>
 CloudRedisClient::DeleteInstance(
     google::cloud::redis::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 

--- a/google/cloud/redis/cloud_redis_client.h
+++ b/google/cloud/redis/cloud_redis_client.h
@@ -79,7 +79,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudRedisClient {
  public:
   explicit CloudRedisClient(std::shared_ptr<CloudRedisConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~CloudRedisClient();
 
   //@{
@@ -115,7 +115,8 @@ class CloudRedisClient {
   /// the form:
   ///      `projects/{project_id}/locations/{location_id}`
   ///  where `location_id` refers to a GCP region.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -125,7 +126,7 @@ class CloudRedisClient {
   /// @googleapis_reference_link{google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
   StreamRange<google::cloud::redis::v1::Instance> ListInstances(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all Redis instances owned by a project in either the specified
@@ -140,7 +141,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::ListInstancesRequest,google/cloud/redis/v1/cloud_redis.proto#L426}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -151,7 +153,7 @@ class CloudRedisClient {
   ///
   StreamRange<google::cloud::redis::v1::Instance> ListInstances(
       google::cloud::redis::v1::ListInstancesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the details of a specific Redis instance.
@@ -159,7 +161,8 @@ class CloudRedisClient {
   /// @param name  Required. Redis instance resource name using the form:
   ///      `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
   ///  where `location_id` refers to a GCP region.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -169,14 +172,15 @@ class CloudRedisClient {
   /// @googleapis_reference_link{google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
   StatusOr<google::cloud::redis::v1::Instance> GetInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the details of a specific Redis instance.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::GetInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L475}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -187,7 +191,7 @@ class CloudRedisClient {
   ///
   StatusOr<google::cloud::redis::v1::Instance> GetInstance(
       google::cloud::redis::v1::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Redis instance based on the specified tier and memory size.
@@ -216,7 +220,8 @@ class CloudRedisClient {
   ///  * Must end with a number or a letter.
   ///  * Must be unique within the customer project / location
   /// @param instance  Required. A Redis [Instance] resource
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -227,7 +232,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> CreateInstance(
       std::string const& parent, std::string const& instance_id,
-      google::cloud::redis::v1::Instance const& instance, Options options = {});
+      google::cloud::redis::v1::Instance const& instance, Options opts = {});
 
   ///
   /// Creates a Redis instance based on the specified tier and memory size.
@@ -245,7 +250,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::CreateInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L488}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -256,7 +262,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> CreateInstance(
       google::cloud::redis::v1::CreateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the metadata and configuration of a specific Redis instance.
@@ -276,7 +282,8 @@ class CloudRedisClient {
   ///   *   `replica_count`
   /// @param instance  Required. Update description.
   ///  Only fields specified in update_mask are updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -287,7 +294,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> UpdateInstance(
       google::protobuf::FieldMask const& update_mask,
-      google::cloud::redis::v1::Instance const& instance, Options options = {});
+      google::cloud::redis::v1::Instance const& instance, Options opts = {});
 
   ///
   /// Updates the metadata and configuration of a specific Redis instance.
@@ -298,7 +305,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::UpdateInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L514}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -309,7 +317,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> UpdateInstance(
       google::cloud::redis::v1::UpdateInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Upgrades Redis instance to the newer Redis version specified in the
@@ -320,7 +328,8 @@ class CloudRedisClient {
   ///  where `location_id` refers to a GCP region.
   /// @param redis_version  Required. Specifies the target version of Redis
   /// software to upgrade to.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -331,7 +340,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> UpgradeInstance(
       std::string const& name, std::string const& redis_version,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Upgrades Redis instance to the newer Redis version specified in the
@@ -339,7 +348,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::UpgradeInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L532}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -350,7 +360,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> UpgradeInstance(
       google::cloud::redis::v1::UpgradeInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
@@ -366,7 +376,8 @@ class CloudRedisClient {
   ///      `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
   ///  where `location_id` refers to a GCP region.
   /// @param input_config  Required. Specify data to be imported.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -378,7 +389,7 @@ class CloudRedisClient {
   future<StatusOr<google::cloud::redis::v1::Instance>> ImportInstance(
       std::string const& name,
       google::cloud::redis::v1::InputConfig const& input_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Import a Redis RDB snapshot file from Cloud Storage into a Redis instance.
@@ -392,7 +403,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::ImportInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L576}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -403,7 +415,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> ImportInstance(
       google::cloud::redis::v1::ImportInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Export Redis instance data into a Redis RDB format file in Cloud Storage.
@@ -417,7 +429,8 @@ class CloudRedisClient {
   ///      `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
   ///  where `location_id` refers to a GCP region.
   /// @param output_config  Required. Specify data to be exported.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -429,7 +442,7 @@ class CloudRedisClient {
   future<StatusOr<google::cloud::redis::v1::Instance>> ExportInstance(
       std::string const& name,
       google::cloud::redis::v1::OutputConfig const& output_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Export Redis instance data into a Redis RDB format file in Cloud Storage.
@@ -441,7 +454,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::ExportInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L603}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -452,7 +466,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> ExportInstance(
       google::cloud::redis::v1::ExportInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates a failover of the primary node to current replica node for a
@@ -464,7 +478,8 @@ class CloudRedisClient {
   /// @param data_protection_mode  Optional. Available data protection modes
   /// that the user can choose. If it's
   ///  unspecified, data protection mode will be LIMITED_DATA_LOSS by default.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -477,7 +492,7 @@ class CloudRedisClient {
       std::string const& name,
       google::cloud::redis::v1::FailoverInstanceRequest::DataProtectionMode
           data_protection_mode,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates a failover of the primary node to current replica node for a
@@ -485,7 +500,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::FailoverInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L614}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::Instance,google/cloud/redis/v1/cloud_redis.proto#L206}
   ///
@@ -496,7 +512,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::Instance>> FailoverInstance(
       google::cloud::redis::v1::FailoverInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a specific Redis instance.  Instance stops serving and data is
@@ -505,7 +521,8 @@ class CloudRedisClient {
   /// @param name  Required. Redis instance resource name using the form:
   ///      `projects/{project_id}/locations/{location_id}/instances/{instance_id}`
   ///  where `location_id` refers to a GCP region.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::OperationMetadata,google/cloud/redis/v1/cloud_redis.proto#L647}
   ///
@@ -515,7 +532,7 @@ class CloudRedisClient {
   /// @googleapis_reference_link{google/cloud/redis/v1/cloud_redis.proto#L647}
   ///
   future<StatusOr<google::cloud::redis::v1::OperationMetadata>> DeleteInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a specific Redis instance.  Instance stops serving and data is
@@ -523,7 +540,8 @@ class CloudRedisClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::redis::v1::DeleteInstanceRequest,google/cloud/redis/v1/cloud_redis.proto#L548}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::redis::v1::OperationMetadata,google/cloud/redis/v1/cloud_redis.proto#L647}
   ///
@@ -534,7 +552,7 @@ class CloudRedisClient {
   ///
   future<StatusOr<google::cloud::redis::v1::OperationMetadata>> DeleteInstance(
       google::cloud::redis::v1::DeleteInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudRedisConnection> connection_;

--- a/google/cloud/resourcemanager/folders_client.cc
+++ b/google/cloud/resourcemanager/folders_client.cc
@@ -28,17 +28,16 @@ namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 FoldersClient::FoldersClient(std::shared_ptr<FoldersConnection> connection,
-                             Options options)
+                             Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), resourcemanager_internal::FoldersDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), resourcemanager_internal::FoldersDefaultOptions(
+                               connection_->options()))) {}
 FoldersClient::~FoldersClient() = default;
 
 StatusOr<google::cloud::resourcemanager::v3::Folder> FoldersClient::GetFolder(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::GetFolderRequest request;
   request.set_name(name);
   return connection_->GetFolder(request);
@@ -46,16 +45,14 @@ StatusOr<google::cloud::resourcemanager::v3::Folder> FoldersClient::GetFolder(
 
 StatusOr<google::cloud::resourcemanager::v3::Folder> FoldersClient::GetFolder(
     google::cloud::resourcemanager::v3::GetFolderRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetFolder(request);
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Folder>
-FoldersClient::ListFolders(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+FoldersClient::ListFolders(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::ListFoldersRequest request;
   request.set_parent(parent);
   return connection_->ListFolders(request);
@@ -64,16 +61,14 @@ FoldersClient::ListFolders(std::string const& parent, Options options) {
 StreamRange<google::cloud::resourcemanager::v3::Folder>
 FoldersClient::ListFolders(
     google::cloud::resourcemanager::v3::ListFoldersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFolders(std::move(request));
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Folder>
-FoldersClient::SearchFolders(std::string const& query, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+FoldersClient::SearchFolders(std::string const& query, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::SearchFoldersRequest request;
   request.set_query(query);
   return connection_->SearchFolders(request);
@@ -82,17 +77,15 @@ FoldersClient::SearchFolders(std::string const& query, Options options) {
 StreamRange<google::cloud::resourcemanager::v3::Folder>
 FoldersClient::SearchFolders(
     google::cloud::resourcemanager::v3::SearchFoldersRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchFolders(std::move(request));
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::CreateFolder(
-    google::cloud::resourcemanager::v3::Folder const& folder, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::resourcemanager::v3::Folder const& folder, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::CreateFolderRequest request;
   *request.mutable_folder() = folder;
   return connection_->CreateFolder(request);
@@ -101,18 +94,16 @@ FoldersClient::CreateFolder(
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::CreateFolder(
     google::cloud::resourcemanager::v3::CreateFolderRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateFolder(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::UpdateFolder(
     google::cloud::resourcemanager::v3::Folder const& folder,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::UpdateFolderRequest request;
   *request.mutable_folder() = folder;
   *request.mutable_update_mask() = update_mask;
@@ -122,18 +113,15 @@ FoldersClient::UpdateFolder(
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::UpdateFolder(
     google::cloud::resourcemanager::v3::UpdateFolderRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateFolder(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::MoveFolder(std::string const& name,
-                          std::string const& destination_parent,
-                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                          std::string const& destination_parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::MoveFolderRequest request;
   request.set_name(name);
   request.set_destination_parent(destination_parent);
@@ -143,16 +131,14 @@ FoldersClient::MoveFolder(std::string const& name,
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::MoveFolder(
     google::cloud::resourcemanager::v3::MoveFolderRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MoveFolder(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
-FoldersClient::DeleteFolder(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+FoldersClient::DeleteFolder(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::DeleteFolderRequest request;
   request.set_name(name);
   return connection_->DeleteFolder(request);
@@ -161,16 +147,14 @@ FoldersClient::DeleteFolder(std::string const& name, Options options) {
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::DeleteFolder(
     google::cloud::resourcemanager::v3::DeleteFolderRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteFolder(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
-FoldersClient::UndeleteFolder(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+FoldersClient::UndeleteFolder(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::UndeleteFolderRequest request;
   request.set_name(name);
   return connection_->UndeleteFolder(request);
@@ -179,33 +163,29 @@ FoldersClient::UndeleteFolder(std::string const& name, Options options) {
 future<StatusOr<google::cloud::resourcemanager::v3::Folder>>
 FoldersClient::UndeleteFolder(
     google::cloud::resourcemanager::v3::UndeleteFolderRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteFolder(request);
 }
 
 StatusOr<google::iam::v1::Policy> FoldersClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> FoldersClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -213,10 +193,9 @@ StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<FoldersBackoffPolicyOption>(options, __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<FoldersBackoffPolicyOption>(opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -242,18 +221,16 @@ StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 FoldersClient::TestIamPermissions(std::string const& resource,
                                   std::vector<std::string> const& permissions,
-                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -262,10 +239,8 @@ FoldersClient::TestIamPermissions(std::string const& resource,
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 FoldersClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/resourcemanager/folders_client.h
+++ b/google/cloud/resourcemanager/folders_client.h
@@ -696,8 +696,8 @@ class FoldersClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/resourcemanager/folders_client.h
+++ b/google/cloud/resourcemanager/folders_client.h
@@ -65,7 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class FoldersClient {
  public:
   explicit FoldersClient(std::shared_ptr<FoldersConnection> connection,
-                         Options options = {});
+                         Options opts = {});
   ~FoldersClient();
 
   //@{
@@ -95,7 +95,8 @@ class FoldersClient {
   ///
   /// @param name  Required. The resource name of the folder to retrieve.
   ///  Must be of the form `folders/{folder_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -105,7 +106,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
   StatusOr<google::cloud::resourcemanager::v3::Folder> GetFolder(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves a folder identified by the supplied resource name.
@@ -116,7 +117,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::GetFolderRequest,google/cloud/resourcemanager/v3/folders.proto#L322}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -127,7 +129,7 @@ class FoldersClient {
   ///
   StatusOr<google::cloud::resourcemanager::v3::Folder> GetFolder(
       google::cloud::resourcemanager::v3::GetFolderRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the folders that are direct descendants of supplied parent resource.
@@ -143,7 +145,8 @@ class FoldersClient {
   ///  Must be of the form `folders/{folder_id}` or `organizations/{org_id}`.
   ///  Access to this method is controlled by checking the
   ///  `resourcemanager.folders.list` permission on the `parent`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -153,7 +156,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
   StreamRange<google::cloud::resourcemanager::v3::Folder> ListFolders(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists the folders that are direct descendants of supplied parent resource.
@@ -165,7 +168,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::ListFoldersRequest,google/cloud/resourcemanager/v3/folders.proto#L334}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -176,7 +180,7 @@ class FoldersClient {
   ///
   StreamRange<google::cloud::resourcemanager::v3::Folder> ListFolders(
       google::cloud::resourcemanager::v3::ListFoldersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Search for folders that match specific filter criteria.
@@ -213,7 +217,8 @@ class FoldersClient {
   ///  Folder resources that have `folders/123` as a parent resource.
   ///  * Query `displayName=\\"Test String\\"` returns Folder resources with
   ///  display names that include both "Test" and "String".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -223,7 +228,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
   StreamRange<google::cloud::resourcemanager::v3::Folder> SearchFolders(
-      std::string const& query, Options options = {});
+      std::string const& query, Options opts = {});
 
   ///
   /// Search for folders that match specific filter criteria.
@@ -235,7 +240,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::SearchFoldersRequest,google/cloud/resourcemanager/v3/folders.proto#L373}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -246,7 +252,7 @@ class FoldersClient {
   ///
   StreamRange<google::cloud::resourcemanager::v3::Folder> SearchFolders(
       google::cloud::resourcemanager::v3::SearchFoldersRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a folder in the resource hierarchy.
@@ -280,7 +286,8 @@ class FoldersClient {
   /// @param folder  Required. The folder being created, only the display name
   /// and parent will be
   ///  consulted. All other fields will be ignored.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -291,7 +298,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> CreateFolder(
       google::cloud::resourcemanager::v3::Folder const& folder,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a folder in the resource hierarchy.
@@ -324,7 +331,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::CreateFolderRequest,google/cloud/resourcemanager/v3/folders.proto#L428}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -335,7 +343,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> CreateFolder(
       google::cloud::resourcemanager::v3::CreateFolderRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a folder, changing its `display_name`.
@@ -361,7 +369,8 @@ class FoldersClient {
   ///  cannot be changed.
   /// @param update_mask  Required. Fields to be updated.
   ///  Only the `display_name` can be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -372,7 +381,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> UpdateFolder(
       google::cloud::resourcemanager::v3::Folder const& folder,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a folder, changing its `display_name`.
@@ -395,7 +404,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::UpdateFolderRequest,google/cloud/resourcemanager/v3/folders.proto#L452}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -406,7 +416,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> UpdateFolder(
       google::cloud::resourcemanager::v3::UpdateFolderRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Moves a folder under a new resource parent.
@@ -433,7 +443,8 @@ class FoldersClient {
   /// organization which should be the
   ///  folder's new parent.
   ///  Must be of the form `folders/{folder_id}` or `organizations/{org_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -444,7 +455,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> MoveFolder(
       std::string const& name, std::string const& destination_parent,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Moves a folder under a new resource parent.
@@ -467,7 +478,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::MoveFolderRequest,google/cloud/resourcemanager/v3/folders.proto#L469}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -478,7 +490,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> MoveFolder(
       google::cloud::resourcemanager::v3::MoveFolderRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Requests deletion of a folder. The folder is moved into the
@@ -495,7 +507,8 @@ class FoldersClient {
   ///
   /// @param name  Required. The resource name of the folder to be deleted.
   ///  Must be of the form `folders/{folder_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -505,7 +518,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> DeleteFolder(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Requests deletion of a folder. The folder is moved into the
@@ -522,7 +535,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::DeleteFolderRequest,google/cloud/resourcemanager/v3/folders.proto#L503}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -533,7 +547,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> DeleteFolder(
       google::cloud::resourcemanager::v3::DeleteFolderRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Cancels the deletion request for a folder. This method may be called on a
@@ -550,7 +564,8 @@ class FoldersClient {
   ///
   /// @param name  Required. The resource name of the folder to undelete.
   ///  Must be of the form `folders/{folder_id}`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -560,7 +575,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> UndeleteFolder(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Cancels the deletion request for a folder. This method may be called on a
@@ -577,7 +592,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::UndeleteFolderRequest,google/cloud/resourcemanager/v3/folders.proto#L521}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Folder,google/cloud/resourcemanager/v3/folders.proto#L263}
   ///
@@ -588,7 +604,7 @@ class FoldersClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Folder>> UndeleteFolder(
       google::cloud::resourcemanager::v3::UndeleteFolderRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy for a folder. The returned policy may be
@@ -600,7 +616,8 @@ class FoldersClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -610,7 +627,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a folder. The returned policy may be
@@ -621,7 +638,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -631,8 +649,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy on a folder, replacing any existing policy.
@@ -649,7 +666,8 @@ class FoldersClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -660,7 +678,7 @@ class FoldersClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -678,14 +696,13 @@ class FoldersClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `FoldersBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on a folder, replacing any existing policy.
@@ -696,7 +713,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -706,8 +724,7 @@ class FoldersClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the specified folder.
@@ -724,7 +741,8 @@ class FoldersClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -735,7 +753,7 @@ class FoldersClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the specified folder.
@@ -746,7 +764,8 @@ class FoldersClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -757,7 +776,7 @@ class FoldersClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<FoldersConnection> connection_;

--- a/google/cloud/resourcemanager/organizations_client.cc
+++ b/google/cloud/resourcemanager/organizations_client.cc
@@ -26,18 +26,17 @@ namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 OrganizationsClient::OrganizationsClient(
-    std::shared_ptr<OrganizationsConnection> connection, Options options)
+    std::shared_ptr<OrganizationsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           resourcemanager_internal::OrganizationsDefaultOptions(
               connection_->options()))) {}
 OrganizationsClient::~OrganizationsClient() = default;
 
 StatusOr<google::cloud::resourcemanager::v3::Organization>
-OrganizationsClient::GetOrganization(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+OrganizationsClient::GetOrganization(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::GetOrganizationRequest request;
   request.set_name(name);
   return connection_->GetOrganization(request);
@@ -46,17 +45,15 @@ OrganizationsClient::GetOrganization(std::string const& name, Options options) {
 StatusOr<google::cloud::resourcemanager::v3::Organization>
 OrganizationsClient::GetOrganization(
     google::cloud::resourcemanager::v3::GetOrganizationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetOrganization(request);
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Organization>
 OrganizationsClient::SearchOrganizations(std::string const& query,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::SearchOrganizationsRequest request;
   request.set_query(query);
   return connection_->SearchOrganizations(request);
@@ -65,50 +62,44 @@ OrganizationsClient::SearchOrganizations(std::string const& query,
 StreamRange<google::cloud::resourcemanager::v3::Organization>
 OrganizationsClient::SearchOrganizations(
     google::cloud::resourcemanager::v3::SearchOrganizationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchOrganizations(std::move(request));
 }
 
 StatusOr<google::iam::v1::Policy> OrganizationsClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> OrganizationsClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> OrganizationsClient::SetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> OrganizationsClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 OrganizationsClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -117,10 +108,8 @@ OrganizationsClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 OrganizationsClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/resourcemanager/organizations_client.h
+++ b/google/cloud/resourcemanager/organizations_client.h
@@ -61,8 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OrganizationsClient {
  public:
   explicit OrganizationsClient(
-      std::shared_ptr<OrganizationsConnection> connection,
-      Options options = {});
+      std::shared_ptr<OrganizationsConnection> connection, Options opts = {});
   ~OrganizationsClient();
 
   //@{
@@ -93,7 +92,8 @@ class OrganizationsClient {
   /// This is the organization's
   ///  relative path in the API, formatted as "organizations/[organizationId]".
   ///  For example, "organizations/1234".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Organization,google/cloud/resourcemanager/v3/organizations.proto#L109}
   ///
@@ -103,7 +103,7 @@ class OrganizationsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/organizations.proto#L109}
   ///
   StatusOr<google::cloud::resourcemanager::v3::Organization> GetOrganization(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Fetches an organization resource identified by the specified resource
@@ -111,7 +111,8 @@ class OrganizationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::GetOrganizationRequest,google/cloud/resourcemanager/v3/organizations.proto#L170}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Organization,google/cloud/resourcemanager/v3/organizations.proto#L109}
   ///
@@ -122,7 +123,7 @@ class OrganizationsClient {
   ///
   StatusOr<google::cloud::resourcemanager::v3::Organization> GetOrganization(
       google::cloud::resourcemanager::v3::GetOrganizationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Searches organization resources that are visible to the user and satisfy
@@ -149,7 +150,8 @@ class OrganizationsClient {
   ///  resources with `owner.directory_customer_id` equal to `123456789`.
   ///  * Query `domain:google.com` returns Organization resources corresponding
   ///  to the domain `google.com`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Organization,google/cloud/resourcemanager/v3/organizations.proto#L109}
   ///
@@ -159,7 +161,7 @@ class OrganizationsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/organizations.proto#L109}
   ///
   StreamRange<google::cloud::resourcemanager::v3::Organization>
-  SearchOrganizations(std::string const& query, Options options = {});
+  SearchOrganizations(std::string const& query, Options opts = {});
 
   ///
   /// Searches organization resources that are visible to the user and satisfy
@@ -172,7 +174,8 @@ class OrganizationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::SearchOrganizationsRequest,google/cloud/resourcemanager/v3/organizations.proto#L183}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Organization,google/cloud/resourcemanager/v3/organizations.proto#L109}
   ///
@@ -184,7 +187,7 @@ class OrganizationsClient {
   StreamRange<google::cloud::resourcemanager::v3::Organization>
   SearchOrganizations(
       google::cloud::resourcemanager::v3::SearchOrganizationsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy for an organization resource. The policy
@@ -199,7 +202,8 @@ class OrganizationsClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -209,7 +213,7 @@ class OrganizationsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for an organization resource. The policy
@@ -223,7 +227,8 @@ class OrganizationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -233,8 +238,7 @@ class OrganizationsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy on an organization resource. Replaces any
@@ -248,7 +252,8 @@ class OrganizationsClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// specified.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -258,7 +263,7 @@ class OrganizationsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on an organization resource. Replaces any
@@ -271,7 +276,8 @@ class OrganizationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -281,8 +287,7 @@ class OrganizationsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns the permissions that a caller has on the specified organization.
@@ -299,7 +304,8 @@ class OrganizationsClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -310,7 +316,7 @@ class OrganizationsClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the permissions that a caller has on the specified organization.
@@ -321,7 +327,8 @@ class OrganizationsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -332,7 +339,7 @@ class OrganizationsClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<OrganizationsConnection> connection_;

--- a/google/cloud/resourcemanager/projects_client.cc
+++ b/google/cloud/resourcemanager/projects_client.cc
@@ -26,17 +26,16 @@ namespace resourcemanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ProjectsClient::ProjectsClient(std::shared_ptr<ProjectsConnection> connection,
-                               Options options)
+                               Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), resourcemanager_internal::ProjectsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), resourcemanager_internal::ProjectsDefaultOptions(
+                               connection_->options()))) {}
 ProjectsClient::~ProjectsClient() = default;
 
 StatusOr<google::cloud::resourcemanager::v3::Project>
-ProjectsClient::GetProject(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProjectsClient::GetProject(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::GetProjectRequest request;
   request.set_name(name);
   return connection_->GetProject(request);
@@ -45,16 +44,14 @@ ProjectsClient::GetProject(std::string const& name, Options options) {
 StatusOr<google::cloud::resourcemanager::v3::Project>
 ProjectsClient::GetProject(
     google::cloud::resourcemanager::v3::GetProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetProject(request);
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Project>
-ProjectsClient::ListProjects(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProjectsClient::ListProjects(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::ListProjectsRequest request;
   request.set_parent(parent);
   return connection_->ListProjects(request);
@@ -63,16 +60,14 @@ ProjectsClient::ListProjects(std::string const& parent, Options options) {
 StreamRange<google::cloud::resourcemanager::v3::Project>
 ProjectsClient::ListProjects(
     google::cloud::resourcemanager::v3::ListProjectsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProjects(std::move(request));
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Project>
-ProjectsClient::SearchProjects(std::string const& query, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProjectsClient::SearchProjects(std::string const& query, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::SearchProjectsRequest request;
   request.set_query(query);
   return connection_->SearchProjects(request);
@@ -81,18 +76,15 @@ ProjectsClient::SearchProjects(std::string const& query, Options options) {
 StreamRange<google::cloud::resourcemanager::v3::Project>
 ProjectsClient::SearchProjects(
     google::cloud::resourcemanager::v3::SearchProjectsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchProjects(std::move(request));
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::CreateProject(
-    google::cloud::resourcemanager::v3::Project const& project,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::resourcemanager::v3::Project const& project, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::CreateProjectRequest request;
   *request.mutable_project() = project;
   return connection_->CreateProject(request);
@@ -101,18 +93,16 @@ ProjectsClient::CreateProject(
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::CreateProject(
     google::cloud::resourcemanager::v3::CreateProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateProject(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::UpdateProject(
     google::cloud::resourcemanager::v3::Project const& project,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::UpdateProjectRequest request;
   *request.mutable_project() = project;
   *request.mutable_update_mask() = update_mask;
@@ -122,18 +112,16 @@ ProjectsClient::UpdateProject(
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::UpdateProject(
     google::cloud::resourcemanager::v3::UpdateProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateProject(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::MoveProject(std::string const& name,
                             std::string const& destination_parent,
-                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::MoveProjectRequest request;
   request.set_name(name);
   request.set_destination_parent(destination_parent);
@@ -143,16 +131,14 @@ ProjectsClient::MoveProject(std::string const& name,
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::MoveProject(
     google::cloud::resourcemanager::v3::MoveProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->MoveProject(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
-ProjectsClient::DeleteProject(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProjectsClient::DeleteProject(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::DeleteProjectRequest request;
   request.set_name(name);
   return connection_->DeleteProject(request);
@@ -161,16 +147,14 @@ ProjectsClient::DeleteProject(std::string const& name, Options options) {
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::DeleteProject(
     google::cloud::resourcemanager::v3::DeleteProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteProject(request);
 }
 
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
-ProjectsClient::UndeleteProject(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProjectsClient::UndeleteProject(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcemanager::v3::UndeleteProjectRequest request;
   request.set_name(name);
   return connection_->UndeleteProject(request);
@@ -179,33 +163,29 @@ ProjectsClient::UndeleteProject(std::string const& name, Options options) {
 future<StatusOr<google::cloud::resourcemanager::v3::Project>>
 ProjectsClient::UndeleteProject(
     google::cloud::resourcemanager::v3::UndeleteProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteProject(request);
 }
 
 StatusOr<google::iam::v1::Policy> ProjectsClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> ProjectsClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> ProjectsClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -213,18 +193,16 @@ StatusOr<google::iam::v1::Policy> ProjectsClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> ProjectsClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 ProjectsClient::TestIamPermissions(std::string const& resource,
                                    std::vector<std::string> const& permissions,
-                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -233,10 +211,8 @@ ProjectsClient::TestIamPermissions(std::string const& resource,
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 ProjectsClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/resourcemanager/projects_client.h
+++ b/google/cloud/resourcemanager/projects_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProjectsClient {
  public:
   explicit ProjectsClient(std::shared_ptr<ProjectsConnection> connection,
-                          Options options = {});
+                          Options opts = {});
   ~ProjectsClient();
 
   //@{
@@ -93,7 +93,8 @@ class ProjectsClient {
   ///
   /// @param name  Required. The name of the project (for example,
   /// `projects/415104041262`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -103,7 +104,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
   StatusOr<google::cloud::resourcemanager::v3::Project> GetProject(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves the project identified by the specified `name` (for example,
@@ -114,7 +115,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::GetProjectRequest,google/cloud/resourcemanager/v3/projects.proto#L373}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -125,7 +127,7 @@ class ProjectsClient {
   ///
   StatusOr<google::cloud::resourcemanager::v3::Project> GetProject(
       google::cloud::resourcemanager::v3::GetProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists projects that are direct children of the specified folder or
@@ -139,7 +141,8 @@ class ProjectsClient {
   /// under.
   ///  For example, setting this field to 'folders/1234' would list all projects
   ///  directly under that folder.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -149,7 +152,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
   StreamRange<google::cloud::resourcemanager::v3::Project> ListProjects(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists projects that are direct children of the specified folder or
@@ -161,7 +164,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::ListProjectsRequest,google/cloud/resourcemanager/v3/projects.proto#L386}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -172,7 +176,7 @@ class ProjectsClient {
   ///
   StreamRange<google::cloud::resourcemanager::v3::Project> ListProjects(
       google::cloud::resourcemanager::v3::ListProjectsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Search for projects that the caller has both
@@ -221,7 +225,8 @@ class ProjectsClient {
   ///  ```
   ///  If no query is specified, the call will return projects for which the
   ///  user has the `resourcemanager.projects.get` permission.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -231,7 +236,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
   StreamRange<google::cloud::resourcemanager::v3::Project> SearchProjects(
-      std::string const& query, Options options = {});
+      std::string const& query, Options opts = {});
 
   ///
   /// Search for projects that the caller has both
@@ -248,7 +253,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::SearchProjectsRequest,google/cloud/resourcemanager/v3/projects.proto#L444}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -259,7 +265,7 @@ class ProjectsClient {
   ///
   StreamRange<google::cloud::resourcemanager::v3::Project> SearchProjects(
       google::cloud::resourcemanager::v3::SearchProjectsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Request that a new project be created. The result is an `Operation` which
@@ -275,7 +281,8 @@ class ProjectsClient {
   ///  permission is checked on the parent resource. If no parent is set and
   ///  the authorization credentials belong to an Organziation, the parent
   ///  will be set to that Organization.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -286,7 +293,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> CreateProject(
       google::cloud::resourcemanager::v3::Project const& project,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Request that a new project be created. The result is an `Operation` which
@@ -297,7 +304,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::CreateProjectRequest,google/cloud/resourcemanager/v3/projects.proto#L526}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -308,7 +316,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> CreateProject(
       google::cloud::resourcemanager::v3::CreateProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the `display_name` and labels of the project identified by the
@@ -320,7 +328,8 @@ class ProjectsClient {
   ///
   /// @param project  Required. The new definition of the project.
   /// @param update_mask  Optional. An update mask to selectively update fields.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -331,7 +340,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> UpdateProject(
       google::cloud::resourcemanager::v3::Project const& project,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the `display_name` and labels of the project identified by the
@@ -343,7 +352,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::UpdateProjectRequest,google/cloud/resourcemanager/v3/projects.proto#L562}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -354,7 +364,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> UpdateProject(
       google::cloud::resourcemanager::v3::UpdateProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Move a project to another place in your resource hierarchy, under a new
@@ -374,7 +384,8 @@ class ProjectsClient {
   /// @param name  Required. The name of the project to move.
   /// @param destination_parent  Required. The new parent to move the Project
   /// under.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -385,7 +396,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> MoveProject(
       std::string const& name, std::string const& destination_parent,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Move a project to another place in your resource hierarchy, under a new
@@ -404,7 +415,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::MoveProjectRequest,google/cloud/resourcemanager/v3/projects.proto#L579}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -415,7 +427,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> MoveProject(
       google::cloud::resourcemanager::v3::MoveProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Marks the project identified by the specified
@@ -454,7 +466,8 @@ class ProjectsClient {
   ///
   /// @param name  Required. The name of the Project (for example,
   /// `projects/415104041262`).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -464,7 +477,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> DeleteProject(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Marks the project identified by the specified
@@ -503,7 +516,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::DeleteProjectRequest,google/cloud/resourcemanager/v3/projects.proto#L605}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -514,7 +528,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> DeleteProject(
       google::cloud::resourcemanager::v3::DeleteProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Restores the project identified by the specified
@@ -530,7 +544,8 @@ class ProjectsClient {
   /// @param name  Required. The name of the project (for example,
   /// `projects/415104041262`).
   ///  Required.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -540,7 +555,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> UndeleteProject(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Restores the project identified by the specified
@@ -555,7 +570,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcemanager::v3::UndeleteProjectRequest,google/cloud/resourcemanager/v3/projects.proto#L624}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcemanager::v3::Project,google/cloud/resourcemanager/v3/projects.proto#L285}
   ///
@@ -566,7 +582,7 @@ class ProjectsClient {
   ///
   future<StatusOr<google::cloud::resourcemanager::v3::Project>> UndeleteProject(
       google::cloud::resourcemanager::v3::UndeleteProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the IAM access control policy for the specified project.
@@ -575,7 +591,8 @@ class ProjectsClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -585,7 +602,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Returns the IAM access control policy for the specified project.
@@ -593,7 +610,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -603,8 +621,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the IAM access control policy for the specified project.
@@ -660,7 +677,8 @@ class ProjectsClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -671,7 +689,7 @@ class ProjectsClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the IAM access control policy for the specified project.
@@ -721,7 +739,8 @@ class ProjectsClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -731,8 +750,7 @@ class ProjectsClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the specified project.
@@ -745,7 +763,8 @@ class ProjectsClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -756,14 +775,15 @@ class ProjectsClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that a caller has on the specified project.
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -774,7 +794,7 @@ class ProjectsClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ProjectsConnection> connection_;

--- a/google/cloud/resourcesettings/resource_settings_client.cc
+++ b/google/cloud/resourcesettings/resource_settings_client.cc
@@ -26,20 +26,18 @@ namespace resourcesettings {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ResourceSettingsServiceClient::ResourceSettingsServiceClient(
-    std::shared_ptr<ResourceSettingsServiceConnection> connection,
-    Options options)
+    std::shared_ptr<ResourceSettingsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           resourcesettings_internal::ResourceSettingsServiceDefaultOptions(
               connection_->options()))) {}
 ResourceSettingsServiceClient::~ResourceSettingsServiceClient() = default;
 
 StreamRange<google::cloud::resourcesettings::v1::Setting>
 ResourceSettingsServiceClient::ListSettings(std::string const& parent,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcesettings::v1::ListSettingsRequest request;
   request.set_parent(parent);
   return connection_->ListSettings(request);
@@ -48,17 +46,15 @@ ResourceSettingsServiceClient::ListSettings(std::string const& parent,
 StreamRange<google::cloud::resourcesettings::v1::Setting>
 ResourceSettingsServiceClient::ListSettings(
     google::cloud::resourcesettings::v1::ListSettingsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSettings(std::move(request));
 }
 
 StatusOr<google::cloud::resourcesettings::v1::Setting>
 ResourceSettingsServiceClient::GetSetting(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::resourcesettings::v1::GetSettingRequest request;
   request.set_name(name);
   return connection_->GetSetting(request);
@@ -67,18 +63,16 @@ ResourceSettingsServiceClient::GetSetting(std::string const& name,
 StatusOr<google::cloud::resourcesettings::v1::Setting>
 ResourceSettingsServiceClient::GetSetting(
     google::cloud::resourcesettings::v1::GetSettingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSetting(request);
 }
 
 StatusOr<google::cloud::resourcesettings::v1::Setting>
 ResourceSettingsServiceClient::UpdateSetting(
     google::cloud::resourcesettings::v1::UpdateSettingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSetting(request);
 }
 

--- a/google/cloud/resourcesettings/resource_settings_client.h
+++ b/google/cloud/resourcesettings/resource_settings_client.h
@@ -73,7 +73,7 @@ class ResourceSettingsServiceClient {
  public:
   explicit ResourceSettingsServiceClient(
       std::shared_ptr<ResourceSettingsServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ResourceSettingsServiceClient();
 
   //@{
@@ -108,7 +108,8 @@ class ResourceSettingsServiceClient {
   ///  * `projects/{project_id}`
   ///  * `folders/{folder_id}`
   ///  * `organizations/{organization_id}`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcesettings::v1::Setting,google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
@@ -118,14 +119,15 @@ class ResourceSettingsServiceClient {
   /// @googleapis_reference_link{google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
   StreamRange<google::cloud::resourcesettings::v1::Setting> ListSettings(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all the settings that are available on the Cloud resource `parent`.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcesettings::v1::ListSettingsRequest,google/cloud/resourcesettings/v1/resource_settings.proto#L238}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcesettings::v1::Setting,google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
@@ -136,7 +138,7 @@ class ResourceSettingsServiceClient {
   ///
   StreamRange<google::cloud::resourcesettings::v1::Setting> ListSettings(
       google::cloud::resourcesettings::v1::ListSettingsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a setting.
@@ -147,7 +149,8 @@ class ResourceSettingsServiceClient {
   /// @param name  Required. The name of the setting to get. See
   /// [Setting][google.cloud.resourcesettings.v1.Setting] for naming
   ///  requirements.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcesettings::v1::Setting,google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
@@ -157,7 +160,7 @@ class ResourceSettingsServiceClient {
   /// @googleapis_reference_link{google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
   StatusOr<google::cloud::resourcesettings::v1::Setting> GetSetting(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a setting.
@@ -167,7 +170,8 @@ class ResourceSettingsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcesettings::v1::GetSettingRequest,google/cloud/resourcesettings/v1/resource_settings.proto#L273}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcesettings::v1::Setting,google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
@@ -178,7 +182,7 @@ class ResourceSettingsServiceClient {
   ///
   StatusOr<google::cloud::resourcesettings::v1::Setting> GetSetting(
       google::cloud::resourcesettings::v1::GetSettingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a setting.
@@ -199,7 +203,8 @@ class ResourceSettingsServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::resourcesettings::v1::UpdateSettingRequest,google/cloud/resourcesettings/v1/resource_settings.proto#L288}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::resourcesettings::v1::Setting,google/cloud/resourcesettings/v1/resource_settings.proto#L115}
   ///
@@ -210,7 +215,7 @@ class ResourceSettingsServiceClient {
   ///
   StatusOr<google::cloud::resourcesettings::v1::Setting> UpdateSetting(
       google::cloud::resourcesettings::v1::UpdateSettingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ResourceSettingsServiceConnection> connection_;

--- a/google/cloud/retail/catalog_client.cc
+++ b/google/cloud/retail/catalog_client.cc
@@ -26,17 +26,16 @@ namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CatalogServiceClient::CatalogServiceClient(
-    std::shared_ptr<CatalogServiceConnection> connection, Options options)
+    std::shared_ptr<CatalogServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::CatalogServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), retail_internal::CatalogServiceDefaultOptions(
+                               connection_->options()))) {}
 CatalogServiceClient::~CatalogServiceClient() = default;
 
 StreamRange<google::cloud::retail::v2::Catalog>
-CatalogServiceClient::ListCatalogs(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CatalogServiceClient::ListCatalogs(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::ListCatalogsRequest request;
   request.set_parent(parent);
   return connection_->ListCatalogs(request);
@@ -44,18 +43,16 @@ CatalogServiceClient::ListCatalogs(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::retail::v2::Catalog>
 CatalogServiceClient::ListCatalogs(
-    google::cloud::retail::v2::ListCatalogsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::retail::v2::ListCatalogsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCatalogs(std::move(request));
 }
 
 StatusOr<google::cloud::retail::v2::Catalog>
 CatalogServiceClient::UpdateCatalog(
     google::cloud::retail::v2::Catalog const& catalog,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::UpdateCatalogRequest request;
   *request.mutable_catalog() = catalog;
   *request.mutable_update_mask() = update_mask;
@@ -65,16 +62,14 @@ CatalogServiceClient::UpdateCatalog(
 StatusOr<google::cloud::retail::v2::Catalog>
 CatalogServiceClient::UpdateCatalog(
     google::cloud::retail::v2::UpdateCatalogRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCatalog(request);
 }
 
 Status CatalogServiceClient::SetDefaultBranch(std::string const& catalog,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::SetDefaultBranchRequest request;
   request.set_catalog(catalog);
   return connection_->SetDefaultBranch(request);
@@ -82,17 +77,15 @@ Status CatalogServiceClient::SetDefaultBranch(std::string const& catalog,
 
 Status CatalogServiceClient::SetDefaultBranch(
     google::cloud::retail::v2::SetDefaultBranchRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetDefaultBranch(request);
 }
 
 StatusOr<google::cloud::retail::v2::GetDefaultBranchResponse>
 CatalogServiceClient::GetDefaultBranch(std::string const& catalog,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::GetDefaultBranchRequest request;
   request.set_catalog(catalog);
   return connection_->GetDefaultBranch(request);
@@ -101,9 +94,8 @@ CatalogServiceClient::GetDefaultBranch(std::string const& catalog,
 StatusOr<google::cloud::retail::v2::GetDefaultBranchResponse>
 CatalogServiceClient::GetDefaultBranch(
     google::cloud::retail::v2::GetDefaultBranchRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDefaultBranch(request);
 }
 

--- a/google/cloud/retail/catalog_client.h
+++ b/google/cloud/retail/catalog_client.h
@@ -61,8 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CatalogServiceClient {
  public:
   explicit CatalogServiceClient(
-      std::shared_ptr<CatalogServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<CatalogServiceConnection> connection, Options opts = {});
   ~CatalogServiceClient();
 
   //@{
@@ -95,7 +94,8 @@ class CatalogServiceClient {
   ///  [Catalog][google.cloud.retail.v2.Catalog]s under this location,
   ///  regardless of whether or not this location exists, a PERMISSION_DENIED
   ///  error is returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Catalog,google/cloud/retail/v2/catalog.proto#L89}
   ///
@@ -105,7 +105,7 @@ class CatalogServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/catalog.proto#L89}
   ///
   StreamRange<google::cloud::retail::v2::Catalog> ListCatalogs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all the [Catalog][google.cloud.retail.v2.Catalog]s associated with
@@ -113,7 +113,8 @@ class CatalogServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::ListCatalogsRequest,google/cloud/retail/v2/catalog_service.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Catalog,google/cloud/retail/v2/catalog.proto#L89}
   ///
@@ -124,7 +125,7 @@ class CatalogServiceClient {
   ///
   StreamRange<google::cloud::retail::v2::Catalog> ListCatalogs(
       google::cloud::retail::v2::ListCatalogsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the [Catalog][google.cloud.retail.v2.Catalog]s.
@@ -140,7 +141,8 @@ class CatalogServiceClient {
   ///  [Catalog][google.cloud.retail.v2.Catalog] to update.
   ///  If an unsupported or unknown field is provided, an INVALID_ARGUMENT error
   ///  is returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Catalog,google/cloud/retail/v2/catalog.proto#L89}
   ///
@@ -151,14 +153,15 @@ class CatalogServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::Catalog> UpdateCatalog(
       google::cloud::retail::v2::Catalog const& catalog,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the [Catalog][google.cloud.retail.v2.Catalog]s.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::UpdateCatalogRequest,google/cloud/retail/v2/catalog_service.proto#L177}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Catalog,google/cloud/retail/v2/catalog.proto#L89}
   ///
@@ -169,7 +172,7 @@ class CatalogServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::Catalog> UpdateCatalog(
       google::cloud::retail::v2::UpdateCatalogRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Set a specified branch id as default branch. API methods such as
@@ -213,12 +216,13 @@ class CatalogServiceClient {
   ///
   /// @param catalog  Full resource name of the catalog, such as
   ///  `projects/*/locations/global/catalogs/default_catalog`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.retail.v2.SetDefaultBranchRequest]:
   /// @googleapis_reference_link{google/cloud/retail/v2/catalog_service.proto#L197}
   ///
-  Status SetDefaultBranch(std::string const& catalog, Options options = {});
+  Status SetDefaultBranch(std::string const& catalog, Options opts = {});
 
   ///
   /// Set a specified branch id as default branch. API methods such as
@@ -262,14 +266,15 @@ class CatalogServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::SetDefaultBranchRequest,google/cloud/retail/v2/catalog_service.proto#L197}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.retail.v2.SetDefaultBranchRequest]:
   /// @googleapis_reference_link{google/cloud/retail/v2/catalog_service.proto#L197}
   ///
   Status SetDefaultBranch(
       google::cloud::retail::v2::SetDefaultBranchRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Get which branch is currently default branch set by
@@ -282,7 +287,8 @@ class CatalogServiceClient {
   ///
   /// @param catalog  The parent catalog resource name, such as
   ///  `projects/*/locations/global/catalogs/default_catalog`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::GetDefaultBranchResponse,google/cloud/retail/v2/catalog_service.proto#L232}
   ///
@@ -292,7 +298,7 @@ class CatalogServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/catalog_service.proto#L232}
   ///
   StatusOr<google::cloud::retail::v2::GetDefaultBranchResponse>
-  GetDefaultBranch(std::string const& catalog, Options options = {});
+  GetDefaultBranch(std::string const& catalog, Options opts = {});
 
   ///
   /// Get which branch is currently default branch set by
@@ -305,7 +311,8 @@ class CatalogServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::GetDefaultBranchRequest,google/cloud/retail/v2/catalog_service.proto#L222}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::GetDefaultBranchResponse,google/cloud/retail/v2/catalog_service.proto#L232}
   ///
@@ -317,7 +324,7 @@ class CatalogServiceClient {
   StatusOr<google::cloud::retail::v2::GetDefaultBranchResponse>
   GetDefaultBranch(
       google::cloud::retail::v2::GetDefaultBranchRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CatalogServiceConnection> connection_;

--- a/google/cloud/retail/completion_client.cc
+++ b/google/cloud/retail/completion_client.cc
@@ -26,28 +26,26 @@ namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CompletionServiceClient::CompletionServiceClient(
-    std::shared_ptr<CompletionServiceConnection> connection, Options options)
+    std::shared_ptr<CompletionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::CompletionServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), retail_internal::CompletionServiceDefaultOptions(
+                               connection_->options()))) {}
 CompletionServiceClient::~CompletionServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::CompleteQueryResponse>
 CompletionServiceClient::CompleteQuery(
     google::cloud::retail::v2::CompleteQueryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CompleteQuery(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::ImportCompletionDataResponse>>
 CompletionServiceClient::ImportCompletionData(
     google::cloud::retail::v2::ImportCompletionDataRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportCompletionData(request);
 }
 

--- a/google/cloud/retail/completion_client.h
+++ b/google/cloud/retail/completion_client.h
@@ -67,7 +67,7 @@ class CompletionServiceClient {
  public:
   explicit CompletionServiceClient(
       std::shared_ptr<CompletionServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~CompletionServiceClient();
 
   //@{
@@ -99,7 +99,8 @@ class CompletionServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::CompleteQueryRequest,google/cloud/retail/v2/completion_service.proto#L78}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::CompleteQueryResponse,google/cloud/retail/v2/completion_service.proto#L151}
   ///
@@ -110,7 +111,7 @@ class CompletionServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::CompleteQueryResponse> CompleteQuery(
       google::cloud::retail::v2::CompleteQueryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Bulk import of processed completion dataset.
@@ -123,7 +124,8 @@ class CompletionServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::ImportCompletionDataRequest,google/cloud/retail/v2/import_config.proto#L239}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::ImportCompletionDataResponse,google/cloud/retail/v2/import_config.proto#L384}
   ///
@@ -135,7 +137,7 @@ class CompletionServiceClient {
   future<StatusOr<google::cloud::retail::v2::ImportCompletionDataResponse>>
   ImportCompletionData(
       google::cloud::retail::v2::ImportCompletionDataRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CompletionServiceConnection> connection_;

--- a/google/cloud/retail/prediction_client.cc
+++ b/google/cloud/retail/prediction_client.cc
@@ -26,18 +26,17 @@ namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 PredictionServiceClient::PredictionServiceClient(
-    std::shared_ptr<PredictionServiceConnection> connection, Options options)
+    std::shared_ptr<PredictionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::PredictionServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), retail_internal::PredictionServiceDefaultOptions(
+                               connection_->options()))) {}
 PredictionServiceClient::~PredictionServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::PredictResponse>
 PredictionServiceClient::Predict(
-    google::cloud::retail::v2::PredictRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::retail::v2::PredictRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Predict(request);
 }
 

--- a/google/cloud/retail/prediction_client.h
+++ b/google/cloud/retail/prediction_client.h
@@ -63,7 +63,7 @@ class PredictionServiceClient {
  public:
   explicit PredictionServiceClient(
       std::shared_ptr<PredictionServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~PredictionServiceClient();
 
   //@{
@@ -91,7 +91,8 @@ class PredictionServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::PredictRequest,google/cloud/retail/v2/prediction_service.proto#L50}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::PredictResponse,google/cloud/retail/v2/prediction_service.proto#L159}
   ///
@@ -102,7 +103,7 @@ class PredictionServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::PredictResponse> Predict(
       google::cloud::retail::v2::PredictRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<PredictionServiceConnection> connection_;

--- a/google/cloud/retail/product_client.cc
+++ b/google/cloud/retail/product_client.cc
@@ -26,20 +26,19 @@ namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ProductServiceClient::ProductServiceClient(
-    std::shared_ptr<ProductServiceConnection> connection, Options options)
+    std::shared_ptr<ProductServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::ProductServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), retail_internal::ProductServiceDefaultOptions(
+                               connection_->options()))) {}
 ProductServiceClient::~ProductServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::Product>
 ProductServiceClient::CreateProduct(
     std::string const& parent,
     google::cloud::retail::v2::Product const& product,
-    std::string const& product_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& product_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::CreateProductRequest request;
   request.set_parent(parent);
   *request.mutable_product() = product;
@@ -50,33 +49,28 @@ ProductServiceClient::CreateProduct(
 StatusOr<google::cloud::retail::v2::Product>
 ProductServiceClient::CreateProduct(
     google::cloud::retail::v2::CreateProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateProduct(request);
 }
 
 StatusOr<google::cloud::retail::v2::Product> ProductServiceClient::GetProduct(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::GetProductRequest request;
   request.set_name(name);
   return connection_->GetProduct(request);
 }
 
 StatusOr<google::cloud::retail::v2::Product> ProductServiceClient::GetProduct(
-    google::cloud::retail::v2::GetProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::retail::v2::GetProductRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetProduct(request);
 }
 
 StreamRange<google::cloud::retail::v2::Product>
-ProductServiceClient::ListProducts(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProductServiceClient::ListProducts(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::ListProductsRequest request;
   request.set_parent(parent);
   return connection_->ListProducts(request);
@@ -84,18 +78,16 @@ ProductServiceClient::ListProducts(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::retail::v2::Product>
 ProductServiceClient::ListProducts(
-    google::cloud::retail::v2::ListProductsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::retail::v2::ListProductsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProducts(std::move(request));
 }
 
 StatusOr<google::cloud::retail::v2::Product>
 ProductServiceClient::UpdateProduct(
     google::cloud::retail::v2::Product const& product,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::UpdateProductRequest request;
   *request.mutable_product() = product;
   *request.mutable_update_mask() = update_mask;
@@ -105,16 +97,14 @@ ProductServiceClient::UpdateProduct(
 StatusOr<google::cloud::retail::v2::Product>
 ProductServiceClient::UpdateProduct(
     google::cloud::retail::v2::UpdateProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateProduct(request);
 }
 
 Status ProductServiceClient::DeleteProduct(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::DeleteProductRequest request;
   request.set_name(name);
   return connection_->DeleteProduct(request);
@@ -122,27 +112,24 @@ Status ProductServiceClient::DeleteProduct(std::string const& name,
 
 Status ProductServiceClient::DeleteProduct(
     google::cloud::retail::v2::DeleteProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteProduct(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::ImportProductsResponse>>
 ProductServiceClient::ImportProducts(
     google::cloud::retail::v2::ImportProductsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportProducts(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::SetInventoryResponse>>
 ProductServiceClient::SetInventory(
     google::cloud::retail::v2::Product const& inventory,
-    google::protobuf::FieldMask const& set_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& set_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::SetInventoryRequest request;
   *request.mutable_inventory() = inventory;
   *request.mutable_set_mask() = set_mask;
@@ -152,17 +139,15 @@ ProductServiceClient::SetInventory(
 future<StatusOr<google::cloud::retail::v2::SetInventoryResponse>>
 ProductServiceClient::SetInventory(
     google::cloud::retail::v2::SetInventoryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetInventory(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::AddFulfillmentPlacesResponse>>
 ProductServiceClient::AddFulfillmentPlaces(std::string const& product,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::AddFulfillmentPlacesRequest request;
   request.set_product(product);
   return connection_->AddFulfillmentPlaces(request);
@@ -171,17 +156,15 @@ ProductServiceClient::AddFulfillmentPlaces(std::string const& product,
 future<StatusOr<google::cloud::retail::v2::AddFulfillmentPlacesResponse>>
 ProductServiceClient::AddFulfillmentPlaces(
     google::cloud::retail::v2::AddFulfillmentPlacesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AddFulfillmentPlaces(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::RemoveFulfillmentPlacesResponse>>
 ProductServiceClient::RemoveFulfillmentPlaces(std::string const& product,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::retail::v2::RemoveFulfillmentPlacesRequest request;
   request.set_product(product);
   return connection_->RemoveFulfillmentPlaces(request);
@@ -190,9 +173,8 @@ ProductServiceClient::RemoveFulfillmentPlaces(std::string const& product,
 future<StatusOr<google::cloud::retail::v2::RemoveFulfillmentPlacesResponse>>
 ProductServiceClient::RemoveFulfillmentPlaces(
     google::cloud::retail::v2::RemoveFulfillmentPlacesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RemoveFulfillmentPlaces(request);
 }
 

--- a/google/cloud/retail/product_client.h
+++ b/google/cloud/retail/product_client.h
@@ -64,8 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProductServiceClient {
  public:
   explicit ProductServiceClient(
-      std::shared_ptr<ProductServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<ProductServiceConnection> connection, Options opts = {});
   ~ProductServiceClient();
 
   //@{
@@ -107,7 +106,8 @@ class ProductServiceClient {
   ///  an ALREADY_EXISTS error is returned. This field must be a UTF-8 encoded
   ///  string with a length limit of 128 characters. Otherwise, an
   ///  INVALID_ARGUMENT error is returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -119,14 +119,15 @@ class ProductServiceClient {
   StatusOr<google::cloud::retail::v2::Product> CreateProduct(
       std::string const& parent,
       google::cloud::retail::v2::Product const& product,
-      std::string const& product_id, Options options = {});
+      std::string const& product_id, Options opts = {});
 
   ///
   /// Creates a [Product][google.cloud.retail.v2.Product].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::CreateProductRequest,google/cloud/retail/v2/product_service.proto#L219}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -137,7 +138,7 @@ class ProductServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::Product> CreateProduct(
       google::cloud::retail::v2::CreateProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a [Product][google.cloud.retail.v2.Product].
@@ -151,7 +152,8 @@ class ProductServiceClient {
   ///  it exists, a PERMISSION_DENIED error is returned. If the requested
   ///  [Product][google.cloud.retail.v2.Product] does not exist, a NOT_FOUND
   ///  error is returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -161,14 +163,15 @@ class ProductServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/product.proto#L43}
   ///
   StatusOr<google::cloud::retail::v2::Product> GetProduct(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a [Product][google.cloud.retail.v2.Product].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::GetProductRequest,google/cloud/retail/v2/product_service.proto#L249}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -179,7 +182,7 @@ class ProductServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::Product> GetProduct(
       google::cloud::retail::v2::GetProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a list of [Product][google.cloud.retail.v2.Product]s.
@@ -192,7 +195,8 @@ class ProductServiceClient {
   ///  [Product][google.cloud.retail.v2.Product]s under this branch, regardless
   ///  of whether or not this branch exists, a PERMISSION_DENIED error is
   ///  returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -202,14 +206,15 @@ class ProductServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/product.proto#L43}
   ///
   StreamRange<google::cloud::retail::v2::Product> ListProducts(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Gets a list of [Product][google.cloud.retail.v2.Product]s.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::ListProductsRequest,google/cloud/retail/v2/product_service.proto#L327}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -220,7 +225,7 @@ class ProductServiceClient {
   ///
   StreamRange<google::cloud::retail::v2::Product> ListProducts(
       google::cloud::retail::v2::ListProductsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a [Product][google.cloud.retail.v2.Product].
@@ -238,7 +243,8 @@ class ProductServiceClient {
   ///  (the fields that are neither immutable nor output only) are updated. If
   ///  an unsupported or unknown field is provided, an INVALID_ARGUMENT error is
   ///  returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -249,14 +255,15 @@ class ProductServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::Product> UpdateProduct(
       google::cloud::retail::v2::Product const& product,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a [Product][google.cloud.retail.v2.Product].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::UpdateProductRequest,google/cloud/retail/v2/product_service.proto#L267}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::Product,google/cloud/retail/v2/product.proto#L43}
   ///
@@ -267,7 +274,7 @@ class ProductServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::Product> UpdateProduct(
       google::cloud::retail::v2::UpdateProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a [Product][google.cloud.retail.v2.Product].
@@ -290,26 +297,28 @@ class ProductServiceClient {
   ///  INVALID_ARGUMENT error is returned.
   ///  All inventory information for the named
   ///  [Product][google.cloud.retail.v2.Product] will be deleted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.retail.v2.DeleteProductRequest]:
   /// @googleapis_reference_link{google/cloud/retail/v2/product_service.proto#L296}
   ///
-  Status DeleteProduct(std::string const& name, Options options = {});
+  Status DeleteProduct(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a [Product][google.cloud.retail.v2.Product].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::DeleteProductRequest,google/cloud/retail/v2/product_service.proto#L296}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.retail.v2.DeleteProductRequest]:
   /// @googleapis_reference_link{google/cloud/retail/v2/product_service.proto#L296}
   ///
   Status DeleteProduct(
       google::cloud::retail::v2::DeleteProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Bulk import of multiple [Product][google.cloud.retail.v2.Product]s.
@@ -322,7 +331,8 @@ class ProductServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::ImportProductsRequest,google/cloud/retail/v2/import_config.proto#L147}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::ImportProductsResponse,google/cloud/retail/v2/import_config.proto#L346}
   ///
@@ -334,7 +344,7 @@ class ProductServiceClient {
   future<StatusOr<google::cloud::retail::v2::ImportProductsResponse>>
   ImportProducts(
       google::cloud::retail::v2::ImportProductsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates inventory information for a
@@ -412,7 +422,8 @@ class ProductServiceClient {
   ///  with empty paths, all inventory fields will be updated. If an unsupported
   ///  or unknown field is provided, an INVALID_ARGUMENT error is returned and
   ///  the entire update will be ignored.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::SetInventoryResponse,google/cloud/retail/v2/product_service.proto#L493}
   ///
@@ -423,8 +434,7 @@ class ProductServiceClient {
   ///
   future<StatusOr<google::cloud::retail::v2::SetInventoryResponse>>
   SetInventory(google::cloud::retail::v2::Product const& inventory,
-               google::protobuf::FieldMask const& set_mask,
-               Options options = {});
+               google::protobuf::FieldMask const& set_mask, Options opts = {});
 
   ///
   /// Updates inventory information for a
@@ -470,7 +480,8 @@ class ProductServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::SetInventoryRequest,google/cloud/retail/v2/product_service.proto#L425}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::SetInventoryResponse,google/cloud/retail/v2/product_service.proto#L493}
   ///
@@ -481,7 +492,7 @@ class ProductServiceClient {
   ///
   future<StatusOr<google::cloud::retail::v2::SetInventoryResponse>>
   SetInventory(google::cloud::retail::v2::SetInventoryRequest const& request,
-               Options options = {});
+               Options opts = {});
 
   ///
   /// Incrementally adds place IDs to
@@ -507,7 +518,8 @@ class ProductServiceClient {
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not
   ///  it exists, a PERMISSION_DENIED error is returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::AddFulfillmentPlacesResponse,google/cloud/retail/v2/product_service.proto#L569}
   ///
@@ -517,7 +529,7 @@ class ProductServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/product_service.proto#L569}
   ///
   future<StatusOr<google::cloud::retail::v2::AddFulfillmentPlacesResponse>>
-  AddFulfillmentPlaces(std::string const& product, Options options = {});
+  AddFulfillmentPlaces(std::string const& product, Options opts = {});
 
   ///
   /// Incrementally adds place IDs to
@@ -538,7 +550,8 @@ class ProductServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::AddFulfillmentPlacesRequest,google/cloud/retail/v2/product_service.proto#L496}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::AddFulfillmentPlacesResponse,google/cloud/retail/v2/product_service.proto#L569}
   ///
@@ -550,7 +563,7 @@ class ProductServiceClient {
   future<StatusOr<google::cloud::retail::v2::AddFulfillmentPlacesResponse>>
   AddFulfillmentPlaces(
       google::cloud::retail::v2::AddFulfillmentPlacesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Incrementally removes place IDs from a
@@ -576,7 +589,8 @@ class ProductServiceClient {
   ///  If the caller does not have permission to access the
   ///  [Product][google.cloud.retail.v2.Product], regardless of whether or not
   ///  it exists, a PERMISSION_DENIED error is returned.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::RemoveFulfillmentPlacesResponse,google/cloud/retail/v2/product_service.proto#L640}
   ///
@@ -586,7 +600,7 @@ class ProductServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/product_service.proto#L640}
   ///
   future<StatusOr<google::cloud::retail::v2::RemoveFulfillmentPlacesResponse>>
-  RemoveFulfillmentPlaces(std::string const& product, Options options = {});
+  RemoveFulfillmentPlaces(std::string const& product, Options opts = {});
 
   ///
   /// Incrementally removes place IDs from a
@@ -607,7 +621,8 @@ class ProductServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::RemoveFulfillmentPlacesRequest,google/cloud/retail/v2/product_service.proto#L572}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::RemoveFulfillmentPlacesResponse,google/cloud/retail/v2/product_service.proto#L640}
   ///
@@ -619,7 +634,7 @@ class ProductServiceClient {
   future<StatusOr<google::cloud::retail::v2::RemoveFulfillmentPlacesResponse>>
   RemoveFulfillmentPlaces(
       google::cloud::retail::v2::RemoveFulfillmentPlacesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ProductServiceConnection> connection_;

--- a/google/cloud/retail/search_client.cc
+++ b/google/cloud/retail/search_client.cc
@@ -26,18 +26,17 @@ namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SearchServiceClient::SearchServiceClient(
-    std::shared_ptr<SearchServiceConnection> connection, Options options)
+    std::shared_ptr<SearchServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::SearchServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), retail_internal::SearchServiceDefaultOptions(
+                               connection_->options()))) {}
 SearchServiceClient::~SearchServiceClient() = default;
 
 StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult>
 SearchServiceClient::Search(google::cloud::retail::v2::SearchRequest request,
-                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Search(std::move(request));
 }
 

--- a/google/cloud/retail/search_client.h
+++ b/google/cloud/retail/search_client.h
@@ -65,8 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SearchServiceClient {
  public:
   explicit SearchServiceClient(
-      std::shared_ptr<SearchServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<SearchServiceConnection> connection, Options opts = {});
   ~SearchServiceClient();
 
   //@{
@@ -98,7 +97,8 @@ class SearchServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::SearchRequest,google/cloud/retail/v2/search_service.proto#L64}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::SearchResponse::SearchResult,google/cloud/retail/v2/search_service.proto#L588}
   ///
@@ -108,7 +108,7 @@ class SearchServiceClient {
   /// @googleapis_reference_link{google/cloud/retail/v2/search_service.proto#L588}
   ///
   StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult> Search(
-      google::cloud::retail::v2::SearchRequest request, Options options = {});
+      google::cloud::retail::v2::SearchRequest request, Options opts = {});
 
  private:
   std::shared_ptr<SearchServiceConnection> connection_;

--- a/google/cloud/retail/user_event_client.cc
+++ b/google/cloud/retail/user_event_client.cc
@@ -26,54 +26,49 @@ namespace retail {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 UserEventServiceClient::UserEventServiceClient(
-    std::shared_ptr<UserEventServiceConnection> connection, Options options)
+    std::shared_ptr<UserEventServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::UserEventServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), retail_internal::UserEventServiceDefaultOptions(
+                               connection_->options()))) {}
 UserEventServiceClient::~UserEventServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::UserEvent>
 UserEventServiceClient::WriteUserEvent(
     google::cloud::retail::v2::WriteUserEventRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->WriteUserEvent(request);
 }
 
 StatusOr<google::api::HttpBody> UserEventServiceClient::CollectUserEvent(
     google::cloud::retail::v2::CollectUserEventRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CollectUserEvent(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::PurgeUserEventsResponse>>
 UserEventServiceClient::PurgeUserEvents(
     google::cloud::retail::v2::PurgeUserEventsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PurgeUserEvents(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::ImportUserEventsResponse>>
 UserEventServiceClient::ImportUserEvents(
     google::cloud::retail::v2::ImportUserEventsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportUserEvents(request);
 }
 
 future<StatusOr<google::cloud::retail::v2::RejoinUserEventsResponse>>
 UserEventServiceClient::RejoinUserEvents(
     google::cloud::retail::v2::RejoinUserEventsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RejoinUserEvents(request);
 }
 

--- a/google/cloud/retail/user_event_client.h
+++ b/google/cloud/retail/user_event_client.h
@@ -64,7 +64,7 @@ class UserEventServiceClient {
  public:
   explicit UserEventServiceClient(
       std::shared_ptr<UserEventServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~UserEventServiceClient();
 
   //@{
@@ -92,7 +92,8 @@ class UserEventServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::WriteUserEventRequest,google/cloud/retail/v2/user_event_service.proto#L118}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::UserEvent,google/cloud/retail/v2/user_event.proto#L37}
   ///
@@ -103,7 +104,7 @@ class UserEventServiceClient {
   ///
   StatusOr<google::cloud::retail::v2::UserEvent> WriteUserEvent(
       google::cloud::retail::v2::WriteUserEventRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Writes a single user event from the browser. This uses a GET request to
@@ -114,7 +115,8 @@ class UserEventServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::CollectUserEventRequest,google/cloud/retail/v2/user_event_service.proto#L128}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::HttpBody,google/api/httpbody.proto#L71}
   ///
@@ -125,7 +127,7 @@ class UserEventServiceClient {
   ///
   StatusOr<google::api::HttpBody> CollectUserEvent(
       google::cloud::retail::v2::CollectUserEventRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes permanently all user events specified by the filter provided.
@@ -135,7 +137,8 @@ class UserEventServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::PurgeUserEventsRequest,google/cloud/retail/v2/purge_config.proto#L36}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::PurgeUserEventsResponse,google/cloud/retail/v2/purge_config.proto#L76}
   ///
@@ -147,7 +150,7 @@ class UserEventServiceClient {
   future<StatusOr<google::cloud::retail::v2::PurgeUserEventsResponse>>
   PurgeUserEvents(
       google::cloud::retail::v2::PurgeUserEventsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Bulk import of User events. Request processing might be
@@ -160,7 +163,8 @@ class UserEventServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::ImportUserEventsRequest,google/cloud/retail/v2/import_config.proto#L222}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::ImportUserEventsResponse,google/cloud/retail/v2/import_config.proto#L357}
   ///
@@ -172,7 +176,7 @@ class UserEventServiceClient {
   future<StatusOr<google::cloud::retail::v2::ImportUserEventsResponse>>
   ImportUserEvents(
       google::cloud::retail::v2::ImportUserEventsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Triggers a user event rejoin operation with latest product catalog. Events
@@ -185,7 +189,8 @@ class UserEventServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::retail::v2::RejoinUserEventsRequest,google/cloud/retail/v2/user_event_service.proto#L150}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::retail::v2::RejoinUserEventsResponse,google/cloud/retail/v2/user_event_service.proto#L182}
   ///
@@ -197,7 +202,7 @@ class UserEventServiceClient {
   future<StatusOr<google::cloud::retail::v2::RejoinUserEventsResponse>>
   RejoinUserEvents(
       google::cloud::retail::v2::RejoinUserEventsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<UserEventServiceConnection> connection_;

--- a/google/cloud/scheduler/cloud_scheduler_client.cc
+++ b/google/cloud/scheduler/cloud_scheduler_client.cc
@@ -26,51 +26,45 @@ namespace scheduler {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudSchedulerClient::CloudSchedulerClient(
-    std::shared_ptr<CloudSchedulerConnection> connection, Options options)
+    std::shared_ptr<CloudSchedulerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), scheduler_internal::CloudSchedulerDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), scheduler_internal::CloudSchedulerDefaultOptions(
+                               connection_->options()))) {}
 CloudSchedulerClient::~CloudSchedulerClient() = default;
 
 StreamRange<google::cloud::scheduler::v1::Job> CloudSchedulerClient::ListJobs(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::ListJobsRequest request;
   request.set_parent(parent);
   return connection_->ListJobs(request);
 }
 
 StreamRange<google::cloud::scheduler::v1::Job> CloudSchedulerClient::ListJobs(
-    google::cloud::scheduler::v1::ListJobsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::scheduler::v1::ListJobsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListJobs(std::move(request));
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::GetJob(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::GetJobRequest request;
   request.set_name(name);
   return connection_->GetJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::GetJob(
-    google::cloud::scheduler::v1::GetJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::scheduler::v1::GetJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::CreateJob(
     std::string const& parent, google::cloud::scheduler::v1::Job const& job,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::CreateJobRequest request;
   request.set_parent(parent);
   *request.mutable_job() = job;
@@ -79,17 +73,15 @@ StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::CreateJob(
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::CreateJob(
     google::cloud::scheduler::v1::CreateJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::UpdateJob(
     google::cloud::scheduler::v1::Job const& job,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::UpdateJobRequest request;
   *request.mutable_job() = job;
   *request.mutable_update_mask() = update_mask;
@@ -98,16 +90,13 @@ StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::UpdateJob(
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::UpdateJob(
     google::cloud::scheduler::v1::UpdateJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateJob(request);
 }
 
-Status CloudSchedulerClient::DeleteJob(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status CloudSchedulerClient::DeleteJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::DeleteJobRequest request;
   request.set_name(name);
   return connection_->DeleteJob(request);
@@ -115,16 +104,14 @@ Status CloudSchedulerClient::DeleteJob(std::string const& name,
 
 Status CloudSchedulerClient::DeleteJob(
     google::cloud::scheduler::v1::DeleteJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::PauseJob(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::PauseJobRequest request;
   request.set_name(name);
   return connection_->PauseJob(request);
@@ -132,16 +119,14 @@ StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::PauseJob(
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::PauseJob(
     google::cloud::scheduler::v1::PauseJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PauseJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::ResumeJob(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::ResumeJobRequest request;
   request.set_name(name);
   return connection_->ResumeJob(request);
@@ -149,26 +134,22 @@ StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::ResumeJob(
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::ResumeJob(
     google::cloud::scheduler::v1::ResumeJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResumeJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::RunJob(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::scheduler::v1::RunJobRequest request;
   request.set_name(name);
   return connection_->RunJob(request);
 }
 
 StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerClient::RunJob(
-    google::cloud::scheduler::v1::RunJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::scheduler::v1::RunJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RunJob(request);
 }
 

--- a/google/cloud/scheduler/cloud_scheduler_client.h
+++ b/google/cloud/scheduler/cloud_scheduler_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudSchedulerClient {
  public:
   explicit CloudSchedulerClient(
-      std::shared_ptr<CloudSchedulerConnection> connection,
-      Options options = {});
+      std::shared_ptr<CloudSchedulerConnection> connection, Options opts = {});
   ~CloudSchedulerClient();
 
   //@{
@@ -91,7 +90,8 @@ class CloudSchedulerClient {
   ///
   /// @param parent  Required. The location name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -101,14 +101,15 @@ class CloudSchedulerClient {
   /// @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L34}
   ///
   StreamRange<google::cloud::scheduler::v1::Job> ListJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists jobs.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::ListJobsRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L133}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -118,15 +119,15 @@ class CloudSchedulerClient {
   /// @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L34}
   ///
   StreamRange<google::cloud::scheduler::v1::Job> ListJobs(
-      google::cloud::scheduler::v1::ListJobsRequest request,
-      Options options = {});
+      google::cloud::scheduler::v1::ListJobsRequest request, Options opts = {});
 
   ///
   /// Gets a job.
   ///
   /// @param name  Required. The job name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/jobs/JOB_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -136,14 +137,15 @@ class CloudSchedulerClient {
   /// @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L34}
   ///
   StatusOr<google::cloud::scheduler::v1::Job> GetJob(std::string const& name,
-                                                     Options options = {});
+                                                     Options opts = {});
 
   ///
   /// Gets a job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::GetJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L177}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -154,7 +156,7 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> GetJob(
       google::cloud::scheduler::v1::GetJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a job.
@@ -168,7 +170,8 @@ class CloudSchedulerClient {
   ///  existing job. If a name is not specified then the system will
   ///  generate a random unique name that will be returned
   ///  ([name][google.cloud.scheduler.v1.Job.name]) in the response.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -179,14 +182,15 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> CreateJob(
       std::string const& parent, google::cloud::scheduler::v1::Job const& job,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::CreateJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L189}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -197,7 +201,7 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> CreateJob(
       google::cloud::scheduler::v1::CreateJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a job.
@@ -217,7 +221,8 @@ class CloudSchedulerClient {
   ///  Any value specified for an output only field will be ignored.
   /// @param update_mask  A  mask used to specify which fields of the job are
   /// being updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -228,7 +233,7 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> UpdateJob(
       google::cloud::scheduler::v1::Job const& job,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a job.
@@ -244,7 +249,8 @@ class CloudSchedulerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::UpdateJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L208}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -255,33 +261,35 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> UpdateJob(
       google::cloud::scheduler::v1::UpdateJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a job.
   ///
   /// @param name  Required. The job name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/jobs/JOB_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.scheduler.v1.DeleteJobRequest]:
   /// @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L222}
   ///
-  Status DeleteJob(std::string const& name, Options options = {});
+  Status DeleteJob(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::DeleteJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L222}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.scheduler.v1.DeleteJobRequest]:
   /// @googleapis_reference_link{google/cloud/scheduler/v1/cloudscheduler.proto#L222}
   ///
   Status DeleteJob(
       google::cloud::scheduler::v1::DeleteJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Pauses a job.
@@ -297,7 +305,8 @@ class CloudSchedulerClient {
   ///
   /// @param name  Required. The job name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/jobs/JOB_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -307,7 +316,7 @@ class CloudSchedulerClient {
   /// @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L34}
   ///
   StatusOr<google::cloud::scheduler::v1::Job> PauseJob(std::string const& name,
-                                                       Options options = {});
+                                                       Options opts = {});
 
   ///
   /// Pauses a job.
@@ -323,7 +332,8 @@ class CloudSchedulerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::PauseJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L234}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -334,7 +344,7 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> PauseJob(
       google::cloud::scheduler::v1::PauseJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resume a job.
@@ -349,7 +359,8 @@ class CloudSchedulerClient {
   ///
   /// @param name  Required. The job name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/jobs/JOB_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -359,7 +370,7 @@ class CloudSchedulerClient {
   /// @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L34}
   ///
   StatusOr<google::cloud::scheduler::v1::Job> ResumeJob(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Resume a job.
@@ -374,7 +385,8 @@ class CloudSchedulerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::ResumeJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L246}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -385,7 +397,7 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> ResumeJob(
       google::cloud::scheduler::v1::ResumeJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Forces a job to run now.
@@ -395,7 +407,8 @@ class CloudSchedulerClient {
   ///
   /// @param name  Required. The job name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/jobs/JOB_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -405,7 +418,7 @@ class CloudSchedulerClient {
   /// @googleapis_reference_link{google/cloud/scheduler/v1/job.proto#L34}
   ///
   StatusOr<google::cloud::scheduler::v1::Job> RunJob(std::string const& name,
-                                                     Options options = {});
+                                                     Options opts = {});
 
   ///
   /// Forces a job to run now.
@@ -415,7 +428,8 @@ class CloudSchedulerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::scheduler::v1::RunJobRequest,google/cloud/scheduler/v1/cloudscheduler.proto#L259}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::scheduler::v1::Job,google/cloud/scheduler/v1/job.proto#L34}
   ///
@@ -426,7 +440,7 @@ class CloudSchedulerClient {
   ///
   StatusOr<google::cloud::scheduler::v1::Job> RunJob(
       google::cloud::scheduler::v1::RunJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudSchedulerConnection> connection_;

--- a/google/cloud/secretmanager/secret_manager_client.cc
+++ b/google/cloud/secretmanager/secret_manager_client.cc
@@ -26,19 +26,18 @@ namespace secretmanager {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SecretManagerServiceClient::SecretManagerServiceClient(
-    std::shared_ptr<SecretManagerServiceConnection> connection, Options options)
+    std::shared_ptr<SecretManagerServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           secretmanager_internal::SecretManagerServiceDefaultOptions(
               connection_->options()))) {}
 SecretManagerServiceClient::~SecretManagerServiceClient() = default;
 
 StreamRange<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::ListSecrets(std::string const& parent,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::ListSecretsRequest request;
   request.set_parent(parent);
   return connection_->ListSecrets(request);
@@ -47,18 +46,16 @@ SecretManagerServiceClient::ListSecrets(std::string const& parent,
 StreamRange<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::ListSecrets(
     google::cloud::secretmanager::v1::ListSecretsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSecrets(std::move(request));
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::CreateSecret(
     std::string const& parent, std::string const& secret_id,
-    google::cloud::secretmanager::v1::Secret const& secret, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::secretmanager::v1::Secret const& secret, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::CreateSecretRequest request;
   request.set_parent(parent);
   request.set_secret_id(secret_id);
@@ -69,9 +66,8 @@ SecretManagerServiceClient::CreateSecret(
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::CreateSecret(
     google::cloud::secretmanager::v1::CreateSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSecret(request);
 }
 
@@ -79,9 +75,8 @@ StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::AddSecretVersion(
     std::string const& parent,
     google::cloud::secretmanager::v1::SecretPayload const& payload,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::AddSecretVersionRequest request;
   request.set_parent(parent);
   *request.mutable_payload() = payload;
@@ -91,17 +86,14 @@ SecretManagerServiceClient::AddSecretVersion(
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::AddSecretVersion(
     google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AddSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
-SecretManagerServiceClient::GetSecret(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+SecretManagerServiceClient::GetSecret(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::GetSecretRequest request;
   request.set_name(name);
   return connection_->GetSecret(request);
@@ -110,18 +102,16 @@ SecretManagerServiceClient::GetSecret(std::string const& name,
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::GetSecret(
     google::cloud::secretmanager::v1::GetSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSecret(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::UpdateSecret(
     google::cloud::secretmanager::v1::Secret const& secret,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::UpdateSecretRequest request;
   *request.mutable_secret() = secret;
   *request.mutable_update_mask() = update_mask;
@@ -131,16 +121,14 @@ SecretManagerServiceClient::UpdateSecret(
 StatusOr<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceClient::UpdateSecret(
     google::cloud::secretmanager::v1::UpdateSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSecret(request);
 }
 
 Status SecretManagerServiceClient::DeleteSecret(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::DeleteSecretRequest request;
   request.set_name(name);
   return connection_->DeleteSecret(request);
@@ -148,17 +136,15 @@ Status SecretManagerServiceClient::DeleteSecret(std::string const& name,
 
 Status SecretManagerServiceClient::DeleteSecret(
     google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteSecret(request);
 }
 
 StreamRange<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::ListSecretVersions(std::string const& parent,
-                                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                               Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::ListSecretVersionsRequest request;
   request.set_parent(parent);
   return connection_->ListSecretVersions(request);
@@ -167,17 +153,15 @@ SecretManagerServiceClient::ListSecretVersions(std::string const& parent,
 StreamRange<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::ListSecretVersions(
     google::cloud::secretmanager::v1::ListSecretVersionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSecretVersions(std::move(request));
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::GetSecretVersion(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::GetSecretVersionRequest request;
   request.set_name(name);
   return connection_->GetSecretVersion(request);
@@ -186,17 +170,15 @@ SecretManagerServiceClient::GetSecretVersion(std::string const& name,
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::GetSecretVersion(
     google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
 SecretManagerServiceClient::AccessSecretVersion(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::AccessSecretVersionRequest request;
   request.set_name(name);
   return connection_->AccessSecretVersion(request);
@@ -205,17 +187,15 @@ SecretManagerServiceClient::AccessSecretVersion(std::string const& name,
 StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
 SecretManagerServiceClient::AccessSecretVersion(
     google::cloud::secretmanager::v1::AccessSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AccessSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::DisableSecretVersion(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::DisableSecretVersionRequest request;
   request.set_name(name);
   return connection_->DisableSecretVersion(request);
@@ -225,17 +205,15 @@ StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::DisableSecretVersion(
     google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DisableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::EnableSecretVersion(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::EnableSecretVersionRequest request;
   request.set_name(name);
   return connection_->EnableSecretVersion(request);
@@ -244,17 +222,15 @@ SecretManagerServiceClient::EnableSecretVersion(std::string const& name,
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::EnableSecretVersion(
     google::cloud::secretmanager::v1::EnableSecretVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->EnableSecretVersion(request);
 }
 
 StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::DestroySecretVersion(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::secretmanager::v1::DestroySecretVersionRequest request;
   request.set_name(name);
   return connection_->DestroySecretVersion(request);
@@ -264,32 +240,27 @@ StatusOr<google::cloud::secretmanager::v1::SecretVersion>
 SecretManagerServiceClient::DestroySecretVersion(
     google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DestroySecretVersion(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecretManagerServiceClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecretManagerServiceClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 SecretManagerServiceClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/secretmanager/secret_manager_client.h
+++ b/google/cloud/secretmanager/secret_manager_client.h
@@ -69,7 +69,7 @@ class SecretManagerServiceClient {
  public:
   explicit SecretManagerServiceClient(
       std::shared_ptr<SecretManagerServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~SecretManagerServiceClient();
 
   //@{
@@ -100,7 +100,8 @@ class SecretManagerServiceClient {
   /// the
   ///  [Secrets][google.cloud.secretmanager.v1.Secret], in the format
   ///  `projects/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -110,14 +111,15 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists [Secrets][google.cloud.secretmanager.v1.Secret].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretsRequest,google/cloud/secretmanager/v1/service.proto#L206}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -128,7 +130,7 @@ class SecretManagerServiceClient {
   ///
   StreamRange<google::cloud::secretmanager::v1::Secret> ListSecrets(
       google::cloud::secretmanager::v1::ListSecretsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -144,7 +146,8 @@ class SecretManagerServiceClient {
   ///  and underscore (`_`) characters.
   /// @param secret  Required. A [Secret][google.cloud.secretmanager.v1.Secret]
   /// with initial field values.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -156,7 +159,7 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
       std::string const& parent, std::string const& secret_id,
       google::cloud::secretmanager::v1::Secret const& secret,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new [Secret][google.cloud.secretmanager.v1.Secret] containing no
@@ -164,7 +167,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::CreateSecretRequest,google/cloud/secretmanager/v1/service.proto#L248}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -175,7 +179,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> CreateSecret(
       google::cloud::secretmanager::v1::CreateSecretRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -188,7 +192,8 @@ class SecretManagerServiceClient {
   ///  format `projects/*/secrets/*`.
   /// @param payload  Required. The secret payload of the
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -200,7 +205,7 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       std::string const& parent,
       google::cloud::secretmanager::v1::SecretPayload const& payload,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new [SecretVersion][google.cloud.secretmanager.v1.SecretVersion]
@@ -209,7 +214,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::AddSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L270}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -220,7 +226,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> AddSecretVersion(
       google::cloud::secretmanager::v1::AddSecretVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
@@ -228,7 +234,8 @@ class SecretManagerServiceClient {
   /// @param name  Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret], in the format
   /// `projects/*/secrets/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -238,14 +245,15 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L40}
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets metadata for a given [Secret][google.cloud.secretmanager.v1.Secret].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretRequest,google/cloud/secretmanager/v1/service.proto#L285}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -256,7 +264,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> GetSecret(
       google::cloud::secretmanager::v1::GetSecretRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates metadata of an existing
@@ -265,7 +273,8 @@ class SecretManagerServiceClient {
   /// @param secret  Required. [Secret][google.cloud.secretmanager.v1.Secret]
   /// with updated field values.
   /// @param update_mask  Required. Specifies the fields to be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -276,7 +285,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::Secret const& secret,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates metadata of an existing
@@ -284,7 +293,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::UpdateSecretRequest,google/cloud/secretmanager/v1/service.proto#L354}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::Secret,google/cloud/secretmanager/v1/resources.proto#L40}
   ///
@@ -295,7 +305,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::Secret> UpdateSecret(
       google::cloud::secretmanager::v1::UpdateSecretRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
@@ -303,26 +313,28 @@ class SecretManagerServiceClient {
   /// @param name  Required. The resource name of the
   /// [Secret][google.cloud.secretmanager.v1.Secret] to delete in the format
   ///  `projects/*/secrets/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
   ///
-  Status DeleteSecret(std::string const& name, Options options = {});
+  Status DeleteSecret(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a [Secret][google.cloud.secretmanager.v1.Secret].
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DeleteSecretRequest,google/cloud/secretmanager/v1/service.proto#L390}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.secretmanager.v1.DeleteSecretRequest]:
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L390}
   ///
   Status DeleteSecret(
       google::cloud::secretmanager::v1::DeleteSecretRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -332,7 +344,8 @@ class SecretManagerServiceClient {
   /// [Secret][google.cloud.secretmanager.v1.Secret] associated with the
   ///  [SecretVersions][google.cloud.secretmanager.v1.SecretVersion] to list, in
   ///  the format `projects/*/secrets/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -342,7 +355,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
-  ListSecretVersions(std::string const& parent, Options options = {});
+  ListSecretVersions(std::string const& parent, Options opts = {});
 
   ///
   /// Lists [SecretVersions][google.cloud.secretmanager.v1.SecretVersion]. This
@@ -350,7 +363,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::ListSecretVersionsRequest,google/cloud/secretmanager/v1/service.proto#L296}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -362,7 +376,7 @@ class SecretManagerServiceClient {
   StreamRange<google::cloud::secretmanager::v1::SecretVersion>
   ListSecretVersions(
       google::cloud::secretmanager::v1::ListSecretVersionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets metadata for a
@@ -376,7 +390,8 @@ class SecretManagerServiceClient {
   ///  `projects/*/secrets/*/versions/*`.
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -386,7 +401,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets metadata for a
@@ -397,7 +412,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::GetSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L339}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -408,7 +424,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> GetSecretVersion(
       google::cloud::secretmanager::v1::GetSecretVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -422,7 +438,8 @@ class SecretManagerServiceClient {
   ///  `projects/*/secrets/*/versions/*`.
   ///  `projects/*/secrets/*/versions/latest` is an alias to the most recently
   ///  created [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
@@ -432,7 +449,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/service.proto#L378}
   ///
   StatusOr<google::cloud::secretmanager::v1::AccessSecretVersionResponse>
-  AccessSecretVersion(std::string const& name, Options options = {});
+  AccessSecretVersion(std::string const& name, Options opts = {});
 
   ///
   /// Accesses a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -443,7 +460,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L363}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::AccessSecretVersionResponse,google/cloud/secretmanager/v1/service.proto#L378}
   ///
@@ -456,7 +474,7 @@ class SecretManagerServiceClient {
   AccessSecretVersion(
       google::cloud::secretmanager::v1::AccessSecretVersionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -469,7 +487,8 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to disable in
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -479,7 +498,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-  DisableSecretVersion(std::string const& name, Options options = {});
+  DisableSecretVersion(std::string const& name, Options opts = {});
 
   ///
   /// Disables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -490,7 +509,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DisableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L407}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -503,7 +523,7 @@ class SecretManagerServiceClient {
   DisableSecretVersion(
       google::cloud::secretmanager::v1::DisableSecretVersionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -516,7 +536,8 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to enable in
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -526,7 +547,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Enables a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -537,7 +558,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::EnableSecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L424}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -549,7 +571,7 @@ class SecretManagerServiceClient {
   StatusOr<google::cloud::secretmanager::v1::SecretVersion> EnableSecretVersion(
       google::cloud::secretmanager::v1::EnableSecretVersionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -563,7 +585,8 @@ class SecretManagerServiceClient {
   /// [SecretVersion][google.cloud.secretmanager.v1.SecretVersion] to destroy in
   /// the format
   ///  `projects/*/secrets/*/versions/*`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -573,7 +596,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/cloud/secretmanager/v1/resources.proto#L103}
   ///
   StatusOr<google::cloud::secretmanager::v1::SecretVersion>
-  DestroySecretVersion(std::string const& name, Options options = {});
+  DestroySecretVersion(std::string const& name, Options opts = {});
 
   ///
   /// Destroys a [SecretVersion][google.cloud.secretmanager.v1.SecretVersion].
@@ -585,7 +608,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::secretmanager::v1::DestroySecretVersionRequest,google/cloud/secretmanager/v1/service.proto#L441}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::secretmanager::v1::SecretVersion,google/cloud/secretmanager/v1/resources.proto#L103}
   ///
@@ -598,7 +622,7 @@ class SecretManagerServiceClient {
   DestroySecretVersion(
       google::cloud::secretmanager::v1::DestroySecretVersionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the access control policy on the specified secret. Replaces any
@@ -611,7 +635,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -621,8 +646,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for a secret.
@@ -630,7 +654,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -640,8 +665,7 @@ class SecretManagerServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that a caller has for the specified secret.
@@ -654,7 +678,8 @@ class SecretManagerServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -665,7 +690,7 @@ class SecretManagerServiceClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<SecretManagerServiceConnection> connection_;

--- a/google/cloud/securitycenter/security_center_client.cc
+++ b/google/cloud/securitycenter/security_center_client.cc
@@ -28,19 +28,18 @@ namespace securitycenter {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 SecurityCenterClient::SecurityCenterClient(
-    std::shared_ptr<SecurityCenterConnection> connection, Options options)
+    std::shared_ptr<SecurityCenterConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           securitycenter_internal::SecurityCenterDefaultOptions(
               connection_->options()))) {}
 SecurityCenterClient::~SecurityCenterClient() = default;
 
 future<StatusOr<google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>
 SecurityCenterClient::BulkMuteFindings(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::BulkMuteFindingsRequest request;
   request.set_parent(parent);
   return connection_->BulkMuteFindings(request);
@@ -49,18 +48,16 @@ SecurityCenterClient::BulkMuteFindings(std::string const& parent,
 future<StatusOr<google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>
 SecurityCenterClient::BulkMuteFindings(
     google::cloud::securitycenter::v1::BulkMuteFindingsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BulkMuteFindings(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::Source>
 SecurityCenterClient::CreateSource(
     std::string const& parent,
-    google::cloud::securitycenter::v1::Source const& source, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::securitycenter::v1::Source const& source, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::CreateSourceRequest request;
   request.set_parent(parent);
   *request.mutable_source() = source;
@@ -70,19 +67,16 @@ SecurityCenterClient::CreateSource(
 StatusOr<google::cloud::securitycenter::v1::Source>
 SecurityCenterClient::CreateSource(
     google::cloud::securitycenter::v1::CreateSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSource(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::CreateFinding(
     std::string const& parent, std::string const& finding_id,
-    google::cloud::securitycenter::v1::Finding const& finding,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::securitycenter::v1::Finding const& finding, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::CreateFindingRequest request;
   request.set_parent(parent);
   request.set_finding_id(finding_id);
@@ -93,9 +87,8 @@ SecurityCenterClient::CreateFinding(
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::CreateFinding(
     google::cloud::securitycenter::v1::CreateFindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateFinding(request);
 }
 
@@ -103,9 +96,8 @@ StatusOr<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::CreateMuteConfig(
     std::string const& parent,
     google::cloud::securitycenter::v1::MuteConfig const& mute_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::CreateMuteConfigRequest request;
   request.set_parent(parent);
   *request.mutable_mute_config() = mute_config;
@@ -116,9 +108,8 @@ StatusOr<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::CreateMuteConfig(
     std::string const& parent,
     google::cloud::securitycenter::v1::MuteConfig const& mute_config,
-    std::string const& mute_config_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& mute_config_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::CreateMuteConfigRequest request;
   request.set_parent(parent);
   *request.mutable_mute_config() = mute_config;
@@ -129,9 +120,8 @@ SecurityCenterClient::CreateMuteConfig(
 StatusOr<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::CreateMuteConfig(
     google::cloud::securitycenter::v1::CreateMuteConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMuteConfig(request);
 }
 
@@ -140,9 +130,8 @@ SecurityCenterClient::CreateNotificationConfig(
     std::string const& parent, std::string const& config_id,
     google::cloud::securitycenter::v1::NotificationConfig const&
         notification_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::CreateNotificationConfigRequest request;
   request.set_parent(parent);
   request.set_config_id(config_id);
@@ -155,9 +144,8 @@ SecurityCenterClient::CreateNotificationConfig(
     std::string const& parent,
     google::cloud::securitycenter::v1::NotificationConfig const&
         notification_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::CreateNotificationConfigRequest request;
   request.set_parent(parent);
   *request.mutable_notification_config() = notification_config;
@@ -168,16 +156,14 @@ StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::CreateNotificationConfig(
     google::cloud::securitycenter::v1::CreateNotificationConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateNotificationConfig(request);
 }
 
 Status SecurityCenterClient::DeleteMuteConfig(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::DeleteMuteConfigRequest request;
   request.set_name(name);
   return connection_->DeleteMuteConfig(request);
@@ -185,16 +171,14 @@ Status SecurityCenterClient::DeleteMuteConfig(std::string const& name,
 
 Status SecurityCenterClient::DeleteMuteConfig(
     google::cloud::securitycenter::v1::DeleteMuteConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMuteConfig(request);
 }
 
 Status SecurityCenterClient::DeleteNotificationConfig(std::string const& name,
-                                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                      Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::DeleteNotificationConfigRequest request;
   request.set_name(name);
   return connection_->DeleteNotificationConfig(request);
@@ -203,32 +187,28 @@ Status SecurityCenterClient::DeleteNotificationConfig(std::string const& name,
 Status SecurityCenterClient::DeleteNotificationConfig(
     google::cloud::securitycenter::v1::DeleteNotificationConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteNotificationConfig(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecurityCenterClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecurityCenterClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::MuteConfig>
-SecurityCenterClient::GetMuteConfig(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+SecurityCenterClient::GetMuteConfig(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::GetMuteConfigRequest request;
   request.set_name(name);
   return connection_->GetMuteConfig(request);
@@ -237,17 +217,15 @@ SecurityCenterClient::GetMuteConfig(std::string const& name, Options options) {
 StatusOr<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::GetMuteConfig(
     google::cloud::securitycenter::v1::GetMuteConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMuteConfig(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::GetNotificationConfig(std::string const& name,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::GetNotificationConfigRequest request;
   request.set_name(name);
   return connection_->GetNotificationConfig(request);
@@ -257,17 +235,15 @@ StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::GetNotificationConfig(
     google::cloud::securitycenter::v1::GetNotificationConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNotificationConfig(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>
 SecurityCenterClient::GetOrganizationSettings(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::GetOrganizationSettingsRequest request;
   request.set_name(name);
   return connection_->GetOrganizationSettings(request);
@@ -277,16 +253,14 @@ StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>
 SecurityCenterClient::GetOrganizationSettings(
     google::cloud::securitycenter::v1::GetOrganizationSettingsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetOrganizationSettings(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::Source>
-SecurityCenterClient::GetSource(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+SecurityCenterClient::GetSource(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::GetSourceRequest request;
   request.set_name(name);
   return connection_->GetSource(request);
@@ -295,27 +269,23 @@ SecurityCenterClient::GetSource(std::string const& name, Options options) {
 StatusOr<google::cloud::securitycenter::v1::Source>
 SecurityCenterClient::GetSource(
     google::cloud::securitycenter::v1::GetSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSource(request);
 }
 
 StreamRange<google::cloud::securitycenter::v1::GroupResult>
 SecurityCenterClient::GroupAssets(
     google::cloud::securitycenter::v1::GroupAssetsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GroupAssets(std::move(request));
 }
 
 StreamRange<google::cloud::securitycenter::v1::GroupResult>
 SecurityCenterClient::GroupFindings(std::string const& parent,
-                                    std::string const& group_by,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    std::string const& group_by, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::GroupFindingsRequest request;
   request.set_parent(parent);
   request.set_group_by(group_by);
@@ -325,9 +295,8 @@ SecurityCenterClient::GroupFindings(std::string const& parent,
 StreamRange<google::cloud::securitycenter::v1::GroupResult>
 SecurityCenterClient::GroupFindings(
     google::cloud::securitycenter::v1::GroupFindingsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GroupFindings(std::move(request));
 }
 
@@ -335,9 +304,8 @@ StreamRange<
     google::cloud::securitycenter::v1::ListAssetsResponse::ListAssetsResult>
 SecurityCenterClient::ListAssets(
     google::cloud::securitycenter::v1::ListAssetsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAssets(std::move(request));
 }
 
@@ -345,17 +313,14 @@ StreamRange<
     google::cloud::securitycenter::v1::ListFindingsResponse::ListFindingsResult>
 SecurityCenterClient::ListFindings(
     google::cloud::securitycenter::v1::ListFindingsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFindings(std::move(request));
 }
 
 StreamRange<google::cloud::securitycenter::v1::MuteConfig>
-SecurityCenterClient::ListMuteConfigs(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+SecurityCenterClient::ListMuteConfigs(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::ListMuteConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListMuteConfigs(request);
@@ -364,17 +329,15 @@ SecurityCenterClient::ListMuteConfigs(std::string const& parent,
 StreamRange<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::ListMuteConfigs(
     google::cloud::securitycenter::v1::ListMuteConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMuteConfigs(std::move(request));
 }
 
 StreamRange<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::ListNotificationConfigs(std::string const& parent,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::ListNotificationConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListNotificationConfigs(request);
@@ -383,16 +346,14 @@ SecurityCenterClient::ListNotificationConfigs(std::string const& parent,
 StreamRange<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::ListNotificationConfigs(
     google::cloud::securitycenter::v1::ListNotificationConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNotificationConfigs(std::move(request));
 }
 
 StreamRange<google::cloud::securitycenter::v1::Source>
-SecurityCenterClient::ListSources(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+SecurityCenterClient::ListSources(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::ListSourcesRequest request;
   request.set_parent(parent);
   return connection_->ListSources(request);
@@ -401,17 +362,15 @@ SecurityCenterClient::ListSources(std::string const& parent, Options options) {
 StreamRange<google::cloud::securitycenter::v1::Source>
 SecurityCenterClient::ListSources(
     google::cloud::securitycenter::v1::ListSourcesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSources(std::move(request));
 }
 
 future<StatusOr<google::cloud::securitycenter::v1::RunAssetDiscoveryResponse>>
 SecurityCenterClient::RunAssetDiscovery(std::string const& parent,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::RunAssetDiscoveryRequest request;
   request.set_parent(parent);
   return connection_->RunAssetDiscovery(request);
@@ -420,9 +379,8 @@ SecurityCenterClient::RunAssetDiscovery(std::string const& parent,
 future<StatusOr<google::cloud::securitycenter::v1::RunAssetDiscoveryResponse>>
 SecurityCenterClient::RunAssetDiscovery(
     google::cloud::securitycenter::v1::RunAssetDiscoveryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RunAssetDiscovery(request);
 }
 
@@ -430,9 +388,8 @@ StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::SetFindingState(
     std::string const& name,
     google::cloud::securitycenter::v1::Finding::State state,
-    google::protobuf::Timestamp const& start_time, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::Timestamp const& start_time, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::SetFindingStateRequest request;
   request.set_name(name);
   request.set_state(state);
@@ -443,18 +400,16 @@ SecurityCenterClient::SetFindingState(
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::SetFindingState(
     google::cloud::securitycenter::v1::SetFindingStateRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetFindingState(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::SetMute(
     std::string const& name,
-    google::cloud::securitycenter::v1::Finding::Mute mute, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::securitycenter::v1::Finding::Mute mute, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::SetMuteRequest request;
   request.set_name(name);
   request.set_mute(mute);
@@ -464,17 +419,15 @@ SecurityCenterClient::SetMute(
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::SetMute(
     google::cloud::securitycenter::v1::SetMuteRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetMute(request);
 }
 
 StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -482,11 +435,10 @@ StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<SecurityCenterBackoffPolicyOption>(options,
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<SecurityCenterBackoffPolicyOption>(opts,
                                                                     __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -513,18 +465,16 @@ StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 SecurityCenterClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -533,19 +483,16 @@ SecurityCenterClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 SecurityCenterClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::ExternalSystem>
 SecurityCenterClient::UpdateExternalSystem(
     google::cloud::securitycenter::v1::ExternalSystem const& external_system,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateExternalSystemRequest request;
   *request.mutable_external_system() = external_system;
   *request.mutable_update_mask() = update_mask;
@@ -556,18 +503,15 @@ StatusOr<google::cloud::securitycenter::v1::ExternalSystem>
 SecurityCenterClient::UpdateExternalSystem(
     google::cloud::securitycenter::v1::UpdateExternalSystemRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateExternalSystem(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::UpdateFinding(
-    google::cloud::securitycenter::v1::Finding const& finding,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::securitycenter::v1::Finding const& finding, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateFindingRequest request;
   *request.mutable_finding() = finding;
   return connection_->UpdateFinding(request);
@@ -576,18 +520,16 @@ SecurityCenterClient::UpdateFinding(
 StatusOr<google::cloud::securitycenter::v1::Finding>
 SecurityCenterClient::UpdateFinding(
     google::cloud::securitycenter::v1::UpdateFindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateFinding(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::UpdateMuteConfig(
     google::cloud::securitycenter::v1::MuteConfig const& mute_config,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateMuteConfigRequest request;
   *request.mutable_mute_config() = mute_config;
   *request.mutable_update_mask() = update_mask;
@@ -597,9 +539,8 @@ SecurityCenterClient::UpdateMuteConfig(
 StatusOr<google::cloud::securitycenter::v1::MuteConfig>
 SecurityCenterClient::UpdateMuteConfig(
     google::cloud::securitycenter::v1::UpdateMuteConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMuteConfig(request);
 }
 
@@ -607,9 +548,8 @@ StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::UpdateNotificationConfig(
     google::cloud::securitycenter::v1::NotificationConfig const&
         notification_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateNotificationConfigRequest request;
   *request.mutable_notification_config() = notification_config;
   return connection_->UpdateNotificationConfig(request);
@@ -619,9 +559,8 @@ StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::UpdateNotificationConfig(
     google::cloud::securitycenter::v1::NotificationConfig const&
         notification_config,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateNotificationConfigRequest request;
   *request.mutable_notification_config() = notification_config;
   *request.mutable_update_mask() = update_mask;
@@ -632,9 +571,8 @@ StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
 SecurityCenterClient::UpdateNotificationConfig(
     google::cloud::securitycenter::v1::UpdateNotificationConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateNotificationConfig(request);
 }
 
@@ -642,9 +580,8 @@ StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>
 SecurityCenterClient::UpdateOrganizationSettings(
     google::cloud::securitycenter::v1::OrganizationSettings const&
         organization_settings,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateOrganizationSettingsRequest request;
   *request.mutable_organization_settings() = organization_settings;
   return connection_->UpdateOrganizationSettings(request);
@@ -654,17 +591,15 @@ StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>
 SecurityCenterClient::UpdateOrganizationSettings(
     google::cloud::securitycenter::v1::UpdateOrganizationSettingsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateOrganizationSettings(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::Source>
 SecurityCenterClient::UpdateSource(
-    google::cloud::securitycenter::v1::Source const& source, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::securitycenter::v1::Source const& source, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateSourceRequest request;
   *request.mutable_source() = source;
   return connection_->UpdateSource(request);
@@ -673,18 +608,16 @@ SecurityCenterClient::UpdateSource(
 StatusOr<google::cloud::securitycenter::v1::Source>
 SecurityCenterClient::UpdateSource(
     google::cloud::securitycenter::v1::UpdateSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSource(request);
 }
 
 StatusOr<google::cloud::securitycenter::v1::SecurityMarks>
 SecurityCenterClient::UpdateSecurityMarks(
     google::cloud::securitycenter::v1::SecurityMarks const& security_marks,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::securitycenter::v1::UpdateSecurityMarksRequest request;
   *request.mutable_security_marks() = security_marks;
   return connection_->UpdateSecurityMarks(request);
@@ -694,9 +627,8 @@ StatusOr<google::cloud::securitycenter::v1::SecurityMarks>
 SecurityCenterClient::UpdateSecurityMarks(
     google::cloud::securitycenter::v1::UpdateSecurityMarksRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSecurityMarks(request);
 }
 

--- a/google/cloud/securitycenter/security_center_client.h
+++ b/google/cloud/securitycenter/security_center_client.h
@@ -1048,8 +1048,8 @@ class SecurityCenterClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/securitycenter/security_center_client.h
+++ b/google/cloud/securitycenter/security_center_client.h
@@ -64,8 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SecurityCenterClient {
  public:
   explicit SecurityCenterClient(
-      std::shared_ptr<SecurityCenterConnection> connection,
-      Options options = {});
+      std::shared_ptr<SecurityCenterConnection> connection, Options opts = {});
   ~SecurityCenterClient();
 
   //@{
@@ -97,7 +96,8 @@ class SecurityCenterClient {
   /// applied. Its format is
   ///  "organizations/[organization_id]", "folders/[folder_id]",
   ///  "projects/[project_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::BulkMuteFindingsResponse,google/cloud/securitycenter/v1/securitycenter_service.proto#L525}
   ///
@@ -107,7 +107,7 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/securitycenter_service.proto#L525}
   ///
   future<StatusOr<google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>
-  BulkMuteFindings(std::string const& parent, Options options = {});
+  BulkMuteFindings(std::string const& parent, Options opts = {});
 
   ///
   /// Kicks off an LRO to bulk mute findings for a parent based on a filter. The
@@ -116,7 +116,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::BulkMuteFindingsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L486}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::BulkMuteFindingsResponse,google/cloud/securitycenter/v1/securitycenter_service.proto#L525}
   ///
@@ -128,7 +129,7 @@ class SecurityCenterClient {
   future<StatusOr<google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>
   BulkMuteFindings(
       google::cloud::securitycenter::v1::BulkMuteFindingsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a source.
@@ -139,7 +140,8 @@ class SecurityCenterClient {
   /// @param source  Required. The Source being created, only the display_name
   /// and description will be
   ///  used. All other fields will be ignored.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -151,14 +153,15 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::Source> CreateSource(
       std::string const& parent,
       google::cloud::securitycenter::v1::Source const& source,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::CreateSourceRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L595}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -169,7 +172,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Source> CreateSource(
       google::cloud::securitycenter::v1::CreateSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a finding. The corresponding source must exist for finding
@@ -185,7 +188,8 @@ class SecurityCenterClient {
   /// @param finding  Required. The Finding being created. The name and
   /// security_marks will be ignored as
   ///  they are both output only fields on this resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -197,7 +201,7 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::Finding> CreateFinding(
       std::string const& parent, std::string const& finding_id,
       google::cloud::securitycenter::v1::Finding const& finding,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a finding. The corresponding source must exist for finding
@@ -205,7 +209,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::CreateFindingRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L530}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -216,7 +221,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Finding> CreateFinding(
       google::cloud::securitycenter::v1::CreateFindingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a mute config.
@@ -226,7 +231,8 @@ class SecurityCenterClient {
   ///  "organizations/[organization_id]", "folders/[folder_id]", or
   ///  "projects/[project_id]".
   /// @param mute_config  Required. The mute config being created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -238,7 +244,7 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> CreateMuteConfig(
       std::string const& parent,
       google::cloud::securitycenter::v1::MuteConfig const& mute_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a mute config.
@@ -253,7 +259,8 @@ class SecurityCenterClient {
   ///  It must consist of lower case letters, numbers, and hyphen, with the
   ///  first character a letter, the last a letter or a number, and a 63
   ///  character maximum.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -265,14 +272,15 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> CreateMuteConfig(
       std::string const& parent,
       google::cloud::securitycenter::v1::MuteConfig const& mute_config,
-      std::string const& mute_config_id, Options options = {});
+      std::string const& mute_config_id, Options opts = {});
 
   ///
   /// Creates a mute config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::CreateMuteConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L551}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -283,7 +291,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> CreateMuteConfig(
       google::cloud::securitycenter::v1::CreateMuteConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a notification config.
@@ -298,7 +306,8 @@ class SecurityCenterClient {
   /// @param notification_config  Required. The notification config being
   /// created. The name and the service account
   ///  will be ignored as they are both output only fields on this resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -312,7 +321,7 @@ class SecurityCenterClient {
       std::string const& parent, std::string const& config_id,
       google::cloud::securitycenter::v1::NotificationConfig const&
           notification_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a notification config.
@@ -323,7 +332,8 @@ class SecurityCenterClient {
   /// @param notification_config  Required. The notification config being
   /// created. The name and the service account
   ///  will be ignored as they are both output only fields on this resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -337,14 +347,15 @@ class SecurityCenterClient {
       std::string const& parent,
       google::cloud::securitycenter::v1::NotificationConfig const&
           notification_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a notification config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::CreateNotificationConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L573}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -357,7 +368,7 @@ class SecurityCenterClient {
   CreateNotificationConfig(
       google::cloud::securitycenter::v1::CreateNotificationConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an existing mute config.
@@ -366,26 +377,28 @@ class SecurityCenterClient {
   ///  organizations/{organization}/muteConfigs/{config_id},
   ///  folders/{folder}/muteConfigs/{config_id}, or
   ///  projects/{project}/muteConfigs/{config_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.securitycenter.v1.DeleteMuteConfigRequest]:
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/securitycenter_service.proto#L611}
   ///
-  Status DeleteMuteConfig(std::string const& name, Options options = {});
+  Status DeleteMuteConfig(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an existing mute config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::DeleteMuteConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L611}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.securitycenter.v1.DeleteMuteConfigRequest]:
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/securitycenter_service.proto#L611}
   ///
   Status DeleteMuteConfig(
       google::cloud::securitycenter::v1::DeleteMuteConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a notification config.
@@ -393,20 +406,21 @@ class SecurityCenterClient {
   /// @param name  Required. Name of the notification config to delete. Its
   /// format is
   ///  "organizations/[organization_id]/notificationConfigs/[config_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.securitycenter.v1.DeleteNotificationConfigRequest]:
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/securitycenter_service.proto#L625}
   ///
-  Status DeleteNotificationConfig(std::string const& name,
-                                  Options options = {});
+  Status DeleteNotificationConfig(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a notification config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::DeleteNotificationConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L625}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.securitycenter.v1.DeleteNotificationConfigRequest]:
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/securitycenter_service.proto#L625}
@@ -414,7 +428,7 @@ class SecurityCenterClient {
   Status DeleteNotificationConfig(
       google::cloud::securitycenter::v1::DeleteNotificationConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy on the specified Source.
@@ -422,7 +436,8 @@ class SecurityCenterClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -432,14 +447,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy on the specified Source.
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -449,8 +465,7 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets a mute config.
@@ -459,7 +474,8 @@ class SecurityCenterClient {
   ///  organizations/{organization}/muteConfigs/{config_id},
   ///  folders/{folder}/muteConfigs/{config_id}, or
   ///  projects/{project}/muteConfigs/{config_id}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -469,14 +485,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> GetMuteConfig(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a mute config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::GetMuteConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L637}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -487,7 +504,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> GetMuteConfig(
       google::cloud::securitycenter::v1::GetMuteConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a notification config.
@@ -495,7 +512,8 @@ class SecurityCenterClient {
   /// @param name  Required. Name of the notification config to get. Its format
   /// is
   ///  "organizations/[organization_id]/notificationConfigs/[config_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -505,14 +523,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
   StatusOr<google::cloud::securitycenter::v1::NotificationConfig>
-  GetNotificationConfig(std::string const& name, Options options = {});
+  GetNotificationConfig(std::string const& name, Options opts = {});
 
   ///
   /// Gets a notification config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::GetNotificationConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L651}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -525,7 +544,7 @@ class SecurityCenterClient {
   GetNotificationConfig(
       google::cloud::securitycenter::v1::GetNotificationConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the settings for an organization.
@@ -533,7 +552,8 @@ class SecurityCenterClient {
   /// @param name  Required. Name of the organization to get organization
   /// settings for. Its format is
   ///  "organizations/[organization_id]/organizationSettings".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::OrganizationSettings,google/cloud/securitycenter/v1/organization_settings.proto#L31}
   ///
@@ -543,14 +563,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/organization_settings.proto#L31}
   ///
   StatusOr<google::cloud::securitycenter::v1::OrganizationSettings>
-  GetOrganizationSettings(std::string const& name, Options options = {});
+  GetOrganizationSettings(std::string const& name, Options opts = {});
 
   ///
   /// Gets the settings for an organization.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::GetOrganizationSettingsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L663}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::OrganizationSettings,google/cloud/securitycenter/v1/organization_settings.proto#L31}
   ///
@@ -563,14 +584,15 @@ class SecurityCenterClient {
   GetOrganizationSettings(
       google::cloud::securitycenter::v1::GetOrganizationSettingsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a source.
   ///
   /// @param name  Required. Relative resource name of the source. Its format is
   ///  "organizations/[organization_id]/source/[source_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -580,14 +602,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/source.proto#L33}
   ///
   StatusOr<google::cloud::securitycenter::v1::Source> GetSource(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::GetSourceRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L675}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -598,7 +621,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Source> GetSource(
       google::cloud::securitycenter::v1::GetSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Filters an organization's assets and  groups them by their specified
@@ -606,7 +629,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::GroupAssetsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L687}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::GroupResult,google/cloud/securitycenter/v1/securitycenter_service.proto#L1008}
   ///
@@ -617,7 +641,7 @@ class SecurityCenterClient {
   ///
   StreamRange<google::cloud::securitycenter::v1::GroupResult> GroupAssets(
       google::cloud::securitycenter::v1::GroupAssetsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Filters an organization or source's findings and  groups them by their
@@ -647,7 +671,8 @@ class SecurityCenterClient {
   ///  * severity
   ///  The following fields are supported when compare_duration is set:
   ///  * state_change
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::GroupResult,google/cloud/securitycenter/v1/securitycenter_service.proto#L1008}
   ///
@@ -658,7 +683,7 @@ class SecurityCenterClient {
   ///
   StreamRange<google::cloud::securitycenter::v1::GroupResult> GroupFindings(
       std::string const& parent, std::string const& group_by,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Filters an organization or source's findings and  groups them by their
@@ -671,7 +696,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::GroupFindingsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L846}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::GroupResult,google/cloud/securitycenter/v1/securitycenter_service.proto#L1008}
   ///
@@ -682,14 +708,15 @@ class SecurityCenterClient {
   ///
   StreamRange<google::cloud::securitycenter::v1::GroupResult> GroupFindings(
       google::cloud::securitycenter::v1::GroupFindingsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists an organization's assets.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::ListAssetsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1117}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::ListAssetsResponse::ListAssetsResult,google/cloud/securitycenter/v1/securitycenter_service.proto#L1265}
   ///
@@ -701,7 +728,7 @@ class SecurityCenterClient {
   StreamRange<
       google::cloud::securitycenter::v1::ListAssetsResponse::ListAssetsResult>
   ListAssets(google::cloud::securitycenter::v1::ListAssetsRequest request,
-             Options options = {});
+             Options opts = {});
 
   ///
   /// Lists an organization or source's findings.
@@ -711,7 +738,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::ListFindingsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1308}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::ListFindingsResponse::ListFindingsResult,google/cloud/securitycenter/v1/securitycenter_service.proto#L1461}
   ///
@@ -723,7 +751,7 @@ class SecurityCenterClient {
   StreamRange<google::cloud::securitycenter::v1::ListFindingsResponse::
                   ListFindingsResult>
   ListFindings(google::cloud::securitycenter::v1::ListFindingsRequest request,
-               Options options = {});
+               Options opts = {});
 
   ///
   /// Lists mute configs.
@@ -732,7 +760,8 @@ class SecurityCenterClient {
   /// configs. Its format is
   ///  "organizations/[organization_id]", "folders/[folder_id]",
   ///  "projects/[project_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -742,14 +771,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
   StreamRange<google::cloud::securitycenter::v1::MuteConfig> ListMuteConfigs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists mute configs.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::ListMuteConfigsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1018}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -760,7 +790,7 @@ class SecurityCenterClient {
   ///
   StreamRange<google::cloud::securitycenter::v1::MuteConfig> ListMuteConfigs(
       google::cloud::securitycenter::v1::ListMuteConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists notification configs.
@@ -768,7 +798,8 @@ class SecurityCenterClient {
   /// @param parent  Required. Name of the organization to list notification
   /// configs.
   ///  Its format is "organizations/[organization_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -778,14 +809,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
   StreamRange<google::cloud::securitycenter::v1::NotificationConfig>
-  ListNotificationConfigs(std::string const& parent, Options options = {});
+  ListNotificationConfigs(std::string const& parent, Options opts = {});
 
   ///
   /// Lists notification configs.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::ListNotificationConfigsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1054}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -797,7 +829,7 @@ class SecurityCenterClient {
   StreamRange<google::cloud::securitycenter::v1::NotificationConfig>
   ListNotificationConfigs(
       google::cloud::securitycenter::v1::ListNotificationConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all sources belonging to an organization.
@@ -806,7 +838,8 @@ class SecurityCenterClient {
   /// Its format should be
   ///  "organizations/[organization_id], folders/[folder_id], or
   ///  projects/[project_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -816,14 +849,15 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/source.proto#L33}
   ///
   StreamRange<google::cloud::securitycenter::v1::Source> ListSources(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all sources belonging to an organization.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::ListSourcesRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1085}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -834,7 +868,7 @@ class SecurityCenterClient {
   ///
   StreamRange<google::cloud::securitycenter::v1::Source> ListSources(
       google::cloud::securitycenter::v1::ListSourcesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Runs asset discovery. The discovery is tracked with a long-running
@@ -847,7 +881,8 @@ class SecurityCenterClient {
   /// @param parent  Required. Name of the organization to run asset discovery
   /// for. Its format is
   ///  "organizations/[organization_id]".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::RunAssetDiscoveryResponse,google/cloud/securitycenter/v1/run_asset_discovery_response.proto#L30}
   ///
@@ -857,7 +892,7 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/cloud/securitycenter/v1/run_asset_discovery_response.proto#L30}
   ///
   future<StatusOr<google::cloud::securitycenter::v1::RunAssetDiscoveryResponse>>
-  RunAssetDiscovery(std::string const& parent, Options options = {});
+  RunAssetDiscovery(std::string const& parent, Options opts = {});
 
   ///
   /// Runs asset discovery. The discovery is tracked with a long-running
@@ -869,7 +904,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::RunAssetDiscoveryRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1585}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::RunAssetDiscoveryResponse,google/cloud/securitycenter/v1/run_asset_discovery_response.proto#L30}
   ///
@@ -882,7 +918,7 @@ class SecurityCenterClient {
   RunAssetDiscovery(
       google::cloud::securitycenter::v1::RunAssetDiscoveryRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the state of a finding.
@@ -894,7 +930,8 @@ class SecurityCenterClient {
   /// @param state  Required. The desired State of the finding.
   /// @param start_time  Required. The time at which the updated state takes
   /// effect.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -906,14 +943,15 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::Finding> SetFindingState(
       std::string const& name,
       google::cloud::securitycenter::v1::Finding::State state,
-      google::protobuf::Timestamp const& start_time, Options options = {});
+      google::protobuf::Timestamp const& start_time, Options opts = {});
 
   ///
   /// Updates the state of a finding.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::SetFindingStateRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1546}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -924,7 +962,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Finding> SetFindingState(
       google::cloud::securitycenter::v1::SetFindingStateRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the mute state of a finding.
@@ -936,7 +974,8 @@ class SecurityCenterClient {
   ///  "folders/{folder_id}/sources/{source_id}/finding/{finding_id}",
   ///  "projects/{project_id}/sources/{source_id}/finding/{finding_id}".
   /// @param mute  Required. The desired state of the Mute.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -947,15 +986,15 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Finding> SetMute(
       std::string const& name,
-      google::cloud::securitycenter::v1::Finding::Mute mute,
-      Options options = {});
+      google::cloud::securitycenter::v1::Finding::Mute mute, Options opts = {});
 
   ///
   /// Updates the mute state of a finding.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::SetMuteRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1566}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -966,7 +1005,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Finding> SetMute(
       google::cloud::securitycenter::v1::SetMuteRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the access control policy on the specified Source.
@@ -979,7 +1018,8 @@ class SecurityCenterClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -990,7 +1030,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -1008,21 +1048,21 @@ class SecurityCenterClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `SecurityCenterBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on the specified Source.
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -1032,8 +1072,7 @@ class SecurityCenterClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns the permissions that a caller has on the specified source.
@@ -1046,7 +1085,8 @@ class SecurityCenterClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -1057,14 +1097,15 @@ class SecurityCenterClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the permissions that a caller has on the specified source.
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -1075,7 +1116,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates external system. This is for a given finding.
@@ -1084,7 +1125,8 @@ class SecurityCenterClient {
   /// @param update_mask  The FieldMask to use when updating the external system
   /// resource.
   ///  If empty all mutable fields will be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::ExternalSystem,google/cloud/securitycenter/v1/external_system.proto#L32}
   ///
@@ -1096,14 +1138,15 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::ExternalSystem>
   UpdateExternalSystem(
       google::cloud::securitycenter::v1::ExternalSystem const& external_system,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates external system. This is for a given finding.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateExternalSystemRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1597}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::ExternalSystem,google/cloud/securitycenter/v1/external_system.proto#L32}
   ///
@@ -1116,7 +1159,7 @@ class SecurityCenterClient {
   UpdateExternalSystem(
       google::cloud::securitycenter::v1::UpdateExternalSystemRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or updates a finding. The corresponding source must exist for a
@@ -1128,7 +1171,8 @@ class SecurityCenterClient {
   ///  In the case of creation, the finding id portion of the name must be
   ///  alphanumeric and less than or equal to 32 characters and greater than 0
   ///  characters in length.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -1139,7 +1183,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Finding> UpdateFinding(
       google::cloud::securitycenter::v1::Finding const& finding,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates or updates a finding. The corresponding source must exist for a
@@ -1147,7 +1191,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateFindingRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1608}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Finding,google/cloud/securitycenter/v1/finding.proto#L43}
   ///
@@ -1158,7 +1203,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Finding> UpdateFinding(
       google::cloud::securitycenter::v1::UpdateFindingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a mute config.
@@ -1166,7 +1211,8 @@ class SecurityCenterClient {
   /// @param mute_config  Required. The mute config being updated.
   /// @param update_mask  The list of fields to be updated.
   ///  If empty all mutable fields will be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -1177,14 +1223,15 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> UpdateMuteConfig(
       google::cloud::securitycenter::v1::MuteConfig const& mute_config,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a mute config.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateMuteConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1628}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::MuteConfig,google/cloud/securitycenter/v1/mute_config.proto#L34}
   ///
@@ -1195,7 +1242,7 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::MuteConfig> UpdateMuteConfig(
       google::cloud::securitycenter::v1::UpdateMuteConfigRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   ///
@@ -1203,7 +1250,8 @@ class SecurityCenterClient {
   /// fields are allowed: description, pubsub_topic, streaming_config.filter
   ///
   /// @param notification_config  Required. The notification config to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -1216,7 +1264,7 @@ class SecurityCenterClient {
   UpdateNotificationConfig(
       google::cloud::securitycenter::v1::NotificationConfig const&
           notification_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   ///
@@ -1227,7 +1275,8 @@ class SecurityCenterClient {
   /// @param update_mask  The FieldMask to use when updating the notification
   /// config.
   ///  If empty all mutable fields will be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -1240,7 +1289,7 @@ class SecurityCenterClient {
   UpdateNotificationConfig(
       google::cloud::securitycenter::v1::NotificationConfig const&
           notification_config,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   ///
@@ -1249,7 +1298,8 @@ class SecurityCenterClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateNotificationConfigRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1638}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::NotificationConfig,google/cloud/securitycenter/v1/notification_config.proto#L39}
   ///
@@ -1262,14 +1312,15 @@ class SecurityCenterClient {
   UpdateNotificationConfig(
       google::cloud::securitycenter::v1::UpdateNotificationConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an organization's settings.
   ///
   /// @param organization_settings  Required. The organization settings resource
   /// to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::OrganizationSettings,google/cloud/securitycenter/v1/organization_settings.proto#L31}
   ///
@@ -1282,14 +1333,15 @@ class SecurityCenterClient {
   UpdateOrganizationSettings(
       google::cloud::securitycenter::v1::OrganizationSettings const&
           organization_settings,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an organization's settings.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateOrganizationSettingsRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1649}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::OrganizationSettings,google/cloud/securitycenter/v1/organization_settings.proto#L31}
   ///
@@ -1302,13 +1354,14 @@ class SecurityCenterClient {
   UpdateOrganizationSettings(
       google::cloud::securitycenter::v1::
           UpdateOrganizationSettingsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a source.
   ///
   /// @param source  Required. The source resource to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -1319,14 +1372,15 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Source> UpdateSource(
       google::cloud::securitycenter::v1::Source const& source,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateSourceRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1660}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::Source,google/cloud/securitycenter/v1/source.proto#L33}
   ///
@@ -1337,13 +1391,14 @@ class SecurityCenterClient {
   ///
   StatusOr<google::cloud::securitycenter::v1::Source> UpdateSource(
       google::cloud::securitycenter::v1::UpdateSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates security marks.
   ///
   /// @param security_marks  Required. The security marks resource to update.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::SecurityMarks,google/cloud/securitycenter/v1/security_marks.proto#L33}
   ///
@@ -1355,14 +1410,15 @@ class SecurityCenterClient {
   StatusOr<google::cloud::securitycenter::v1::SecurityMarks>
   UpdateSecurityMarks(
       google::cloud::securitycenter::v1::SecurityMarks const& security_marks,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates security marks.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::securitycenter::v1::UpdateSecurityMarksRequest,google/cloud/securitycenter/v1/securitycenter_service.proto#L1671}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::securitycenter::v1::SecurityMarks,google/cloud/securitycenter/v1/security_marks.proto#L33}
   ///
@@ -1375,7 +1431,7 @@ class SecurityCenterClient {
   UpdateSecurityMarks(
       google::cloud::securitycenter::v1::UpdateSecurityMarksRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<SecurityCenterConnection> connection_;

--- a/google/cloud/servicecontrol/quota_controller_client.cc
+++ b/google/cloud/servicecontrol/quota_controller_client.cc
@@ -26,10 +26,10 @@ namespace servicecontrol {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 QuotaControllerClient::QuotaControllerClient(
-    std::shared_ptr<QuotaControllerConnection> connection, Options options)
+    std::shared_ptr<QuotaControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           servicecontrol_internal::QuotaControllerDefaultOptions(
               connection_->options()))) {}
 QuotaControllerClient::~QuotaControllerClient() = default;
@@ -37,9 +37,8 @@ QuotaControllerClient::~QuotaControllerClient() = default;
 StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>
 QuotaControllerClient::AllocateQuota(
     google::api::servicecontrol::v1::AllocateQuotaRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AllocateQuota(request);
 }
 

--- a/google/cloud/servicecontrol/quota_controller_client.h
+++ b/google/cloud/servicecontrol/quota_controller_client.h
@@ -64,8 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class QuotaControllerClient {
  public:
   explicit QuotaControllerClient(
-      std::shared_ptr<QuotaControllerConnection> connection,
-      Options options = {});
+      std::shared_ptr<QuotaControllerConnection> connection, Options opts = {});
   ~QuotaControllerClient();
 
   //@{
@@ -103,7 +102,8 @@ class QuotaControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicecontrol::v1::AllocateQuotaRequest,google/api/servicecontrol/v1/quota_controller.proto#L63}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicecontrol::v1::AllocateQuotaResponse,google/api/servicecontrol/v1/quota_controller.proto#L178}
   ///
@@ -115,7 +115,7 @@ class QuotaControllerClient {
   StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>
   AllocateQuota(
       google::api::servicecontrol::v1::AllocateQuotaRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<QuotaControllerConnection> connection_;

--- a/google/cloud/servicecontrol/service_controller_client.cc
+++ b/google/cloud/servicecontrol/service_controller_client.cc
@@ -26,10 +26,10 @@ namespace servicecontrol {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceControllerClient::ServiceControllerClient(
-    std::shared_ptr<ServiceControllerConnection> connection, Options options)
+    std::shared_ptr<ServiceControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           servicecontrol_internal::ServiceControllerDefaultOptions(
               connection_->options()))) {}
 ServiceControllerClient::~ServiceControllerClient() = default;
@@ -37,18 +37,16 @@ ServiceControllerClient::~ServiceControllerClient() = default;
 StatusOr<google::api::servicecontrol::v1::CheckResponse>
 ServiceControllerClient::Check(
     google::api::servicecontrol::v1::CheckRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Check(request);
 }
 
 StatusOr<google::api::servicecontrol::v1::ReportResponse>
 ServiceControllerClient::Report(
     google::api::servicecontrol::v1::ReportRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->Report(request);
 }
 

--- a/google/cloud/servicecontrol/service_controller_client.h
+++ b/google/cloud/servicecontrol/service_controller_client.h
@@ -65,7 +65,7 @@ class ServiceControllerClient {
  public:
   explicit ServiceControllerClient(
       std::shared_ptr<ServiceControllerConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~ServiceControllerClient();
 
   //@{
@@ -109,7 +109,8 @@ class ServiceControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicecontrol::v1::CheckRequest,google/api/servicecontrol/v1/service_controller.proto#L94}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicecontrol::v1::CheckResponse,google/api/servicecontrol/v1/service_controller.proto#L115}
   ///
@@ -120,7 +121,7 @@ class ServiceControllerClient {
   ///
   StatusOr<google::api::servicecontrol::v1::CheckResponse> Check(
       google::api::servicecontrol::v1::CheckRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Reports operation results to Google Service Control, such as logs and
@@ -141,7 +142,8 @@ class ServiceControllerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicecontrol::v1::ReportRequest,google/api/servicecontrol/v1/service_controller.proto#L190}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicecontrol::v1::ReportResponse,google/api/servicecontrol/v1/service_controller.proto#L221}
   ///
@@ -152,7 +154,7 @@ class ServiceControllerClient {
   ///
   StatusOr<google::api::servicecontrol::v1::ReportResponse> Report(
       google::api::servicecontrol::v1::ReportRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ServiceControllerConnection> connection_;

--- a/google/cloud/servicedirectory/lookup_client.cc
+++ b/google/cloud/servicedirectory/lookup_client.cc
@@ -26,10 +26,10 @@ namespace servicedirectory {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 LookupServiceClient::LookupServiceClient(
-    std::shared_ptr<LookupServiceConnection> connection, Options options)
+    std::shared_ptr<LookupServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           servicedirectory_internal::LookupServiceDefaultOptions(
               connection_->options()))) {}
 LookupServiceClient::~LookupServiceClient() = default;
@@ -37,9 +37,8 @@ LookupServiceClient::~LookupServiceClient() = default;
 StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>
 LookupServiceClient::ResolveService(
     google::cloud::servicedirectory::v1::ResolveServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResolveService(request);
 }
 

--- a/google/cloud/servicedirectory/lookup_client.h
+++ b/google/cloud/servicedirectory/lookup_client.h
@@ -61,8 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class LookupServiceClient {
  public:
   explicit LookupServiceClient(
-      std::shared_ptr<LookupServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<LookupServiceConnection> connection, Options opts = {});
   ~LookupServiceClient();
 
   //@{
@@ -92,7 +91,8 @@ class LookupServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::ResolveServiceRequest,google/cloud/servicedirectory/v1/lookup_service.proto#L54}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::ResolveServiceResponse,google/cloud/servicedirectory/v1/lookup_service.proto#L91}
   ///
@@ -104,7 +104,7 @@ class LookupServiceClient {
   StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>
   ResolveService(
       google::cloud::servicedirectory::v1::ResolveServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<LookupServiceConnection> connection_;

--- a/google/cloud/servicedirectory/registration_client.cc
+++ b/google/cloud/servicedirectory/registration_client.cc
@@ -26,10 +26,10 @@ namespace servicedirectory {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 RegistrationServiceClient::RegistrationServiceClient(
-    std::shared_ptr<RegistrationServiceConnection> connection, Options options)
+    std::shared_ptr<RegistrationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           servicedirectory_internal::RegistrationServiceDefaultOptions(
               connection_->options()))) {}
 RegistrationServiceClient::~RegistrationServiceClient() = default;
@@ -38,9 +38,8 @@ StatusOr<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::CreateNamespace(
     std::string const& parent,
     google::cloud::servicedirectory::v1::Namespace const& namespace_,
-    std::string const& namespace_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& namespace_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::CreateNamespaceRequest request;
   request.set_parent(parent);
   *request.mutable_namespace_() = namespace_;
@@ -51,17 +50,15 @@ RegistrationServiceClient::CreateNamespace(
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::CreateNamespace(
     google::cloud::servicedirectory::v1::CreateNamespaceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateNamespace(request);
 }
 
 StreamRange<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::ListNamespaces(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::ListNamespacesRequest request;
   request.set_parent(parent);
   return connection_->ListNamespaces(request);
@@ -70,17 +67,14 @@ RegistrationServiceClient::ListNamespaces(std::string const& parent,
 StreamRange<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::ListNamespaces(
     google::cloud::servicedirectory::v1::ListNamespacesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNamespaces(std::move(request));
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
-RegistrationServiceClient::GetNamespace(std::string const& name,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+RegistrationServiceClient::GetNamespace(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::GetNamespaceRequest request;
   request.set_name(name);
   return connection_->GetNamespace(request);
@@ -89,18 +83,16 @@ RegistrationServiceClient::GetNamespace(std::string const& name,
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::GetNamespace(
     google::cloud::servicedirectory::v1::GetNamespaceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNamespace(request);
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::UpdateNamespace(
     google::cloud::servicedirectory::v1::Namespace const& namespace_,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::UpdateNamespaceRequest request;
   *request.mutable_namespace_() = namespace_;
   *request.mutable_update_mask() = update_mask;
@@ -110,16 +102,14 @@ RegistrationServiceClient::UpdateNamespace(
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceClient::UpdateNamespace(
     google::cloud::servicedirectory::v1::UpdateNamespaceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateNamespace(request);
 }
 
 Status RegistrationServiceClient::DeleteNamespace(std::string const& name,
-                                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::DeleteNamespaceRequest request;
   request.set_name(name);
   return connection_->DeleteNamespace(request);
@@ -127,9 +117,8 @@ Status RegistrationServiceClient::DeleteNamespace(std::string const& name,
 
 Status RegistrationServiceClient::DeleteNamespace(
     google::cloud::servicedirectory::v1::DeleteNamespaceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteNamespace(request);
 }
 
@@ -137,9 +126,8 @@ StatusOr<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::CreateService(
     std::string const& parent,
     google::cloud::servicedirectory::v1::Service const& service,
-    std::string const& service_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& service_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::CreateServiceRequest request;
   request.set_parent(parent);
   *request.mutable_service() = service;
@@ -150,17 +138,15 @@ RegistrationServiceClient::CreateService(
 StatusOr<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::CreateService(
     google::cloud::servicedirectory::v1::CreateServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateService(request);
 }
 
 StreamRange<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::ListServices(std::string const& parent,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::ListServicesRequest request;
   request.set_parent(parent);
   return connection_->ListServices(request);
@@ -169,17 +155,14 @@ RegistrationServiceClient::ListServices(std::string const& parent,
 StreamRange<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::ListServices(
     google::cloud::servicedirectory::v1::ListServicesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServices(std::move(request));
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Service>
-RegistrationServiceClient::GetService(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+RegistrationServiceClient::GetService(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::GetServiceRequest request;
   request.set_name(name);
   return connection_->GetService(request);
@@ -188,18 +171,16 @@ RegistrationServiceClient::GetService(std::string const& name,
 StatusOr<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::GetService(
     google::cloud::servicedirectory::v1::GetServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetService(request);
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::UpdateService(
     google::cloud::servicedirectory::v1::Service const& service,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::UpdateServiceRequest request;
   *request.mutable_service() = service;
   *request.mutable_update_mask() = update_mask;
@@ -209,16 +190,14 @@ RegistrationServiceClient::UpdateService(
 StatusOr<google::cloud::servicedirectory::v1::Service>
 RegistrationServiceClient::UpdateService(
     google::cloud::servicedirectory::v1::UpdateServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateService(request);
 }
 
 Status RegistrationServiceClient::DeleteService(std::string const& name,
-                                                Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::DeleteServiceRequest request;
   request.set_name(name);
   return connection_->DeleteService(request);
@@ -226,9 +205,8 @@ Status RegistrationServiceClient::DeleteService(std::string const& name,
 
 Status RegistrationServiceClient::DeleteService(
     google::cloud::servicedirectory::v1::DeleteServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteService(request);
 }
 
@@ -236,9 +214,8 @@ StatusOr<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::CreateEndpoint(
     std::string const& parent,
     google::cloud::servicedirectory::v1::Endpoint const& endpoint,
-    std::string const& endpoint_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& endpoint_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::CreateEndpointRequest request;
   request.set_parent(parent);
   *request.mutable_endpoint() = endpoint;
@@ -249,17 +226,15 @@ RegistrationServiceClient::CreateEndpoint(
 StatusOr<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::CreateEndpoint(
     google::cloud::servicedirectory::v1::CreateEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateEndpoint(request);
 }
 
 StreamRange<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::ListEndpoints(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::ListEndpointsRequest request;
   request.set_parent(parent);
   return connection_->ListEndpoints(request);
@@ -268,17 +243,14 @@ RegistrationServiceClient::ListEndpoints(std::string const& parent,
 StreamRange<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::ListEndpoints(
     google::cloud::servicedirectory::v1::ListEndpointsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListEndpoints(std::move(request));
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Endpoint>
-RegistrationServiceClient::GetEndpoint(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+RegistrationServiceClient::GetEndpoint(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::GetEndpointRequest request;
   request.set_name(name);
   return connection_->GetEndpoint(request);
@@ -287,18 +259,16 @@ RegistrationServiceClient::GetEndpoint(std::string const& name,
 StatusOr<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::GetEndpoint(
     google::cloud::servicedirectory::v1::GetEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEndpoint(request);
 }
 
 StatusOr<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::UpdateEndpoint(
     google::cloud::servicedirectory::v1::Endpoint const& endpoint,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::UpdateEndpointRequest request;
   *request.mutable_endpoint() = endpoint;
   *request.mutable_update_mask() = update_mask;
@@ -308,16 +278,14 @@ RegistrationServiceClient::UpdateEndpoint(
 StatusOr<google::cloud::servicedirectory::v1::Endpoint>
 RegistrationServiceClient::UpdateEndpoint(
     google::cloud::servicedirectory::v1::UpdateEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateEndpoint(request);
 }
 
 Status RegistrationServiceClient::DeleteEndpoint(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::servicedirectory::v1::DeleteEndpointRequest request;
   request.set_name(name);
   return connection_->DeleteEndpoint(request);
@@ -325,32 +293,27 @@ Status RegistrationServiceClient::DeleteEndpoint(std::string const& name,
 
 Status RegistrationServiceClient::DeleteEndpoint(
     google::cloud::servicedirectory::v1::DeleteEndpointRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteEndpoint(request);
 }
 
 StatusOr<google::iam::v1::Policy> RegistrationServiceClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> RegistrationServiceClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 RegistrationServiceClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/servicedirectory/registration_client.h
+++ b/google/cloud/servicedirectory/registration_client.h
@@ -77,7 +77,7 @@ class RegistrationServiceClient {
  public:
   explicit RegistrationServiceClient(
       std::shared_ptr<RegistrationServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~RegistrationServiceClient();
 
   //@{
@@ -117,7 +117,8 @@ class RegistrationServiceClient {
   ///  be a lowercase letter, and all following characters must be a dash,
   ///  lowercase letter, or digit, except the last character, which cannot be a
   ///  dash.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -129,14 +130,15 @@ class RegistrationServiceClient {
   StatusOr<google::cloud::servicedirectory::v1::Namespace> CreateNamespace(
       std::string const& parent,
       google::cloud::servicedirectory::v1::Namespace const& namespace_,
-      std::string const& namespace_id, Options options = {});
+      std::string const& namespace_id, Options opts = {});
 
   ///
   /// Creates a namespace, and returns the new Namespace.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::CreateNamespaceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L230}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -148,7 +150,7 @@ class RegistrationServiceClient {
   StatusOr<google::cloud::servicedirectory::v1::Namespace> CreateNamespace(
       google::cloud::servicedirectory::v1::CreateNamespaceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all namespaces.
@@ -156,7 +158,8 @@ class RegistrationServiceClient {
   /// @param parent  Required. The resource name of the project and location
   /// whose namespaces
   ///  we'd like to list.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -166,14 +169,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
   StreamRange<google::cloud::servicedirectory::v1::Namespace> ListNamespaces(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all namespaces.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::ListNamespacesRequest,google/cloud/servicedirectory/v1/registration_service.proto#L255}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -184,13 +188,14 @@ class RegistrationServiceClient {
   ///
   StreamRange<google::cloud::servicedirectory::v1::Namespace> ListNamespaces(
       google::cloud::servicedirectory::v1::ListNamespacesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a namespace.
   ///
   /// @param name  Required. The name of the namespace to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -200,14 +205,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
   StatusOr<google::cloud::servicedirectory::v1::Namespace> GetNamespace(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a namespace.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::GetNamespaceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L322}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -218,7 +224,7 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Namespace> GetNamespace(
       google::cloud::servicedirectory::v1::GetNamespaceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a namespace.
@@ -226,7 +232,8 @@ class RegistrationServiceClient {
   /// @param namespace_  Required. The updated namespace.
   /// @param update_mask  Required. List of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -237,14 +244,15 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Namespace> UpdateNamespace(
       google::cloud::servicedirectory::v1::Namespace const& namespace_,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a namespace.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::UpdateNamespaceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L334}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Namespace,google/cloud/servicedirectory/v1/namespace.proto#L35}
   ///
@@ -256,19 +264,20 @@ class RegistrationServiceClient {
   StatusOr<google::cloud::servicedirectory::v1::Namespace> UpdateNamespace(
       google::cloud::servicedirectory::v1::UpdateNamespaceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a namespace. This also deletes all services and endpoints in
   /// the namespace.
   ///
   /// @param name  Required. The name of the namespace to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.servicedirectory.v1.DeleteNamespaceRequest]:
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/registration_service.proto#L345}
   ///
-  Status DeleteNamespace(std::string const& name, Options options = {});
+  Status DeleteNamespace(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a namespace. This also deletes all services and endpoints in
@@ -276,7 +285,8 @@ class RegistrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::DeleteNamespaceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L345}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.servicedirectory.v1.DeleteNamespaceRequest]:
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/registration_service.proto#L345}
@@ -284,7 +294,7 @@ class RegistrationServiceClient {
   Status DeleteNamespace(
       google::cloud::servicedirectory::v1::DeleteNamespaceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a service, and returns the new Service.
@@ -301,7 +311,8 @@ class RegistrationServiceClient {
   ///  be a lowercase letter, and all following characters must be a dash,
   ///  lowercase letter, or digit, except the last character, which cannot be a
   ///  dash.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -313,14 +324,15 @@ class RegistrationServiceClient {
   StatusOr<google::cloud::servicedirectory::v1::Service> CreateService(
       std::string const& parent,
       google::cloud::servicedirectory::v1::Service const& service,
-      std::string const& service_id, Options options = {});
+      std::string const& service_id, Options opts = {});
 
   ///
   /// Creates a service, and returns the new Service.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::CreateServiceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L357}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -331,7 +343,7 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Service> CreateService(
       google::cloud::servicedirectory::v1::CreateServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all services belonging to a namespace.
@@ -339,7 +351,8 @@ class RegistrationServiceClient {
   /// @param parent  Required. The resource name of the namespace whose services
   /// we'd
   ///  like to list.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -349,14 +362,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/service.proto#L37}
   ///
   StreamRange<google::cloud::servicedirectory::v1::Service> ListServices(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all services belonging to a namespace.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::ListServicesRequest,google/cloud/servicedirectory/v1/registration_service.proto#L381}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -367,13 +381,14 @@ class RegistrationServiceClient {
   ///
   StreamRange<google::cloud::servicedirectory::v1::Service> ListServices(
       google::cloud::servicedirectory::v1::ListServicesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a service.
   ///
   /// @param name  Required. The name of the service to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -383,14 +398,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/service.proto#L37}
   ///
   StatusOr<google::cloud::servicedirectory::v1::Service> GetService(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a service.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::GetServiceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L442}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -401,7 +417,7 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Service> GetService(
       google::cloud::servicedirectory::v1::GetServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a service.
@@ -409,7 +425,8 @@ class RegistrationServiceClient {
   /// @param service  Required. The updated service.
   /// @param update_mask  Required. List of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -420,14 +437,15 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Service> UpdateService(
       google::cloud::servicedirectory::v1::Service const& service,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a service.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::UpdateServiceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L454}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Service,google/cloud/servicedirectory/v1/service.proto#L37}
   ///
@@ -438,19 +456,20 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Service> UpdateService(
       google::cloud::servicedirectory::v1::UpdateServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a service. This also deletes all endpoints associated with
   /// the service.
   ///
   /// @param name  Required. The name of the service to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.servicedirectory.v1.DeleteServiceRequest]:
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/registration_service.proto#L465}
   ///
-  Status DeleteService(std::string const& name, Options options = {});
+  Status DeleteService(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a service. This also deletes all endpoints associated with
@@ -458,14 +477,15 @@ class RegistrationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::DeleteServiceRequest,google/cloud/servicedirectory/v1/registration_service.proto#L465}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.servicedirectory.v1.DeleteServiceRequest]:
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/registration_service.proto#L465}
   ///
   Status DeleteService(
       google::cloud::servicedirectory::v1::DeleteServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a endpoint, and returns the new Endpoint.
@@ -482,7 +502,8 @@ class RegistrationServiceClient {
   ///  be a lowercase letter, and all following characters must be a dash,
   ///  lowercase letter, or digit, except the last character, which cannot be a
   ///  dash.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -494,14 +515,15 @@ class RegistrationServiceClient {
   StatusOr<google::cloud::servicedirectory::v1::Endpoint> CreateEndpoint(
       std::string const& parent,
       google::cloud::servicedirectory::v1::Endpoint const& endpoint,
-      std::string const& endpoint_id, Options options = {});
+      std::string const& endpoint_id, Options opts = {});
 
   ///
   /// Creates a endpoint, and returns the new Endpoint.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::CreateEndpointRequest,google/cloud/servicedirectory/v1/registration_service.proto#L477}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -512,7 +534,7 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Endpoint> CreateEndpoint(
       google::cloud::servicedirectory::v1::CreateEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all endpoints.
@@ -520,7 +542,8 @@ class RegistrationServiceClient {
   /// @param parent  Required. The resource name of the service whose endpoints
   /// we'd like to
   ///  list.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -530,14 +553,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
   StreamRange<google::cloud::servicedirectory::v1::Endpoint> ListEndpoints(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all endpoints.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::ListEndpointsRequest,google/cloud/servicedirectory/v1/registration_service.proto#L501}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -548,13 +572,14 @@ class RegistrationServiceClient {
   ///
   StreamRange<google::cloud::servicedirectory::v1::Endpoint> ListEndpoints(
       google::cloud::servicedirectory::v1::ListEndpointsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a endpoint.
   ///
   /// @param name  Required. The name of the endpoint to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -564,14 +589,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
   StatusOr<google::cloud::servicedirectory::v1::Endpoint> GetEndpoint(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a endpoint.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::GetEndpointRequest,google/cloud/servicedirectory/v1/registration_service.proto#L564}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -582,7 +608,7 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Endpoint> GetEndpoint(
       google::cloud::servicedirectory::v1::GetEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a endpoint.
@@ -590,7 +616,8 @@ class RegistrationServiceClient {
   /// @param endpoint  Required. The updated endpoint.
   /// @param update_mask  Required. List of fields to be updated in this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -601,14 +628,15 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Endpoint> UpdateEndpoint(
       google::cloud::servicedirectory::v1::Endpoint const& endpoint,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a endpoint.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::UpdateEndpointRequest,google/cloud/servicedirectory/v1/registration_service.proto#L576}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::servicedirectory::v1::Endpoint,google/cloud/servicedirectory/v1/endpoint.proto#L34}
   ///
@@ -619,39 +647,42 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::cloud::servicedirectory::v1::Endpoint> UpdateEndpoint(
       google::cloud::servicedirectory::v1::UpdateEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a endpoint.
   ///
   /// @param name  Required. The name of the endpoint to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.servicedirectory.v1.DeleteEndpointRequest]:
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/registration_service.proto#L587}
   ///
-  Status DeleteEndpoint(std::string const& name, Options options = {});
+  Status DeleteEndpoint(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a endpoint.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::servicedirectory::v1::DeleteEndpointRequest,google/cloud/servicedirectory/v1/registration_service.proto#L587}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.servicedirectory.v1.DeleteEndpointRequest]:
   /// @googleapis_reference_link{google/cloud/servicedirectory/v1/registration_service.proto#L587}
   ///
   Status DeleteEndpoint(
       google::cloud::servicedirectory::v1::DeleteEndpointRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the IAM Policy for a resource (namespace or service only).
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -661,15 +692,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the IAM Policy for a resource (namespace or service only).
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -679,15 +710,15 @@ class RegistrationServiceClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Tests IAM permissions for a resource (namespace or service only).
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -698,7 +729,7 @@ class RegistrationServiceClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<RegistrationServiceConnection> connection_;

--- a/google/cloud/servicemanagement/service_manager_client.cc
+++ b/google/cloud/servicemanagement/service_manager_client.cc
@@ -26,10 +26,10 @@ namespace servicemanagement {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceManagerClient::ServiceManagerClient(
-    std::shared_ptr<ServiceManagerConnection> connection, Options options)
+    std::shared_ptr<ServiceManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           servicemanagement_internal::ServiceManagerDefaultOptions(
               connection_->options()))) {}
 ServiceManagerClient::~ServiceManagerClient() = default;
@@ -37,17 +37,15 @@ ServiceManagerClient::~ServiceManagerClient() = default;
 StreamRange<google::api::servicemanagement::v1::ManagedService>
 ServiceManagerClient::ListServices(
     google::api::servicemanagement::v1::ListServicesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServices(std::move(request));
 }
 
 StatusOr<google::api::servicemanagement::v1::ManagedService>
 ServiceManagerClient::GetService(std::string const& service_name,
-                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::GetServiceRequest request;
   request.set_service_name(service_name);
   return connection_->GetService(request);
@@ -56,18 +54,16 @@ ServiceManagerClient::GetService(std::string const& service_name,
 StatusOr<google::api::servicemanagement::v1::ManagedService>
 ServiceManagerClient::GetService(
     google::api::servicemanagement::v1::GetServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetService(request);
 }
 
 future<StatusOr<google::api::servicemanagement::v1::ManagedService>>
 ServiceManagerClient::CreateService(
     google::api::servicemanagement::v1::ManagedService const& service,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::CreateServiceRequest request;
   *request.mutable_service() = service;
   return connection_->CreateService(request);
@@ -76,17 +72,15 @@ ServiceManagerClient::CreateService(
 future<StatusOr<google::api::servicemanagement::v1::ManagedService>>
 ServiceManagerClient::CreateService(
     google::api::servicemanagement::v1::CreateServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateService(request);
 }
 
 future<StatusOr<google::api::servicemanagement::v1::OperationMetadata>>
 ServiceManagerClient::DeleteService(std::string const& service_name,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::DeleteServiceRequest request;
   request.set_service_name(service_name);
   return connection_->DeleteService(request);
@@ -95,17 +89,15 @@ ServiceManagerClient::DeleteService(std::string const& service_name,
 future<StatusOr<google::api::servicemanagement::v1::OperationMetadata>>
 ServiceManagerClient::DeleteService(
     google::api::servicemanagement::v1::DeleteServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteService(request);
 }
 
 future<StatusOr<google::api::servicemanagement::v1::UndeleteServiceResponse>>
 ServiceManagerClient::UndeleteService(std::string const& service_name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                      Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::UndeleteServiceRequest request;
   request.set_service_name(service_name);
   return connection_->UndeleteService(request);
@@ -114,16 +106,14 @@ ServiceManagerClient::UndeleteService(std::string const& service_name,
 future<StatusOr<google::api::servicemanagement::v1::UndeleteServiceResponse>>
 ServiceManagerClient::UndeleteService(
     google::api::servicemanagement::v1::UndeleteServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UndeleteService(request);
 }
 
 StreamRange<google::api::Service> ServiceManagerClient::ListServiceConfigs(
-    std::string const& service_name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& service_name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::ListServiceConfigsRequest request;
   request.set_service_name(service_name);
   return connection_->ListServiceConfigs(request);
@@ -131,9 +121,8 @@ StreamRange<google::api::Service> ServiceManagerClient::ListServiceConfigs(
 
 StreamRange<google::api::Service> ServiceManagerClient::ListServiceConfigs(
     google::api::servicemanagement::v1::ListServiceConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServiceConfigs(std::move(request));
 }
 
@@ -141,9 +130,8 @@ StatusOr<google::api::Service> ServiceManagerClient::GetServiceConfig(
     std::string const& service_name, std::string const& config_id,
     google::api::servicemanagement::v1::GetServiceConfigRequest::ConfigView
         view,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::GetServiceConfigRequest request;
   request.set_service_name(service_name);
   request.set_config_id(config_id);
@@ -153,17 +141,15 @@ StatusOr<google::api::Service> ServiceManagerClient::GetServiceConfig(
 
 StatusOr<google::api::Service> ServiceManagerClient::GetServiceConfig(
     google::api::servicemanagement::v1::GetServiceConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServiceConfig(request);
 }
 
 StatusOr<google::api::Service> ServiceManagerClient::CreateServiceConfig(
     std::string const& service_name, google::api::Service const& service_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::CreateServiceConfigRequest request;
   request.set_service_name(service_name);
   *request.mutable_service_config() = service_config;
@@ -173,9 +159,8 @@ StatusOr<google::api::Service> ServiceManagerClient::CreateServiceConfig(
 StatusOr<google::api::Service> ServiceManagerClient::CreateServiceConfig(
     google::api::servicemanagement::v1::CreateServiceConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServiceConfig(request);
 }
 
@@ -183,9 +168,8 @@ future<StatusOr<google::api::servicemanagement::v1::SubmitConfigSourceResponse>>
 ServiceManagerClient::SubmitConfigSource(
     std::string const& service_name,
     google::api::servicemanagement::v1::ConfigSource const& config_source,
-    bool validate_only, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    bool validate_only, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::SubmitConfigSourceRequest request;
   request.set_service_name(service_name);
   *request.mutable_config_source() = config_source;
@@ -197,18 +181,16 @@ future<StatusOr<google::api::servicemanagement::v1::SubmitConfigSourceResponse>>
 ServiceManagerClient::SubmitConfigSource(
     google::api::servicemanagement::v1::SubmitConfigSourceRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SubmitConfigSource(request);
 }
 
 StreamRange<google::api::servicemanagement::v1::Rollout>
 ServiceManagerClient::ListServiceRollouts(std::string const& service_name,
                                           std::string const& filter,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::ListServiceRolloutsRequest request;
   request.set_service_name(service_name);
   request.set_filter(filter);
@@ -218,18 +200,16 @@ ServiceManagerClient::ListServiceRollouts(std::string const& service_name,
 StreamRange<google::api::servicemanagement::v1::Rollout>
 ServiceManagerClient::ListServiceRollouts(
     google::api::servicemanagement::v1::ListServiceRolloutsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServiceRollouts(std::move(request));
 }
 
 StatusOr<google::api::servicemanagement::v1::Rollout>
 ServiceManagerClient::GetServiceRollout(std::string const& service_name,
                                         std::string const& rollout_id,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::GetServiceRolloutRequest request;
   request.set_service_name(service_name);
   request.set_rollout_id(rollout_id);
@@ -239,19 +219,16 @@ ServiceManagerClient::GetServiceRollout(std::string const& service_name,
 StatusOr<google::api::servicemanagement::v1::Rollout>
 ServiceManagerClient::GetServiceRollout(
     google::api::servicemanagement::v1::GetServiceRolloutRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetServiceRollout(request);
 }
 
 future<StatusOr<google::api::servicemanagement::v1::Rollout>>
 ServiceManagerClient::CreateServiceRollout(
     std::string const& service_name,
-    google::api::servicemanagement::v1::Rollout const& rollout,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::api::servicemanagement::v1::Rollout const& rollout, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::CreateServiceRolloutRequest request;
   request.set_service_name(service_name);
   *request.mutable_rollout() = rollout;
@@ -262,18 +239,16 @@ future<StatusOr<google::api::servicemanagement::v1::Rollout>>
 ServiceManagerClient::CreateServiceRollout(
     google::api::servicemanagement::v1::CreateServiceRolloutRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateServiceRollout(request);
 }
 
 StatusOr<google::api::servicemanagement::v1::GenerateConfigReportResponse>
 ServiceManagerClient::GenerateConfigReport(
     google::protobuf::Any const& new_config,
-    google::protobuf::Any const& old_config, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::Any const& old_config, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::GenerateConfigReportRequest request;
   *request.mutable_new_config() = new_config;
   *request.mutable_old_config() = old_config;
@@ -284,18 +259,16 @@ StatusOr<google::api::servicemanagement::v1::GenerateConfigReportResponse>
 ServiceManagerClient::GenerateConfigReport(
     google::api::servicemanagement::v1::GenerateConfigReportRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GenerateConfigReport(request);
 }
 
 future<StatusOr<google::api::servicemanagement::v1::EnableServiceResponse>>
 ServiceManagerClient::EnableService(std::string const& service_name,
                                     std::string const& consumer_id,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::EnableServiceRequest request;
   request.set_service_name(service_name);
   request.set_consumer_id(consumer_id);
@@ -305,18 +278,16 @@ ServiceManagerClient::EnableService(std::string const& service_name,
 future<StatusOr<google::api::servicemanagement::v1::EnableServiceResponse>>
 ServiceManagerClient::EnableService(
     google::api::servicemanagement::v1::EnableServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->EnableService(request);
 }
 
 future<StatusOr<google::api::servicemanagement::v1::DisableServiceResponse>>
 ServiceManagerClient::DisableService(std::string const& service_name,
                                      std::string const& consumer_id,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::api::servicemanagement::v1::DisableServiceRequest request;
   request.set_service_name(service_name);
   request.set_consumer_id(consumer_id);
@@ -326,9 +297,8 @@ ServiceManagerClient::DisableService(std::string const& service_name,
 future<StatusOr<google::api::servicemanagement::v1::DisableServiceResponse>>
 ServiceManagerClient::DisableService(
     google::api::servicemanagement::v1::DisableServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DisableService(request);
 }
 

--- a/google/cloud/servicemanagement/service_manager_client.h
+++ b/google/cloud/servicemanagement/service_manager_client.h
@@ -63,8 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceManagerClient {
  public:
   explicit ServiceManagerClient(
-      std::shared_ptr<ServiceManagerConnection> connection,
-      Options options = {});
+      std::shared_ptr<ServiceManagerConnection> connection, Options opts = {});
   ~ServiceManagerClient();
 
   //@{
@@ -100,7 +99,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::ListServicesRequest,google/api/servicemanagement/v1/servicemanager.proto#L284}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::ManagedService,google/api/servicemanagement/v1/resources.proto#L43}
   ///
@@ -111,7 +111,7 @@ class ServiceManagerClient {
   ///
   StreamRange<google::api::servicemanagement::v1::ManagedService> ListServices(
       google::api::servicemanagement::v1::ListServicesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a managed service. Authentication is required unless the service is
@@ -120,7 +120,8 @@ class ServiceManagerClient {
   /// @param service_name  Required. The name of the service.  See the
   /// `ServiceManager` overview for naming
   ///  requirements.  For example: `example.googleapis.com`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::ManagedService,google/api/servicemanagement/v1/resources.proto#L43}
   ///
@@ -130,7 +131,7 @@ class ServiceManagerClient {
   /// @googleapis_reference_link{google/api/servicemanagement/v1/resources.proto#L43}
   ///
   StatusOr<google::api::servicemanagement::v1::ManagedService> GetService(
-      std::string const& service_name, Options options = {});
+      std::string const& service_name, Options opts = {});
 
   ///
   /// Gets a managed service. Authentication is required unless the service is
@@ -138,7 +139,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::GetServiceRequest,google/api/servicemanagement/v1/servicemanager.proto#L314}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::ManagedService,google/api/servicemanagement/v1/resources.proto#L43}
   ///
@@ -149,7 +151,7 @@ class ServiceManagerClient {
   ///
   StatusOr<google::api::servicemanagement::v1::ManagedService> GetService(
       google::api::servicemanagement::v1::GetServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new managed service.
@@ -158,7 +160,8 @@ class ServiceManagerClient {
   /// Operation<response: ManagedService>
   ///
   /// @param service  Required. Initial values for the service resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::ManagedService,google/api/servicemanagement/v1/resources.proto#L43}
   ///
@@ -170,7 +173,7 @@ class ServiceManagerClient {
   future<StatusOr<google::api::servicemanagement::v1::ManagedService>>
   CreateService(
       google::api::servicemanagement::v1::ManagedService const& service,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new managed service.
@@ -180,7 +183,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::CreateServiceRequest,google/api/servicemanagement/v1/servicemanager.proto#L321}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::ManagedService,google/api/servicemanagement/v1/resources.proto#L43}
   ///
@@ -192,7 +196,7 @@ class ServiceManagerClient {
   future<StatusOr<google::api::servicemanagement::v1::ManagedService>>
   CreateService(
       google::api::servicemanagement::v1::CreateServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a managed service. This method will change the service to the
@@ -207,7 +211,8 @@ class ServiceManagerClient {
   /// @param service_name  Required. The name of the service.  See the
   /// [overview](https://cloud.google.com/service-management/overview)
   ///  for naming requirements.  For example: `example.googleapis.com`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::OperationMetadata,google/api/servicemanagement/v1/resources.proto#L53}
   ///
@@ -217,7 +222,7 @@ class ServiceManagerClient {
   /// @googleapis_reference_link{google/api/servicemanagement/v1/resources.proto#L53}
   ///
   future<StatusOr<google::api::servicemanagement::v1::OperationMetadata>>
-  DeleteService(std::string const& service_name, Options options = {});
+  DeleteService(std::string const& service_name, Options opts = {});
 
   ///
   /// Deletes a managed service. This method will change the service to the
@@ -231,7 +236,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::DeleteServiceRequest,google/api/servicemanagement/v1/servicemanager.proto#L327}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::OperationMetadata,google/api/servicemanagement/v1/resources.proto#L53}
   ///
@@ -243,7 +249,7 @@ class ServiceManagerClient {
   future<StatusOr<google::api::servicemanagement::v1::OperationMetadata>>
   DeleteService(
       google::api::servicemanagement::v1::DeleteServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Revives a previously deleted managed service. The method restores the
@@ -256,7 +262,8 @@ class ServiceManagerClient {
   /// @param service_name  Required. The name of the service. See the
   /// [overview](https://cloud.google.com/service-management/overview)
   ///  for naming requirements. For example: `example.googleapis.com`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::UndeleteServiceResponse,google/api/servicemanagement/v1/servicemanager.proto#L341}
   ///
@@ -266,7 +273,7 @@ class ServiceManagerClient {
   /// @googleapis_reference_link{google/api/servicemanagement/v1/servicemanager.proto#L341}
   ///
   future<StatusOr<google::api::servicemanagement::v1::UndeleteServiceResponse>>
-  UndeleteService(std::string const& service_name, Options options = {});
+  UndeleteService(std::string const& service_name, Options opts = {});
 
   ///
   /// Revives a previously deleted managed service. The method restores the
@@ -278,7 +285,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::UndeleteServiceRequest,google/api/servicemanagement/v1/servicemanager.proto#L334}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::UndeleteServiceResponse,google/api/servicemanagement/v1/servicemanager.proto#L341}
   ///
@@ -290,7 +298,7 @@ class ServiceManagerClient {
   future<StatusOr<google::api::servicemanagement::v1::UndeleteServiceResponse>>
   UndeleteService(
       google::api::servicemanagement::v1::UndeleteServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the history of the service configuration for a managed service,
@@ -299,7 +307,8 @@ class ServiceManagerClient {
   /// @param service_name  Required. The name of the service.  See the
   /// [overview](https://cloud.google.com/service-management/overview)
   ///  for naming requirements.  For example: `example.googleapis.com`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::Service,google/api/service.proto#L71}
   ///
@@ -309,7 +318,7 @@ class ServiceManagerClient {
   /// @googleapis_reference_link{google/api/service.proto#L71}
   ///
   StreamRange<google::api::Service> ListServiceConfigs(
-      std::string const& service_name, Options options = {});
+      std::string const& service_name, Options opts = {});
 
   ///
   /// Lists the history of the service configuration for a managed service,
@@ -317,7 +326,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::ListServiceConfigsRequest,google/api/servicemanagement/v1/servicemanager.proto#L375}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::Service,google/api/service.proto#L71}
   ///
@@ -328,7 +338,7 @@ class ServiceManagerClient {
   ///
   StreamRange<google::api::Service> ListServiceConfigs(
       google::api::servicemanagement::v1::ListServiceConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a service configuration (version) for a managed service.
@@ -342,7 +352,8 @@ class ServiceManagerClient {
   /// @param view  Specifies which parts of the Service Config should be
   /// returned in the
   ///  response.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::Service,google/api/service.proto#L71}
   ///
@@ -355,14 +366,15 @@ class ServiceManagerClient {
       std::string const& service_name, std::string const& config_id,
       google::api::servicemanagement::v1::GetServiceConfigRequest::ConfigView
           view,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a service configuration (version) for a managed service.
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::GetServiceConfigRequest,google/api/servicemanagement/v1/servicemanager.proto#L347}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::Service,google/api/service.proto#L71}
   ///
@@ -374,7 +386,7 @@ class ServiceManagerClient {
   StatusOr<google::api::Service> GetServiceConfig(
       google::api::servicemanagement::v1::GetServiceConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new service configuration (version) for a managed service.
@@ -390,7 +402,8 @@ class ServiceManagerClient {
   /// [overview](https://cloud.google.com/service-management/overview)
   ///  for naming requirements.  For example: `example.googleapis.com`.
   /// @param service_config  Required. The service configuration resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::Service,google/api/service.proto#L71}
   ///
@@ -401,7 +414,7 @@ class ServiceManagerClient {
   ///
   StatusOr<google::api::Service> CreateServiceConfig(
       std::string const& service_name,
-      google::api::Service const& service_config, Options options = {});
+      google::api::Service const& service_config, Options opts = {});
 
   ///
   /// Creates a new service configuration (version) for a managed service.
@@ -415,7 +428,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::CreateServiceConfigRequest,google/api/servicemanagement/v1/servicemanager.proto#L398}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::Service,google/api/service.proto#L71}
   ///
@@ -427,7 +441,7 @@ class ServiceManagerClient {
   StatusOr<google::api::Service> CreateServiceConfig(
       google::api::servicemanagement::v1::CreateServiceConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new service configuration (version) for a managed service based
@@ -452,7 +466,8 @@ class ServiceManagerClient {
   /// of a
   ///  `google.api.Service` configuration based on the `ConfigSource` provided,
   ///  but the generated config and the sources will NOT be persisted.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::SubmitConfigSourceResponse,google/api/servicemanagement/v1/servicemanager.proto#L423}
   ///
@@ -466,7 +481,7 @@ class ServiceManagerClient {
   SubmitConfigSource(
       std::string const& service_name,
       google::api::servicemanagement::v1::ConfigSource const& config_source,
-      bool validate_only, Options options = {});
+      bool validate_only, Options opts = {});
 
   ///
   /// Creates a new service configuration (version) for a managed service based
@@ -485,7 +500,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::SubmitConfigSourceRequest,google/api/servicemanagement/v1/servicemanager.proto#L408}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::SubmitConfigSourceResponse,google/api/servicemanagement/v1/servicemanager.proto#L423}
   ///
@@ -499,7 +515,7 @@ class ServiceManagerClient {
   SubmitConfigSource(
       google::api::servicemanagement::v1::SubmitConfigSourceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the history of the service configuration rollouts for a managed
@@ -516,7 +532,8 @@ class ServiceManagerClient {
   ///    -- To limit the results to those in
   ///       status (google.api.servicemanagement.v1.RolloutStatus) 'CANCELLED'
   ///       or 'FAILED', use filter='status=CANCELLED OR status=FAILED'
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::Rollout,google/api/servicemanagement/v1/resources.proto#L198}
   ///
@@ -527,7 +544,7 @@ class ServiceManagerClient {
   ///
   StreamRange<google::api::servicemanagement::v1::Rollout> ListServiceRollouts(
       std::string const& service_name, std::string const& filter,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the history of the service configuration rollouts for a managed
@@ -535,7 +552,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::ListServiceRolloutsRequest,google/api/servicemanagement/v1/servicemanager.proto#L439}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::Rollout,google/api/servicemanagement/v1/resources.proto#L198}
   ///
@@ -546,7 +564,7 @@ class ServiceManagerClient {
   ///
   StreamRange<google::api::servicemanagement::v1::Rollout> ListServiceRollouts(
       google::api::servicemanagement::v1::ListServiceRolloutsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a service configuration
@@ -556,7 +574,8 @@ class ServiceManagerClient {
   /// [overview](https://cloud.google.com/service-management/overview)
   ///  for naming requirements.  For example: `example.googleapis.com`.
   /// @param rollout_id  Required. The id of the rollout resource.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::Rollout,google/api/servicemanagement/v1/resources.proto#L198}
   ///
@@ -567,7 +586,7 @@ class ServiceManagerClient {
   ///
   StatusOr<google::api::servicemanagement::v1::Rollout> GetServiceRollout(
       std::string const& service_name, std::string const& rollout_id,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a service configuration
@@ -575,7 +594,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::GetServiceRolloutRequest,google/api/servicemanagement/v1/servicemanager.proto#L472}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::Rollout,google/api/servicemanagement/v1/resources.proto#L198}
   ///
@@ -587,7 +607,7 @@ class ServiceManagerClient {
   StatusOr<google::api::servicemanagement::v1::Rollout> GetServiceRollout(
       google::api::servicemanagement::v1::GetServiceRolloutRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new service configuration rollout. Based on rollout, the
@@ -610,7 +630,8 @@ class ServiceManagerClient {
   ///  for naming requirements.  For example: `example.googleapis.com`.
   /// @param rollout  Required. The rollout resource. The `service_name` field
   /// is output only.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::Rollout,google/api/servicemanagement/v1/resources.proto#L198}
   ///
@@ -623,7 +644,7 @@ class ServiceManagerClient {
   CreateServiceRollout(
       std::string const& service_name,
       google::api::servicemanagement::v1::Rollout const& rollout,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new service configuration rollout. Based on rollout, the
@@ -643,7 +664,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::CreateServiceRolloutRequest,google/api/servicemanagement/v1/servicemanager.proto#L429}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::Rollout,google/api/servicemanagement/v1/resources.proto#L198}
   ///
@@ -656,7 +678,7 @@ class ServiceManagerClient {
   CreateServiceRollout(
       google::api::servicemanagement::v1::CreateServiceRolloutRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Generates and returns a report (errors, warnings and changes from
@@ -683,7 +705,8 @@ class ServiceManagerClient {
   ///  [google.api.servicemanagement.v1.ConfigRef][google.api.servicemanagement.v1.ConfigRef],
   ///  [google.api.servicemanagement.v1.ConfigSource][google.api.servicemanagement.v1.ConfigSource],
   ///  and [google.api.Service][google.api.Service]
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::GenerateConfigReportResponse,google/api/servicemanagement/v1/servicemanager.proto#L545}
   ///
@@ -695,7 +718,7 @@ class ServiceManagerClient {
   StatusOr<google::api::servicemanagement::v1::GenerateConfigReportResponse>
   GenerateConfigReport(google::protobuf::Any const& new_config,
                        google::protobuf::Any const& old_config,
-                       Options options = {});
+                       Options opts = {});
 
   ///
   /// Generates and returns a report (errors, warnings and changes from
@@ -712,7 +735,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::GenerateConfigReportRequest,google/api/servicemanagement/v1/servicemanager.proto#L528}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::GenerateConfigReportResponse,google/api/servicemanagement/v1/servicemanager.proto#L545}
   ///
@@ -725,7 +749,7 @@ class ServiceManagerClient {
   GenerateConfigReport(
       google::api::servicemanagement::v1::GenerateConfigReportRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enables a [service][google.api.servicemanagement.v1.ManagedService] for a
@@ -745,7 +769,8 @@ class ServiceManagerClient {
   ///  - "project:<project_id>"
   ///  Note: this is made compatible with
   ///  google.api.servicecontrol.v1.Operation.consumer_id.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::EnableServiceResponse,google/api/servicemanagement/v1/servicemanager.proto#L500}
   ///
@@ -756,7 +781,7 @@ class ServiceManagerClient {
   ///
   future<StatusOr<google::api::servicemanagement::v1::EnableServiceResponse>>
   EnableService(std::string const& service_name, std::string const& consumer_id,
-                Options options = {});
+                Options opts = {});
 
   ///
   /// Enables a [service][google.api.servicemanagement.v1.ManagedService] for a
@@ -767,7 +792,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::EnableServiceRequest,google/api/servicemanagement/v1/servicemanager.proto#L482}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::EnableServiceResponse,google/api/servicemanagement/v1/servicemanager.proto#L500}
   ///
@@ -779,7 +805,7 @@ class ServiceManagerClient {
   future<StatusOr<google::api::servicemanagement::v1::EnableServiceResponse>>
   EnableService(
       google::api::servicemanagement::v1::EnableServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Disables a [service][google.api.servicemanagement.v1.ManagedService] for a
@@ -800,7 +826,8 @@ class ServiceManagerClient {
   ///  - "project:<project_id>"
   ///  Note: this is made compatible with
   ///  google.api.servicecontrol.v1.Operation.consumer_id.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::DisableServiceResponse,google/api/servicemanagement/v1/servicemanager.proto#L523}
   ///
@@ -811,7 +838,7 @@ class ServiceManagerClient {
   ///
   future<StatusOr<google::api::servicemanagement::v1::DisableServiceResponse>>
   DisableService(std::string const& service_name,
-                 std::string const& consumer_id, Options options = {});
+                 std::string const& consumer_id, Options opts = {});
 
   ///
   /// Disables a [service][google.api.servicemanagement.v1.ManagedService] for a
@@ -823,7 +850,8 @@ class ServiceManagerClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::servicemanagement::v1::DisableServiceRequest,google/api/servicemanagement/v1/servicemanager.proto#L505}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::servicemanagement::v1::DisableServiceResponse,google/api/servicemanagement/v1/servicemanager.proto#L523}
   ///
@@ -835,7 +863,7 @@ class ServiceManagerClient {
   future<StatusOr<google::api::servicemanagement::v1::DisableServiceResponse>>
   DisableService(
       google::api::servicemanagement::v1::DisableServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ServiceManagerConnection> connection_;

--- a/google/cloud/serviceusage/service_usage_client.cc
+++ b/google/cloud/serviceusage/service_usage_client.cc
@@ -26,63 +26,56 @@ namespace serviceusage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ServiceUsageClient::ServiceUsageClient(
-    std::shared_ptr<ServiceUsageConnection> connection, Options options)
+    std::shared_ptr<ServiceUsageConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), serviceusage_internal::ServiceUsageDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), serviceusage_internal::ServiceUsageDefaultOptions(
+                               connection_->options()))) {}
 ServiceUsageClient::~ServiceUsageClient() = default;
 
 future<StatusOr<google::api::serviceusage::v1::EnableServiceResponse>>
 ServiceUsageClient::EnableService(
     google::api::serviceusage::v1::EnableServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->EnableService(request);
 }
 
 future<StatusOr<google::api::serviceusage::v1::DisableServiceResponse>>
 ServiceUsageClient::DisableService(
     google::api::serviceusage::v1::DisableServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DisableService(request);
 }
 
 StatusOr<google::api::serviceusage::v1::Service> ServiceUsageClient::GetService(
     google::api::serviceusage::v1::GetServiceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetService(request);
 }
 
 StreamRange<google::api::serviceusage::v1::Service>
 ServiceUsageClient::ListServices(
-    google::api::serviceusage::v1::ListServicesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::api::serviceusage::v1::ListServicesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListServices(std::move(request));
 }
 
 future<StatusOr<google::api::serviceusage::v1::BatchEnableServicesResponse>>
 ServiceUsageClient::BatchEnableServices(
     google::api::serviceusage::v1::BatchEnableServicesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchEnableServices(request);
 }
 
 StatusOr<google::api::serviceusage::v1::BatchGetServicesResponse>
 ServiceUsageClient::BatchGetServices(
     google::api::serviceusage::v1::BatchGetServicesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchGetServices(request);
 }
 

--- a/google/cloud/serviceusage/service_usage_client.h
+++ b/google/cloud/serviceusage/service_usage_client.h
@@ -67,7 +67,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ServiceUsageClient {
  public:
   explicit ServiceUsageClient(
-      std::shared_ptr<ServiceUsageConnection> connection, Options options = {});
+      std::shared_ptr<ServiceUsageConnection> connection, Options opts = {});
   ~ServiceUsageClient();
 
   //@{
@@ -95,7 +95,8 @@ class ServiceUsageClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::serviceusage::v1::EnableServiceRequest,google/api/serviceusage/v1/serviceusage.proto#L124}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::serviceusage::v1::EnableServiceResponse,google/api/serviceusage/v1/serviceusage.proto#L142}
   ///
@@ -107,7 +108,7 @@ class ServiceUsageClient {
   future<StatusOr<google::api::serviceusage::v1::EnableServiceResponse>>
   EnableService(
       google::api::serviceusage::v1::EnableServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Disable a service so that it can no longer be used with a project.
@@ -120,7 +121,8 @@ class ServiceUsageClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::serviceusage::v1::DisableServiceRequest,google/api/serviceusage/v1/serviceusage.proto#L148}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::serviceusage::v1::DisableServiceResponse,google/api/serviceusage/v1/serviceusage.proto#L187}
   ///
@@ -132,14 +134,15 @@ class ServiceUsageClient {
   future<StatusOr<google::api::serviceusage::v1::DisableServiceResponse>>
   DisableService(
       google::api::serviceusage::v1::DisableServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the service configuration and enabled state for a given service.
   ///
   /// @param request
   /// @googleapis_link{google::api::serviceusage::v1::GetServiceRequest,google/api/serviceusage/v1/serviceusage.proto#L193}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::serviceusage::v1::Service,google/api/serviceusage/v1/resources.proto#L38}
   ///
@@ -150,7 +153,7 @@ class ServiceUsageClient {
   ///
   StatusOr<google::api::serviceusage::v1::Service> GetService(
       google::api::serviceusage::v1::GetServiceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List all services available to the specified project, and the current
@@ -169,7 +172,8 @@ class ServiceUsageClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::serviceusage::v1::ListServicesRequest,google/api/serviceusage/v1/serviceusage.proto#L203}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::serviceusage::v1::Service,google/api/serviceusage/v1/resources.proto#L38}
   ///
@@ -180,7 +184,7 @@ class ServiceUsageClient {
   ///
   StreamRange<google::api::serviceusage::v1::Service> ListServices(
       google::api::serviceusage::v1::ListServicesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Enable multiple services on a project. The operation is atomic: if
@@ -190,7 +194,8 @@ class ServiceUsageClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::serviceusage::v1::BatchEnableServicesRequest,google/api/serviceusage/v1/serviceusage.proto#L235}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::serviceusage::v1::BatchEnableServicesResponse,google/api/serviceusage/v1/serviceusage.proto#L261}
   ///
@@ -202,7 +207,7 @@ class ServiceUsageClient {
   future<StatusOr<google::api::serviceusage::v1::BatchEnableServicesResponse>>
   BatchEnableServices(
       google::api::serviceusage::v1::BatchEnableServicesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the service configurations and enabled states for a given list of
@@ -210,7 +215,8 @@ class ServiceUsageClient {
   ///
   /// @param request
   /// @googleapis_link{google::api::serviceusage::v1::BatchGetServicesRequest,google/api/serviceusage/v1/serviceusage.proto#L280}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::api::serviceusage::v1::BatchGetServicesResponse,google/api/serviceusage/v1/serviceusage.proto#L298}
   ///
@@ -222,7 +228,7 @@ class ServiceUsageClient {
   StatusOr<google::api::serviceusage::v1::BatchGetServicesResponse>
   BatchGetServices(
       google::api::serviceusage::v1::BatchGetServicesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ServiceUsageConnection> connection_;

--- a/google/cloud/shell/cloud_shell_client.cc
+++ b/google/cloud/shell/cloud_shell_client.cc
@@ -26,18 +26,16 @@ namespace shell {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudShellServiceClient::CloudShellServiceClient(
-    std::shared_ptr<CloudShellServiceConnection> connection, Options options)
+    std::shared_ptr<CloudShellServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), shell_internal::CloudShellServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), shell_internal::CloudShellServiceDefaultOptions(
+                               connection_->options()))) {}
 CloudShellServiceClient::~CloudShellServiceClient() = default;
 
 StatusOr<google::cloud::shell::v1::Environment>
-CloudShellServiceClient::GetEnvironment(std::string const& name,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CloudShellServiceClient::GetEnvironment(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::shell::v1::GetEnvironmentRequest request;
   request.set_name(name);
   return connection_->GetEnvironment(request);
@@ -46,45 +44,40 @@ CloudShellServiceClient::GetEnvironment(std::string const& name,
 StatusOr<google::cloud::shell::v1::Environment>
 CloudShellServiceClient::GetEnvironment(
     google::cloud::shell::v1::GetEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetEnvironment(request);
 }
 
 future<StatusOr<google::cloud::shell::v1::StartEnvironmentResponse>>
 CloudShellServiceClient::StartEnvironment(
     google::cloud::shell::v1::StartEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartEnvironment(request);
 }
 
 future<StatusOr<google::cloud::shell::v1::AuthorizeEnvironmentResponse>>
 CloudShellServiceClient::AuthorizeEnvironment(
     google::cloud::shell::v1::AuthorizeEnvironmentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AuthorizeEnvironment(request);
 }
 
 future<StatusOr<google::cloud::shell::v1::AddPublicKeyResponse>>
 CloudShellServiceClient::AddPublicKey(
     google::cloud::shell::v1::AddPublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AddPublicKey(request);
 }
 
 future<StatusOr<google::cloud::shell::v1::RemovePublicKeyResponse>>
 CloudShellServiceClient::RemovePublicKey(
     google::cloud::shell::v1::RemovePublicKeyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RemovePublicKey(request);
 }
 

--- a/google/cloud/shell/cloud_shell_client.h
+++ b/google/cloud/shell/cloud_shell_client.h
@@ -69,7 +69,7 @@ class CloudShellServiceClient {
  public:
   explicit CloudShellServiceClient(
       std::shared_ptr<CloudShellServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~CloudShellServiceClient();
 
   //@{
@@ -98,7 +98,8 @@ class CloudShellServiceClient {
   /// @param name  Required. Name of the requested resource, for example
   /// `users/me/environments/default`
   ///  or `users/someone@example.com/environments/default`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::shell::v1::Environment,google/cloud/shell/v1/cloudshell.proto#L117}
   ///
@@ -108,14 +109,15 @@ class CloudShellServiceClient {
   /// @googleapis_reference_link{google/cloud/shell/v1/cloudshell.proto#L117}
   ///
   StatusOr<google::cloud::shell::v1::Environment> GetEnvironment(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets an environment. Returns NOT_FOUND if the environment does not exist.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::shell::v1::GetEnvironmentRequest,google/cloud/shell/v1/cloudshell.proto#L192}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::shell::v1::Environment,google/cloud/shell/v1/cloudshell.proto#L117}
   ///
@@ -126,7 +128,7 @@ class CloudShellServiceClient {
   ///
   StatusOr<google::cloud::shell::v1::Environment> GetEnvironment(
       google::cloud::shell::v1::GetEnvironmentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts an existing environment, allowing clients to connect to it. The
@@ -138,7 +140,8 @@ class CloudShellServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::shell::v1::StartEnvironmentRequest,google/cloud/shell/v1/cloudshell.proto#L217}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::shell::v1::StartEnvironmentResponse,google/cloud/shell/v1/cloudshell.proto#L304}
   ///
@@ -150,7 +153,7 @@ class CloudShellServiceClient {
   future<StatusOr<google::cloud::shell::v1::StartEnvironmentResponse>>
   StartEnvironment(
       google::cloud::shell::v1::StartEnvironmentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sends OAuth credentials to a running environment on behalf of a user. When
@@ -160,7 +163,8 @@ class CloudShellServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::shell::v1::AuthorizeEnvironmentRequest,google/cloud/shell/v1/cloudshell.proto#L235}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::shell::v1::AuthorizeEnvironmentResponse,google/cloud/shell/v1/cloudshell.proto#L254}
   ///
@@ -172,7 +176,7 @@ class CloudShellServiceClient {
   future<StatusOr<google::cloud::shell::v1::AuthorizeEnvironmentResponse>>
   AuthorizeEnvironment(
       google::cloud::shell::v1::AuthorizeEnvironmentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds a public SSH key to an environment, allowing clients with the
@@ -181,7 +185,8 @@ class CloudShellServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::shell::v1::AddPublicKeyRequest,google/cloud/shell/v1/cloudshell.proto#L311}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::shell::v1::AddPublicKeyResponse,google/cloud/shell/v1/cloudshell.proto#L327}
   ///
@@ -192,7 +197,7 @@ class CloudShellServiceClient {
   ///
   future<StatusOr<google::cloud::shell::v1::AddPublicKeyResponse>> AddPublicKey(
       google::cloud::shell::v1::AddPublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes a public SSH key from an environment. Clients will no longer be
@@ -202,7 +207,8 @@ class CloudShellServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::shell::v1::RemovePublicKeyRequest,google/cloud/shell/v1/cloudshell.proto#L340}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::shell::v1::RemovePublicKeyResponse,google/cloud/shell/v1/cloudshell.proto#L351}
   ///
@@ -214,7 +220,7 @@ class CloudShellServiceClient {
   future<StatusOr<google::cloud::shell::v1::RemovePublicKeyResponse>>
   RemovePublicKey(
       google::cloud::shell::v1::RemovePublicKeyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudShellServiceConnection> connection_;

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -28,18 +28,16 @@ namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DatabaseAdminClient::DatabaseAdminClient(
-    std::shared_ptr<DatabaseAdminConnection> connection, Options options)
+    std::shared_ptr<DatabaseAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          spanner_admin_internal::DatabaseAdminDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), spanner_admin_internal::DatabaseAdminDefaultOptions(
+                               connection_->options()))) {}
 DatabaseAdminClient::~DatabaseAdminClient() = default;
 
 StreamRange<google::spanner::admin::database::v1::Database>
-DatabaseAdminClient::ListDatabases(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DatabaseAdminClient::ListDatabases(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::ListDatabasesRequest request;
   request.set_parent(parent);
   return connection_->ListDatabases(request);
@@ -48,18 +46,16 @@ DatabaseAdminClient::ListDatabases(std::string const& parent, Options options) {
 StreamRange<google::spanner::admin::database::v1::Database>
 DatabaseAdminClient::ListDatabases(
     google::spanner::admin::database::v1::ListDatabasesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDatabases(std::move(request));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::CreateDatabase(std::string const& parent,
                                     std::string const& create_statement,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(parent);
   request.set_create_statement(create_statement);
@@ -69,16 +65,14 @@ DatabaseAdminClient::CreateDatabase(std::string const& parent,
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::CreateDatabase(
     google::spanner::admin::database::v1::CreateDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDatabase(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::Database>
-DatabaseAdminClient::GetDatabase(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DatabaseAdminClient::GetDatabase(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::GetDatabaseRequest request;
   request.set_name(name);
   return connection_->GetDatabase(request);
@@ -87,9 +81,8 @@ DatabaseAdminClient::GetDatabase(std::string const& name, Options options) {
 StatusOr<google::spanner::admin::database::v1::Database>
 DatabaseAdminClient::GetDatabase(
     google::spanner::admin::database::v1::GetDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDatabase(request);
 }
 
@@ -97,9 +90,8 @@ future<
     StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
 DatabaseAdminClient::UpdateDatabaseDdl(
     std::string const& database, std::vector<std::string> const& statements,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::UpdateDatabaseDdlRequest request;
   request.set_database(database);
   *request.mutable_statements() = {statements.begin(), statements.end()};
@@ -111,16 +103,14 @@ future<
 DatabaseAdminClient::UpdateDatabaseDdl(
     google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateDatabaseDdl(request);
 }
 
 Status DatabaseAdminClient::DropDatabase(std::string const& database,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::DropDatabaseRequest request;
   request.set_database(database);
   return connection_->DropDatabase(request);
@@ -128,17 +118,14 @@ Status DatabaseAdminClient::DropDatabase(std::string const& database,
 
 Status DatabaseAdminClient::DropDatabase(
     google::spanner::admin::database::v1::DropDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DropDatabase(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
-DatabaseAdminClient::GetDatabaseDdl(std::string const& database,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DatabaseAdminClient::GetDatabaseDdl(std::string const& database, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::GetDatabaseDdlRequest request;
   request.set_database(database);
   return connection_->GetDatabaseDdl(request);
@@ -147,17 +134,15 @@ DatabaseAdminClient::GetDatabaseDdl(std::string const& database,
 StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
 DatabaseAdminClient::GetDatabaseDdl(
     google::spanner::admin::database::v1::GetDatabaseDdlRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDatabaseDdl(request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -165,11 +150,10 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<DatabaseAdminBackoffPolicyOption>(options,
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<DatabaseAdminBackoffPolicyOption>(opts,
                                                                    __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -196,34 +180,30 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> DatabaseAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DatabaseAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -232,10 +212,8 @@ DatabaseAdminClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 DatabaseAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
@@ -243,9 +221,8 @@ future<StatusOr<google::spanner::admin::database::v1::Backup>>
 DatabaseAdminClient::CreateBackup(
     std::string const& parent,
     google::spanner::admin::database::v1::Backup const& backup,
-    std::string const& backup_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& backup_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::CreateBackupRequest request;
   request.set_parent(parent);
   *request.mutable_backup() = backup;
@@ -256,16 +233,14 @@ DatabaseAdminClient::CreateBackup(
 future<StatusOr<google::spanner::admin::database::v1::Backup>>
 DatabaseAdminClient::CreateBackup(
     google::spanner::admin::database::v1::CreateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateBackup(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::GetBackup(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DatabaseAdminClient::GetBackup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::GetBackupRequest request;
   request.set_name(name);
   return connection_->GetBackup(request);
@@ -274,18 +249,16 @@ DatabaseAdminClient::GetBackup(std::string const& name, Options options) {
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::GetBackup(
     google::spanner::admin::database::v1::GetBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetBackup(request);
 }
 
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::UpdateBackup(
     google::spanner::admin::database::v1::Backup const& backup,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::UpdateBackupRequest request;
   *request.mutable_backup() = backup;
   *request.mutable_update_mask() = update_mask;
@@ -295,16 +268,14 @@ DatabaseAdminClient::UpdateBackup(
 StatusOr<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::UpdateBackup(
     google::spanner::admin::database::v1::UpdateBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateBackup(request);
 }
 
 Status DatabaseAdminClient::DeleteBackup(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::DeleteBackupRequest request;
   request.set_name(name);
   return connection_->DeleteBackup(request);
@@ -312,16 +283,14 @@ Status DatabaseAdminClient::DeleteBackup(std::string const& name,
 
 Status DatabaseAdminClient::DeleteBackup(
     google::spanner::admin::database::v1::DeleteBackupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteBackup(request);
 }
 
 StreamRange<google::spanner::admin::database::v1::Backup>
-DatabaseAdminClient::ListBackups(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+DatabaseAdminClient::ListBackups(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::ListBackupsRequest request;
   request.set_parent(parent);
   return connection_->ListBackups(request);
@@ -330,19 +299,16 @@ DatabaseAdminClient::ListBackups(std::string const& parent, Options options) {
 StreamRange<google::spanner::admin::database::v1::Backup>
 DatabaseAdminClient::ListBackups(
     google::spanner::admin::database::v1::ListBackupsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackups(std::move(request));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::RestoreDatabase(std::string const& parent,
                                      std::string const& database_id,
-                                     std::string const& backup,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                     std::string const& backup, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::RestoreDatabaseRequest request;
   request.set_parent(parent);
   request.set_database_id(database_id);
@@ -353,17 +319,15 @@ DatabaseAdminClient::RestoreDatabase(std::string const& parent,
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 DatabaseAdminClient::RestoreDatabase(
     google::spanner::admin::database::v1::RestoreDatabaseRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RestoreDatabase(request);
 }
 
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListDatabaseOperations(std::string const& parent,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::ListDatabaseOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListDatabaseOperations(request);
@@ -372,17 +336,15 @@ DatabaseAdminClient::ListDatabaseOperations(std::string const& parent,
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListDatabaseOperations(
     google::spanner::admin::database::v1::ListDatabaseOperationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDatabaseOperations(std::move(request));
 }
 
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListBackupOperations(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::database::v1::ListBackupOperationsRequest request;
   request.set_parent(parent);
   return connection_->ListBackupOperations(request);
@@ -391,9 +353,8 @@ DatabaseAdminClient::ListBackupOperations(std::string const& parent,
 StreamRange<google::longrunning::Operation>
 DatabaseAdminClient::ListBackupOperations(
     google::spanner::admin::database::v1::ListBackupOperationsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListBackupOperations(std::move(request));
 }
 

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -411,8 +411,8 @@ class DatabaseAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/spanner/admin/database_admin_client.h
+++ b/google/cloud/spanner/admin/database_admin_client.h
@@ -69,8 +69,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DatabaseAdminClient {
  public:
   explicit DatabaseAdminClient(
-      std::shared_ptr<DatabaseAdminConnection> connection,
-      Options options = {});
+      std::shared_ptr<DatabaseAdminConnection> connection, Options opts = {});
   ~DatabaseAdminClient();
 
   //@{
@@ -98,7 +97,8 @@ class DatabaseAdminClient {
   ///
   /// @param parent  Required. The instance whose databases should be listed.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -108,14 +108,15 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Cloud Spanner databases.
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabasesRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L420}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -126,7 +127,7 @@ class DatabaseAdminClient {
   ///
   StreamRange<google::spanner::admin::database::v1::Database> ListDatabases(
       google::spanner::admin::database::v1::ListDatabasesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -147,7 +148,8 @@ class DatabaseAdminClient {
   ///  `[a-z][a-z0-9_\-]*[a-z0-9]` and be between 2 and 30 characters in length.
   ///  If the database ID is a reserved word or if it contains a hyphen, the
   ///  database ID must be enclosed in backticks (`` ` ``).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -158,7 +160,7 @@ class DatabaseAdminClient {
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement,
-                 Options options = {});
+                 Options opts = {});
 
   ///
   /// Creates a new Cloud Spanner database and starts to prepare it for serving.
@@ -172,7 +174,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::CreateDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L452}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -185,7 +188,7 @@ class DatabaseAdminClient {
   CreateDatabase(
       google::spanner::admin::database::v1::CreateDatabaseRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the state of a Cloud Spanner database.
@@ -193,7 +196,8 @@ class DatabaseAdminClient {
   /// @param name  Required. The name of the requested database. Values are of
   /// the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -203,14 +207,15 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets the state of a Cloud Spanner database.
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L494}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -221,7 +226,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       google::spanner::admin::database::v1::GetDatabaseRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the schema of a Cloud Spanner database by
@@ -235,7 +240,8 @@ class DatabaseAdminClient {
   ///
   /// @param database  Required. The database to update.
   /// @param statements  Required. DDL statements to be applied to the database.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L557}
   ///
@@ -248,7 +254,7 @@ class DatabaseAdminClient {
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database,
                     std::vector<std::string> const& statements,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Updates the schema of a Cloud Spanner database by
@@ -262,7 +268,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L521}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata,google/spanner/admin/database/v1/spanner_database_admin.proto#L557}
   ///
@@ -276,7 +283,7 @@ class DatabaseAdminClient {
   UpdateDatabaseDdl(
       google::spanner::admin::database::v1::UpdateDatabaseDdlRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Drops (aka deletes) a Cloud Spanner database.
@@ -286,12 +293,13 @@ class DatabaseAdminClient {
   /// after the database has been deleted.
   ///
   /// @param database  Required. The database to be dropped.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L589}
   ///
-  Status DropDatabase(std::string const& database, Options options = {});
+  Status DropDatabase(std::string const& database, Options opts = {});
 
   ///
   /// Drops (aka deletes) a Cloud Spanner database.
@@ -302,14 +310,15 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::DropDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L589}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.spanner.admin.database.v1.DropDatabaseRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L589}
   ///
   Status DropDatabase(
       google::spanner::admin::database::v1::DropDatabaseRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -319,7 +328,8 @@ class DatabaseAdminClient {
   /// @param database  Required. The database whose schema we wish to get.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/databases/<database>`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L613}
   ///
@@ -329,7 +339,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/spanner_database_admin.proto#L613}
   ///
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
-  GetDatabaseDdl(std::string const& database, Options options = {});
+  GetDatabaseDdl(std::string const& database, Options opts = {});
 
   ///
   /// Returns the schema of a Cloud Spanner database as a list of formatted
@@ -338,7 +348,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L600}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::GetDatabaseDdlResponse,google/spanner/admin/database/v1/spanner_database_admin.proto#L613}
   ///
@@ -351,7 +362,7 @@ class DatabaseAdminClient {
   GetDatabaseDdl(
       google::spanner::admin::database::v1::GetDatabaseDdlRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -370,7 +381,8 @@ class DatabaseAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -381,7 +393,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -399,14 +411,13 @@ class DatabaseAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `DatabaseAdminBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on a database or backup resource.
@@ -419,7 +430,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -429,8 +441,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for a database or backup resource.
@@ -445,7 +456,8 @@ class DatabaseAdminClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -455,7 +467,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a database or backup resource.
@@ -469,7 +481,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -479,8 +492,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or
@@ -502,7 +514,8 @@ class DatabaseAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -513,7 +526,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified database or
@@ -529,7 +542,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -540,7 +554,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts creating a new Cloud Spanner Backup.
@@ -568,7 +582,8 @@ class DatabaseAdminClient {
   /// `backup_id` appended to
   ///  `parent` forms the full backup name of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup_id>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -580,7 +595,7 @@ class DatabaseAdminClient {
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       std::string const& parent,
       google::spanner::admin::database::v1::Backup const& backup,
-      std::string const& backup_id, Options options = {});
+      std::string const& backup_id, Options opts = {});
 
   ///
   /// Starts creating a new Cloud Spanner Backup.
@@ -598,7 +613,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::CreateBackupRequest,google/spanner/admin/database/v1/backup.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -609,7 +625,7 @@ class DatabaseAdminClient {
   ///
   future<StatusOr<google::spanner::admin::database::v1::Backup>> CreateBackup(
       google::spanner::admin::database::v1::CreateBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets metadata on a pending or completed
@@ -618,7 +634,8 @@ class DatabaseAdminClient {
   /// @param name  Required. Name of the backup.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -628,7 +645,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets metadata on a pending or completed
@@ -636,7 +653,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::GetBackupRequest,google/spanner/admin/database/v1/backup.proto#L205}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -647,7 +665,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       google::spanner::admin::database::v1::GetBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a pending or completed
@@ -664,7 +682,8 @@ class DatabaseAdminClient {
   ///  resource, not to the request message. The field mask must always be
   ///  specified; this prevents any future fields from being erased accidentally
   ///  by clients that do not know about them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -675,7 +694,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::Backup const& backup,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a pending or completed
@@ -683,7 +702,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::UpdateBackupRequest,google/spanner/admin/database/v1/backup.proto#L189}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -694,7 +714,7 @@ class DatabaseAdminClient {
   ///
   StatusOr<google::spanner::admin::database::v1::Backup> UpdateBackup(
       google::spanner::admin::database::v1::UpdateBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a pending or completed
@@ -703,12 +723,13 @@ class DatabaseAdminClient {
   /// @param name  Required. Name of the backup to delete.
   ///  Values are of the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L218}
   ///
-  Status DeleteBackup(std::string const& name, Options options = {});
+  Status DeleteBackup(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a pending or completed
@@ -716,14 +737,15 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::DeleteBackupRequest,google/spanner/admin/database/v1/backup.proto#L218}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.spanner.admin.database.v1.DeleteBackupRequest]:
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L218}
   ///
   Status DeleteBackup(
       google::spanner::admin::database::v1::DeleteBackupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists completed and pending backups.
@@ -733,7 +755,8 @@ class DatabaseAdminClient {
   /// @param parent  Required. The instance to list backups from.  Values are of
   /// the
   ///  form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -743,7 +766,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/database/v1/backup.proto#L36}
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists completed and pending backups.
@@ -752,7 +775,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupsRequest,google/spanner/admin/database/v1/backup.proto#L231}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Backup,google/spanner/admin/database/v1/backup.proto#L36}
   ///
@@ -763,7 +787,7 @@ class DatabaseAdminClient {
   ///
   StreamRange<google::spanner::admin::database::v1::Backup> ListBackups(
       google::spanner::admin::database::v1::ListBackupsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -797,7 +821,8 @@ class DatabaseAdminClient {
   /// @param backup  Name of the backup from which to restore.  Values are of
   /// the form
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -808,7 +833,7 @@ class DatabaseAdminClient {
   ///
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id,
-                  std::string const& backup, Options options = {});
+                  std::string const& backup, Options opts = {});
 
   ///
   /// Create a new database by restoring from a completed backup. The new
@@ -831,7 +856,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::RestoreDatabaseRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L702}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::database::v1::Database,google/spanner/admin/database/v1/spanner_database_admin.proto#L330}
   ///
@@ -844,7 +870,7 @@ class DatabaseAdminClient {
   RestoreDatabase(
       google::spanner::admin::database::v1::RestoreDatabaseRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -858,7 +884,8 @@ class DatabaseAdminClient {
   ///
   /// @param parent  Required. The instance of the database operations.
   ///  Values are of the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -868,7 +895,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists database [longrunning-operations][google.longrunning.Operation].
@@ -882,7 +909,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListDatabaseOperationsRequest,google/spanner/admin/database/v1/spanner_database_admin.proto#L621}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -894,7 +922,7 @@ class DatabaseAdminClient {
   StreamRange<google::longrunning::Operation> ListDatabaseOperations(
       google::spanner::admin::database::v1::ListDatabaseOperationsRequest
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation]
@@ -911,7 +939,8 @@ class DatabaseAdminClient {
   /// @param parent  Required. The instance of the backup operations. Values are
   /// of
   ///  the form `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -921,7 +950,7 @@ class DatabaseAdminClient {
   /// @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists the backup [long-running operations][google.longrunning.Operation]
@@ -937,7 +966,8 @@ class DatabaseAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::database::v1::ListBackupOperationsRequest,google/spanner/admin/database/v1/backup.proto#L303}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
@@ -948,7 +978,7 @@ class DatabaseAdminClient {
   ///
   StreamRange<google::longrunning::Operation> ListBackupOperations(
       google::spanner::admin::database::v1::ListBackupOperationsRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<DatabaseAdminConnection> connection_;

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -28,19 +28,17 @@ namespace spanner_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 InstanceAdminClient::InstanceAdminClient(
-    std::shared_ptr<InstanceAdminConnection> connection, Options options)
+    std::shared_ptr<InstanceAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          spanner_admin_internal::InstanceAdminDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), spanner_admin_internal::InstanceAdminDefaultOptions(
+                               connection_->options()))) {}
 InstanceAdminClient::~InstanceAdminClient() = default;
 
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::ListInstanceConfigs(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::ListInstanceConfigsRequest request;
   request.set_parent(parent);
   return connection_->ListInstanceConfigs(request);
@@ -49,17 +47,14 @@ InstanceAdminClient::ListInstanceConfigs(std::string const& parent,
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::ListInstanceConfigs(
     google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstanceConfigs(std::move(request));
 }
 
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
-InstanceAdminClient::GetInstanceConfig(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+InstanceAdminClient::GetInstanceConfig(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::GetInstanceConfigRequest request;
   request.set_name(name);
   return connection_->GetInstanceConfig(request);
@@ -69,16 +64,14 @@ StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::GetInstanceConfig(
     google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstanceConfig(request);
 }
 
 StreamRange<google::spanner::admin::instance::v1::Instance>
-InstanceAdminClient::ListInstances(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+InstanceAdminClient::ListInstances(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::ListInstancesRequest request;
   request.set_parent(parent);
   return connection_->ListInstances(request);
@@ -87,16 +80,14 @@ InstanceAdminClient::ListInstances(std::string const& parent, Options options) {
 StreamRange<google::spanner::admin::instance::v1::Instance>
 InstanceAdminClient::ListInstances(
     google::spanner::admin::instance::v1::ListInstancesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListInstances(std::move(request));
 }
 
 StatusOr<google::spanner::admin::instance::v1::Instance>
-InstanceAdminClient::GetInstance(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+InstanceAdminClient::GetInstance(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::GetInstanceRequest request;
   request.set_name(name);
   return connection_->GetInstance(request);
@@ -105,9 +96,8 @@ InstanceAdminClient::GetInstance(std::string const& name, Options options) {
 StatusOr<google::spanner::admin::instance::v1::Instance>
 InstanceAdminClient::GetInstance(
     google::spanner::admin::instance::v1::GetInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetInstance(request);
 }
 
@@ -115,9 +105,8 @@ future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::CreateInstance(
     std::string const& parent, std::string const& instance_id,
     google::spanner::admin::instance::v1::Instance const& instance,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::CreateInstanceRequest request;
   request.set_parent(parent);
   request.set_instance_id(instance_id);
@@ -128,18 +117,16 @@ InstanceAdminClient::CreateInstance(
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::CreateInstance(
     google::spanner::admin::instance::v1::CreateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateInstance(request);
 }
 
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::UpdateInstance(
     google::spanner::admin::instance::v1::Instance const& instance,
-    google::protobuf::FieldMask const& field_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& field_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::UpdateInstanceRequest request;
   *request.mutable_instance() = instance;
   *request.mutable_field_mask() = field_mask;
@@ -149,16 +136,14 @@ InstanceAdminClient::UpdateInstance(
 future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::UpdateInstance(
     google::spanner::admin::instance::v1::UpdateInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateInstance(request);
 }
 
 Status InstanceAdminClient::DeleteInstance(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::spanner::admin::instance::v1::DeleteInstanceRequest request;
   request.set_name(name);
   return connection_->DeleteInstance(request);
@@ -166,17 +151,15 @@ Status InstanceAdminClient::DeleteInstance(std::string const& name,
 
 Status InstanceAdminClient::DeleteInstance(
     google::spanner::admin::instance::v1::DeleteInstanceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteInstance(request);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -184,11 +167,10 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<InstanceAdminBackoffPolicyOption>(options,
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<InstanceAdminBackoffPolicyOption>(opts,
                                                                    __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -215,34 +197,30 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -251,10 +229,8 @@ InstanceAdminClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -600,8 +600,8 @@ class InstanceAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/spanner/admin/instance_admin_client.h
+++ b/google/cloud/spanner/admin/instance_admin_client.h
@@ -84,8 +84,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class InstanceAdminClient {
  public:
   explicit InstanceAdminClient(
-      std::shared_ptr<InstanceAdminConnection> connection,
-      Options options = {});
+      std::shared_ptr<InstanceAdminConnection> connection, Options opts = {});
   ~InstanceAdminClient();
 
   //@{
@@ -115,7 +114,8 @@ class InstanceAdminClient {
   /// supported instance
   ///  configurations is requested. Values are of the form
   ///  `projects/<project>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -125,14 +125,15 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
-  ListInstanceConfigs(std::string const& parent, Options options = {});
+  ListInstanceConfigs(std::string const& parent, Options opts = {});
 
   ///
   /// Lists the supported instance configurations for a given project.
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstanceConfigsRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L415}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -144,7 +145,7 @@ class InstanceAdminClient {
   StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
   ListInstanceConfigs(
       google::spanner::admin::instance::v1::ListInstanceConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information about a particular instance configuration.
@@ -152,7 +153,8 @@ class InstanceAdminClient {
   /// @param name  Required. The name of the requested instance configuration.
   /// Values are of
   ///  the form `projects/<project>/instanceConfigs/<config>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -162,14 +164,15 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
   StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
-  GetInstanceConfig(std::string const& name, Options options = {});
+  GetInstanceConfig(std::string const& name, Options opts = {});
 
   ///
   /// Gets information about a particular instance configuration.
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceConfigRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L449}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::InstanceConfig,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L304}
   ///
@@ -182,7 +185,7 @@ class InstanceAdminClient {
   GetInstanceConfig(
       google::spanner::admin::instance::v1::GetInstanceConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all instances in the given project.
@@ -190,7 +193,8 @@ class InstanceAdminClient {
   /// @param parent  Required. The name of the project for which a list of
   /// instances is
   ///  requested. Values are of the form `projects/<project>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -200,14 +204,15 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all instances in the given project.
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::ListInstancesRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L499}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -218,7 +223,7 @@ class InstanceAdminClient {
   ///
   StreamRange<google::spanner::admin::instance::v1::Instance> ListInstances(
       google::spanner::admin::instance::v1::ListInstancesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information about a particular instance.
@@ -226,7 +231,8 @@ class InstanceAdminClient {
   /// @param name  Required. The name of the requested instance. Values are of
   /// the form
   ///  `projects/<project>/instances/<instance>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -236,14 +242,15 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information about a particular instance.
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::GetInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L461}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -254,7 +261,7 @@ class InstanceAdminClient {
   ///
   StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(
       google::spanner::admin::instance::v1::GetInstanceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates an instance and begins preparing it to begin serving. The
@@ -302,7 +309,8 @@ class InstanceAdminClient {
   /// @param instance  Required. The instance to create.  The name may be
   /// omitted, but if
   ///  specified must be `<parent>/instances/<instance_id>`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -314,7 +322,7 @@ class InstanceAdminClient {
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   CreateInstance(std::string const& parent, std::string const& instance_id,
                  google::spanner::admin::instance::v1::Instance const& instance,
-                 Options options = {});
+                 Options opts = {});
 
   ///
   /// Creates an instance and begins preparing it to begin serving. The
@@ -354,7 +362,8 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::CreateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L478}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -367,7 +376,7 @@ class InstanceAdminClient {
   CreateInstance(
       google::spanner::admin::instance::v1::CreateInstanceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an instance, and begins allocating or releasing resources
@@ -421,7 +430,8 @@ class InstanceAdminClient {
   ///  The field mask must always be specified; this prevents any future fields
   ///  in [Instance][google.spanner.admin.instance.v1.Instance] from being
   ///  erased accidentally by clients that do not know about them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -433,7 +443,7 @@ class InstanceAdminClient {
   future<StatusOr<google::spanner::admin::instance::v1::Instance>>
   UpdateInstance(google::spanner::admin::instance::v1::Instance const& instance,
                  google::protobuf::FieldMask const& field_mask,
-                 Options options = {});
+                 Options opts = {});
 
   ///
   /// Updates an instance, and begins allocating or releasing resources
@@ -479,7 +489,8 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::UpdateInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L552}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::spanner::admin::instance::v1::Instance,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L328}
   ///
@@ -492,7 +503,7 @@ class InstanceAdminClient {
   UpdateInstance(
       google::spanner::admin::instance::v1::UpdateInstanceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an instance.
@@ -510,12 +521,13 @@ class InstanceAdminClient {
   /// @param name  Required. The name of the instance to be deleted. Values are
   /// of the form
   ///  `projects/<project>/instances/<instance>`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
   ///
-  Status DeleteInstance(std::string const& name, Options options = {});
+  Status DeleteInstance(std::string const& name, Options opts = {});
 
   ///
   /// Deletes an instance.
@@ -532,7 +544,8 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::spanner::admin::instance::v1::DeleteInstanceRequest,google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.spanner.admin.instance.v1.DeleteInstanceRequest]:
   /// @googleapis_reference_link{google/spanner/admin/instance/v1/spanner_instance_admin.proto#L565}
@@ -540,7 +553,7 @@ class InstanceAdminClient {
   Status DeleteInstance(
       google::spanner::admin::instance::v1::DeleteInstanceRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sets the access control policy on an instance resource. Replaces any
@@ -557,7 +570,8 @@ class InstanceAdminClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -568,7 +582,7 @@ class InstanceAdminClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -586,14 +600,13 @@ class InstanceAdminClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `InstanceAdminBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy on an instance resource. Replaces any
@@ -604,7 +617,8 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -614,8 +628,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Gets the access control policy for an instance resource. Returns an empty
@@ -627,7 +640,8 @@ class InstanceAdminClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -637,7 +651,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for an instance resource. Returns an empty
@@ -648,7 +662,8 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -658,8 +673,7 @@ class InstanceAdminClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified instance
@@ -678,7 +692,8 @@ class InstanceAdminClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -689,7 +704,7 @@ class InstanceAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that the caller has on the specified instance
@@ -702,7 +717,8 @@ class InstanceAdminClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -713,7 +729,7 @@ class InstanceAdminClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<InstanceAdminConnection> connection_;

--- a/google/cloud/storagetransfer/storage_transfer_client.cc
+++ b/google/cloud/storagetransfer/storage_transfer_client.cc
@@ -26,11 +26,10 @@ namespace storagetransfer {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StorageTransferServiceClient::StorageTransferServiceClient(
-    std::shared_ptr<StorageTransferServiceConnection> connection,
-    Options options)
+    std::shared_ptr<StorageTransferServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           storagetransfer_internal::StorageTransferServiceDefaultOptions(
               connection_->options()))) {}
 StorageTransferServiceClient::~StorageTransferServiceClient() = default;
@@ -38,70 +37,62 @@ StorageTransferServiceClient::~StorageTransferServiceClient() = default;
 StatusOr<google::storagetransfer::v1::GoogleServiceAccount>
 StorageTransferServiceClient::GetGoogleServiceAccount(
     google::storagetransfer::v1::GetGoogleServiceAccountRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGoogleServiceAccount(request);
 }
 
 StatusOr<google::storagetransfer::v1::TransferJob>
 StorageTransferServiceClient::CreateTransferJob(
     google::storagetransfer::v1::CreateTransferJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTransferJob(request);
 }
 
 StatusOr<google::storagetransfer::v1::TransferJob>
 StorageTransferServiceClient::UpdateTransferJob(
     google::storagetransfer::v1::UpdateTransferJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTransferJob(request);
 }
 
 StatusOr<google::storagetransfer::v1::TransferJob>
 StorageTransferServiceClient::GetTransferJob(
     google::storagetransfer::v1::GetTransferJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTransferJob(request);
 }
 
 StreamRange<google::storagetransfer::v1::TransferJob>
 StorageTransferServiceClient::ListTransferJobs(
     google::storagetransfer::v1::ListTransferJobsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTransferJobs(std::move(request));
 }
 
 Status StorageTransferServiceClient::PauseTransferOperation(
     google::storagetransfer::v1::PauseTransferOperationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PauseTransferOperation(request);
 }
 
 Status StorageTransferServiceClient::ResumeTransferOperation(
     google::storagetransfer::v1::ResumeTransferOperationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResumeTransferOperation(request);
 }
 
 future<StatusOr<google::storagetransfer::v1::TransferOperation>>
 StorageTransferServiceClient::RunTransferJob(
     google::storagetransfer::v1::RunTransferJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RunTransferJob(request);
 }
 

--- a/google/cloud/storagetransfer/storage_transfer_client.h
+++ b/google/cloud/storagetransfer/storage_transfer_client.h
@@ -65,7 +65,7 @@ class StorageTransferServiceClient {
  public:
   explicit StorageTransferServiceClient(
       std::shared_ptr<StorageTransferServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~StorageTransferServiceClient();
 
   //@{
@@ -102,7 +102,8 @@ class StorageTransferServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::GetGoogleServiceAccountRequest,google/storagetransfer/v1/transfer.proto#L132}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::storagetransfer::v1::GoogleServiceAccount,google/storagetransfer/v1/transfer_types.proto#L37}
   ///
@@ -115,14 +116,15 @@ class StorageTransferServiceClient {
   GetGoogleServiceAccount(
       google::storagetransfer::v1::GetGoogleServiceAccountRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a transfer job that runs periodically.
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::CreateTransferJobRequest,google/storagetransfer/v1/transfer.proto#L139}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::storagetransfer::v1::TransferJob,google/storagetransfer/v1/transfer_types.proto#L462}
   ///
@@ -133,7 +135,7 @@ class StorageTransferServiceClient {
   ///
   StatusOr<google::storagetransfer::v1::TransferJob> CreateTransferJob(
       google::storagetransfer::v1::CreateTransferJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a transfer job. Updating a job's transfer spec does not affect
@@ -147,7 +149,8 @@ class StorageTransferServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::UpdateTransferJobRequest,google/storagetransfer/v1/transfer.proto#L145}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::storagetransfer::v1::TransferJob,google/storagetransfer/v1/transfer_types.proto#L462}
   ///
@@ -158,14 +161,15 @@ class StorageTransferServiceClient {
   ///
   StatusOr<google::storagetransfer::v1::TransferJob> UpdateTransferJob(
       google::storagetransfer::v1::UpdateTransferJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a transfer job.
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::GetTransferJobRequest,google/storagetransfer/v1/transfer.proto#L180}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::storagetransfer::v1::TransferJob,google/storagetransfer/v1/transfer_types.proto#L462}
   ///
@@ -176,14 +180,15 @@ class StorageTransferServiceClient {
   ///
   StatusOr<google::storagetransfer::v1::TransferJob> GetTransferJob(
       google::storagetransfer::v1::GetTransferJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists transfer jobs.
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::ListTransferJobsRequest,google/storagetransfer/v1/transfer.proto#L192}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::storagetransfer::v1::TransferJob,google/storagetransfer/v1/transfer_types.proto#L462}
   ///
@@ -194,28 +199,30 @@ class StorageTransferServiceClient {
   ///
   StreamRange<google::storagetransfer::v1::TransferJob> ListTransferJobs(
       google::storagetransfer::v1::ListTransferJobsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Pauses a transfer operation.
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::PauseTransferOperationRequest,google/storagetransfer/v1/transfer.proto#L224}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.storagetransfer.v1.PauseTransferOperationRequest]:
   /// @googleapis_reference_link{google/storagetransfer/v1/transfer.proto#L224}
   ///
   Status PauseTransferOperation(
       google::storagetransfer::v1::PauseTransferOperationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resumes a transfer operation that is paused.
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::ResumeTransferOperationRequest,google/storagetransfer/v1/transfer.proto#L230}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.storagetransfer.v1.ResumeTransferOperationRequest]:
   /// @googleapis_reference_link{google/storagetransfer/v1/transfer.proto#L230}
@@ -223,7 +230,7 @@ class StorageTransferServiceClient {
   Status ResumeTransferOperation(
       google::storagetransfer::v1::ResumeTransferOperationRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Attempts to start a new TransferOperation for the current TransferJob. A
@@ -232,7 +239,8 @@ class StorageTransferServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::storagetransfer::v1::RunTransferJobRequest,google/storagetransfer/v1/transfer.proto#L236}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::storagetransfer::v1::TransferOperation,google/storagetransfer/v1/transfer_types.proto#L706}
   ///
@@ -244,7 +252,7 @@ class StorageTransferServiceClient {
   future<StatusOr<google::storagetransfer::v1::TransferOperation>>
   RunTransferJob(
       google::storagetransfer::v1::RunTransferJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<StorageTransferServiceConnection> connection_;

--- a/google/cloud/talent/company_client.cc
+++ b/google/cloud/talent/company_client.cc
@@ -26,19 +26,18 @@ namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CompanyServiceClient::CompanyServiceClient(
-    std::shared_ptr<CompanyServiceConnection> connection, Options options)
+    std::shared_ptr<CompanyServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), talent_internal::CompanyServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), talent_internal::CompanyServiceDefaultOptions(
+                               connection_->options()))) {}
 CompanyServiceClient::~CompanyServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::Company>
 CompanyServiceClient::CreateCompany(
     std::string const& parent,
-    google::cloud::talent::v4::Company const& company, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::Company const& company, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::CreateCompanyRequest request;
   request.set_parent(parent);
   *request.mutable_company() = company;
@@ -48,35 +47,30 @@ CompanyServiceClient::CreateCompany(
 StatusOr<google::cloud::talent::v4::Company>
 CompanyServiceClient::CreateCompany(
     google::cloud::talent::v4::CreateCompanyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCompany(request);
 }
 
 StatusOr<google::cloud::talent::v4::Company> CompanyServiceClient::GetCompany(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::GetCompanyRequest request;
   request.set_name(name);
   return connection_->GetCompany(request);
 }
 
 StatusOr<google::cloud::talent::v4::Company> CompanyServiceClient::GetCompany(
-    google::cloud::talent::v4::GetCompanyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::GetCompanyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCompany(request);
 }
 
 StatusOr<google::cloud::talent::v4::Company>
 CompanyServiceClient::UpdateCompany(
     google::cloud::talent::v4::Company const& company,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::UpdateCompanyRequest request;
   *request.mutable_company() = company;
   *request.mutable_update_mask() = update_mask;
@@ -86,16 +80,14 @@ CompanyServiceClient::UpdateCompany(
 StatusOr<google::cloud::talent::v4::Company>
 CompanyServiceClient::UpdateCompany(
     google::cloud::talent::v4::UpdateCompanyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateCompany(request);
 }
 
 Status CompanyServiceClient::DeleteCompany(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::DeleteCompanyRequest request;
   request.set_name(name);
   return connection_->DeleteCompany(request);
@@ -103,17 +95,14 @@ Status CompanyServiceClient::DeleteCompany(std::string const& name,
 
 Status CompanyServiceClient::DeleteCompany(
     google::cloud::talent::v4::DeleteCompanyRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteCompany(request);
 }
 
 StreamRange<google::cloud::talent::v4::Company>
-CompanyServiceClient::ListCompanies(std::string const& parent,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+CompanyServiceClient::ListCompanies(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::ListCompaniesRequest request;
   request.set_parent(parent);
   return connection_->ListCompanies(request);
@@ -121,9 +110,8 @@ CompanyServiceClient::ListCompanies(std::string const& parent,
 
 StreamRange<google::cloud::talent::v4::Company>
 CompanyServiceClient::ListCompanies(
-    google::cloud::talent::v4::ListCompaniesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::ListCompaniesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCompanies(std::move(request));
 }
 

--- a/google/cloud/talent/company_client.h
+++ b/google/cloud/talent/company_client.h
@@ -61,8 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompanyServiceClient {
  public:
   explicit CompanyServiceClient(
-      std::shared_ptr<CompanyServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<CompanyServiceConnection> connection, Options opts = {});
   ~CompanyServiceClient();
 
   //@{
@@ -93,7 +92,8 @@ class CompanyServiceClient {
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
   /// @param company  Required. The company to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -104,14 +104,15 @@ class CompanyServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Company> CreateCompany(
       std::string const& parent,
-      google::cloud::talent::v4::Company const& company, Options options = {});
+      google::cloud::talent::v4::Company const& company, Options opts = {});
 
   ///
   /// Creates a new company entity.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::CreateCompanyRequest,google/cloud/talent/v4/company_service.proto#L86}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -122,7 +123,7 @@ class CompanyServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Company> CreateCompany(
       google::cloud::talent::v4::CreateCompanyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves specified company.
@@ -131,7 +132,8 @@ class CompanyServiceClient {
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}", for
   ///  example, "projects/api-test-project/tenants/foo/companies/bar".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -141,14 +143,15 @@ class CompanyServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/company.proto#L33}
   ///
   StatusOr<google::cloud::talent::v4::Company> GetCompany(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Retrieves specified company.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::GetCompanyRequest,google/cloud/talent/v4/company_service.proto#L103}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -159,7 +162,7 @@ class CompanyServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Company> GetCompany(
       google::cloud::talent::v4::GetCompanyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates specified company.
@@ -173,7 +176,8 @@ class CompanyServiceClient {
   ///  updated. Otherwise all the fields are updated. A field mask to specify
   ///  the company fields to be updated. Only top level fields of
   ///  [Company][google.cloud.talent.v4.Company] are supported.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -184,14 +188,15 @@ class CompanyServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Company> UpdateCompany(
       google::cloud::talent::v4::Company const& company,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates specified company.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::UpdateCompanyRequest,google/cloud/talent/v4/company_service.proto#L118}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -202,7 +207,7 @@ class CompanyServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Company> UpdateCompany(
       google::cloud::talent::v4::UpdateCompanyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes specified company.
@@ -212,12 +217,13 @@ class CompanyServiceClient {
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/companies/{company_id}", for
   ///  example, "projects/foo/tenants/bar/companies/baz".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.talent.v4.DeleteCompanyRequest]:
   /// @googleapis_reference_link{google/cloud/talent/v4/company_service.proto#L133}
   ///
-  Status DeleteCompany(std::string const& name, Options options = {});
+  Status DeleteCompany(std::string const& name, Options opts = {});
 
   ///
   /// Deletes specified company.
@@ -225,14 +231,15 @@ class CompanyServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::DeleteCompanyRequest,google/cloud/talent/v4/company_service.proto#L133}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.talent.v4.DeleteCompanyRequest]:
   /// @googleapis_reference_link{google/cloud/talent/v4/company_service.proto#L133}
   ///
   Status DeleteCompany(
       google::cloud::talent::v4::DeleteCompanyRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all companies associated with the project.
@@ -241,7 +248,8 @@ class CompanyServiceClient {
   /// company is created.
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -251,14 +259,15 @@ class CompanyServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/company.proto#L33}
   ///
   StreamRange<google::cloud::talent::v4::Company> ListCompanies(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all companies associated with the project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::ListCompaniesRequest,google/cloud/talent/v4/company_service.proto#L148}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Company,google/cloud/talent/v4/company.proto#L33}
   ///
@@ -269,7 +278,7 @@ class CompanyServiceClient {
   ///
   StreamRange<google::cloud::talent::v4::Company> ListCompanies(
       google::cloud::talent::v4::ListCompaniesRequest request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CompanyServiceConnection> connection_;

--- a/google/cloud/talent/completion_client.cc
+++ b/google/cloud/talent/completion_client.cc
@@ -26,19 +26,18 @@ namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CompletionClient::CompletionClient(
-    std::shared_ptr<CompletionConnection> connection, Options options)
+    std::shared_ptr<CompletionConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           talent_internal::CompletionDefaultOptions(connection_->options()))) {}
 CompletionClient::~CompletionClient() = default;
 
 StatusOr<google::cloud::talent::v4::CompleteQueryResponse>
 CompletionClient::CompleteQuery(
     google::cloud::talent::v4::CompleteQueryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CompleteQuery(request);
 }
 

--- a/google/cloud/talent/completion_client.h
+++ b/google/cloud/talent/completion_client.h
@@ -61,7 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CompletionClient {
  public:
   explicit CompletionClient(std::shared_ptr<CompletionConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~CompletionClient();
 
   //@{
@@ -88,7 +88,8 @@ class CompletionClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::CompleteQueryRequest,google/cloud/talent/v4/completion_service.proto#L48}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::CompleteQueryResponse,google/cloud/talent/v4/completion_service.proto#L134}
   ///
@@ -99,7 +100,7 @@ class CompletionClient {
   ///
   StatusOr<google::cloud::talent::v4::CompleteQueryResponse> CompleteQuery(
       google::cloud::talent::v4::CompleteQueryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CompletionConnection> connection_;

--- a/google/cloud/talent/event_client.cc
+++ b/google/cloud/talent/event_client.cc
@@ -26,20 +26,18 @@ namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 EventServiceClient::EventServiceClient(
-    std::shared_ptr<EventServiceConnection> connection, Options options)
+    std::shared_ptr<EventServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), talent_internal::EventServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), talent_internal::EventServiceDefaultOptions(
+                               connection_->options()))) {}
 EventServiceClient::~EventServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::ClientEvent>
 EventServiceClient::CreateClientEvent(
     std::string const& parent,
-    google::cloud::talent::v4::ClientEvent const& client_event,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::ClientEvent const& client_event, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::CreateClientEventRequest request;
   request.set_parent(parent);
   *request.mutable_client_event() = client_event;
@@ -49,9 +47,8 @@ EventServiceClient::CreateClientEvent(
 StatusOr<google::cloud::talent::v4::ClientEvent>
 EventServiceClient::CreateClientEvent(
     google::cloud::talent::v4::CreateClientEventRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateClientEvent(request);
 }
 

--- a/google/cloud/talent/event_client.h
+++ b/google/cloud/talent/event_client.h
@@ -61,7 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class EventServiceClient {
  public:
   explicit EventServiceClient(
-      std::shared_ptr<EventServiceConnection> connection, Options options = {});
+      std::shared_ptr<EventServiceConnection> connection, Options opts = {});
   ~EventServiceClient();
 
   //@{
@@ -100,7 +100,8 @@ class EventServiceClient {
   /// @param client_event  Required. Events issued when end user interacts with
   /// customer's application that
   ///  uses Cloud Talent Solution.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::ClientEvent,google/cloud/talent/v4/event.proto#L34}
   ///
@@ -112,7 +113,7 @@ class EventServiceClient {
   StatusOr<google::cloud::talent::v4::ClientEvent> CreateClientEvent(
       std::string const& parent,
       google::cloud::talent::v4::ClientEvent const& client_event,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Report events issued when end user interacts with customer's application
@@ -125,7 +126,8 @@ class EventServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::CreateClientEventRequest,google/cloud/talent/v4/event_service.proto#L55}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::ClientEvent,google/cloud/talent/v4/event.proto#L34}
   ///
@@ -136,7 +138,7 @@ class EventServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::ClientEvent> CreateClientEvent(
       google::cloud::talent::v4::CreateClientEventRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<EventServiceConnection> connection_;

--- a/google/cloud/talent/job_client.cc
+++ b/google/cloud/talent/job_client.cc
@@ -26,18 +26,17 @@ namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 JobServiceClient::JobServiceClient(
-    std::shared_ptr<JobServiceConnection> connection, Options options)
+    std::shared_ptr<JobServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           talent_internal::JobServiceDefaultOptions(connection_->options()))) {}
 JobServiceClient::~JobServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::CreateJob(
     std::string const& parent, google::cloud::talent::v4::Job const& job,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::CreateJobRequest request;
   request.set_parent(parent);
   *request.mutable_job() = job;
@@ -45,19 +44,16 @@ StatusOr<google::cloud::talent::v4::Job> JobServiceClient::CreateJob(
 }
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::CreateJob(
-    google::cloud::talent::v4::CreateJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::CreateJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateJob(request);
 }
 
 future<StatusOr<google::cloud::talent::v4::BatchCreateJobsResponse>>
 JobServiceClient::BatchCreateJobs(
     std::string const& parent,
-    std::vector<google::cloud::talent::v4::Job> const& jobs, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<google::cloud::talent::v4::Job> const& jobs, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::BatchCreateJobsRequest request;
   request.set_parent(parent);
   *request.mutable_jobs() = {jobs.begin(), jobs.end()};
@@ -67,33 +63,29 @@ JobServiceClient::BatchCreateJobs(
 future<StatusOr<google::cloud::talent::v4::BatchCreateJobsResponse>>
 JobServiceClient::BatchCreateJobs(
     google::cloud::talent::v4::BatchCreateJobsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchCreateJobs(request);
 }
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::GetJob(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::GetJobRequest request;
   request.set_name(name);
   return connection_->GetJob(request);
 }
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::GetJob(
-    google::cloud::talent::v4::GetJobRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::GetJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetJob(request);
 }
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::UpdateJob(
     google::cloud::talent::v4::Job const& job,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::UpdateJobRequest request;
   *request.mutable_job() = job;
   *request.mutable_update_mask() = update_mask;
@@ -101,19 +93,16 @@ StatusOr<google::cloud::talent::v4::Job> JobServiceClient::UpdateJob(
 }
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::UpdateJob(
-    google::cloud::talent::v4::UpdateJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::UpdateJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateJob(request);
 }
 
 future<StatusOr<google::cloud::talent::v4::BatchUpdateJobsResponse>>
 JobServiceClient::BatchUpdateJobs(
     std::string const& parent,
-    std::vector<google::cloud::talent::v4::Job> const& jobs, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<google::cloud::talent::v4::Job> const& jobs, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::BatchUpdateJobsRequest request;
   request.set_parent(parent);
   *request.mutable_jobs() = {jobs.begin(), jobs.end()};
@@ -123,34 +112,29 @@ JobServiceClient::BatchUpdateJobs(
 future<StatusOr<google::cloud::talent::v4::BatchUpdateJobsResponse>>
 JobServiceClient::BatchUpdateJobs(
     google::cloud::talent::v4::BatchUpdateJobsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchUpdateJobs(request);
 }
 
-Status JobServiceClient::DeleteJob(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status JobServiceClient::DeleteJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::DeleteJobRequest request;
   request.set_name(name);
   return connection_->DeleteJob(request);
 }
 
 Status JobServiceClient::DeleteJob(
-    google::cloud::talent::v4::DeleteJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::DeleteJobRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteJob(request);
 }
 
 future<StatusOr<google::cloud::talent::v4::BatchDeleteJobsResponse>>
 JobServiceClient::BatchDeleteJobs(std::string const& parent,
                                   std::vector<std::string> const& names,
-                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::BatchDeleteJobsRequest request;
   request.set_parent(parent);
   *request.mutable_names() = {names.begin(), names.end()};
@@ -160,16 +144,14 @@ JobServiceClient::BatchDeleteJobs(std::string const& parent,
 future<StatusOr<google::cloud::talent::v4::BatchDeleteJobsResponse>>
 JobServiceClient::BatchDeleteJobs(
     google::cloud::talent::v4::BatchDeleteJobsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchDeleteJobs(request);
 }
 
 StreamRange<google::cloud::talent::v4::Job> JobServiceClient::ListJobs(
-    std::string const& parent, std::string const& filter, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, std::string const& filter, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::ListJobsRequest request;
   request.set_parent(parent);
   request.set_filter(filter);
@@ -177,27 +159,22 @@ StreamRange<google::cloud::talent::v4::Job> JobServiceClient::ListJobs(
 }
 
 StreamRange<google::cloud::talent::v4::Job> JobServiceClient::ListJobs(
-    google::cloud::talent::v4::ListJobsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::ListJobsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListJobs(std::move(request));
 }
 
 StatusOr<google::cloud::talent::v4::SearchJobsResponse>
 JobServiceClient::SearchJobs(
-    google::cloud::talent::v4::SearchJobsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::SearchJobsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchJobs(request);
 }
 
 StatusOr<google::cloud::talent::v4::SearchJobsResponse>
 JobServiceClient::SearchJobsForAlert(
-    google::cloud::talent::v4::SearchJobsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::SearchJobsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchJobsForAlert(request);
 }
 

--- a/google/cloud/talent/job_client.h
+++ b/google/cloud/talent/job_client.h
@@ -64,7 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class JobServiceClient {
  public:
   explicit JobServiceClient(std::shared_ptr<JobServiceConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~JobServiceClient();
 
   //@{
@@ -96,7 +96,8 @@ class JobServiceClient {
   ///  The format is "projects/{project_id}/tenants/{tenant_id}". For example,
   ///  "projects/foo/tenants/bar".
   /// @param job  Required. The Job to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -107,7 +108,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Job> CreateJob(
       std::string const& parent, google::cloud::talent::v4::Job const& job,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new job.
@@ -117,7 +118,8 @@ class JobServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::CreateJobRequest,google/cloud/talent/v4/job_service.proto#L169}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -128,7 +130,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Job> CreateJob(
       google::cloud::talent::v4::CreateJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Begins executing a batch create jobs operation.
@@ -139,7 +141,8 @@ class JobServiceClient {
   ///  "projects/foo/tenants/bar".
   /// @param jobs  Required. The jobs to be created.
   ///  A maximum of 200 jobs can be created in a batch.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::BatchCreateJobsResponse,google/cloud/talent/v4/job_service.proto#L919}
   ///
@@ -151,14 +154,15 @@ class JobServiceClient {
   future<StatusOr<google::cloud::talent::v4::BatchCreateJobsResponse>>
   BatchCreateJobs(std::string const& parent,
                   std::vector<google::cloud::talent::v4::Job> const& jobs,
-                  Options options = {});
+                  Options opts = {});
 
   ///
   /// Begins executing a batch create jobs operation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::BatchCreateJobsRequest,google/cloud/talent/v4/job_service.proto#L827}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::BatchCreateJobsResponse,google/cloud/talent/v4/job_service.proto#L919}
   ///
@@ -170,7 +174,7 @@ class JobServiceClient {
   future<StatusOr<google::cloud::talent::v4::BatchCreateJobsResponse>>
   BatchCreateJobs(
       google::cloud::talent::v4::BatchCreateJobsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves the specified job, whose status is OPEN or recently EXPIRED
@@ -180,7 +184,8 @@ class JobServiceClient {
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For
   ///  example, "projects/foo/tenants/bar/jobs/baz".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -190,7 +195,7 @@ class JobServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/job.proto#L34}
   ///
   StatusOr<google::cloud::talent::v4::Job> GetJob(std::string const& name,
-                                                  Options options = {});
+                                                  Options opts = {});
 
   ///
   /// Retrieves the specified job, whose status is OPEN or recently EXPIRED
@@ -198,7 +203,8 @@ class JobServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::GetJobRequest,google/cloud/talent/v4/job_service.proto#L186}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -209,7 +215,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Job> GetJob(
       google::cloud::talent::v4::GetJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates specified job.
@@ -225,7 +231,8 @@ class JobServiceClient {
   ///  all the fields are updated. A field mask to restrict the fields that are
   ///  updated. Only top level fields of [Job][google.cloud.talent.v4.Job] are
   ///  supported.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -236,7 +243,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Job> UpdateJob(
       google::cloud::talent::v4::Job const& job,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates specified job.
@@ -246,7 +253,8 @@ class JobServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::UpdateJobRequest,google/cloud/talent/v4/job_service.proto#L201}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -257,7 +265,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Job> UpdateJob(
       google::cloud::talent::v4::UpdateJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Begins executing a batch update jobs operation.
@@ -268,7 +276,8 @@ class JobServiceClient {
   ///  "projects/foo/tenants/bar".
   /// @param jobs  Required. The jobs to be updated.
   ///  A maximum of 200 jobs can be updated in a batch.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::BatchUpdateJobsResponse,google/cloud/talent/v4/job_service.proto#L927}
   ///
@@ -280,14 +289,15 @@ class JobServiceClient {
   future<StatusOr<google::cloud::talent::v4::BatchUpdateJobsResponse>>
   BatchUpdateJobs(std::string const& parent,
                   std::vector<google::cloud::talent::v4::Job> const& jobs,
-                  Options options = {});
+                  Options opts = {});
 
   ///
   /// Begins executing a batch update jobs operation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::BatchUpdateJobsRequest,google/cloud/talent/v4/job_service.proto#L845}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::BatchUpdateJobsResponse,google/cloud/talent/v4/job_service.proto#L927}
   ///
@@ -299,7 +309,7 @@ class JobServiceClient {
   future<StatusOr<google::cloud::talent::v4::BatchUpdateJobsResponse>>
   BatchUpdateJobs(
       google::cloud::talent::v4::BatchUpdateJobsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes the specified job.
@@ -311,12 +321,13 @@ class JobServiceClient {
   ///  The format is
   ///  "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}". For
   ///  example, "projects/foo/tenants/bar/jobs/baz".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.talent.v4.DeleteJobRequest]:
   /// @googleapis_reference_link{google/cloud/talent/v4/job_service.proto#L216}
   ///
-  Status DeleteJob(std::string const& name, Options options = {});
+  Status DeleteJob(std::string const& name, Options opts = {});
 
   ///
   /// Deletes the specified job.
@@ -326,13 +337,14 @@ class JobServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::DeleteJobRequest,google/cloud/talent/v4/job_service.proto#L216}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.talent.v4.DeleteJobRequest]:
   /// @googleapis_reference_link{google/cloud/talent/v4/job_service.proto#L216}
   ///
   Status DeleteJob(google::cloud::talent::v4::DeleteJobRequest const& request,
-                   Options options = {});
+                   Options opts = {});
 
   ///
   /// Begins executing a batch delete jobs operation.
@@ -346,7 +358,8 @@ class JobServiceClient {
   ///  The format is "projects/{project_id}/tenants/{tenant_id}/jobs/{job_id}".
   ///  For example, "projects/foo/tenants/bar/jobs/baz".
   ///  A maximum of 200 jobs can be deleted in a batch.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::BatchDeleteJobsResponse,google/cloud/talent/v4/job_service.proto#L935}
   ///
@@ -357,14 +370,15 @@ class JobServiceClient {
   ///
   future<StatusOr<google::cloud::talent::v4::BatchDeleteJobsResponse>>
   BatchDeleteJobs(std::string const& parent,
-                  std::vector<std::string> const& names, Options options = {});
+                  std::vector<std::string> const& names, Options opts = {});
 
   ///
   /// Begins executing a batch delete jobs operation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::BatchDeleteJobsRequest,google/cloud/talent/v4/job_service.proto#L879}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::BatchDeleteJobsResponse,google/cloud/talent/v4/job_service.proto#L935}
   ///
@@ -376,7 +390,7 @@ class JobServiceClient {
   future<StatusOr<google::cloud::talent::v4::BatchDeleteJobsResponse>>
   BatchDeleteJobs(
       google::cloud::talent::v4::BatchDeleteJobsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists jobs by filter.
@@ -403,7 +417,8 @@ class JobServiceClient {
   ///  status = "EXPIRED"
   ///  * requisitionId = "req-1"
   ///  * requisitionId = "req-1" AND status = "EXPIRED"
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -413,15 +428,15 @@ class JobServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/job.proto#L34}
   ///
   StreamRange<google::cloud::talent::v4::Job> ListJobs(
-      std::string const& parent, std::string const& filter,
-      Options options = {});
+      std::string const& parent, std::string const& filter, Options opts = {});
 
   ///
   /// Lists jobs by filter.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::ListJobsRequest,google/cloud/talent/v4/job_service.proto#L231}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Job,google/cloud/talent/v4/job.proto#L34}
   ///
@@ -431,7 +446,7 @@ class JobServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/job.proto#L34}
   ///
   StreamRange<google::cloud::talent::v4::Job> ListJobs(
-      google::cloud::talent::v4::ListJobsRequest request, Options options = {});
+      google::cloud::talent::v4::ListJobsRequest request, Options opts = {});
 
   ///
   /// Searches for jobs using the provided
@@ -444,7 +459,8 @@ class JobServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::SearchJobsRequest,google/cloud/talent/v4/job_service.proto#L328}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::SearchJobsResponse,google/cloud/talent/v4/job_service.proto#L750}
   ///
@@ -455,7 +471,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::SearchJobsResponse> SearchJobs(
       google::cloud::talent::v4::SearchJobsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Searches for jobs using the provided
@@ -473,7 +489,8 @@ class JobServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::SearchJobsRequest,google/cloud/talent/v4/job_service.proto#L328}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::SearchJobsResponse,google/cloud/talent/v4/job_service.proto#L750}
   ///
@@ -484,7 +501,7 @@ class JobServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::SearchJobsResponse> SearchJobsForAlert(
       google::cloud::talent::v4::SearchJobsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<JobServiceConnection> connection_;

--- a/google/cloud/talent/tenant_client.cc
+++ b/google/cloud/talent/tenant_client.cc
@@ -26,18 +26,17 @@ namespace talent {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TenantServiceClient::TenantServiceClient(
-    std::shared_ptr<TenantServiceConnection> connection, Options options)
+    std::shared_ptr<TenantServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), talent_internal::TenantServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), talent_internal::TenantServiceDefaultOptions(
+                               connection_->options()))) {}
 TenantServiceClient::~TenantServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::CreateTenant(
     std::string const& parent, google::cloud::talent::v4::Tenant const& tenant,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::CreateTenantRequest request;
   request.set_parent(parent);
   *request.mutable_tenant() = tenant;
@@ -46,34 +45,29 @@ StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::CreateTenant(
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::CreateTenant(
     google::cloud::talent::v4::CreateTenantRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTenant(request);
 }
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::GetTenant(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::GetTenantRequest request;
   request.set_name(name);
   return connection_->GetTenant(request);
 }
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::GetTenant(
-    google::cloud::talent::v4::GetTenantRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::GetTenantRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTenant(request);
 }
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::UpdateTenant(
     google::cloud::talent::v4::Tenant const& tenant,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::UpdateTenantRequest request;
   *request.mutable_tenant() = tenant;
   *request.mutable_update_mask() = update_mask;
@@ -82,16 +76,14 @@ StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::UpdateTenant(
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::UpdateTenant(
     google::cloud::talent::v4::UpdateTenantRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTenant(request);
 }
 
 Status TenantServiceClient::DeleteTenant(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::DeleteTenantRequest request;
   request.set_name(name);
   return connection_->DeleteTenant(request);
@@ -99,25 +91,22 @@ Status TenantServiceClient::DeleteTenant(std::string const& name,
 
 Status TenantServiceClient::DeleteTenant(
     google::cloud::talent::v4::DeleteTenantRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTenant(request);
 }
 
 StreamRange<google::cloud::talent::v4::Tenant> TenantServiceClient::ListTenants(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::talent::v4::ListTenantsRequest request;
   request.set_parent(parent);
   return connection_->ListTenants(request);
 }
 
 StreamRange<google::cloud::talent::v4::Tenant> TenantServiceClient::ListTenants(
-    google::cloud::talent::v4::ListTenantsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::talent::v4::ListTenantsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTenants(std::move(request));
 }
 

--- a/google/cloud/talent/tenant_client.h
+++ b/google/cloud/talent/tenant_client.h
@@ -61,8 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TenantServiceClient {
  public:
   explicit TenantServiceClient(
-      std::shared_ptr<TenantServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<TenantServiceConnection> connection, Options opts = {});
   ~TenantServiceClient();
 
   //@{
@@ -93,7 +92,8 @@ class TenantServiceClient {
   ///  The format is "projects/{project_id}", for example,
   ///  "projects/foo".
   /// @param tenant  Required. The tenant to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -104,14 +104,15 @@ class TenantServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Tenant> CreateTenant(
       std::string const& parent,
-      google::cloud::talent::v4::Tenant const& tenant, Options options = {});
+      google::cloud::talent::v4::Tenant const& tenant, Options opts = {});
 
   ///
   /// Creates a new tenant entity.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::CreateTenantRequest,google/cloud/talent/v4/tenant_service.proto#L85}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -122,7 +123,7 @@ class TenantServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Tenant> CreateTenant(
       google::cloud::talent::v4::CreateTenantRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Retrieves specified tenant.
@@ -130,7 +131,8 @@ class TenantServiceClient {
   /// @param name  Required. The resource name of the tenant to be retrieved.
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -140,14 +142,15 @@ class TenantServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/tenant.proto#L33}
   ///
   StatusOr<google::cloud::talent::v4::Tenant> GetTenant(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Retrieves specified tenant.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::GetTenantRequest,google/cloud/talent/v4/tenant_service.proto#L102}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -158,7 +161,7 @@ class TenantServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Tenant> GetTenant(
       google::cloud::talent::v4::GetTenantRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates specified tenant.
@@ -172,7 +175,8 @@ class TenantServiceClient {
   ///  Otherwise all the fields are updated. A field mask to specify the tenant
   ///  fields to be updated. Only top level fields of
   ///  [Tenant][google.cloud.talent.v4.Tenant] are supported.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -183,14 +187,15 @@ class TenantServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Tenant> UpdateTenant(
       google::cloud::talent::v4::Tenant const& tenant,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates specified tenant.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::UpdateTenantRequest,google/cloud/talent/v4/tenant_service.proto#L116}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -201,7 +206,7 @@ class TenantServiceClient {
   ///
   StatusOr<google::cloud::talent::v4::Tenant> UpdateTenant(
       google::cloud::talent::v4::UpdateTenantRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes specified tenant.
@@ -209,26 +214,28 @@ class TenantServiceClient {
   /// @param name  Required. The resource name of the tenant to be deleted.
   ///  The format is "projects/{project_id}/tenants/{tenant_id}", for example,
   ///  "projects/foo/tenants/bar".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.talent.v4.DeleteTenantRequest]:
   /// @googleapis_reference_link{google/cloud/talent/v4/tenant_service.proto#L131}
   ///
-  Status DeleteTenant(std::string const& name, Options options = {});
+  Status DeleteTenant(std::string const& name, Options opts = {});
 
   ///
   /// Deletes specified tenant.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::DeleteTenantRequest,google/cloud/talent/v4/tenant_service.proto#L131}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.talent.v4.DeleteTenantRequest]:
   /// @googleapis_reference_link{google/cloud/talent/v4/tenant_service.proto#L131}
   ///
   Status DeleteTenant(
       google::cloud::talent::v4::DeleteTenantRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists all tenants associated with the project.
@@ -237,7 +244,8 @@ class TenantServiceClient {
   /// tenant is created.
   ///  The format is "projects/{project_id}", for example,
   ///  "projects/foo".
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -247,14 +255,15 @@ class TenantServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/tenant.proto#L33}
   ///
   StreamRange<google::cloud::talent::v4::Tenant> ListTenants(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists all tenants associated with the project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::talent::v4::ListTenantsRequest,google/cloud/talent/v4/tenant_service.proto#L145}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::talent::v4::Tenant,google/cloud/talent/v4/tenant.proto#L33}
   ///
@@ -264,8 +273,7 @@ class TenantServiceClient {
   /// @googleapis_reference_link{google/cloud/talent/v4/tenant.proto#L33}
   ///
   StreamRange<google::cloud::talent::v4::Tenant> ListTenants(
-      google::cloud::talent::v4::ListTenantsRequest request,
-      Options options = {});
+      google::cloud::talent::v4::ListTenantsRequest request, Options opts = {});
 
  private:
   std::shared_ptr<TenantServiceConnection> connection_;

--- a/google/cloud/tasks/cloud_tasks_client.cc
+++ b/google/cloud/tasks/cloud_tasks_client.cc
@@ -28,50 +28,45 @@ namespace tasks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 CloudTasksClient::CloudTasksClient(
-    std::shared_ptr<CloudTasksConnection> connection, Options options)
+    std::shared_ptr<CloudTasksConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           tasks_internal::CloudTasksDefaultOptions(connection_->options()))) {}
 CloudTasksClient::~CloudTasksClient() = default;
 
 StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::ListQueuesRequest request;
   request.set_parent(parent);
   return connection_->ListQueues(request);
 }
 
 StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(
-    google::cloud::tasks::v2::ListQueuesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::ListQueuesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListQueues(std::move(request));
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::GetQueueRequest request;
   request.set_name(name);
   return connection_->GetQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::GetQueue(
-    google::cloud::tasks::v2::GetQueueRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::GetQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
     std::string const& parent, google::cloud::tasks::v2::Queue const& queue,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::CreateQueueRequest request;
   request.set_parent(parent);
   *request.mutable_queue() = queue;
@@ -79,18 +74,15 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::CreateQueue(
-    google::cloud::tasks::v2::CreateQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::CreateQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
     google::cloud::tasks::v2::Queue const& queue,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::UpdateQueueRequest request;
   *request.mutable_queue() = queue;
   *request.mutable_update_mask() = update_mask;
@@ -98,101 +90,84 @@ StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::UpdateQueue(
-    google::cloud::tasks::v2::UpdateQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::UpdateQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateQueue(request);
 }
 
-Status CloudTasksClient::DeleteQueue(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status CloudTasksClient::DeleteQueue(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::DeleteQueueRequest request;
   request.set_name(name);
   return connection_->DeleteQueue(request);
 }
 
 Status CloudTasksClient::DeleteQueue(
-    google::cloud::tasks::v2::DeleteQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::DeleteQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::PurgeQueueRequest request;
   request.set_name(name);
   return connection_->PurgeQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PurgeQueue(
-    google::cloud::tasks::v2::PurgeQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::PurgeQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PurgeQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::PauseQueueRequest request;
   request.set_name(name);
   return connection_->PauseQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::PauseQueue(
-    google::cloud::tasks::v2::PauseQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::PauseQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PauseQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::ResumeQueueRequest request;
   request.set_name(name);
   return connection_->ResumeQueue(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Queue> CloudTasksClient::ResumeQueue(
-    google::cloud::tasks::v2::ResumeQueueRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::ResumeQueueRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResumeQueue(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
-    std::string const& resource, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(resource);
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::GetIamPolicy(
-    google::iam::v1::GetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::GetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
     std::string const& resource, google::iam::v1::Policy const& policy,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(resource);
   *request.mutable_policy() = policy;
@@ -200,11 +175,9 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
-    std::string const& resource, IamUpdater const& updater, Options options) {
-  internal::CheckExpectedOptions<CloudTasksBackoffPolicyOption>(options,
-                                                                __func__);
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& resource, IamUpdater const& updater, Options opts) {
+  internal::CheckExpectedOptions<CloudTasksBackoffPolicyOption>(opts, __func__);
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::GetIamPolicyRequest get_request;
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
@@ -230,18 +203,16 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
 }
 
 StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
-    google::iam::v1::SetIamPolicyRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::SetIamPolicyRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SetIamPolicy(request);
 }
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudTasksClient::TestIamPermissions(
     std::string const& resource, std::vector<std::string> const& permissions,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(resource);
   *request.mutable_permissions() = {permissions.begin(), permissions.end()};
@@ -250,50 +221,43 @@ CloudTasksClient::TestIamPermissions(
 
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 CloudTasksClient::TestIamPermissions(
-    google::iam::v1::TestIamPermissionsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::iam::v1::TestIamPermissionsRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TestIamPermissions(request);
 }
 
 StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::ListTasksRequest request;
   request.set_parent(parent);
   return connection_->ListTasks(request);
 }
 
 StreamRange<google::cloud::tasks::v2::Task> CloudTasksClient::ListTasks(
-    google::cloud::tasks::v2::ListTasksRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::ListTasksRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTasks(std::move(request));
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::GetTaskRequest request;
   request.set_name(name);
   return connection_->GetTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::GetTask(
-    google::cloud::tasks::v2::GetTaskRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::GetTaskRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
     std::string const& parent, google::cloud::tasks::v2::Task const& task,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::CreateTaskRequest request;
   request.set_parent(parent);
   *request.mutable_task() = task;
@@ -301,42 +265,35 @@ StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::CreateTask(
-    google::cloud::tasks::v2::CreateTaskRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::CreateTaskRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTask(request);
 }
 
-Status CloudTasksClient::DeleteTask(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+Status CloudTasksClient::DeleteTask(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::DeleteTaskRequest request;
   request.set_name(name);
   return connection_->DeleteTask(request);
 }
 
 Status CloudTasksClient::DeleteTask(
-    google::cloud::tasks::v2::DeleteTaskRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::DeleteTaskRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::RunTask(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tasks::v2::RunTaskRequest request;
   request.set_name(name);
   return connection_->RunTask(request);
 }
 
 StatusOr<google::cloud::tasks::v2::Task> CloudTasksClient::RunTask(
-    google::cloud::tasks::v2::RunTaskRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tasks::v2::RunTaskRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RunTask(request);
 }
 

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -613,8 +613,8 @@ class CloudTasksClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param opts  Optional. Override the default class-level options, such as
-   *     retry and backoff policies.
+   * @param opts  Optional. Override the class-level options, such as retry and
+   *    backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,

--- a/google/cloud/tasks/cloud_tasks_client.h
+++ b/google/cloud/tasks/cloud_tasks_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CloudTasksClient {
  public:
   explicit CloudTasksClient(std::shared_ptr<CloudTasksConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~CloudTasksClient();
 
   //@{
@@ -91,7 +91,8 @@ class CloudTasksClient {
   ///
   /// @param parent  Required. The location name.
   ///  For example: `projects/PROJECT_ID/locations/LOCATION_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -101,7 +102,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists queues.
@@ -110,7 +111,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::ListQueuesRequest,google/cloud/tasks/v2/cloudtasks.proto#L308}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -120,15 +122,15 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StreamRange<google::cloud::tasks::v2::Queue> ListQueues(
-      google::cloud::tasks::v2::ListQueuesRequest request,
-      Options options = {});
+      google::cloud::tasks::v2::ListQueuesRequest request, Options opts = {});
 
   ///
   /// Gets a queue.
   ///
   /// @param name  Required. The resource name of the queue. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -138,14 +140,15 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(std::string const& name,
-                                                     Options options = {});
+                                                     Options opts = {});
 
   ///
   /// Gets a queue.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::GetQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L369}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -156,7 +159,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> GetQueue(
       google::cloud::tasks::v2::GetQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a queue.
@@ -180,7 +183,8 @@ class CloudTasksClient {
   /// @param queue  Required. The queue to create.
   ///  [Queue's name][google.cloud.tasks.v2.Queue.name] cannot be the same as an
   ///  existing queue.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -191,7 +195,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       std::string const& parent, google::cloud::tasks::v2::Queue const& queue,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a queue.
@@ -208,7 +212,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::CreateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L381}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -219,7 +224,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> CreateQueue(
       google::cloud::tasks::v2::CreateQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a queue.
@@ -245,7 +250,8 @@ class CloudTasksClient {
   /// @param update_mask  A mask used to specify which fields of the queue are
   /// being updated.
   ///  If empty, then all fields will be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -256,7 +262,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::Queue const& queue,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates a queue.
@@ -276,7 +282,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::UpdateQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L402}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -287,7 +294,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> UpdateQueue(
       google::cloud::tasks::v2::UpdateQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a queue.
@@ -305,12 +312,13 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
-  Status DeleteQueue(std::string const& name, Options options = {});
+  Status DeleteQueue(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a queue.
@@ -328,14 +336,15 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::DeleteQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L419}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.tasks.v2.DeleteQueueRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L419}
   ///
   Status DeleteQueue(
       google::cloud::tasks::v2::DeleteQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Purges a queue by deleting all of its tasks.
@@ -348,7 +357,8 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -358,7 +368,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(std::string const& name,
-                                                       Options options = {});
+                                                       Options opts = {});
 
   ///
   /// Purges a queue by deleting all of its tasks.
@@ -371,7 +381,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::PurgeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L431}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -382,7 +393,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PurgeQueue(
       google::cloud::tasks::v2::PurgeQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Pauses the queue.
@@ -396,7 +407,8 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -406,7 +418,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(std::string const& name,
-                                                       Options options = {});
+                                                       Options opts = {});
 
   ///
   /// Pauses the queue.
@@ -420,7 +432,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::PauseQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L443}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -431,7 +444,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> PauseQueue(
       google::cloud::tasks::v2::PauseQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resume a queue.
@@ -451,7 +464,8 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/location/LOCATION_ID/queues/QUEUE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -461,7 +475,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/queue.proto#L34}
   ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(std::string const& name,
-                                                        Options options = {});
+                                                        Options opts = {});
 
   ///
   /// Resume a queue.
@@ -481,7 +495,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::ResumeQueueRequest,google/cloud/tasks/v2/cloudtasks.proto#L455}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Queue,google/cloud/tasks/v2/queue.proto#L34}
   ///
@@ -492,7 +507,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Queue> ResumeQueue(
       google::cloud::tasks::v2::ResumeQueueRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -508,7 +523,8 @@ class CloudTasksClient {
   /// @param resource  REQUIRED: The resource for which the policy is being
   /// requested.
   ///  See the operation documentation for the appropriate value for this field.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -518,7 +534,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(std::string const& resource,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -533,7 +549,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::GetIamPolicyRequest,google/iam/v1/iam_policy.proto#L113}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -543,8 +560,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> GetIamPolicy(
-      google::iam::v1::GetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::GetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -567,7 +583,8 @@ class CloudTasksClient {
   ///  the policy is limited to a few 10s of KB. An empty policy is a
   ///  valid policy but certain Cloud Platform services (such as Projects)
   ///  might reject them.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -578,7 +595,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
       std::string const& resource, google::iam::v1::Policy const& policy,
-      Options options = {});
+      Options opts = {});
 
   /**
    * Updates the IAM policy for @p resource using an optimistic concurrency
@@ -596,14 +613,13 @@ class CloudTasksClient {
    * specified. See the operation documentation for the appropriate value for
    * this field.
    * @param updater  Required. Functor to map the current policy to a new one.
-   * @param options  Optional. Options to control the loop. Expected options
-   * are:
-   *       - `CloudTasksBackoffPolicyOption`
+   * @param opts  Optional. Override the default class-level options, such as
+   *     retry and backoff policies.
    * @return google::iam::v1::Policy
    */
   StatusOr<google::iam::v1::Policy> SetIamPolicy(std::string const& resource,
                                                  IamUpdater const& updater,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Sets the access control policy for a [Queue][google.cloud.tasks.v2.Queue].
@@ -620,7 +636,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::SetIamPolicyRequest,google/iam/v1/iam_policy.proto#L98}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::Policy,google/iam/v1/policy.proto#L88}
   ///
@@ -630,8 +647,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/iam/v1/policy.proto#L88}
   ///
   StatusOr<google::iam::v1::Policy> SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const& request,
-      Options options = {});
+      google::iam::v1::SetIamPolicyRequest const& request, Options opts = {});
 
   ///
   /// Returns permissions that a caller has on a
@@ -651,7 +667,8 @@ class CloudTasksClient {
   ///  wildcards (such as '*' or 'storage.*') are not allowed. For more
   ///  information see
   ///  [IAM Overview](https://cloud.google.com/iam/docs/overview#permissions).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -662,7 +679,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       std::string const& resource, std::vector<std::string> const& permissions,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns permissions that a caller has on a
@@ -676,7 +693,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::iam::v1::TestIamPermissionsRequest,google/iam/v1/iam_policy.proto#L126}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::iam::v1::TestIamPermissionsResponse,google/iam/v1/iam_policy.proto#L141}
   ///
@@ -687,7 +705,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       google::iam::v1::TestIamPermissionsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the tasks in a queue.
@@ -702,7 +720,8 @@ class CloudTasksClient {
   ///
   /// @param parent  Required. The queue name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -712,7 +731,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists the tasks in a queue.
@@ -727,7 +746,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::ListTasksRequest,google/cloud/tasks/v2/cloudtasks.proto#L467}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -737,14 +757,15 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StreamRange<google::cloud::tasks::v2::Task> ListTasks(
-      google::cloud::tasks::v2::ListTasksRequest request, Options options = {});
+      google::cloud::tasks::v2::ListTasksRequest request, Options opts = {});
 
   ///
   /// Gets a task.
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -754,14 +775,15 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(std::string const& name,
-                                                   Options options = {});
+                                                   Options opts = {});
 
   ///
   /// Gets a task.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::GetTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L529}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -772,7 +794,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Task> GetTask(
       google::cloud::tasks::v2::GetTaskRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a task and adds it to a queue.
@@ -811,7 +833,8 @@ class CloudTasksClient {
   ///  task commands. The infrastructure relies on an approximately
   ///  uniform distribution of task ids to store and serve tasks
   ///  efficiently.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -822,7 +845,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       std::string const& parent, google::cloud::tasks::v2::Task const& task,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a task and adds it to a queue.
@@ -833,7 +856,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::CreateTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L555}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -844,7 +868,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Task> CreateTask(
       google::cloud::tasks::v2::CreateTaskRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a task.
@@ -855,12 +879,13 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
-  Status DeleteTask(std::string const& name, Options options = {});
+  Status DeleteTask(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a task.
@@ -871,13 +896,14 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::DeleteTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L619}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.tasks.v2.DeleteTaskRequest]:
   /// @googleapis_reference_link{google/cloud/tasks/v2/cloudtasks.proto#L619}
   ///
   Status DeleteTask(google::cloud::tasks::v2::DeleteTaskRequest const& request,
-                    Options options = {});
+                    Options opts = {});
 
   ///
   /// Forces a task to run now.
@@ -909,7 +935,8 @@ class CloudTasksClient {
   ///
   /// @param name  Required. The task name. For example:
   ///  `projects/PROJECT_ID/locations/LOCATION_ID/queues/QUEUE_ID/tasks/TASK_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -919,7 +946,7 @@ class CloudTasksClient {
   /// @googleapis_reference_link{google/cloud/tasks/v2/task.proto#L33}
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(std::string const& name,
-                                                   Options options = {});
+                                                   Options opts = {});
 
   ///
   /// Forces a task to run now.
@@ -951,7 +978,8 @@ class CloudTasksClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tasks::v2::RunTaskRequest,google/cloud/tasks/v2/cloudtasks.proto#L632}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tasks::v2::Task,google/cloud/tasks/v2/task.proto#L33}
   ///
@@ -962,7 +990,7 @@ class CloudTasksClient {
   ///
   StatusOr<google::cloud::tasks::v2::Task> RunTask(
       google::cloud::tasks::v2::RunTaskRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<CloudTasksConnection> connection_;

--- a/google/cloud/texttospeech/text_to_speech_client.cc
+++ b/google/cloud/texttospeech/text_to_speech_client.cc
@@ -26,18 +26,16 @@ namespace texttospeech {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TextToSpeechClient::TextToSpeechClient(
-    std::shared_ptr<TextToSpeechConnection> connection, Options options)
+    std::shared_ptr<TextToSpeechConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), texttospeech_internal::TextToSpeechDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), texttospeech_internal::TextToSpeechDefaultOptions(
+                               connection_->options()))) {}
 TextToSpeechClient::~TextToSpeechClient() = default;
 
 StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>
-TextToSpeechClient::ListVoices(std::string const& language_code,
-                               Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+TextToSpeechClient::ListVoices(std::string const& language_code, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::texttospeech::v1::ListVoicesRequest request;
   request.set_language_code(language_code);
   return connection_->ListVoices(request);
@@ -46,9 +44,8 @@ TextToSpeechClient::ListVoices(std::string const& language_code,
 StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>
 TextToSpeechClient::ListVoices(
     google::cloud::texttospeech::v1::ListVoicesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListVoices(request);
 }
 
@@ -57,9 +54,8 @@ TextToSpeechClient::SynthesizeSpeech(
     google::cloud::texttospeech::v1::SynthesisInput const& input,
     google::cloud::texttospeech::v1::VoiceSelectionParams const& voice,
     google::cloud::texttospeech::v1::AudioConfig const& audio_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::texttospeech::v1::SynthesizeSpeechRequest request;
   *request.mutable_input() = input;
   *request.mutable_voice() = voice;
@@ -70,9 +66,8 @@ TextToSpeechClient::SynthesizeSpeech(
 StatusOr<google::cloud::texttospeech::v1::SynthesizeSpeechResponse>
 TextToSpeechClient::SynthesizeSpeech(
     google::cloud::texttospeech::v1::SynthesizeSpeechRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SynthesizeSpeech(request);
 }
 

--- a/google/cloud/texttospeech/text_to_speech_client.h
+++ b/google/cloud/texttospeech/text_to_speech_client.h
@@ -61,7 +61,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TextToSpeechClient {
  public:
   explicit TextToSpeechClient(
-      std::shared_ptr<TextToSpeechConnection> connection, Options options = {});
+      std::shared_ptr<TextToSpeechConnection> connection, Options opts = {});
   ~TextToSpeechClient();
 
   //@{
@@ -96,7 +96,8 @@ class TextToSpeechClient {
   ///  `"no-\*"` (Norwegian) and `"nb-\*"` (Norwegian Bokmal) voices; specifying
   ///  `"zh"` will also get supported `"cmn-\*"` voices; specifying `"zh-hk"`
   ///  will also get supported `"yue-\*"` voices.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::texttospeech::v1::ListVoicesResponse,google/cloud/texttospeech/v1/cloud_tts.proto#L123}
   ///
@@ -106,14 +107,15 @@ class TextToSpeechClient {
   /// @googleapis_reference_link{google/cloud/texttospeech/v1/cloud_tts.proto#L123}
   ///
   StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse> ListVoices(
-      std::string const& language_code, Options options = {});
+      std::string const& language_code, Options opts = {});
 
   ///
   /// Returns a list of Voice supported for synthesis.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::texttospeech::v1::ListVoicesRequest,google/cloud/texttospeech/v1/cloud_tts.proto#L62}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::texttospeech::v1::ListVoicesResponse,google/cloud/texttospeech/v1/cloud_tts.proto#L123}
   ///
@@ -124,7 +126,7 @@ class TextToSpeechClient {
   ///
   StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse> ListVoices(
       google::cloud::texttospeech::v1::ListVoicesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Synthesizes speech synchronously: receive results after all text input
@@ -134,7 +136,8 @@ class TextToSpeechClient {
   /// as input.
   /// @param voice  Required. The desired voice of the synthesized audio.
   /// @param audio_config  Required. The configuration of the synthesized audio.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::texttospeech::v1::SynthesizeSpeechResponse,google/cloud/texttospeech/v1/cloud_tts.proto#L259}
   ///
@@ -148,7 +151,7 @@ class TextToSpeechClient {
       google::cloud::texttospeech::v1::SynthesisInput const& input,
       google::cloud::texttospeech::v1::VoiceSelectionParams const& voice,
       google::cloud::texttospeech::v1::AudioConfig const& audio_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Synthesizes speech synchronously: receive results after all text input
@@ -156,7 +159,8 @@ class TextToSpeechClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::texttospeech::v1::SynthesizeSpeechRequest,google/cloud/texttospeech/v1/cloud_tts.proto#L146}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::texttospeech::v1::SynthesizeSpeechResponse,google/cloud/texttospeech/v1/cloud_tts.proto#L259}
   ///
@@ -168,7 +172,7 @@ class TextToSpeechClient {
   StatusOr<google::cloud::texttospeech::v1::SynthesizeSpeechResponse>
   SynthesizeSpeech(
       google::cloud::texttospeech::v1::SynthesizeSpeechRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<TextToSpeechConnection> connection_;

--- a/google/cloud/tpu/tpu_client.cc
+++ b/google/cloud/tpu/tpu_client.cc
@@ -25,50 +25,45 @@ namespace cloud {
 namespace tpu {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-TpuClient::TpuClient(std::shared_ptr<TpuConnection> connection, Options options)
+TpuClient::TpuClient(std::shared_ptr<TpuConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           tpu_internal::TpuDefaultOptions(connection_->options()))) {}
 TpuClient::~TpuClient() = default;
 
 StreamRange<google::cloud::tpu::v1::Node> TpuClient::ListNodes(
-    std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::ListNodesRequest request;
   request.set_parent(parent);
   return connection_->ListNodes(request);
 }
 
 StreamRange<google::cloud::tpu::v1::Node> TpuClient::ListNodes(
-    google::cloud::tpu::v1::ListNodesRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::ListNodesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListNodes(std::move(request));
 }
 
 StatusOr<google::cloud::tpu::v1::Node> TpuClient::GetNode(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::GetNodeRequest request;
   request.set_name(name);
   return connection_->GetNode(request);
 }
 
 StatusOr<google::cloud::tpu::v1::Node> TpuClient::GetNode(
-    google::cloud::tpu::v1::GetNodeRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::GetNodeRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetNode(request);
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::CreateNode(
     std::string const& parent, google::cloud::tpu::v1::Node const& node,
-    std::string const& node_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& node_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::CreateNodeRequest request;
   request.set_parent(parent);
   *request.mutable_node() = node;
@@ -77,54 +72,46 @@ future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::CreateNode(
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::CreateNode(
-    google::cloud::tpu::v1::CreateNodeRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::CreateNodeRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateNode(request);
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::DeleteNode(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::DeleteNodeRequest request;
   request.set_name(name);
   return connection_->DeleteNode(request);
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::DeleteNode(
-    google::cloud::tpu::v1::DeleteNodeRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::DeleteNodeRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteNode(request);
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::ReimageNode(
-    google::cloud::tpu::v1::ReimageNodeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::ReimageNodeRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ReimageNode(request);
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::StopNode(
-    google::cloud::tpu::v1::StopNodeRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::StopNodeRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StopNode(request);
 }
 
 future<StatusOr<google::cloud::tpu::v1::Node>> TpuClient::StartNode(
-    google::cloud::tpu::v1::StartNodeRequest const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::StartNodeRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartNode(request);
 }
 
 StreamRange<google::cloud::tpu::v1::TensorFlowVersion>
-TpuClient::ListTensorFlowVersions(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+TpuClient::ListTensorFlowVersions(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::ListTensorFlowVersionsRequest request;
   request.set_parent(parent);
   return connection_->ListTensorFlowVersions(request);
@@ -133,16 +120,14 @@ TpuClient::ListTensorFlowVersions(std::string const& parent, Options options) {
 StreamRange<google::cloud::tpu::v1::TensorFlowVersion>
 TpuClient::ListTensorFlowVersions(
     google::cloud::tpu::v1::ListTensorFlowVersionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTensorFlowVersions(std::move(request));
 }
 
 StatusOr<google::cloud::tpu::v1::TensorFlowVersion>
-TpuClient::GetTensorFlowVersion(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+TpuClient::GetTensorFlowVersion(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::GetTensorFlowVersionRequest request;
   request.set_name(name);
   return connection_->GetTensorFlowVersion(request);
@@ -151,16 +136,14 @@ TpuClient::GetTensorFlowVersion(std::string const& name, Options options) {
 StatusOr<google::cloud::tpu::v1::TensorFlowVersion>
 TpuClient::GetTensorFlowVersion(
     google::cloud::tpu::v1::GetTensorFlowVersionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTensorFlowVersion(request);
 }
 
 StreamRange<google::cloud::tpu::v1::AcceleratorType>
-TpuClient::ListAcceleratorTypes(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+TpuClient::ListAcceleratorTypes(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::ListAcceleratorTypesRequest request;
   request.set_parent(parent);
   return connection_->ListAcceleratorTypes(request);
@@ -168,17 +151,14 @@ TpuClient::ListAcceleratorTypes(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::tpu::v1::AcceleratorType>
 TpuClient::ListAcceleratorTypes(
-    google::cloud::tpu::v1::ListAcceleratorTypesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::tpu::v1::ListAcceleratorTypesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListAcceleratorTypes(std::move(request));
 }
 
 StatusOr<google::cloud::tpu::v1::AcceleratorType> TpuClient::GetAcceleratorType(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::tpu::v1::GetAcceleratorTypeRequest request;
   request.set_name(name);
   return connection_->GetAcceleratorType(request);
@@ -186,9 +166,8 @@ StatusOr<google::cloud::tpu::v1::AcceleratorType> TpuClient::GetAcceleratorType(
 
 StatusOr<google::cloud::tpu::v1::AcceleratorType> TpuClient::GetAcceleratorType(
     google::cloud::tpu::v1::GetAcceleratorTypeRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetAcceleratorType(request);
 }
 

--- a/google/cloud/tpu/tpu_client.h
+++ b/google/cloud/tpu/tpu_client.h
@@ -65,7 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TpuClient {
  public:
   explicit TpuClient(std::shared_ptr<TpuConnection> connection,
-                     Options options = {});
+                     Options opts = {});
   ~TpuClient();
 
   //@{
@@ -90,7 +90,8 @@ class TpuClient {
   /// Lists nodes.
   ///
   /// @param parent  Required. The parent resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -100,14 +101,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
   StreamRange<google::cloud::tpu::v1::Node> ListNodes(std::string const& parent,
-                                                      Options options = {});
+                                                      Options opts = {});
 
   ///
   /// Lists nodes.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::ListNodesRequest,google/cloud/tpu/v1/cloud_tpu.proto#L345}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -117,13 +119,14 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
   StreamRange<google::cloud::tpu::v1::Node> ListNodes(
-      google::cloud::tpu::v1::ListNodesRequest request, Options options = {});
+      google::cloud::tpu::v1::ListNodesRequest request, Options opts = {});
 
   ///
   /// Gets the details of a node.
   ///
   /// @param name  Required. The resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -133,14 +136,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
   StatusOr<google::cloud::tpu::v1::Node> GetNode(std::string const& name,
-                                                 Options options = {});
+                                                 Options opts = {});
 
   ///
   /// Gets the details of a node.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::GetNodeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L374}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -150,8 +154,7 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
   StatusOr<google::cloud::tpu::v1::Node> GetNode(
-      google::cloud::tpu::v1::GetNodeRequest const& request,
-      Options options = {});
+      google::cloud::tpu::v1::GetNodeRequest const& request, Options opts = {});
 
   ///
   /// Creates a node.
@@ -159,7 +162,8 @@ class TpuClient {
   /// @param parent  Required. The parent resource name.
   /// @param node  Required. The node.
   /// @param node_id  The unqualified resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -170,14 +174,15 @@ class TpuClient {
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> CreateNode(
       std::string const& parent, google::cloud::tpu::v1::Node const& node,
-      std::string const& node_id, Options options = {});
+      std::string const& node_id, Options opts = {});
 
   ///
   /// Creates a node.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::CreateNodeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L385}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -188,13 +193,14 @@ class TpuClient {
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> CreateNode(
       google::cloud::tpu::v1::CreateNodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a node.
   ///
   /// @param name  Required. The resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -204,14 +210,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> DeleteNode(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Deletes a node.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::DeleteNodeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L402}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -222,14 +229,15 @@ class TpuClient {
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> DeleteNode(
       google::cloud::tpu::v1::DeleteNodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Reimages a node's OS.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::ReimageNodeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L413}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -240,14 +248,15 @@ class TpuClient {
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> ReimageNode(
       google::cloud::tpu::v1::ReimageNodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a node.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::StopNodeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L422}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -258,14 +267,15 @@ class TpuClient {
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> StopNode(
       google::cloud::tpu::v1::StopNodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts a node.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::StartNodeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L428}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::Node,google/cloud/tpu/v1/cloud_tpu.proto#L167}
   ///
@@ -276,13 +286,14 @@ class TpuClient {
   ///
   future<StatusOr<google::cloud::tpu::v1::Node>> StartNode(
       google::cloud::tpu::v1::StartNodeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List TensorFlow versions supported by this API.
   ///
   /// @param parent  Required. The parent resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::TensorFlowVersion,google/cloud/tpu/v1/cloud_tpu.proto#L434}
   ///
@@ -292,14 +303,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L434}
   ///
   StreamRange<google::cloud::tpu::v1::TensorFlowVersion> ListTensorFlowVersions(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// List TensorFlow versions supported by this API.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::ListTensorFlowVersionsRequest,google/cloud/tpu/v1/cloud_tpu.proto#L459}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::TensorFlowVersion,google/cloud/tpu/v1/cloud_tpu.proto#L434}
   ///
@@ -310,13 +322,14 @@ class TpuClient {
   ///
   StreamRange<google::cloud::tpu::v1::TensorFlowVersion> ListTensorFlowVersions(
       google::cloud::tpu::v1::ListTensorFlowVersionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets TensorFlow Version.
   ///
   /// @param name  Required. The resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::TensorFlowVersion,google/cloud/tpu/v1/cloud_tpu.proto#L434}
   ///
@@ -326,14 +339,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L434}
   ///
   StatusOr<google::cloud::tpu::v1::TensorFlowVersion> GetTensorFlowVersion(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets TensorFlow Version.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::GetTensorFlowVersionRequest,google/cloud/tpu/v1/cloud_tpu.proto#L448}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::TensorFlowVersion,google/cloud/tpu/v1/cloud_tpu.proto#L434}
   ///
@@ -344,13 +358,14 @@ class TpuClient {
   ///
   StatusOr<google::cloud::tpu::v1::TensorFlowVersion> GetTensorFlowVersion(
       google::cloud::tpu::v1::GetTensorFlowVersionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists accelerator types supported by this API.
   ///
   /// @param parent  Required. The parent resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::AcceleratorType,google/cloud/tpu/v1/cloud_tpu.proto#L494}
   ///
@@ -360,14 +375,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L494}
   ///
   StreamRange<google::cloud::tpu::v1::AcceleratorType> ListAcceleratorTypes(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists accelerator types supported by this API.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::ListAcceleratorTypesRequest,google/cloud/tpu/v1/cloud_tpu.proto#L519}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::AcceleratorType,google/cloud/tpu/v1/cloud_tpu.proto#L494}
   ///
@@ -378,13 +394,14 @@ class TpuClient {
   ///
   StreamRange<google::cloud::tpu::v1::AcceleratorType> ListAcceleratorTypes(
       google::cloud::tpu::v1::ListAcceleratorTypesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets AcceleratorType.
   ///
   /// @param name  Required. The resource name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::AcceleratorType,google/cloud/tpu/v1/cloud_tpu.proto#L494}
   ///
@@ -394,14 +411,15 @@ class TpuClient {
   /// @googleapis_reference_link{google/cloud/tpu/v1/cloud_tpu.proto#L494}
   ///
   StatusOr<google::cloud::tpu::v1::AcceleratorType> GetAcceleratorType(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets AcceleratorType.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::tpu::v1::GetAcceleratorTypeRequest,google/cloud/tpu/v1/cloud_tpu.proto#L508}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::tpu::v1::AcceleratorType,google/cloud/tpu/v1/cloud_tpu.proto#L494}
   ///
@@ -412,7 +430,7 @@ class TpuClient {
   ///
   StatusOr<google::cloud::tpu::v1::AcceleratorType> GetAcceleratorType(
       google::cloud::tpu::v1::GetAcceleratorTypeRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<TpuConnection> connection_;

--- a/google/cloud/trace/trace_client.cc
+++ b/google/cloud/trace/trace_client.cc
@@ -26,10 +26,10 @@ namespace trace {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TraceServiceClient::TraceServiceClient(
-    std::shared_ptr<TraceServiceConnection> connection, Options options)
+    std::shared_ptr<TraceServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           trace_internal::TraceServiceDefaultOptions(connection_->options()))) {
 }
 TraceServiceClient::~TraceServiceClient() = default;
@@ -37,9 +37,8 @@ TraceServiceClient::~TraceServiceClient() = default;
 Status TraceServiceClient::BatchWriteSpans(
     std::string const& name,
     std::vector<google::devtools::cloudtrace::v2::Span> const& spans,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::devtools::cloudtrace::v2::BatchWriteSpansRequest request;
   request.set_name(name);
   *request.mutable_spans() = {spans.begin(), spans.end()};
@@ -48,16 +47,14 @@ Status TraceServiceClient::BatchWriteSpans(
 
 Status TraceServiceClient::BatchWriteSpans(
     google::devtools::cloudtrace::v2::BatchWriteSpansRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchWriteSpans(request);
 }
 
 StatusOr<google::devtools::cloudtrace::v2::Span> TraceServiceClient::CreateSpan(
-    google::devtools::cloudtrace::v2::Span const& request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::devtools::cloudtrace::v2::Span const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSpan(request);
 }
 

--- a/google/cloud/trace/trace_client.h
+++ b/google/cloud/trace/trace_client.h
@@ -65,7 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class TraceServiceClient {
  public:
   explicit TraceServiceClient(
-      std::shared_ptr<TraceServiceConnection> connection, Options options = {});
+      std::shared_ptr<TraceServiceConnection> connection, Options opts = {});
   ~TraceServiceClient();
 
   //@{
@@ -98,7 +98,8 @@ class TraceServiceClient {
   /// @param spans  Required. A list of new spans. The span names must not match
   /// existing
   ///  spans, or the results are undefined.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.devtools.cloudtrace.v2.BatchWriteSpansRequest]:
   /// @googleapis_reference_link{google/devtools/cloudtrace/v2/tracing.proto#L66}
@@ -106,7 +107,7 @@ class TraceServiceClient {
   Status BatchWriteSpans(
       std::string const& name,
       std::vector<google::devtools::cloudtrace::v2::Span> const& spans,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Sends new spans to new or existing traces. You cannot update
@@ -114,21 +115,23 @@ class TraceServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudtrace::v2::BatchWriteSpansRequest,google/devtools/cloudtrace/v2/tracing.proto#L66}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.devtools.cloudtrace.v2.BatchWriteSpansRequest]:
   /// @googleapis_reference_link{google/devtools/cloudtrace/v2/tracing.proto#L66}
   ///
   Status BatchWriteSpans(
       google::devtools::cloudtrace::v2::BatchWriteSpansRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new span.
   ///
   /// @param request
   /// @googleapis_link{google::devtools::cloudtrace::v2::Span,google/devtools/cloudtrace/v2/trace.proto#L40}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::devtools::cloudtrace::v2::Span,google/devtools/cloudtrace/v2/trace.proto#L40}
   ///
@@ -138,8 +141,7 @@ class TraceServiceClient {
   /// @googleapis_reference_link{google/devtools/cloudtrace/v2/trace.proto#L40}
   ///
   StatusOr<google::devtools::cloudtrace::v2::Span> CreateSpan(
-      google::devtools::cloudtrace::v2::Span const& request,
-      Options options = {});
+      google::devtools::cloudtrace::v2::Span const& request, Options opts = {});
 
  private:
   std::shared_ptr<TraceServiceConnection> connection_;

--- a/google/cloud/translate/translation_client.cc
+++ b/google/cloud/translate/translation_client.cc
@@ -26,20 +26,18 @@ namespace translate {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TranslationServiceClient::TranslationServiceClient(
-    std::shared_ptr<TranslationServiceConnection> connection, Options options)
+    std::shared_ptr<TranslationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          translate_internal::TranslationServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), translate_internal::TranslationServiceDefaultOptions(
+                               connection_->options()))) {}
 TranslationServiceClient::~TranslationServiceClient() = default;
 
 StatusOr<google::cloud::translation::v3::TranslateTextResponse>
 TranslationServiceClient::TranslateText(
     std::string const& parent, std::string const& target_language_code,
-    std::vector<std::string> const& contents, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<std::string> const& contents, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::TranslateTextRequest request;
   request.set_parent(parent);
   request.set_target_language_code(target_language_code);
@@ -52,9 +50,8 @@ TranslationServiceClient::TranslateText(
     std::string const& parent, std::string const& model,
     std::string const& mime_type, std::string const& source_language_code,
     std::string const& target_language_code,
-    std::vector<std::string> const& contents, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::vector<std::string> const& contents, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::TranslateTextRequest request;
   request.set_parent(parent);
   request.set_model(model);
@@ -68,9 +65,8 @@ TranslationServiceClient::TranslateText(
 StatusOr<google::cloud::translation::v3::TranslateTextResponse>
 TranslationServiceClient::TranslateText(
     google::cloud::translation::v3::TranslateTextRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TranslateText(request);
 }
 
@@ -79,9 +75,8 @@ TranslationServiceClient::DetectLanguage(std::string const& parent,
                                          std::string const& model,
                                          std::string const& mime_type,
                                          std::string const& content,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::DetectLanguageRequest request;
   request.set_parent(parent);
   request.set_model(model);
@@ -93,18 +88,16 @@ TranslationServiceClient::DetectLanguage(std::string const& parent,
 StatusOr<google::cloud::translation::v3::DetectLanguageResponse>
 TranslationServiceClient::DetectLanguage(
     google::cloud::translation::v3::DetectLanguageRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DetectLanguage(request);
 }
 
 StatusOr<google::cloud::translation::v3::SupportedLanguages>
 TranslationServiceClient::GetSupportedLanguages(
     std::string const& parent, std::string const& model,
-    std::string const& display_language_code, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& display_language_code, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::GetSupportedLanguagesRequest request;
   request.set_parent(parent);
   request.set_model(model);
@@ -115,27 +108,24 @@ TranslationServiceClient::GetSupportedLanguages(
 StatusOr<google::cloud::translation::v3::SupportedLanguages>
 TranslationServiceClient::GetSupportedLanguages(
     google::cloud::translation::v3::GetSupportedLanguagesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSupportedLanguages(request);
 }
 
 StatusOr<google::cloud::translation::v3::TranslateDocumentResponse>
 TranslationServiceClient::TranslateDocument(
     google::cloud::translation::v3::TranslateDocumentRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->TranslateDocument(request);
 }
 
 future<StatusOr<google::cloud::translation::v3::BatchTranslateResponse>>
 TranslationServiceClient::BatchTranslateText(
     google::cloud::translation::v3::BatchTranslateTextRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchTranslateText(request);
 }
 
@@ -147,9 +137,8 @@ TranslationServiceClient::BatchTranslateDocument(
         input_configs,
     google::cloud::translation::v3::BatchDocumentOutputConfig const&
         output_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::BatchTranslateDocumentRequest request;
   request.set_parent(parent);
   request.set_source_language_code(source_language_code);
@@ -165,18 +154,16 @@ future<StatusOr<google::cloud::translation::v3::BatchTranslateDocumentResponse>>
 TranslationServiceClient::BatchTranslateDocument(
     google::cloud::translation::v3::BatchTranslateDocumentRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchTranslateDocument(request);
 }
 
 future<StatusOr<google::cloud::translation::v3::Glossary>>
 TranslationServiceClient::CreateGlossary(
     std::string const& parent,
-    google::cloud::translation::v3::Glossary const& glossary, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::translation::v3::Glossary const& glossary, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::CreateGlossaryRequest request;
   request.set_parent(parent);
   *request.mutable_glossary() = glossary;
@@ -186,17 +173,15 @@ TranslationServiceClient::CreateGlossary(
 future<StatusOr<google::cloud::translation::v3::Glossary>>
 TranslationServiceClient::CreateGlossary(
     google::cloud::translation::v3::CreateGlossaryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGlossary(request);
 }
 
 StreamRange<google::cloud::translation::v3::Glossary>
 TranslationServiceClient::ListGlossaries(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::ListGlossariesRequest request;
   request.set_parent(parent);
   return connection_->ListGlossaries(request);
@@ -205,17 +190,14 @@ TranslationServiceClient::ListGlossaries(std::string const& parent,
 StreamRange<google::cloud::translation::v3::Glossary>
 TranslationServiceClient::ListGlossaries(
     google::cloud::translation::v3::ListGlossariesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGlossaries(std::move(request));
 }
 
 StatusOr<google::cloud::translation::v3::Glossary>
-TranslationServiceClient::GetGlossary(std::string const& name,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+TranslationServiceClient::GetGlossary(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::GetGlossaryRequest request;
   request.set_name(name);
   return connection_->GetGlossary(request);
@@ -224,17 +206,15 @@ TranslationServiceClient::GetGlossary(std::string const& name,
 StatusOr<google::cloud::translation::v3::Glossary>
 TranslationServiceClient::GetGlossary(
     google::cloud::translation::v3::GetGlossaryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGlossary(request);
 }
 
 future<StatusOr<google::cloud::translation::v3::DeleteGlossaryResponse>>
 TranslationServiceClient::DeleteGlossary(std::string const& name,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::translation::v3::DeleteGlossaryRequest request;
   request.set_name(name);
   return connection_->DeleteGlossary(request);
@@ -243,9 +223,8 @@ TranslationServiceClient::DeleteGlossary(std::string const& name,
 future<StatusOr<google::cloud::translation::v3::DeleteGlossaryResponse>>
 TranslationServiceClient::DeleteGlossary(
     google::cloud::translation::v3::DeleteGlossaryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGlossary(request);
 }
 

--- a/google/cloud/translate/translation_client.h
+++ b/google/cloud/translate/translation_client.h
@@ -64,7 +64,7 @@ class TranslationServiceClient {
  public:
   explicit TranslationServiceClient(
       std::shared_ptr<TranslationServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~TranslationServiceClient();
 
   //@{
@@ -107,7 +107,8 @@ class TranslationServiceClient {
   /// @param contents  Required. The content of the input in string format.
   ///  We recommend the total content be less than 30k codepoints. The max
   ///  length of this field is 1024. Use BatchTranslateText for larger text.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::TranslateTextResponse,google/cloud/translate/v3/translation_service.proto#L279}
   ///
@@ -118,7 +119,7 @@ class TranslationServiceClient {
   ///
   StatusOr<google::cloud::translation::v3::TranslateTextResponse> TranslateText(
       std::string const& parent, std::string const& target_language_code,
-      std::vector<std::string> const& contents, Options options = {});
+      std::vector<std::string> const& contents, Options opts = {});
 
   ///
   /// Translates input text and returns translated text.
@@ -159,7 +160,8 @@ class TranslationServiceClient {
   /// @param contents  Required. The content of the input in string format.
   ///  We recommend the total content be less than 30k codepoints. The max
   ///  length of this field is 1024. Use BatchTranslateText for larger text.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::TranslateTextResponse,google/cloud/translate/v3/translation_service.proto#L279}
   ///
@@ -172,14 +174,15 @@ class TranslationServiceClient {
       std::string const& parent, std::string const& model,
       std::string const& mime_type, std::string const& source_language_code,
       std::string const& target_language_code,
-      std::vector<std::string> const& contents, Options options = {});
+      std::vector<std::string> const& contents, Options opts = {});
 
   ///
   /// Translates input text and returns translated text.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::TranslateTextRequest,google/cloud/translate/v3/translation_service.proto#L200}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::TranslateTextResponse,google/cloud/translate/v3/translation_service.proto#L279}
   ///
@@ -190,7 +193,7 @@ class TranslationServiceClient {
   ///
   StatusOr<google::cloud::translation::v3::TranslateTextResponse> TranslateText(
       google::cloud::translation::v3::TranslateTextRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Detects the language of text within a request.
@@ -214,7 +217,8 @@ class TranslationServiceClient {
   /// "text/html",
   ///  "text/plain". If left blank, the MIME type defaults to "text/html".
   /// @param content  The content of the input stored as a string.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::DetectLanguageResponse,google/cloud/translate/v3/translation_service.proto#L384}
   ///
@@ -226,14 +230,15 @@ class TranslationServiceClient {
   StatusOr<google::cloud::translation::v3::DetectLanguageResponse>
   DetectLanguage(std::string const& parent, std::string const& model,
                  std::string const& mime_type, std::string const& content,
-                 Options options = {});
+                 Options opts = {});
 
   ///
   /// Detects the language of text within a request.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::DetectLanguageRequest,google/cloud/translate/v3/translation_service.proto#L321}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::DetectLanguageResponse,google/cloud/translate/v3/translation_service.proto#L384}
   ///
@@ -245,7 +250,7 @@ class TranslationServiceClient {
   StatusOr<google::cloud::translation::v3::DetectLanguageResponse>
   DetectLanguage(
       google::cloud::translation::v3::DetectLanguageRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns a list of supported languages for translation.
@@ -272,7 +277,8 @@ class TranslationServiceClient {
   /// localized, human readable names
   ///  of supported languages. If missing, then display names are not returned
   ///  in a response.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::SupportedLanguages,google/cloud/translate/v3/translation_service.proto#L434}
   ///
@@ -284,14 +290,15 @@ class TranslationServiceClient {
   StatusOr<google::cloud::translation::v3::SupportedLanguages>
   GetSupportedLanguages(std::string const& parent, std::string const& model,
                         std::string const& display_language_code,
-                        Options options = {});
+                        Options opts = {});
 
   ///
   /// Returns a list of supported languages for translation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::GetSupportedLanguagesRequest,google/cloud/translate/v3/translation_service.proto#L391}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::SupportedLanguages,google/cloud/translate/v3/translation_service.proto#L434}
   ///
@@ -304,14 +311,15 @@ class TranslationServiceClient {
   GetSupportedLanguages(
       google::cloud::translation::v3::GetSupportedLanguagesRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Translates documents in synchronous mode.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::TranslateDocumentRequest,google/cloud/translate/v3/translation_service.proto#L686}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::TranslateDocumentResponse,google/cloud/translate/v3/translation_service.proto#L777}
   ///
@@ -323,7 +331,7 @@ class TranslationServiceClient {
   StatusOr<google::cloud::translation::v3::TranslateDocumentResponse>
   TranslateDocument(
       google::cloud::translation::v3::TranslateDocumentRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Translates a large volume of text in asynchronous batch mode.
@@ -336,7 +344,8 @@ class TranslationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::BatchTranslateTextRequest,google/cloud/translate/v3/translation_service.proto#L801}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::BatchTranslateResponse,google/cloud/translate/v3/translation_service.proto#L921}
   ///
@@ -348,7 +357,7 @@ class TranslationServiceClient {
   future<StatusOr<google::cloud::translation::v3::BatchTranslateResponse>>
   BatchTranslateText(
       google::cloud::translation::v3::BatchTranslateTextRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Translates a large volume of document in asynchronous batch mode.
@@ -379,7 +388,8 @@ class TranslationServiceClient {
   /// @param output_config  Required. Output configuration.
   ///  If 2 input configs match to the same file (that is, same input path),
   ///  we don't generate output for duplicate inputs.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::BatchTranslateDocumentResponse,google/cloud/translate/v3/translation_service.proto#L1359}
   ///
@@ -398,7 +408,7 @@ class TranslationServiceClient {
           input_configs,
       google::cloud::translation::v3::BatchDocumentOutputConfig const&
           output_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Translates a large volume of document in asynchronous batch mode.
@@ -411,7 +421,8 @@ class TranslationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::BatchTranslateDocumentRequest,google/cloud/translate/v3/translation_service.proto#L1199}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::BatchTranslateDocumentResponse,google/cloud/translate/v3/translation_service.proto#L1359}
   ///
@@ -425,7 +436,7 @@ class TranslationServiceClient {
   BatchTranslateDocument(
       google::cloud::translation::v3::BatchTranslateDocumentRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a glossary and returns the long-running operation. Returns
@@ -433,7 +444,8 @@ class TranslationServiceClient {
   ///
   /// @param parent  Required. The project name.
   /// @param glossary  Required. The glossary to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::Glossary,google/cloud/translate/v3/translation_service.proto#L970}
   ///
@@ -445,7 +457,7 @@ class TranslationServiceClient {
   future<StatusOr<google::cloud::translation::v3::Glossary>> CreateGlossary(
       std::string const& parent,
       google::cloud::translation::v3::Glossary const& glossary,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a glossary and returns the long-running operation. Returns
@@ -453,7 +465,8 @@ class TranslationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::CreateGlossaryRequest,google/cloud/translate/v3/translation_service.proto#L1025}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::Glossary,google/cloud/translate/v3/translation_service.proto#L970}
   ///
@@ -464,7 +477,7 @@ class TranslationServiceClient {
   ///
   future<StatusOr<google::cloud::translation::v3::Glossary>> CreateGlossary(
       google::cloud::translation::v3::CreateGlossaryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists glossaries in a project. Returns NOT_FOUND, if the project doesn't
@@ -472,7 +485,8 @@ class TranslationServiceClient {
   ///
   /// @param parent  Required. The name of the project from which to list all of
   /// the glossaries.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::Glossary,google/cloud/translate/v3/translation_service.proto#L970}
   ///
@@ -482,7 +496,7 @@ class TranslationServiceClient {
   /// @googleapis_reference_link{google/cloud/translate/v3/translation_service.proto#L970}
   ///
   StreamRange<google::cloud::translation::v3::Glossary> ListGlossaries(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists glossaries in a project. Returns NOT_FOUND, if the project doesn't
@@ -490,7 +504,8 @@ class TranslationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::ListGlossariesRequest,google/cloud/translate/v3/translation_service.proto#L1061}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::Glossary,google/cloud/translate/v3/translation_service.proto#L970}
   ///
@@ -501,14 +516,15 @@ class TranslationServiceClient {
   ///
   StreamRange<google::cloud::translation::v3::Glossary> ListGlossaries(
       google::cloud::translation::v3::ListGlossariesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
   /// exist.
   ///
   /// @param name  Required. The name of the glossary to retrieve.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::Glossary,google/cloud/translate/v3/translation_service.proto#L970}
   ///
@@ -518,7 +534,7 @@ class TranslationServiceClient {
   /// @googleapis_reference_link{google/cloud/translate/v3/translation_service.proto#L970}
   ///
   StatusOr<google::cloud::translation::v3::Glossary> GetGlossary(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a glossary. Returns NOT_FOUND, if the glossary doesn't
@@ -526,7 +542,8 @@ class TranslationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::GetGlossaryRequest,google/cloud/translate/v3/translation_service.proto#L1039}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::Glossary,google/cloud/translate/v3/translation_service.proto#L970}
   ///
@@ -537,7 +554,7 @@ class TranslationServiceClient {
   ///
   StatusOr<google::cloud::translation::v3::Glossary> GetGlossary(
       google::cloud::translation::v3::GetGlossaryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a glossary, or cancels glossary construction
@@ -545,7 +562,8 @@ class TranslationServiceClient {
   /// Returns NOT_FOUND, if the glossary doesn't exist.
   ///
   /// @param name  Required. The name of the glossary to delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::DeleteGlossaryResponse,google/cloud/translate/v3/translation_service.proto#L1185}
   ///
@@ -555,7 +573,7 @@ class TranslationServiceClient {
   /// @googleapis_reference_link{google/cloud/translate/v3/translation_service.proto#L1185}
   ///
   future<StatusOr<google::cloud::translation::v3::DeleteGlossaryResponse>>
-  DeleteGlossary(std::string const& name, Options options = {});
+  DeleteGlossary(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a glossary, or cancels glossary construction
@@ -564,7 +582,8 @@ class TranslationServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::translation::v3::DeleteGlossaryRequest,google/cloud/translate/v3/translation_service.proto#L1050}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::translation::v3::DeleteGlossaryResponse,google/cloud/translate/v3/translation_service.proto#L1185}
   ///
@@ -576,7 +595,7 @@ class TranslationServiceClient {
   future<StatusOr<google::cloud::translation::v3::DeleteGlossaryResponse>>
   DeleteGlossary(
       google::cloud::translation::v3::DeleteGlossaryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<TranslationServiceConnection> connection_;

--- a/google/cloud/videointelligence/video_intelligence_client.cc
+++ b/google/cloud/videointelligence/video_intelligence_client.cc
@@ -27,10 +27,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VideoIntelligenceServiceClient::VideoIntelligenceServiceClient(
     std::shared_ptr<VideoIntelligenceServiceConnection> connection,
-    Options options)
+    Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           videointelligence_internal::VideoIntelligenceServiceDefaultOptions(
               connection_->options()))) {}
 VideoIntelligenceServiceClient::~VideoIntelligenceServiceClient() = default;
@@ -39,9 +39,8 @@ future<StatusOr<google::cloud::videointelligence::v1::AnnotateVideoResponse>>
 VideoIntelligenceServiceClient::AnnotateVideo(
     std::string const& input_uri,
     std::vector<google::cloud::videointelligence::v1::Feature> const& features,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::videointelligence::v1::AnnotateVideoRequest request;
   request.set_input_uri(input_uri);
   *request.mutable_features() = {features.begin(), features.end()};
@@ -51,9 +50,8 @@ VideoIntelligenceServiceClient::AnnotateVideo(
 future<StatusOr<google::cloud::videointelligence::v1::AnnotateVideoResponse>>
 VideoIntelligenceServiceClient::AnnotateVideo(
     google::cloud::videointelligence::v1::AnnotateVideoRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AnnotateVideo(request);
 }
 

--- a/google/cloud/videointelligence/video_intelligence_client.h
+++ b/google/cloud/videointelligence/video_intelligence_client.h
@@ -63,7 +63,7 @@ class VideoIntelligenceServiceClient {
  public:
   explicit VideoIntelligenceServiceClient(
       std::shared_ptr<VideoIntelligenceServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~VideoIntelligenceServiceClient();
 
   //@{
@@ -107,7 +107,8 @@ class VideoIntelligenceServiceClient {
   ///  '?' to match 1 character. If unset, the input video should be embedded
   ///  in the request as `input_content`. If set, `input_content` must be unset.
   /// @param features  Required. Requested video annotation features.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::videointelligence::v1::AnnotateVideoResponse,google/cloud/videointelligence/v1/video_intelligence.proto#L602}
   ///
@@ -121,7 +122,7 @@ class VideoIntelligenceServiceClient {
       std::string const& input_uri,
       std::vector<google::cloud::videointelligence::v1::Feature> const&
           features,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Performs asynchronous video annotation. Progress and results can be
@@ -131,7 +132,8 @@ class VideoIntelligenceServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::videointelligence::v1::AnnotateVideoRequest,google/cloud/videointelligence/v1/video_intelligence.proto#L60}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::videointelligence::v1::AnnotateVideoResponse,google/cloud/videointelligence/v1/video_intelligence.proto#L602}
   ///
@@ -143,7 +145,7 @@ class VideoIntelligenceServiceClient {
   future<StatusOr<google::cloud::videointelligence::v1::AnnotateVideoResponse>>
   AnnotateVideo(
       google::cloud::videointelligence::v1::AnnotateVideoRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<VideoIntelligenceServiceConnection> connection_;

--- a/google/cloud/vision/image_annotator_client.cc
+++ b/google/cloud/vision/image_annotator_client.cc
@@ -26,20 +26,19 @@ namespace vision {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ImageAnnotatorClient::ImageAnnotatorClient(
-    std::shared_ptr<ImageAnnotatorConnection> connection, Options options)
+    std::shared_ptr<ImageAnnotatorConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), vision_internal::ImageAnnotatorDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), vision_internal::ImageAnnotatorDefaultOptions(
+                               connection_->options()))) {}
 ImageAnnotatorClient::~ImageAnnotatorClient() = default;
 
 StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>
 ImageAnnotatorClient::BatchAnnotateImages(
     std::vector<google::cloud::vision::v1::AnnotateImageRequest> const&
         requests,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::BatchAnnotateImagesRequest request;
   *request.mutable_requests() = {requests.begin(), requests.end()};
   return connection_->BatchAnnotateImages(request);
@@ -48,18 +47,16 @@ ImageAnnotatorClient::BatchAnnotateImages(
 StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>
 ImageAnnotatorClient::BatchAnnotateImages(
     google::cloud::vision::v1::BatchAnnotateImagesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchAnnotateImages(request);
 }
 
 StatusOr<google::cloud::vision::v1::BatchAnnotateFilesResponse>
 ImageAnnotatorClient::BatchAnnotateFiles(
     std::vector<google::cloud::vision::v1::AnnotateFileRequest> const& requests,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::BatchAnnotateFilesRequest request;
   *request.mutable_requests() = {requests.begin(), requests.end()};
   return connection_->BatchAnnotateFiles(request);
@@ -68,9 +65,8 @@ ImageAnnotatorClient::BatchAnnotateFiles(
 StatusOr<google::cloud::vision::v1::BatchAnnotateFilesResponse>
 ImageAnnotatorClient::BatchAnnotateFiles(
     google::cloud::vision::v1::BatchAnnotateFilesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->BatchAnnotateFiles(request);
 }
 
@@ -79,9 +75,8 @@ ImageAnnotatorClient::AsyncBatchAnnotateImages(
     std::vector<google::cloud::vision::v1::AnnotateImageRequest> const&
         requests,
     google::cloud::vision::v1::OutputConfig const& output_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest request;
   *request.mutable_requests() = {requests.begin(), requests.end()};
   *request.mutable_output_config() = output_config;
@@ -91,9 +86,8 @@ ImageAnnotatorClient::AsyncBatchAnnotateImages(
 future<StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse>>
 ImageAnnotatorClient::AsyncBatchAnnotateImages(
     google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncBatchAnnotateImages(request);
 }
 
@@ -101,9 +95,8 @@ future<StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>>
 ImageAnnotatorClient::AsyncBatchAnnotateFiles(
     std::vector<google::cloud::vision::v1::AsyncAnnotateFileRequest> const&
         requests,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::AsyncBatchAnnotateFilesRequest request;
   *request.mutable_requests() = {requests.begin(), requests.end()};
   return connection_->AsyncBatchAnnotateFiles(request);
@@ -112,9 +105,8 @@ ImageAnnotatorClient::AsyncBatchAnnotateFiles(
 future<StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>>
 ImageAnnotatorClient::AsyncBatchAnnotateFiles(
     google::cloud::vision::v1::AsyncBatchAnnotateFilesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AsyncBatchAnnotateFiles(request);
 }
 

--- a/google/cloud/vision/image_annotator_client.h
+++ b/google/cloud/vision/image_annotator_client.h
@@ -64,8 +64,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ImageAnnotatorClient {
  public:
   explicit ImageAnnotatorClient(
-      std::shared_ptr<ImageAnnotatorConnection> connection,
-      Options options = {});
+      std::shared_ptr<ImageAnnotatorConnection> connection, Options opts = {});
   ~ImageAnnotatorClient();
 
   //@{
@@ -93,7 +92,8 @@ class ImageAnnotatorClient {
   ///
   /// @param requests  Required. Individual image annotation requests for this
   /// batch.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::BatchAnnotateImagesResponse,google/cloud/vision/v1/image_annotator.proto#L814}
   ///
@@ -106,14 +106,15 @@ class ImageAnnotatorClient {
   BatchAnnotateImages(
       std::vector<google::cloud::vision::v1::AnnotateImageRequest> const&
           requests,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Run image detection and annotation for a batch of images.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::BatchAnnotateImagesRequest,google/cloud/vision/v1/image_annotator.proto#L793}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::BatchAnnotateImagesResponse,google/cloud/vision/v1/image_annotator.proto#L814}
   ///
@@ -125,7 +126,7 @@ class ImageAnnotatorClient {
   StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>
   BatchAnnotateImages(
       google::cloud::vision::v1::BatchAnnotateImagesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Service that performs image detection and annotation for a batch of files.
@@ -139,7 +140,8 @@ class ImageAnnotatorClient {
   /// @param requests  Required. The list of file annotation requests. Right now
   /// we support only
   ///  one AnnotateFileRequest in BatchAnnotateFilesRequest.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::BatchAnnotateFilesResponse,google/cloud/vision/v1/image_annotator.proto#L888}
   ///
@@ -152,7 +154,7 @@ class ImageAnnotatorClient {
   BatchAnnotateFiles(
       std::vector<google::cloud::vision::v1::AnnotateFileRequest> const&
           requests,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Service that performs image detection and annotation for a batch of files.
@@ -165,7 +167,8 @@ class ImageAnnotatorClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::BatchAnnotateFilesRequest,google/cloud/vision/v1/image_annotator.proto#L866}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::BatchAnnotateFilesResponse,google/cloud/vision/v1/image_annotator.proto#L888}
   ///
@@ -177,7 +180,7 @@ class ImageAnnotatorClient {
   StatusOr<google::cloud::vision::v1::BatchAnnotateFilesResponse>
   BatchAnnotateFiles(
       google::cloud::vision::v1::BatchAnnotateFilesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Run asynchronous image detection and annotation for a list of images.
@@ -195,7 +198,8 @@ class ImageAnnotatorClient {
   /// batch.
   /// @param output_config  Required. The desired output location and metadata
   /// (e.g. format).
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse,google/cloud/vision/v1/image_annotator.proto#L940}
   ///
@@ -209,7 +213,7 @@ class ImageAnnotatorClient {
       std::vector<google::cloud::vision::v1::AnnotateImageRequest> const&
           requests,
       google::cloud::vision::v1::OutputConfig const& output_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Run asynchronous image detection and annotation for a list of images.
@@ -225,7 +229,8 @@ class ImageAnnotatorClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest,google/cloud/vision/v1/image_annotator.proto#L916}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse,google/cloud/vision/v1/image_annotator.proto#L940}
   ///
@@ -237,7 +242,7 @@ class ImageAnnotatorClient {
   future<StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateImagesResponse>>
   AsyncBatchAnnotateImages(
       google::cloud::vision::v1::AsyncBatchAnnotateImagesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Run asynchronous image detection and annotation for a list of generic
@@ -249,7 +254,8 @@ class ImageAnnotatorClient {
   ///
   /// @param requests  Required. Individual async file annotation requests for
   /// this batch.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse,google/cloud/vision/v1/image_annotator.proto#L968}
   ///
@@ -262,7 +268,7 @@ class ImageAnnotatorClient {
   AsyncBatchAnnotateFiles(
       std::vector<google::cloud::vision::v1::AsyncAnnotateFileRequest> const&
           requests,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Run asynchronous image detection and annotation for a list of generic
@@ -274,7 +280,8 @@ class ImageAnnotatorClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::AsyncBatchAnnotateFilesRequest,google/cloud/vision/v1/image_annotator.proto#L947}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse,google/cloud/vision/v1/image_annotator.proto#L968}
   ///
@@ -286,7 +293,7 @@ class ImageAnnotatorClient {
   future<StatusOr<google::cloud::vision::v1::AsyncBatchAnnotateFilesResponse>>
   AsyncBatchAnnotateFiles(
       google::cloud::vision::v1::AsyncBatchAnnotateFilesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ImageAnnotatorConnection> connection_;

--- a/google/cloud/vision/product_search_client.cc
+++ b/google/cloud/vision/product_search_client.cc
@@ -26,20 +26,19 @@ namespace vision {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ProductSearchClient::ProductSearchClient(
-    std::shared_ptr<ProductSearchConnection> connection, Options options)
+    std::shared_ptr<ProductSearchConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), vision_internal::ProductSearchDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), vision_internal::ProductSearchDefaultOptions(
+                               connection_->options()))) {}
 ProductSearchClient::~ProductSearchClient() = default;
 
 StatusOr<google::cloud::vision::v1::ProductSet>
 ProductSearchClient::CreateProductSet(
     std::string const& parent,
     google::cloud::vision::v1::ProductSet const& product_set,
-    std::string const& product_set_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& product_set_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::CreateProductSetRequest request;
   request.set_parent(parent);
   *request.mutable_product_set() = product_set;
@@ -50,17 +49,14 @@ ProductSearchClient::CreateProductSet(
 StatusOr<google::cloud::vision::v1::ProductSet>
 ProductSearchClient::CreateProductSet(
     google::cloud::vision::v1::CreateProductSetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateProductSet(request);
 }
 
 StreamRange<google::cloud::vision::v1::ProductSet>
-ProductSearchClient::ListProductSets(std::string const& parent,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProductSearchClient::ListProductSets(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::ListProductSetsRequest request;
   request.set_parent(parent);
   return connection_->ListProductSets(request);
@@ -68,17 +64,14 @@ ProductSearchClient::ListProductSets(std::string const& parent,
 
 StreamRange<google::cloud::vision::v1::ProductSet>
 ProductSearchClient::ListProductSets(
-    google::cloud::vision::v1::ListProductSetsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vision::v1::ListProductSetsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProductSets(std::move(request));
 }
 
 StatusOr<google::cloud::vision::v1::ProductSet>
-ProductSearchClient::GetProductSet(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProductSearchClient::GetProductSet(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::GetProductSetRequest request;
   request.set_name(name);
   return connection_->GetProductSet(request);
@@ -87,18 +80,16 @@ ProductSearchClient::GetProductSet(std::string const& name, Options options) {
 StatusOr<google::cloud::vision::v1::ProductSet>
 ProductSearchClient::GetProductSet(
     google::cloud::vision::v1::GetProductSetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetProductSet(request);
 }
 
 StatusOr<google::cloud::vision::v1::ProductSet>
 ProductSearchClient::UpdateProductSet(
     google::cloud::vision::v1::ProductSet const& product_set,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::UpdateProductSetRequest request;
   *request.mutable_product_set() = product_set;
   *request.mutable_update_mask() = update_mask;
@@ -108,16 +99,14 @@ ProductSearchClient::UpdateProductSet(
 StatusOr<google::cloud::vision::v1::ProductSet>
 ProductSearchClient::UpdateProductSet(
     google::cloud::vision::v1::UpdateProductSetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateProductSet(request);
 }
 
 Status ProductSearchClient::DeleteProductSet(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::DeleteProductSetRequest request;
   request.set_name(name);
   return connection_->DeleteProductSet(request);
@@ -125,18 +114,16 @@ Status ProductSearchClient::DeleteProductSet(std::string const& name,
 
 Status ProductSearchClient::DeleteProductSet(
     google::cloud::vision::v1::DeleteProductSetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteProductSet(request);
 }
 
 StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::CreateProduct(
     std::string const& parent,
     google::cloud::vision::v1::Product const& product,
-    std::string const& product_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& product_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::CreateProductRequest request;
   request.set_parent(parent);
   *request.mutable_product() = product;
@@ -146,16 +133,14 @@ StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::CreateProduct(
 
 StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::CreateProduct(
     google::cloud::vision::v1::CreateProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateProduct(request);
 }
 
 StreamRange<google::cloud::vision::v1::Product>
-ProductSearchClient::ListProducts(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProductSearchClient::ListProducts(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::ListProductsRequest request;
   request.set_parent(parent);
   return connection_->ListProducts(request);
@@ -163,34 +148,29 @@ ProductSearchClient::ListProducts(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::vision::v1::Product>
 ProductSearchClient::ListProducts(
-    google::cloud::vision::v1::ListProductsRequest request, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vision::v1::ListProductsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProducts(std::move(request));
 }
 
 StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::GetProduct(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::GetProductRequest request;
   request.set_name(name);
   return connection_->GetProduct(request);
 }
 
 StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::GetProduct(
-    google::cloud::vision::v1::GetProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vision::v1::GetProductRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetProduct(request);
 }
 
 StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::UpdateProduct(
     google::cloud::vision::v1::Product const& product,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::UpdateProductRequest request;
   *request.mutable_product() = product;
   *request.mutable_update_mask() = update_mask;
@@ -199,16 +179,14 @@ StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::UpdateProduct(
 
 StatusOr<google::cloud::vision::v1::Product> ProductSearchClient::UpdateProduct(
     google::cloud::vision::v1::UpdateProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateProduct(request);
 }
 
 Status ProductSearchClient::DeleteProduct(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::DeleteProductRequest request;
   request.set_name(name);
   return connection_->DeleteProduct(request);
@@ -216,9 +194,8 @@ Status ProductSearchClient::DeleteProduct(std::string const& name,
 
 Status ProductSearchClient::DeleteProduct(
     google::cloud::vision::v1::DeleteProductRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteProduct(request);
 }
 
@@ -226,9 +203,8 @@ StatusOr<google::cloud::vision::v1::ReferenceImage>
 ProductSearchClient::CreateReferenceImage(
     std::string const& parent,
     google::cloud::vision::v1::ReferenceImage const& reference_image,
-    std::string const& reference_image_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& reference_image_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::CreateReferenceImageRequest request;
   request.set_parent(parent);
   *request.mutable_reference_image() = reference_image;
@@ -239,16 +215,14 @@ ProductSearchClient::CreateReferenceImage(
 StatusOr<google::cloud::vision::v1::ReferenceImage>
 ProductSearchClient::CreateReferenceImage(
     google::cloud::vision::v1::CreateReferenceImageRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateReferenceImage(request);
 }
 
 Status ProductSearchClient::DeleteReferenceImage(std::string const& name,
-                                                 Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                 Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::DeleteReferenceImageRequest request;
   request.set_name(name);
   return connection_->DeleteReferenceImage(request);
@@ -256,17 +230,15 @@ Status ProductSearchClient::DeleteReferenceImage(std::string const& name,
 
 Status ProductSearchClient::DeleteReferenceImage(
     google::cloud::vision::v1::DeleteReferenceImageRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteReferenceImage(request);
 }
 
 StreamRange<google::cloud::vision::v1::ReferenceImage>
 ProductSearchClient::ListReferenceImages(std::string const& parent,
-                                         Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                         Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::ListReferenceImagesRequest request;
   request.set_parent(parent);
   return connection_->ListReferenceImages(request);
@@ -275,17 +247,14 @@ ProductSearchClient::ListReferenceImages(std::string const& parent,
 StreamRange<google::cloud::vision::v1::ReferenceImage>
 ProductSearchClient::ListReferenceImages(
     google::cloud::vision::v1::ListReferenceImagesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListReferenceImages(std::move(request));
 }
 
 StatusOr<google::cloud::vision::v1::ReferenceImage>
-ProductSearchClient::GetReferenceImage(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProductSearchClient::GetReferenceImage(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::GetReferenceImageRequest request;
   request.set_name(name);
   return connection_->GetReferenceImage(request);
@@ -294,17 +263,15 @@ ProductSearchClient::GetReferenceImage(std::string const& name,
 StatusOr<google::cloud::vision::v1::ReferenceImage>
 ProductSearchClient::GetReferenceImage(
     google::cloud::vision::v1::GetReferenceImageRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetReferenceImage(request);
 }
 
 Status ProductSearchClient::AddProductToProductSet(std::string const& name,
                                                    std::string const& product,
-                                                   Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                                   Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::AddProductToProductSetRequest request;
   request.set_name(name);
   request.set_product(product);
@@ -313,16 +280,14 @@ Status ProductSearchClient::AddProductToProductSet(std::string const& name,
 
 Status ProductSearchClient::AddProductToProductSet(
     google::cloud::vision::v1::AddProductToProductSetRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AddProductToProductSet(request);
 }
 
 Status ProductSearchClient::RemoveProductFromProductSet(
-    std::string const& name, std::string const& product, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, std::string const& product, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::RemoveProductFromProductSetRequest request;
   request.set_name(name);
   request.set_product(product);
@@ -332,17 +297,15 @@ Status ProductSearchClient::RemoveProductFromProductSet(
 Status ProductSearchClient::RemoveProductFromProductSet(
     google::cloud::vision::v1::RemoveProductFromProductSetRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RemoveProductFromProductSet(request);
 }
 
 StreamRange<google::cloud::vision::v1::Product>
 ProductSearchClient::ListProductsInProductSet(std::string const& name,
-                                              Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                              Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::ListProductsInProductSetRequest request;
   request.set_name(name);
   return connection_->ListProductsInProductSet(request);
@@ -351,9 +314,8 @@ ProductSearchClient::ListProductsInProductSet(std::string const& name,
 StreamRange<google::cloud::vision::v1::Product>
 ProductSearchClient::ListProductsInProductSet(
     google::cloud::vision::v1::ListProductsInProductSetRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListProductsInProductSet(std::move(request));
 }
 
@@ -361,9 +323,8 @@ future<StatusOr<google::cloud::vision::v1::ImportProductSetsResponse>>
 ProductSearchClient::ImportProductSets(
     std::string const& parent,
     google::cloud::vision::v1::ImportProductSetsInputConfig const& input_config,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::ImportProductSetsRequest request;
   request.set_parent(parent);
   *request.mutable_input_config() = input_config;
@@ -373,16 +334,14 @@ ProductSearchClient::ImportProductSets(
 future<StatusOr<google::cloud::vision::v1::ImportProductSetsResponse>>
 ProductSearchClient::ImportProductSets(
     google::cloud::vision::v1::ImportProductSetsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ImportProductSets(request);
 }
 
 future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>
-ProductSearchClient::PurgeProducts(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ProductSearchClient::PurgeProducts(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vision::v1::PurgeProductsRequest request;
   request.set_parent(parent);
   return connection_->PurgeProducts(request);
@@ -391,9 +350,8 @@ ProductSearchClient::PurgeProducts(std::string const& parent, Options options) {
 future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>
 ProductSearchClient::PurgeProducts(
     google::cloud::vision::v1::PurgeProductsRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PurgeProducts(request);
 }
 

--- a/google/cloud/vision/product_search_client.h
+++ b/google/cloud/vision/product_search_client.h
@@ -78,8 +78,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ProductSearchClient {
  public:
   explicit ProductSearchClient(
-      std::shared_ptr<ProductSearchConnection> connection,
-      Options options = {});
+      std::shared_ptr<ProductSearchConnection> connection, Options opts = {});
   ~ProductSearchClient();
 
   //@{
@@ -119,7 +118,8 @@ class ProductSearchClient {
   ///  attempt to use this value as the resource id. If it is already in use, an
   ///  error is returned with code ALREADY_EXISTS. Must be at most 128
   ///  characters long. It cannot contain the character `/`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -131,7 +131,7 @@ class ProductSearchClient {
   StatusOr<google::cloud::vision::v1::ProductSet> CreateProductSet(
       std::string const& parent,
       google::cloud::vision::v1::ProductSet const& product_set,
-      std::string const& product_set_id, Options options = {});
+      std::string const& product_set_id, Options opts = {});
 
   ///
   /// Creates and returns a new ProductSet resource.
@@ -143,7 +143,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::CreateProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L584}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -154,7 +155,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::ProductSet> CreateProductSet(
       google::cloud::vision::v1::CreateProductSetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists ProductSets in an unspecified order.
@@ -167,7 +168,8 @@ class ProductSearchClient {
   /// @param parent  Required. The project from which ProductSets should be
   /// listed.
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -177,7 +179,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L423}
   ///
   StreamRange<google::cloud::vision::v1::ProductSet> ListProductSets(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists ProductSets in an unspecified order.
@@ -189,7 +191,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::ListProductSetsRequest,google/cloud/vision/v1/product_search_service.proto#L606}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -200,7 +203,7 @@ class ProductSearchClient {
   ///
   StreamRange<google::cloud::vision::v1::ProductSet> ListProductSets(
       google::cloud::vision::v1::ListProductSetsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information associated with a ProductSet.
@@ -212,7 +215,8 @@ class ProductSearchClient {
   /// @param name  Required. Resource name of the ProductSet to get.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -222,7 +226,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L423}
   ///
   StatusOr<google::cloud::vision::v1::ProductSet> GetProductSet(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information associated with a ProductSet.
@@ -233,7 +237,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::GetProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L635}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -244,7 +249,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::ProductSet> GetProductSet(
       google::cloud::vision::v1::GetProductSetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Makes changes to a ProductSet resource.
@@ -263,7 +268,8 @@ class ProductSearchClient {
   ///  update.
   ///  If update_mask isn't specified, all mutable fields are to be updated.
   ///  Valid mask path is `display_name`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -274,7 +280,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::ProductSet> UpdateProductSet(
       google::cloud::vision::v1::ProductSet const& product_set,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Makes changes to a ProductSet resource.
@@ -288,7 +294,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::UpdateProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L649}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ProductSet,google/cloud/vision/v1/product_search_service.proto#L423}
   ///
@@ -299,7 +306,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::ProductSet> UpdateProductSet(
       google::cloud::vision::v1::UpdateProductSetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Permanently deletes a ProductSet. Products and ReferenceImages in the
@@ -310,12 +317,13 @@ class ProductSearchClient {
   /// @param name  Required. Resource name of the ProductSet to delete.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.DeleteProductSetRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L661}
   ///
-  Status DeleteProductSet(std::string const& name, Options options = {});
+  Status DeleteProductSet(std::string const& name, Options opts = {});
 
   ///
   /// Permanently deletes a ProductSet. Products and ReferenceImages in the
@@ -325,14 +333,15 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::DeleteProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L661}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.DeleteProductSetRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L661}
   ///
   Status DeleteProductSet(
       google::cloud::vision::v1::DeleteProductSetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates and returns a new product resource.
@@ -354,7 +363,8 @@ class ProductSearchClient {
   ///  attempt to use this value as the resource id. If it is already in use, an
   ///  error is returned with code ALREADY_EXISTS. Must be at most 128
   ///  characters long. It cannot contain the character `/`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -366,7 +376,7 @@ class ProductSearchClient {
   StatusOr<google::cloud::vision::v1::Product> CreateProduct(
       std::string const& parent,
       google::cloud::vision::v1::Product const& product,
-      std::string const& product_id, Options options = {});
+      std::string const& product_id, Options opts = {});
 
   ///
   /// Creates and returns a new product resource.
@@ -380,7 +390,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::CreateProductRequest,google/cloud/vision/v1/product_search_service.proto#L489}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -391,7 +402,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::Product> CreateProduct(
       google::cloud::vision::v1::CreateProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists products in an unspecified order.
@@ -405,7 +416,8 @@ class ProductSearchClient {
   /// should be listed.
   ///  Format:
   ///  `projects/PROJECT_ID/locations/LOC_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -415,7 +427,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L365}
   ///
   StreamRange<google::cloud::vision::v1::Product> ListProducts(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists products in an unspecified order.
@@ -427,7 +439,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::ListProductsRequest,google/cloud/vision/v1/product_search_service.proto#L512}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -438,7 +451,7 @@ class ProductSearchClient {
   ///
   StreamRange<google::cloud::vision::v1::Product> ListProducts(
       google::cloud::vision::v1::ListProductsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information associated with a Product.
@@ -450,7 +463,8 @@ class ProductSearchClient {
   /// @param name  Required. Resource name of the Product to get.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -460,7 +474,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L365}
   ///
   StatusOr<google::cloud::vision::v1::Product> GetProduct(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information associated with a Product.
@@ -471,7 +485,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::GetProductRequest,google/cloud/vision/v1/product_search_service.proto#L542}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -482,7 +497,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::Product> GetProduct(
       google::cloud::vision::v1::GetProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Makes changes to a Product resource.
@@ -511,7 +526,8 @@ class ProductSearchClient {
   ///  If update_mask isn't specified, all mutable fields are to be updated.
   ///  Valid mask paths include `product_labels`, `display_name`, and
   ///  `description`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -522,7 +538,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::Product> UpdateProduct(
       google::cloud::vision::v1::Product const& product,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Makes changes to a Product resource.
@@ -544,7 +560,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::UpdateProductRequest,google/cloud/vision/v1/product_search_service.proto#L556}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -555,7 +572,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::Product> UpdateProduct(
       google::cloud::vision::v1::UpdateProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Permanently deletes a product and its reference images.
@@ -567,12 +584,13 @@ class ProductSearchClient {
   /// @param name  Required. Resource name of product to delete.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.DeleteProductRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L570}
   ///
-  Status DeleteProduct(std::string const& name, Options options = {});
+  Status DeleteProduct(std::string const& name, Options opts = {});
 
   ///
   /// Permanently deletes a product and its reference images.
@@ -583,14 +601,15 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::DeleteProductRequest,google/cloud/vision/v1/product_search_service.proto#L570}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.DeleteProductRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L570}
   ///
   Status DeleteProduct(
       google::cloud::vision::v1::DeleteProductRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates and returns a new ReferenceImage resource.
@@ -625,7 +644,8 @@ class ProductSearchClient {
   ///  the server will attempt to use this value as the resource id. If it is
   ///  already in use, an error is returned with code ALREADY_EXISTS. Must be at
   ///  most 128 characters long. It cannot contain the character `/`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ReferenceImage,google/cloud/vision/v1/product_search_service.proto#L458}
   ///
@@ -637,7 +657,7 @@ class ProductSearchClient {
   StatusOr<google::cloud::vision::v1::ReferenceImage> CreateReferenceImage(
       std::string const& parent,
       google::cloud::vision::v1::ReferenceImage const& reference_image,
-      std::string const& reference_image_id, Options options = {});
+      std::string const& reference_image_id, Options opts = {});
 
   ///
   /// Creates and returns a new ReferenceImage resource.
@@ -663,7 +683,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::CreateReferenceImageRequest,google/cloud/vision/v1/product_search_service.proto#L675}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ReferenceImage,google/cloud/vision/v1/product_search_service.proto#L458}
   ///
@@ -674,7 +695,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::ReferenceImage> CreateReferenceImage(
       google::cloud::vision::v1::CreateReferenceImageRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Permanently deletes a reference image.
@@ -688,12 +709,13 @@ class ProductSearchClient {
   /// @param name  Required. The resource name of the reference image to delete.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.DeleteReferenceImageRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L748}
   ///
-  Status DeleteReferenceImage(std::string const& name, Options options = {});
+  Status DeleteReferenceImage(std::string const& name, Options opts = {});
 
   ///
   /// Permanently deletes a reference image.
@@ -706,14 +728,15 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::DeleteReferenceImageRequest,google/cloud/vision/v1/product_search_service.proto#L748}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.DeleteReferenceImageRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L748}
   ///
   Status DeleteReferenceImage(
       google::cloud::vision::v1::DeleteReferenceImageRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists reference images.
@@ -728,7 +751,8 @@ class ProductSearchClient {
   /// reference images.
   ///  Format is
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ReferenceImage,google/cloud/vision/v1/product_search_service.proto#L458}
   ///
@@ -738,7 +762,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L458}
   ///
   StreamRange<google::cloud::vision::v1::ReferenceImage> ListReferenceImages(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists reference images.
@@ -751,7 +775,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::ListReferenceImagesRequest,google/cloud/vision/v1/product_search_service.proto#L699}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ReferenceImage,google/cloud/vision/v1/product_search_service.proto#L458}
   ///
@@ -762,7 +787,7 @@ class ProductSearchClient {
   ///
   StreamRange<google::cloud::vision::v1::ReferenceImage> ListReferenceImages(
       google::cloud::vision::v1::ListReferenceImagesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets information associated with a ReferenceImage.
@@ -774,7 +799,8 @@ class ProductSearchClient {
   /// @param name  Required. The resource name of the ReferenceImage to get.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID/referenceImages/IMAGE_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ReferenceImage,google/cloud/vision/v1/product_search_service.proto#L458}
   ///
@@ -784,7 +810,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L458}
   ///
   StatusOr<google::cloud::vision::v1::ReferenceImage> GetReferenceImage(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets information associated with a ReferenceImage.
@@ -795,7 +821,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::GetReferenceImageRequest,google/cloud/vision/v1/product_search_service.proto#L734}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ReferenceImage,google/cloud/vision/v1/product_search_service.proto#L458}
   ///
@@ -806,7 +833,7 @@ class ProductSearchClient {
   ///
   StatusOr<google::cloud::vision::v1::ReferenceImage> GetReferenceImage(
       google::cloud::vision::v1::GetReferenceImageRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Adds a Product to the specified ProductSet. If the Product is already
@@ -825,14 +852,14 @@ class ProductSearchClient {
   /// this ProductSet.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.AddProductToProductSetRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L762}
   ///
   Status AddProductToProductSet(std::string const& name,
-                                std::string const& product,
-                                Options options = {});
+                                std::string const& product, Options opts = {});
 
   ///
   /// Adds a Product to the specified ProductSet. If the Product is already
@@ -846,14 +873,15 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::AddProductToProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L762}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.AddProductToProductSetRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L762}
   ///
   Status AddProductToProductSet(
       google::cloud::vision::v1::AddProductToProductSetRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes a Product from the specified ProductSet.
@@ -865,21 +893,23 @@ class ProductSearchClient {
   /// from this ProductSet.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/products/PRODUCT_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.RemoveProductFromProductSetRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L787}
   ///
   Status RemoveProductFromProductSet(std::string const& name,
                                      std::string const& product,
-                                     Options options = {});
+                                     Options opts = {});
 
   ///
   /// Removes a Product from the specified ProductSet.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::RemoveProductFromProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L787}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.vision.v1.RemoveProductFromProductSetRequest]:
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L787}
@@ -887,7 +917,7 @@ class ProductSearchClient {
   Status RemoveProductFromProductSet(
       google::cloud::vision::v1::RemoveProductFromProductSetRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists the Products in a ProductSet, in an unspecified order. If the
@@ -903,7 +933,8 @@ class ProductSearchClient {
   /// Products.
   ///  Format is:
   ///  `projects/PROJECT_ID/locations/LOC_ID/productSets/PRODUCT_SET_ID`
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -913,7 +944,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L365}
   ///
   StreamRange<google::cloud::vision::v1::Product> ListProductsInProductSet(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Lists the Products in a ProductSet, in an unspecified order. If the
@@ -927,7 +958,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::ListProductsInProductSetRequest,google/cloud/vision/v1/product_search_service.proto#L812}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::Product,google/cloud/vision/v1/product_search_service.proto#L365}
   ///
@@ -938,7 +970,7 @@ class ProductSearchClient {
   ///
   StreamRange<google::cloud::vision::v1::Product> ListProductsInProductSet(
       google::cloud::vision::v1::ListProductsInProductSetRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Asynchronous API that imports a list of reference images to specified
@@ -957,7 +989,8 @@ class ProductSearchClient {
   /// imported.
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
   /// @param input_config  Required. The input content for the list of requests.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ImportProductSetsResponse,google/cloud/vision/v1/product_search_service.proto#L939}
   ///
@@ -971,7 +1004,7 @@ class ProductSearchClient {
       std::string const& parent,
       google::cloud::vision::v1::ImportProductSetsInputConfig const&
           input_config,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Asynchronous API that imports a list of reference images to specified
@@ -988,7 +1021,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::ImportProductSetsRequest,google/cloud/vision/v1/product_search_service.proto#L919}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::ImportProductSetsResponse,google/cloud/vision/v1/product_search_service.proto#L939}
   ///
@@ -1000,7 +1034,7 @@ class ProductSearchClient {
   future<StatusOr<google::cloud::vision::v1::ImportProductSetsResponse>>
   ImportProductSets(
       google::cloud::vision::v1::ImportProductSetsRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Asynchronous API to delete all Products in a ProductSet or all Products
@@ -1031,7 +1065,8 @@ class ProductSearchClient {
   /// @param parent  Required. The project and location in which the Products
   /// should be deleted.
   ///  Format is `projects/PROJECT_ID/locations/LOC_ID`.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::BatchOperationMetadata,google/cloud/vision/v1/product_search_service.proto#L956}
   ///
@@ -1041,7 +1076,7 @@ class ProductSearchClient {
   /// @googleapis_reference_link{google/cloud/vision/v1/product_search_service.proto#L956}
   ///
   future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>
-  PurgeProducts(std::string const& parent, Options options = {});
+  PurgeProducts(std::string const& parent, Options opts = {});
 
   ///
   /// Asynchronous API to delete all Products in a ProductSet or all Products
@@ -1071,7 +1106,8 @@ class ProductSearchClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vision::v1::PurgeProductsRequest,google/cloud/vision/v1/product_search_service.proto#L998}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vision::v1::BatchOperationMetadata,google/cloud/vision/v1/product_search_service.proto#L956}
   ///
@@ -1082,7 +1118,7 @@ class ProductSearchClient {
   ///
   future<StatusOr<google::cloud::vision::v1::BatchOperationMetadata>>
   PurgeProducts(google::cloud::vision::v1::PurgeProductsRequest const& request,
-                Options options = {});
+                Options opts = {});
 
  private:
   std::shared_ptr<ProductSearchConnection> connection_;

--- a/google/cloud/vmmigration/vm_migration_client.cc
+++ b/google/cloud/vmmigration/vm_migration_client.cc
@@ -26,17 +26,16 @@ namespace vmmigration {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VmMigrationClient::VmMigrationClient(
-    std::shared_ptr<VmMigrationConnection> connection, Options options)
+    std::shared_ptr<VmMigrationConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), vmmigration_internal::VmMigrationDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), vmmigration_internal::VmMigrationDefaultOptions(
+                               connection_->options()))) {}
 VmMigrationClient::~VmMigrationClient() = default;
 
 StreamRange<google::cloud::vmmigration::v1::Source>
-VmMigrationClient::ListSources(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::ListSources(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListSourcesRequest request;
   request.set_parent(parent);
   return connection_->ListSources(request);
@@ -44,17 +43,14 @@ VmMigrationClient::ListSources(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::vmmigration::v1::Source>
 VmMigrationClient::ListSources(
-    google::cloud::vmmigration::v1::ListSourcesRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vmmigration::v1::ListSourcesRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListSources(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::Source> VmMigrationClient::GetSource(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetSourceRequest request;
   request.set_name(name);
   return connection_->GetSource(request);
@@ -62,9 +58,8 @@ StatusOr<google::cloud::vmmigration::v1::Source> VmMigrationClient::GetSource(
 
 StatusOr<google::cloud::vmmigration::v1::Source> VmMigrationClient::GetSource(
     google::cloud::vmmigration::v1::GetSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetSource(request);
 }
 
@@ -72,9 +67,8 @@ future<StatusOr<google::cloud::vmmigration::v1::Source>>
 VmMigrationClient::CreateSource(
     std::string const& parent,
     google::cloud::vmmigration::v1::Source const& source,
-    std::string const& source_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& source_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateSourceRequest request;
   request.set_parent(parent);
   *request.mutable_source() = source;
@@ -85,18 +79,16 @@ VmMigrationClient::CreateSource(
 future<StatusOr<google::cloud::vmmigration::v1::Source>>
 VmMigrationClient::CreateSource(
     google::cloud::vmmigration::v1::CreateSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSource(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::Source>>
 VmMigrationClient::UpdateSource(
     google::cloud::vmmigration::v1::Source const& source,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::UpdateSourceRequest request;
   *request.mutable_source() = source;
   *request.mutable_update_mask() = update_mask;
@@ -106,16 +98,14 @@ VmMigrationClient::UpdateSource(
 future<StatusOr<google::cloud::vmmigration::v1::Source>>
 VmMigrationClient::UpdateSource(
     google::cloud::vmmigration::v1::UpdateSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateSource(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-VmMigrationClient::DeleteSource(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::DeleteSource(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::DeleteSourceRequest request;
   request.set_name(name);
   return connection_->DeleteSource(request);
@@ -124,16 +114,14 @@ VmMigrationClient::DeleteSource(std::string const& name, Options options) {
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteSource(
     google::cloud::vmmigration::v1::DeleteSourceRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteSource(request);
 }
 
 StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>
-VmMigrationClient::FetchInventory(std::string const& source, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::FetchInventory(std::string const& source, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::FetchInventoryRequest request;
   request.set_source(source);
   return connection_->FetchInventory(request);
@@ -142,17 +130,15 @@ VmMigrationClient::FetchInventory(std::string const& source, Options options) {
 StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>
 VmMigrationClient::FetchInventory(
     google::cloud::vmmigration::v1::FetchInventoryRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FetchInventory(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::UtilizationReport>
 VmMigrationClient::ListUtilizationReports(std::string const& parent,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListUtilizationReportsRequest request;
   request.set_parent(parent);
   return connection_->ListUtilizationReports(request);
@@ -161,17 +147,14 @@ VmMigrationClient::ListUtilizationReports(std::string const& parent,
 StreamRange<google::cloud::vmmigration::v1::UtilizationReport>
 VmMigrationClient::ListUtilizationReports(
     google::cloud::vmmigration::v1::ListUtilizationReportsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListUtilizationReports(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::UtilizationReport>
-VmMigrationClient::GetUtilizationReport(std::string const& name,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::GetUtilizationReport(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetUtilizationReportRequest request;
   request.set_name(name);
   return connection_->GetUtilizationReport(request);
@@ -180,9 +163,8 @@ VmMigrationClient::GetUtilizationReport(std::string const& name,
 StatusOr<google::cloud::vmmigration::v1::UtilizationReport>
 VmMigrationClient::GetUtilizationReport(
     google::cloud::vmmigration::v1::GetUtilizationReportRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetUtilizationReport(request);
 }
 
@@ -190,9 +172,8 @@ future<StatusOr<google::cloud::vmmigration::v1::UtilizationReport>>
 VmMigrationClient::CreateUtilizationReport(
     std::string const& parent,
     google::cloud::vmmigration::v1::UtilizationReport const& utilization_report,
-    std::string const& utilization_report_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& utilization_report_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateUtilizationReportRequest request;
   request.set_parent(parent);
   *request.mutable_utilization_report() = utilization_report;
@@ -204,17 +185,15 @@ future<StatusOr<google::cloud::vmmigration::v1::UtilizationReport>>
 VmMigrationClient::CreateUtilizationReport(
     google::cloud::vmmigration::v1::CreateUtilizationReportRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateUtilizationReport(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteUtilizationReport(std::string const& name,
-                                           Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                           Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::DeleteUtilizationReportRequest request;
   request.set_name(name);
   return connection_->DeleteUtilizationReport(request);
@@ -224,17 +203,15 @@ future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteUtilizationReport(
     google::cloud::vmmigration::v1::DeleteUtilizationReportRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteUtilizationReport(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>
 VmMigrationClient::ListDatacenterConnectors(std::string const& parent,
-                                            Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                            Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListDatacenterConnectorsRequest request;
   request.set_parent(parent);
   return connection_->ListDatacenterConnectors(request);
@@ -243,17 +220,15 @@ VmMigrationClient::ListDatacenterConnectors(std::string const& parent,
 StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>
 VmMigrationClient::ListDatacenterConnectors(
     google::cloud::vmmigration::v1::ListDatacenterConnectorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListDatacenterConnectors(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>
 VmMigrationClient::GetDatacenterConnector(std::string const& name,
-                                          Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                          Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetDatacenterConnectorRequest request;
   request.set_name(name);
   return connection_->GetDatacenterConnector(request);
@@ -263,9 +238,8 @@ StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>
 VmMigrationClient::GetDatacenterConnector(
     google::cloud::vmmigration::v1::GetDatacenterConnectorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetDatacenterConnector(request);
 }
 
@@ -274,9 +248,8 @@ VmMigrationClient::CreateDatacenterConnector(
     std::string const& parent,
     google::cloud::vmmigration::v1::DatacenterConnector const&
         datacenter_connector,
-    std::string const& datacenter_connector_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& datacenter_connector_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateDatacenterConnectorRequest request;
   request.set_parent(parent);
   *request.mutable_datacenter_connector() = datacenter_connector;
@@ -288,17 +261,15 @@ future<StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>>
 VmMigrationClient::CreateDatacenterConnector(
     google::cloud::vmmigration::v1::CreateDatacenterConnectorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateDatacenterConnector(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteDatacenterConnector(std::string const& name,
-                                             Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                             Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::DeleteDatacenterConnectorRequest request;
   request.set_name(name);
   return connection_->DeleteDatacenterConnector(request);
@@ -308,9 +279,8 @@ future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteDatacenterConnector(
     google::cloud::vmmigration::v1::DeleteDatacenterConnectorRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteDatacenterConnector(request);
 }
 
@@ -318,9 +288,8 @@ future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
 VmMigrationClient::CreateMigratingVm(
     std::string const& parent,
     google::cloud::vmmigration::v1::MigratingVm const& migrating_vm,
-    std::string const& migrating_vm_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& migrating_vm_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateMigratingVmRequest request;
   request.set_parent(parent);
   *request.mutable_migrating_vm() = migrating_vm;
@@ -331,17 +300,14 @@ VmMigrationClient::CreateMigratingVm(
 future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
 VmMigrationClient::CreateMigratingVm(
     google::cloud::vmmigration::v1::CreateMigratingVmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateMigratingVm(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::MigratingVm>
-VmMigrationClient::ListMigratingVms(std::string const& parent,
-                                    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::ListMigratingVms(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListMigratingVmsRequest request;
   request.set_parent(parent);
   return connection_->ListMigratingVms(request);
@@ -350,16 +316,14 @@ VmMigrationClient::ListMigratingVms(std::string const& parent,
 StreamRange<google::cloud::vmmigration::v1::MigratingVm>
 VmMigrationClient::ListMigratingVms(
     google::cloud::vmmigration::v1::ListMigratingVmsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListMigratingVms(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::MigratingVm>
-VmMigrationClient::GetMigratingVm(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::GetMigratingVm(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetMigratingVmRequest request;
   request.set_name(name);
   return connection_->GetMigratingVm(request);
@@ -368,18 +332,16 @@ VmMigrationClient::GetMigratingVm(std::string const& name, Options options) {
 StatusOr<google::cloud::vmmigration::v1::MigratingVm>
 VmMigrationClient::GetMigratingVm(
     google::cloud::vmmigration::v1::GetMigratingVmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetMigratingVm(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
 VmMigrationClient::UpdateMigratingVm(
     google::cloud::vmmigration::v1::MigratingVm const& migrating_vm,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::UpdateMigratingVmRequest request;
   *request.mutable_migrating_vm() = migrating_vm;
   *request.mutable_update_mask() = update_mask;
@@ -389,16 +351,14 @@ VmMigrationClient::UpdateMigratingVm(
 future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
 VmMigrationClient::UpdateMigratingVm(
     google::cloud::vmmigration::v1::UpdateMigratingVmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateMigratingVm(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-VmMigrationClient::DeleteMigratingVm(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::DeleteMigratingVm(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::DeleteMigratingVmRequest request;
   request.set_name(name);
   return connection_->DeleteMigratingVm(request);
@@ -407,17 +367,15 @@ VmMigrationClient::DeleteMigratingVm(std::string const& name, Options options) {
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteMigratingVm(
     google::cloud::vmmigration::v1::DeleteMigratingVmRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteMigratingVm(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>
 VmMigrationClient::StartMigration(std::string const& migrating_vm,
-                                  Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                  Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::StartMigrationRequest request;
   request.set_migrating_vm(migrating_vm);
   return connection_->StartMigration(request);
@@ -426,35 +384,31 @@ VmMigrationClient::StartMigration(std::string const& migrating_vm,
 future<StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>
 VmMigrationClient::StartMigration(
     google::cloud::vmmigration::v1::StartMigrationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartMigration(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::ResumeMigrationResponse>>
 VmMigrationClient::ResumeMigration(
     google::cloud::vmmigration::v1::ResumeMigrationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ResumeMigration(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::PauseMigrationResponse>>
 VmMigrationClient::PauseMigration(
     google::cloud::vmmigration::v1::PauseMigrationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->PauseMigration(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>
 VmMigrationClient::FinalizeMigration(std::string const& migrating_vm,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                     Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::FinalizeMigrationRequest request;
   request.set_migrating_vm(migrating_vm);
   return connection_->FinalizeMigration(request);
@@ -463,9 +417,8 @@ VmMigrationClient::FinalizeMigration(std::string const& migrating_vm,
 future<StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>
 VmMigrationClient::FinalizeMigration(
     google::cloud::vmmigration::v1::FinalizeMigrationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->FinalizeMigration(request);
 }
 
@@ -473,9 +426,8 @@ future<StatusOr<google::cloud::vmmigration::v1::CloneJob>>
 VmMigrationClient::CreateCloneJob(
     std::string const& parent,
     google::cloud::vmmigration::v1::CloneJob const& clone_job,
-    std::string const& clone_job_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& clone_job_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateCloneJobRequest request;
   request.set_parent(parent);
   *request.mutable_clone_job() = clone_job;
@@ -486,16 +438,14 @@ VmMigrationClient::CreateCloneJob(
 future<StatusOr<google::cloud::vmmigration::v1::CloneJob>>
 VmMigrationClient::CreateCloneJob(
     google::cloud::vmmigration::v1::CreateCloneJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCloneJob(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>
-VmMigrationClient::CancelCloneJob(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::CancelCloneJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CancelCloneJobRequest request;
   request.set_name(name);
   return connection_->CancelCloneJob(request);
@@ -504,16 +454,14 @@ VmMigrationClient::CancelCloneJob(std::string const& name, Options options) {
 future<StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>
 VmMigrationClient::CancelCloneJob(
     google::cloud::vmmigration::v1::CancelCloneJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelCloneJob(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::CloneJob>
-VmMigrationClient::ListCloneJobs(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::ListCloneJobs(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListCloneJobsRequest request;
   request.set_parent(parent);
   return connection_->ListCloneJobs(request);
@@ -522,16 +470,14 @@ VmMigrationClient::ListCloneJobs(std::string const& parent, Options options) {
 StreamRange<google::cloud::vmmigration::v1::CloneJob>
 VmMigrationClient::ListCloneJobs(
     google::cloud::vmmigration::v1::ListCloneJobsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCloneJobs(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::CloneJob>
-VmMigrationClient::GetCloneJob(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::GetCloneJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetCloneJobRequest request;
   request.set_name(name);
   return connection_->GetCloneJob(request);
@@ -540,9 +486,8 @@ VmMigrationClient::GetCloneJob(std::string const& name, Options options) {
 StatusOr<google::cloud::vmmigration::v1::CloneJob>
 VmMigrationClient::GetCloneJob(
     google::cloud::vmmigration::v1::GetCloneJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCloneJob(request);
 }
 
@@ -550,9 +495,8 @@ future<StatusOr<google::cloud::vmmigration::v1::CutoverJob>>
 VmMigrationClient::CreateCutoverJob(
     std::string const& parent,
     google::cloud::vmmigration::v1::CutoverJob const& cutover_job,
-    std::string const& cutover_job_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& cutover_job_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateCutoverJobRequest request;
   request.set_parent(parent);
   *request.mutable_cutover_job() = cutover_job;
@@ -563,16 +507,14 @@ VmMigrationClient::CreateCutoverJob(
 future<StatusOr<google::cloud::vmmigration::v1::CutoverJob>>
 VmMigrationClient::CreateCutoverJob(
     google::cloud::vmmigration::v1::CreateCutoverJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateCutoverJob(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>
-VmMigrationClient::CancelCutoverJob(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::CancelCutoverJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CancelCutoverJobRequest request;
   request.set_name(name);
   return connection_->CancelCutoverJob(request);
@@ -581,16 +523,14 @@ VmMigrationClient::CancelCutoverJob(std::string const& name, Options options) {
 future<StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>
 VmMigrationClient::CancelCutoverJob(
     google::cloud::vmmigration::v1::CancelCutoverJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelCutoverJob(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::CutoverJob>
-VmMigrationClient::ListCutoverJobs(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::ListCutoverJobs(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListCutoverJobsRequest request;
   request.set_parent(parent);
   return connection_->ListCutoverJobs(request);
@@ -599,16 +539,14 @@ VmMigrationClient::ListCutoverJobs(std::string const& parent, Options options) {
 StreamRange<google::cloud::vmmigration::v1::CutoverJob>
 VmMigrationClient::ListCutoverJobs(
     google::cloud::vmmigration::v1::ListCutoverJobsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCutoverJobs(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::CutoverJob>
-VmMigrationClient::GetCutoverJob(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::GetCutoverJob(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetCutoverJobRequest request;
   request.set_name(name);
   return connection_->GetCutoverJob(request);
@@ -617,16 +555,14 @@ VmMigrationClient::GetCutoverJob(std::string const& name, Options options) {
 StatusOr<google::cloud::vmmigration::v1::CutoverJob>
 VmMigrationClient::GetCutoverJob(
     google::cloud::vmmigration::v1::GetCutoverJobRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetCutoverJob(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::Group>
-VmMigrationClient::ListGroups(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::ListGroups(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListGroupsRequest request;
   request.set_parent(parent);
   return connection_->ListGroups(request);
@@ -634,17 +570,14 @@ VmMigrationClient::ListGroups(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::vmmigration::v1::Group>
 VmMigrationClient::ListGroups(
-    google::cloud::vmmigration::v1::ListGroupsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vmmigration::v1::ListGroupsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListGroups(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::Group> VmMigrationClient::GetGroup(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetGroupRequest request;
   request.set_name(name);
   return connection_->GetGroup(request);
@@ -652,9 +585,8 @@ StatusOr<google::cloud::vmmigration::v1::Group> VmMigrationClient::GetGroup(
 
 StatusOr<google::cloud::vmmigration::v1::Group> VmMigrationClient::GetGroup(
     google::cloud::vmmigration::v1::GetGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetGroup(request);
 }
 
@@ -662,9 +594,8 @@ future<StatusOr<google::cloud::vmmigration::v1::Group>>
 VmMigrationClient::CreateGroup(
     std::string const& parent,
     google::cloud::vmmigration::v1::Group const& group,
-    std::string const& group_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& group_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateGroupRequest request;
   request.set_parent(parent);
   *request.mutable_group() = group;
@@ -675,18 +606,16 @@ VmMigrationClient::CreateGroup(
 future<StatusOr<google::cloud::vmmigration::v1::Group>>
 VmMigrationClient::CreateGroup(
     google::cloud::vmmigration::v1::CreateGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateGroup(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::Group>>
 VmMigrationClient::UpdateGroup(
     google::cloud::vmmigration::v1::Group const& group,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::UpdateGroupRequest request;
   *request.mutable_group() = group;
   *request.mutable_update_mask() = update_mask;
@@ -696,16 +625,14 @@ VmMigrationClient::UpdateGroup(
 future<StatusOr<google::cloud::vmmigration::v1::Group>>
 VmMigrationClient::UpdateGroup(
     google::cloud::vmmigration::v1::UpdateGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateGroup(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-VmMigrationClient::DeleteGroup(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::DeleteGroup(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::DeleteGroupRequest request;
   request.set_name(name);
   return connection_->DeleteGroup(request);
@@ -714,17 +641,14 @@ VmMigrationClient::DeleteGroup(std::string const& name, Options options) {
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteGroup(
     google::cloud::vmmigration::v1::DeleteGroupRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteGroup(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>
-VmMigrationClient::AddGroupMigration(std::string const& group,
-                                     Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::AddGroupMigration(std::string const& group, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::AddGroupMigrationRequest request;
   request.set_group(group);
   return connection_->AddGroupMigration(request);
@@ -733,17 +657,15 @@ VmMigrationClient::AddGroupMigration(std::string const& group,
 future<StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>
 VmMigrationClient::AddGroupMigration(
     google::cloud::vmmigration::v1::AddGroupMigrationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->AddGroupMigration(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>>
 VmMigrationClient::RemoveGroupMigration(std::string const& group,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                        Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::RemoveGroupMigrationRequest request;
   request.set_group(group);
   return connection_->RemoveGroupMigration(request);
@@ -752,17 +674,14 @@ VmMigrationClient::RemoveGroupMigration(std::string const& group,
 future<StatusOr<google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>>
 VmMigrationClient::RemoveGroupMigration(
     google::cloud::vmmigration::v1::RemoveGroupMigrationRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->RemoveGroupMigration(request);
 }
 
 StreamRange<google::cloud::vmmigration::v1::TargetProject>
-VmMigrationClient::ListTargetProjects(std::string const& parent,
-                                      Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::ListTargetProjects(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::ListTargetProjectsRequest request;
   request.set_parent(parent);
   return connection_->ListTargetProjects(request);
@@ -771,16 +690,14 @@ VmMigrationClient::ListTargetProjects(std::string const& parent,
 StreamRange<google::cloud::vmmigration::v1::TargetProject>
 VmMigrationClient::ListTargetProjects(
     google::cloud::vmmigration::v1::ListTargetProjectsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListTargetProjects(std::move(request));
 }
 
 StatusOr<google::cloud::vmmigration::v1::TargetProject>
-VmMigrationClient::GetTargetProject(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::GetTargetProject(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::GetTargetProjectRequest request;
   request.set_name(name);
   return connection_->GetTargetProject(request);
@@ -789,9 +706,8 @@ VmMigrationClient::GetTargetProject(std::string const& name, Options options) {
 StatusOr<google::cloud::vmmigration::v1::TargetProject>
 VmMigrationClient::GetTargetProject(
     google::cloud::vmmigration::v1::GetTargetProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetTargetProject(request);
 }
 
@@ -799,9 +715,8 @@ future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
 VmMigrationClient::CreateTargetProject(
     std::string const& parent,
     google::cloud::vmmigration::v1::TargetProject const& target_project,
-    std::string const& target_project_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& target_project_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::CreateTargetProjectRequest request;
   request.set_parent(parent);
   *request.mutable_target_project() = target_project;
@@ -812,18 +727,16 @@ VmMigrationClient::CreateTargetProject(
 future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
 VmMigrationClient::CreateTargetProject(
     google::cloud::vmmigration::v1::CreateTargetProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateTargetProject(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
 VmMigrationClient::UpdateTargetProject(
     google::cloud::vmmigration::v1::TargetProject const& target_project,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::UpdateTargetProjectRequest request;
   *request.mutable_target_project() = target_project;
   *request.mutable_update_mask() = update_mask;
@@ -833,17 +746,14 @@ VmMigrationClient::UpdateTargetProject(
 future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
 VmMigrationClient::UpdateTargetProject(
     google::cloud::vmmigration::v1::UpdateTargetProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateTargetProject(request);
 }
 
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-VmMigrationClient::DeleteTargetProject(std::string const& name,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VmMigrationClient::DeleteTargetProject(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vmmigration::v1::DeleteTargetProjectRequest request;
   request.set_name(name);
   return connection_->DeleteTargetProject(request);
@@ -852,9 +762,8 @@ VmMigrationClient::DeleteTargetProject(std::string const& name,
 future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
 VmMigrationClient::DeleteTargetProject(
     google::cloud::vmmigration::v1::DeleteTargetProjectRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteTargetProject(request);
 }
 

--- a/google/cloud/vmmigration/vm_migration_client.h
+++ b/google/cloud/vmmigration/vm_migration_client.h
@@ -63,7 +63,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class VmMigrationClient {
  public:
   explicit VmMigrationClient(std::shared_ptr<VmMigrationConnection> connection,
-                             Options options = {});
+                             Options opts = {});
   ~VmMigrationClient();
 
   //@{
@@ -91,7 +91,8 @@ class VmMigrationClient {
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// sources.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -101,14 +102,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
   StreamRange<google::cloud::vmmigration::v1::Source> ListSources(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Sources in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListSourcesRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1074}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -119,13 +121,14 @@ class VmMigrationClient {
   ///
   StreamRange<google::cloud::vmmigration::v1::Source> ListSources(
       google::cloud::vmmigration::v1::ListSourcesRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Source.
   ///
   /// @param name  Required. The Source name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -135,14 +138,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
   StatusOr<google::cloud::vmmigration::v1::Source> GetSource(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetSourceRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1117}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -153,7 +157,7 @@ class VmMigrationClient {
   ///
   StatusOr<google::cloud::vmmigration::v1::Source> GetSource(
       google::cloud::vmmigration::v1::GetSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Source in a given project and location.
@@ -161,7 +165,8 @@ class VmMigrationClient {
   /// @param parent  Required. The Source's parent.
   /// @param source  Required. The create request body.
   /// @param source_id  Required. The source identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -173,14 +178,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::Source>> CreateSource(
       std::string const& parent,
       google::cloud::vmmigration::v1::Source const& source,
-      std::string const& source_id, Options options = {});
+      std::string const& source_id, Options opts = {});
 
   ///
   /// Creates a new Source in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateSourceRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1128}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -191,7 +197,7 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::Source>> CreateSource(
       google::cloud::vmmigration::v1::CreateSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single Source.
@@ -203,7 +209,8 @@ class VmMigrationClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -214,14 +221,15 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::Source>> UpdateSource(
       google::cloud::vmmigration::v1::Source const& source,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::UpdateSourceRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1160}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Source,google/cloud/vmmigration/v1/vmmigration.proto#L962}
   ///
@@ -232,13 +240,14 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::Source>> UpdateSource(
       google::cloud::vmmigration::v1::UpdateSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Source.
   ///
   /// @param name  Required. The Source name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -248,14 +257,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-  DeleteSource(std::string const& name, Options options = {});
+  DeleteSource(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::DeleteSourceRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1188}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -267,7 +277,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
   DeleteSource(
       google::cloud::vmmigration::v1::DeleteSourceRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List remote source's inventory of VMs.
@@ -277,7 +287,8 @@ class VmMigrationClient {
   /// opposed to listing the MigratingVms resources in the vmmigration service.
   ///
   /// @param source  Required. The name of the Source.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::FetchInventoryResponse,google/cloud/vmmigration/v1/vmmigration.proto#L1306}
   ///
@@ -287,7 +298,7 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L1306}
   ///
   StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>
-  FetchInventory(std::string const& source, Options options = {});
+  FetchInventory(std::string const& source, Options opts = {});
 
   ///
   /// List remote source's inventory of VMs.
@@ -298,7 +309,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::FetchInventoryRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1215}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::FetchInventoryResponse,google/cloud/vmmigration/v1/vmmigration.proto#L1306}
   ///
@@ -310,13 +322,14 @@ class VmMigrationClient {
   StatusOr<google::cloud::vmmigration::v1::FetchInventoryResponse>
   FetchInventory(
       google::cloud::vmmigration::v1::FetchInventoryRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Utilization Reports of the given Source.
   ///
   /// @param parent  Required. The Utilization Reports parent.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::UtilizationReport,google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
@@ -326,14 +339,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
   StreamRange<google::cloud::vmmigration::v1::UtilizationReport>
-  ListUtilizationReports(std::string const& parent, Options options = {});
+  ListUtilizationReports(std::string const& parent, Options opts = {});
 
   ///
   /// Lists Utilization Reports of the given Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListUtilizationReportsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1437}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::UtilizationReport,google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
@@ -345,13 +359,14 @@ class VmMigrationClient {
   StreamRange<google::cloud::vmmigration::v1::UtilizationReport>
   ListUtilizationReports(
       google::cloud::vmmigration::v1::ListUtilizationReportsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a single Utilization Report.
   ///
   /// @param name  Required. The Utilization Report name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::UtilizationReport,google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
@@ -361,14 +376,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
   StatusOr<google::cloud::vmmigration::v1::UtilizationReport>
-  GetUtilizationReport(std::string const& name, Options options = {});
+  GetUtilizationReport(std::string const& name, Options opts = {});
 
   ///
   /// Gets a single Utilization Report.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetUtilizationReportRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1484}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::UtilizationReport,google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
@@ -381,7 +397,7 @@ class VmMigrationClient {
   GetUtilizationReport(
       google::cloud::vmmigration::v1::GetUtilizationReportRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new UtilizationReport.
@@ -394,7 +410,8 @@ class VmMigrationClient {
   ///  This value maximum length is 63 characters, and valid characters
   ///  are /[a-z][0-9]-/. It must start with an english letter and must not
   ///  end with a hyphen.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::UtilizationReport,google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
@@ -408,14 +425,15 @@ class VmMigrationClient {
       std::string const& parent,
       google::cloud::vmmigration::v1::UtilizationReport const&
           utilization_report,
-      std::string const& utilization_report_id, Options options = {});
+      std::string const& utilization_report_id, Options opts = {});
 
   ///
   /// Creates a new UtilizationReport.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateUtilizationReportRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1499}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::UtilizationReport,google/cloud/vmmigration/v1/vmmigration.proto#L1319}
   ///
@@ -428,13 +446,14 @@ class VmMigrationClient {
   CreateUtilizationReport(
       google::cloud::vmmigration::v1::CreateUtilizationReportRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Utilization Report.
   ///
   /// @param name  Required. The Utilization Report name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -444,14 +463,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-  DeleteUtilizationReport(std::string const& name, Options options = {});
+  DeleteUtilizationReport(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Utilization Report.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::DeleteUtilizationReportRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1536}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -464,14 +484,15 @@ class VmMigrationClient {
   DeleteUtilizationReport(
       google::cloud::vmmigration::v1::DeleteUtilizationReportRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists DatacenterConnectors in a given Source.
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// connectors.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::DatacenterConnector,google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
@@ -481,14 +502,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
   StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>
-  ListDatacenterConnectors(std::string const& parent, Options options = {});
+  ListDatacenterConnectors(std::string const& parent, Options opts = {});
 
   ///
   /// Lists DatacenterConnectors in a given Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListDatacenterConnectorsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1647}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::DatacenterConnector,google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
@@ -500,13 +522,14 @@ class VmMigrationClient {
   StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>
   ListDatacenterConnectors(
       google::cloud::vmmigration::v1::ListDatacenterConnectorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single DatacenterConnector.
   ///
   /// @param name  Required. The name of the DatacenterConnector.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::DatacenterConnector,google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
@@ -516,14 +539,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
   StatusOr<google::cloud::vmmigration::v1::DatacenterConnector>
-  GetDatacenterConnector(std::string const& name, Options options = {});
+  GetDatacenterConnector(std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single DatacenterConnector.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetDatacenterConnectorRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1575}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::DatacenterConnector,google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
@@ -536,7 +560,7 @@ class VmMigrationClient {
   GetDatacenterConnector(
       google::cloud::vmmigration::v1::GetDatacenterConnectorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new DatacenterConnector in a given Source.
@@ -548,7 +572,8 @@ class VmMigrationClient {
   /// @param datacenter_connector  Required. The create request body.
   /// @param datacenter_connector_id  Required. The datacenterConnector
   /// identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::DatacenterConnector,google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
@@ -562,14 +587,15 @@ class VmMigrationClient {
       std::string const& parent,
       google::cloud::vmmigration::v1::DatacenterConnector const&
           datacenter_connector,
-      std::string const& datacenter_connector_id, Options options = {});
+      std::string const& datacenter_connector_id, Options opts = {});
 
   ///
   /// Creates a new DatacenterConnector in a given Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateDatacenterConnectorRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1586}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::DatacenterConnector,google/cloud/vmmigration/v1/vmmigration.proto#L1009}
   ///
@@ -582,13 +608,14 @@ class VmMigrationClient {
   CreateDatacenterConnector(
       google::cloud::vmmigration::v1::CreateDatacenterConnectorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single DatacenterConnector.
   ///
   /// @param name  Required. The DatacenterConnector name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -598,14 +625,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-  DeleteDatacenterConnector(std::string const& name, Options options = {});
+  DeleteDatacenterConnector(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single DatacenterConnector.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::DeleteDatacenterConnectorRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1621}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -618,7 +646,7 @@ class VmMigrationClient {
   DeleteDatacenterConnector(
       google::cloud::vmmigration::v1::DeleteDatacenterConnectorRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new MigratingVm in a given Source.
@@ -626,7 +654,8 @@ class VmMigrationClient {
   /// @param parent  Required. The MigratingVm's parent.
   /// @param migrating_vm  Required. The create request body.
   /// @param migrating_vm_id  Required. The migratingVm identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -639,14 +668,15 @@ class VmMigrationClient {
   CreateMigratingVm(
       std::string const& parent,
       google::cloud::vmmigration::v1::MigratingVm const& migrating_vm,
-      std::string const& migrating_vm_id, Options options = {});
+      std::string const& migrating_vm_id, Options opts = {});
 
   ///
   /// Creates a new MigratingVm in a given Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateMigratingVmRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1918}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -658,14 +688,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
   CreateMigratingVm(
       google::cloud::vmmigration::v1::CreateMigratingVmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists MigratingVms in a given Source.
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// MigratingVms.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -675,14 +706,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
   StreamRange<google::cloud::vmmigration::v1::MigratingVm> ListMigratingVms(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists MigratingVms in a given Source.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListMigratingVmsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1950}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -693,13 +725,14 @@ class VmMigrationClient {
   ///
   StreamRange<google::cloud::vmmigration::v1::MigratingVm> ListMigratingVms(
       google::cloud::vmmigration::v1::ListMigratingVmsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single MigratingVm.
   ///
   /// @param name  Required. The name of the MigratingVm.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -709,14 +742,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
   StatusOr<google::cloud::vmmigration::v1::MigratingVm> GetMigratingVm(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single MigratingVm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetMigratingVmRequest,google/cloud/vmmigration/v1/vmmigration.proto#L1993}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -727,7 +761,7 @@ class VmMigrationClient {
   ///
   StatusOr<google::cloud::vmmigration::v1::MigratingVm> GetMigratingVm(
       google::cloud::vmmigration::v1::GetMigratingVmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single MigratingVm.
@@ -739,7 +773,8 @@ class VmMigrationClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -751,14 +786,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
   UpdateMigratingVm(
       google::cloud::vmmigration::v1::MigratingVm const& migrating_vm,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single MigratingVm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::UpdateMigratingVmRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2004}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::MigratingVm,google/cloud/vmmigration/v1/vmmigration.proto#L612}
   ///
@@ -770,13 +806,14 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::MigratingVm>>
   UpdateMigratingVm(
       google::cloud::vmmigration::v1::UpdateMigratingVmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single MigratingVm.
   ///
   /// @param name  Required. The name of the MigratingVm.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -786,14 +823,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-  DeleteMigratingVm(std::string const& name, Options options = {});
+  DeleteMigratingVm(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single MigratingVm.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::DeleteMigratingVmRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2032}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -805,7 +843,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
   DeleteMigratingVm(
       google::cloud::vmmigration::v1::DeleteMigratingVmRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Starts migration for a VM. Starts the process of uploading
@@ -813,7 +851,8 @@ class VmMigrationClient {
   /// policy.
   ///
   /// @param migrating_vm  Required. The name of the MigratingVm.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::StartMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2054}
   ///
@@ -823,7 +862,7 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2054}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>
-  StartMigration(std::string const& migrating_vm, Options options = {});
+  StartMigration(std::string const& migrating_vm, Options opts = {});
 
   ///
   /// Starts migration for a VM. Starts the process of uploading
@@ -832,7 +871,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::StartMigrationRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2043}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::StartMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2054}
   ///
@@ -844,7 +884,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::StartMigrationResponse>>
   StartMigration(
       google::cloud::vmmigration::v1::StartMigrationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Resumes a migration for a VM. When called on a paused migration, will
@@ -854,7 +894,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ResumeMigrationRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2075}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::ResumeMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2086}
   ///
@@ -866,7 +907,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::ResumeMigrationResponse>>
   ResumeMigration(
       google::cloud::vmmigration::v1::ResumeMigrationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Pauses a migration for a VM. If cycle tasks are running they will be
@@ -875,7 +916,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::PauseMigrationRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2059}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::PauseMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2070}
   ///
@@ -887,14 +929,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::PauseMigrationResponse>>
   PauseMigration(
       google::cloud::vmmigration::v1::PauseMigrationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Marks a migration as completed, deleting migration resources that are no
   /// longer being used. Only applicable after cutover is done.
   ///
   /// @param migrating_vm  Required. The name of the MigratingVm.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::FinalizeMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2102}
   ///
@@ -904,7 +947,7 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2102}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>
-  FinalizeMigration(std::string const& migrating_vm, Options options = {});
+  FinalizeMigration(std::string const& migrating_vm, Options opts = {});
 
   ///
   /// Marks a migration as completed, deleting migration resources that are no
@@ -912,7 +955,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::FinalizeMigrationRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2091}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::FinalizeMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2102}
   ///
@@ -924,7 +968,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::FinalizeMigrationResponse>>
   FinalizeMigration(
       google::cloud::vmmigration::v1::FinalizeMigrationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates a Clone of a specific migrating VM.
@@ -932,7 +976,8 @@ class VmMigrationClient {
   /// @param parent  Required. The Clone's parent.
   /// @param clone_job  Required. The clone request body.
   /// @param clone_job_id  Required. The clone job identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CloneJob,google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
@@ -944,14 +989,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::CloneJob>> CreateCloneJob(
       std::string const& parent,
       google::cloud::vmmigration::v1::CloneJob const& clone_job,
-      std::string const& clone_job_id, Options options = {});
+      std::string const& clone_job_id, Options opts = {});
 
   ///
   /// Initiates a Clone of a specific migrating VM.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateCloneJobRequest,google/cloud/vmmigration/v1/vmmigration.proto#L859}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CloneJob,google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
@@ -962,13 +1008,14 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::CloneJob>> CreateCloneJob(
       google::cloud::vmmigration::v1::CreateCloneJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates the cancellation of a running clone job.
   ///
   /// @param name  Required. The clone job id
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CancelCloneJobResponse,google/cloud/vmmigration/v1/vmmigration.proto#L902}
   ///
@@ -978,14 +1025,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L902}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>
-  CancelCloneJob(std::string const& name, Options options = {});
+  CancelCloneJob(std::string const& name, Options opts = {});
 
   ///
   /// Initiates the cancellation of a running clone job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CancelCloneJobRequest,google/cloud/vmmigration/v1/vmmigration.proto#L891}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CancelCloneJobResponse,google/cloud/vmmigration/v1/vmmigration.proto#L902}
   ///
@@ -997,14 +1045,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::CancelCloneJobResponse>>
   CancelCloneJob(
       google::cloud::vmmigration::v1::CancelCloneJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists CloneJobs of a given migrating VM.
   ///
   /// @param parent  Required. The parent, which owns this collection of source
   /// VMs.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CloneJob,google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
@@ -1014,14 +1063,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
   StreamRange<google::cloud::vmmigration::v1::CloneJob> ListCloneJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists CloneJobs of a given migrating VM.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListCloneJobsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L907}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CloneJob,google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
@@ -1032,13 +1082,14 @@ class VmMigrationClient {
   ///
   StreamRange<google::cloud::vmmigration::v1::CloneJob> ListCloneJobs(
       google::cloud::vmmigration::v1::ListCloneJobsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single CloneJob.
   ///
   /// @param name  Required. The name of the CloneJob.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CloneJob,google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
@@ -1048,14 +1099,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
   StatusOr<google::cloud::vmmigration::v1::CloneJob> GetCloneJob(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single CloneJob.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetCloneJobRequest,google/cloud/vmmigration/v1/vmmigration.proto#L950}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CloneJob,google/cloud/vmmigration/v1/vmmigration.proto#L735}
   ///
@@ -1066,7 +1118,7 @@ class VmMigrationClient {
   ///
   StatusOr<google::cloud::vmmigration::v1::CloneJob> GetCloneJob(
       google::cloud::vmmigration::v1::GetCloneJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates a Cutover of a specific migrating VM.
@@ -1076,7 +1128,8 @@ class VmMigrationClient {
   /// @param parent  Required. The Cutover's parent.
   /// @param cutover_job  Required. The cutover request body.
   /// @param cutover_job_id  Required. The cutover job identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CutoverJob,google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
@@ -1088,7 +1141,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::CutoverJob>> CreateCutoverJob(
       std::string const& parent,
       google::cloud::vmmigration::v1::CutoverJob const& cutover_job,
-      std::string const& cutover_job_id, Options options = {});
+      std::string const& cutover_job_id, Options opts = {});
 
   ///
   /// Initiates a Cutover of a specific migrating VM.
@@ -1097,7 +1150,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateCutoverJobRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2478}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CutoverJob,google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
@@ -1108,13 +1162,14 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::CutoverJob>> CreateCutoverJob(
       google::cloud::vmmigration::v1::CreateCutoverJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Initiates the cancellation of a running cutover job.
   ///
   /// @param name  Required. The cutover job id
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CancelCutoverJobResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2521}
   ///
@@ -1124,14 +1179,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2521}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>
-  CancelCutoverJob(std::string const& name, Options options = {});
+  CancelCutoverJob(std::string const& name, Options opts = {});
 
   ///
   /// Initiates the cancellation of a running cutover job.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CancelCutoverJobRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2510}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CancelCutoverJobResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2521}
   ///
@@ -1143,14 +1199,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::CancelCutoverJobResponse>>
   CancelCutoverJob(
       google::cloud::vmmigration::v1::CancelCutoverJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists CutoverJobs of a given migrating VM.
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// migrating VMs.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CutoverJob,google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
@@ -1160,14 +1217,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
   StreamRange<google::cloud::vmmigration::v1::CutoverJob> ListCutoverJobs(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists CutoverJobs of a given migrating VM.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListCutoverJobsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2526}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CutoverJob,google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
@@ -1178,13 +1236,14 @@ class VmMigrationClient {
   ///
   StreamRange<google::cloud::vmmigration::v1::CutoverJob> ListCutoverJobs(
       google::cloud::vmmigration::v1::ListCutoverJobsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single CutoverJob.
   ///
   /// @param name  Required. The name of the CutoverJob.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CutoverJob,google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
@@ -1194,14 +1253,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
   StatusOr<google::cloud::vmmigration::v1::CutoverJob> GetCutoverJob(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single CutoverJob.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetCutoverJobRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2569}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::CutoverJob,google/cloud/vmmigration/v1/vmmigration.proto#L795}
   ///
@@ -1212,13 +1272,14 @@ class VmMigrationClient {
   ///
   StatusOr<google::cloud::vmmigration::v1::CutoverJob> GetCutoverJob(
       google::cloud::vmmigration::v1::GetCutoverJobRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Groups in a given project and location.
   ///
   /// @param parent  Required. The parent, which owns this collection of groups.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1228,14 +1289,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
   StreamRange<google::cloud::vmmigration::v1::Group> ListGroups(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Groups in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListGroupsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2296}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1246,13 +1308,14 @@ class VmMigrationClient {
   ///
   StreamRange<google::cloud::vmmigration::v1::Group> ListGroups(
       google::cloud::vmmigration::v1::ListGroupsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Group.
   ///
   /// @param name  Required. The group name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1262,14 +1325,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
   StatusOr<google::cloud::vmmigration::v1::Group> GetGroup(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Group.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetGroupRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2339}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1280,7 +1344,7 @@ class VmMigrationClient {
   ///
   StatusOr<google::cloud::vmmigration::v1::Group> GetGroup(
       google::cloud::vmmigration::v1::GetGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new Group in a given project and location.
@@ -1288,7 +1352,8 @@ class VmMigrationClient {
   /// @param parent  Required. The Group's parent.
   /// @param group  Required. The create request body.
   /// @param group_id  Required. The group identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1300,14 +1365,15 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::Group>> CreateGroup(
       std::string const& parent,
       google::cloud::vmmigration::v1::Group const& group,
-      std::string const& group_id, Options options = {});
+      std::string const& group_id, Options opts = {});
 
   ///
   /// Creates a new Group in a given project and location.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateGroupRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2350}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1318,7 +1384,7 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::Group>> CreateGroup(
       google::cloud::vmmigration::v1::CreateGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single Group.
@@ -1330,7 +1396,8 @@ class VmMigrationClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1341,14 +1408,15 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::Group>> UpdateGroup(
       google::cloud::vmmigration::v1::Group const& group,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single Group.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::UpdateGroupRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2382}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::Group,google/cloud/vmmigration/v1/vmmigration.proto#L2273}
   ///
@@ -1359,13 +1427,14 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::Group>> UpdateGroup(
       google::cloud::vmmigration::v1::UpdateGroupRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single Group.
   ///
   /// @param name  Required. The Group name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -1375,14 +1444,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-  DeleteGroup(std::string const& name, Options options = {});
+  DeleteGroup(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single Group.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::DeleteGroupRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2410}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -1393,13 +1463,14 @@ class VmMigrationClient {
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
   DeleteGroup(google::cloud::vmmigration::v1::DeleteGroupRequest const& request,
-              Options options = {});
+              Options opts = {});
 
   ///
   /// Adds a MigratingVm to a Group.
   ///
   /// @param group  Required. The full path name of the Group to add to.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::AddGroupMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2452}
   ///
@@ -1409,14 +1480,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2452}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>
-  AddGroupMigration(std::string const& group, Options options = {});
+  AddGroupMigration(std::string const& group, Options opts = {});
 
   ///
   /// Adds a MigratingVm to a Group.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::AddGroupMigrationRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2436}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::AddGroupMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2452}
   ///
@@ -1428,13 +1500,14 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::AddGroupMigrationResponse>>
   AddGroupMigration(
       google::cloud::vmmigration::v1::AddGroupMigrationRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Removes a MigratingVm from a Group.
   ///
   /// @param group  Required. The name of the Group.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::RemoveGroupMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2473}
   ///
@@ -1444,14 +1517,15 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2473}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::RemoveGroupMigrationResponse>>
-  RemoveGroupMigration(std::string const& group, Options options = {});
+  RemoveGroupMigration(std::string const& group, Options opts = {});
 
   ///
   /// Removes a MigratingVm from a Group.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::RemoveGroupMigrationRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2457}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::RemoveGroupMigrationResponse,google/cloud/vmmigration/v1/vmmigration.proto#L2473}
   ///
@@ -1464,7 +1538,7 @@ class VmMigrationClient {
   RemoveGroupMigration(
       google::cloud::vmmigration::v1::RemoveGroupMigrationRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists TargetProjects in a given project.
@@ -1474,7 +1548,8 @@ class VmMigrationClient {
   ///
   /// @param parent  Required. The parent, which owns this collection of
   /// targets.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1484,7 +1559,7 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
   StreamRange<google::cloud::vmmigration::v1::TargetProject> ListTargetProjects(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists TargetProjects in a given project.
@@ -1494,7 +1569,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::ListTargetProjectsRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2143}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1505,7 +1581,7 @@ class VmMigrationClient {
   ///
   StreamRange<google::cloud::vmmigration::v1::TargetProject> ListTargetProjects(
       google::cloud::vmmigration::v1::ListTargetProjectsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single TargetProject.
@@ -1514,7 +1590,8 @@ class VmMigrationClient {
   /// for location is `global`.
   ///
   /// @param name  Required. The TargetProject name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1524,7 +1601,7 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
   StatusOr<google::cloud::vmmigration::v1::TargetProject> GetTargetProject(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single TargetProject.
@@ -1534,7 +1611,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::GetTargetProjectRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2132}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1545,7 +1623,7 @@ class VmMigrationClient {
   ///
   StatusOr<google::cloud::vmmigration::v1::TargetProject> GetTargetProject(
       google::cloud::vmmigration::v1::GetTargetProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new TargetProject in a given project.
@@ -1556,7 +1634,8 @@ class VmMigrationClient {
   /// @param parent  Required. The TargetProject's parent.
   /// @param target_project  Required. The create request body.
   /// @param target_project_id  Required. The target_project identifier.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1569,7 +1648,7 @@ class VmMigrationClient {
   CreateTargetProject(
       std::string const& parent,
       google::cloud::vmmigration::v1::TargetProject const& target_project,
-      std::string const& target_project_id, Options options = {});
+      std::string const& target_project_id, Options opts = {});
 
   ///
   /// Creates a new TargetProject in a given project.
@@ -1579,7 +1658,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::CreateTargetProjectRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2186}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1591,7 +1671,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
   CreateTargetProject(
       google::cloud::vmmigration::v1::CreateTargetProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates the parameters of a single TargetProject.
@@ -1606,7 +1686,8 @@ class VmMigrationClient {
   ///  The fields specified in the update_mask are relative to the resource, not
   ///  the full request. A field will be overwritten if it is in the mask. If
   ///  the user does not provide a mask then all fields will be overwritten.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1618,7 +1699,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
   UpdateTargetProject(
       google::cloud::vmmigration::v1::TargetProject const& target_project,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates the parameters of a single TargetProject.
@@ -1628,7 +1709,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::UpdateTargetProjectRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2218}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::TargetProject,google/cloud/vmmigration/v1/vmmigration.proto#L2108}
   ///
@@ -1640,7 +1722,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::TargetProject>>
   UpdateTargetProject(
       google::cloud::vmmigration::v1::UpdateTargetProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a single TargetProject.
@@ -1649,7 +1731,8 @@ class VmMigrationClient {
   /// for location is `global`.
   ///
   /// @param name  Required. The TargetProject name.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -1659,7 +1742,7 @@ class VmMigrationClient {
   /// @googleapis_reference_link{google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
-  DeleteTargetProject(std::string const& name, Options options = {});
+  DeleteTargetProject(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a single TargetProject.
@@ -1669,7 +1752,8 @@ class VmMigrationClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vmmigration::v1::DeleteTargetProjectRequest,google/cloud/vmmigration/v1/vmmigration.proto#L2246}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vmmigration::v1::OperationMetadata,google/cloud/vmmigration/v1/vmmigration.proto#L2580}
   ///
@@ -1681,7 +1765,7 @@ class VmMigrationClient {
   future<StatusOr<google::cloud::vmmigration::v1::OperationMetadata>>
   DeleteTargetProject(
       google::cloud::vmmigration::v1::DeleteTargetProjectRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<VmMigrationConnection> connection_;

--- a/google/cloud/vpcaccess/vpc_access_client.cc
+++ b/google/cloud/vpcaccess/vpc_access_client.cc
@@ -26,20 +26,18 @@ namespace vpcaccess {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 VpcAccessServiceClient::VpcAccessServiceClient(
-    std::shared_ptr<VpcAccessServiceConnection> connection, Options options)
+    std::shared_ptr<VpcAccessServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
-          vpcaccess_internal::VpcAccessServiceDefaultOptions(
-              connection_->options()))) {}
+          std::move(opts), vpcaccess_internal::VpcAccessServiceDefaultOptions(
+                               connection_->options()))) {}
 VpcAccessServiceClient::~VpcAccessServiceClient() = default;
 
 future<StatusOr<google::cloud::vpcaccess::v1::Connector>>
 VpcAccessServiceClient::CreateConnector(
     std::string const& parent, std::string const& connector_id,
-    google::cloud::vpcaccess::v1::Connector const& connector, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vpcaccess::v1::Connector const& connector, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vpcaccess::v1::CreateConnectorRequest request;
   request.set_parent(parent);
   request.set_connector_id(connector_id);
@@ -50,16 +48,14 @@ VpcAccessServiceClient::CreateConnector(
 future<StatusOr<google::cloud::vpcaccess::v1::Connector>>
 VpcAccessServiceClient::CreateConnector(
     google::cloud::vpcaccess::v1::CreateConnectorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateConnector(request);
 }
 
 StatusOr<google::cloud::vpcaccess::v1::Connector>
-VpcAccessServiceClient::GetConnector(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VpcAccessServiceClient::GetConnector(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vpcaccess::v1::GetConnectorRequest request;
   request.set_name(name);
   return connection_->GetConnector(request);
@@ -68,17 +64,15 @@ VpcAccessServiceClient::GetConnector(std::string const& name, Options options) {
 StatusOr<google::cloud::vpcaccess::v1::Connector>
 VpcAccessServiceClient::GetConnector(
     google::cloud::vpcaccess::v1::GetConnectorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetConnector(request);
 }
 
 StreamRange<google::cloud::vpcaccess::v1::Connector>
 VpcAccessServiceClient::ListConnectors(std::string const& parent,
-                                       Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+                                       Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vpcaccess::v1::ListConnectorsRequest request;
   request.set_parent(parent);
   return connection_->ListConnectors(request);
@@ -86,18 +80,14 @@ VpcAccessServiceClient::ListConnectors(std::string const& parent,
 
 StreamRange<google::cloud::vpcaccess::v1::Connector>
 VpcAccessServiceClient::ListConnectors(
-    google::cloud::vpcaccess::v1::ListConnectorsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::vpcaccess::v1::ListConnectorsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListConnectors(std::move(request));
 }
 
 future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>
-VpcAccessServiceClient::DeleteConnector(std::string const& name,
-                                        Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+VpcAccessServiceClient::DeleteConnector(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::vpcaccess::v1::DeleteConnectorRequest request;
   request.set_name(name);
   return connection_->DeleteConnector(request);
@@ -106,9 +96,8 @@ VpcAccessServiceClient::DeleteConnector(std::string const& name,
 future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>
 VpcAccessServiceClient::DeleteConnector(
     google::cloud::vpcaccess::v1::DeleteConnectorRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteConnector(request);
 }
 

--- a/google/cloud/vpcaccess/vpc_access_client.h
+++ b/google/cloud/vpcaccess/vpc_access_client.h
@@ -65,7 +65,7 @@ class VpcAccessServiceClient {
  public:
   explicit VpcAccessServiceClient(
       std::shared_ptr<VpcAccessServiceConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~VpcAccessServiceClient();
 
   //@{
@@ -96,7 +96,8 @@ class VpcAccessServiceClient {
   ///  specified in the format `projects/*/locations/*`.
   /// @param connector_id  Required. The ID to use for this connector.
   /// @param connector  Required. Resource to create.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::Connector,google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
@@ -108,14 +109,15 @@ class VpcAccessServiceClient {
   future<StatusOr<google::cloud::vpcaccess::v1::Connector>> CreateConnector(
       std::string const& parent, std::string const& connector_id,
       google::cloud::vpcaccess::v1::Connector const& connector,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Serverless VPC Access connector, returns an operation.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vpcaccess::v1::CreateConnectorRequest,google/cloud/vpcaccess/v1/vpc_access.proto#L154}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::Connector,google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
@@ -126,14 +128,15 @@ class VpcAccessServiceClient {
   ///
   future<StatusOr<google::cloud::vpcaccess::v1::Connector>> CreateConnector(
       google::cloud::vpcaccess::v1::CreateConnectorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a Serverless VPC Access connector. Returns NOT_FOUND if the resource
   /// does not exist.
   ///
   /// @param name  Required. Name of a Serverless VPC Access connector to get.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::Connector,google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
@@ -143,7 +146,7 @@ class VpcAccessServiceClient {
   /// @googleapis_reference_link{google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
   StatusOr<google::cloud::vpcaccess::v1::Connector> GetConnector(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets a Serverless VPC Access connector. Returns NOT_FOUND if the resource
@@ -151,7 +154,8 @@ class VpcAccessServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vpcaccess::v1::GetConnectorRequest,google/cloud/vpcaccess/v1/vpc_access.proto#L172}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::Connector,google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
@@ -162,14 +166,15 @@ class VpcAccessServiceClient {
   ///
   StatusOr<google::cloud::vpcaccess::v1::Connector> GetConnector(
       google::cloud::vpcaccess::v1::GetConnectorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists Serverless VPC Access connectors.
   ///
   /// @param parent  Required. The project and location from which the routes
   /// should be listed.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::Connector,google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
@@ -179,14 +184,15 @@ class VpcAccessServiceClient {
   /// @googleapis_reference_link{google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
   StreamRange<google::cloud::vpcaccess::v1::Connector> ListConnectors(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Serverless VPC Access connectors.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vpcaccess::v1::ListConnectorsRequest,google/cloud/vpcaccess/v1/vpc_access.proto#L183}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::Connector,google/cloud/vpcaccess/v1/vpc_access.proto#L86}
   ///
@@ -197,7 +203,7 @@ class VpcAccessServiceClient {
   ///
   StreamRange<google::cloud::vpcaccess::v1::Connector> ListConnectors(
       google::cloud::vpcaccess::v1::ListConnectorsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a Serverless VPC Access connector. Returns NOT_FOUND if the
@@ -205,7 +211,8 @@ class VpcAccessServiceClient {
   ///
   /// @param name  Required. Name of a Serverless VPC Access connector to
   /// delete.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::OperationMetadata,google/cloud/vpcaccess/v1/vpc_access.proto#L220}
   ///
@@ -215,7 +222,7 @@ class VpcAccessServiceClient {
   /// @googleapis_reference_link{google/cloud/vpcaccess/v1/vpc_access.proto#L220}
   ///
   future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>
-  DeleteConnector(std::string const& name, Options options = {});
+  DeleteConnector(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a Serverless VPC Access connector. Returns NOT_FOUND if the
@@ -223,7 +230,8 @@ class VpcAccessServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::vpcaccess::v1::DeleteConnectorRequest,google/cloud/vpcaccess/v1/vpc_access.proto#L209}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::vpcaccess::v1::OperationMetadata,google/cloud/vpcaccess/v1/vpc_access.proto#L220}
   ///
@@ -235,7 +243,7 @@ class VpcAccessServiceClient {
   future<StatusOr<google::cloud::vpcaccess::v1::OperationMetadata>>
   DeleteConnector(
       google::cloud::vpcaccess::v1::DeleteConnectorRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<VpcAccessServiceConnection> connection_;

--- a/google/cloud/webrisk/web_risk_client.cc
+++ b/google/cloud/webrisk/web_risk_client.cc
@@ -26,11 +26,11 @@ namespace webrisk {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WebRiskServiceClient::WebRiskServiceClient(
-    std::shared_ptr<WebRiskServiceConnection> connection, Options options)
+    std::shared_ptr<WebRiskServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), webrisk_internal::WebRiskServiceDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), webrisk_internal::WebRiskServiceDefaultOptions(
+                               connection_->options()))) {}
 WebRiskServiceClient::~WebRiskServiceClient() = default;
 
 StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>
@@ -39,9 +39,8 @@ WebRiskServiceClient::ComputeThreatListDiff(
     std::string const& version_token,
     google::cloud::webrisk::v1::ComputeThreatListDiffRequest::Constraints const&
         constraints,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::webrisk::v1::ComputeThreatListDiffRequest request;
   request.set_threat_type(threat_type);
   request.set_version_token(version_token);
@@ -52,9 +51,8 @@ WebRiskServiceClient::ComputeThreatListDiff(
 StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>
 WebRiskServiceClient::ComputeThreatListDiff(
     google::cloud::webrisk::v1::ComputeThreatListDiffRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ComputeThreatListDiff(request);
 }
 
@@ -62,9 +60,8 @@ StatusOr<google::cloud::webrisk::v1::SearchUrisResponse>
 WebRiskServiceClient::SearchUris(
     std::string const& uri,
     std::vector<google::cloud::webrisk::v1::ThreatType> const& threat_types,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::webrisk::v1::SearchUrisRequest request;
   request.set_uri(uri);
   *request.mutable_threat_types() = {threat_types.begin(), threat_types.end()};
@@ -74,9 +71,8 @@ WebRiskServiceClient::SearchUris(
 StatusOr<google::cloud::webrisk::v1::SearchUrisResponse>
 WebRiskServiceClient::SearchUris(
     google::cloud::webrisk::v1::SearchUrisRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchUris(request);
 }
 
@@ -84,9 +80,8 @@ StatusOr<google::cloud::webrisk::v1::SearchHashesResponse>
 WebRiskServiceClient::SearchHashes(
     std::string const& hash_prefix,
     std::vector<google::cloud::webrisk::v1::ThreatType> const& threat_types,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::webrisk::v1::SearchHashesRequest request;
   request.set_hash_prefix(hash_prefix);
   *request.mutable_threat_types() = {threat_types.begin(), threat_types.end()};
@@ -96,18 +91,16 @@ WebRiskServiceClient::SearchHashes(
 StatusOr<google::cloud::webrisk::v1::SearchHashesResponse>
 WebRiskServiceClient::SearchHashes(
     google::cloud::webrisk::v1::SearchHashesRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->SearchHashes(request);
 }
 
 StatusOr<google::cloud::webrisk::v1::Submission>
 WebRiskServiceClient::CreateSubmission(
     std::string const& parent,
-    google::cloud::webrisk::v1::Submission const& submission, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::webrisk::v1::Submission const& submission, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::webrisk::v1::CreateSubmissionRequest request;
   request.set_parent(parent);
   *request.mutable_submission() = submission;
@@ -117,9 +110,8 @@ WebRiskServiceClient::CreateSubmission(
 StatusOr<google::cloud::webrisk::v1::Submission>
 WebRiskServiceClient::CreateSubmission(
     google::cloud::webrisk::v1::CreateSubmissionRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateSubmission(request);
 }
 

--- a/google/cloud/webrisk/web_risk_client.h
+++ b/google/cloud/webrisk/web_risk_client.h
@@ -62,8 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WebRiskServiceClient {
  public:
   explicit WebRiskServiceClient(
-      std::shared_ptr<WebRiskServiceConnection> connection,
-      Options options = {});
+      std::shared_ptr<WebRiskServiceConnection> connection, Options opts = {});
   ~WebRiskServiceClient();
 
   //@{
@@ -104,7 +103,8 @@ class WebRiskServiceClient {
   ///  database snapshot will be returned.
   /// @param constraints  Required. The constraints associated with this
   /// request.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::ComputeThreatListDiffResponse,google/cloud/webrisk/v1/webrisk.proto#L124}
   ///
@@ -119,7 +119,7 @@ class WebRiskServiceClient {
       std::string const& version_token,
       google::cloud::webrisk::v1::ComputeThreatListDiffRequest::
           Constraints const& constraints,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the most recent threat list diffs. These diffs should be applied to
@@ -131,7 +131,8 @@ class WebRiskServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::webrisk::v1::ComputeThreatListDiffRequest,google/cloud/webrisk/v1/webrisk.proto#L93}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::ComputeThreatListDiffResponse,google/cloud/webrisk/v1/webrisk.proto#L124}
   ///
@@ -143,7 +144,7 @@ class WebRiskServiceClient {
   StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>
   ComputeThreatListDiff(
       google::cloud::webrisk::v1::ComputeThreatListDiffRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// This method is used to check whether a URI is on a given threatList.
@@ -155,7 +156,8 @@ class WebRiskServiceClient {
   /// @param uri  Required. The URI to be checked for matches.
   /// @param threat_types  Required. The ThreatLists to search in. Multiple
   /// ThreatLists may be specified.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::SearchUrisResponse,google/cloud/webrisk/v1/webrisk.proto#L184}
   ///
@@ -167,7 +169,7 @@ class WebRiskServiceClient {
   StatusOr<google::cloud::webrisk::v1::SearchUrisResponse> SearchUris(
       std::string const& uri,
       std::vector<google::cloud::webrisk::v1::ThreatType> const& threat_types,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// This method is used to check whether a URI is on a given threatList.
@@ -178,7 +180,8 @@ class WebRiskServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::webrisk::v1::SearchUrisRequest,google/cloud/webrisk/v1/webrisk.proto#L176}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::SearchUrisResponse,google/cloud/webrisk/v1/webrisk.proto#L184}
   ///
@@ -189,7 +192,7 @@ class WebRiskServiceClient {
   ///
   StatusOr<google::cloud::webrisk::v1::SearchUrisResponse> SearchUris(
       google::cloud::webrisk::v1::SearchUrisRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the full hashes that match the requested hash prefix.
@@ -203,7 +206,8 @@ class WebRiskServiceClient {
   ///  hash. For JSON requests, this field is base64-encoded.
   /// @param threat_types  Required. The ThreatLists to search in. Multiple
   /// ThreatLists may be specified.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::SearchHashesResponse,google/cloud/webrisk/v1/webrisk.proto#L209}
   ///
@@ -215,7 +219,7 @@ class WebRiskServiceClient {
   StatusOr<google::cloud::webrisk::v1::SearchHashesResponse> SearchHashes(
       std::string const& hash_prefix,
       std::vector<google::cloud::webrisk::v1::ThreatType> const& threat_types,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets the full hashes that match the requested hash prefix.
@@ -226,7 +230,8 @@ class WebRiskServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::webrisk::v1::SearchHashesRequest,google/cloud/webrisk/v1/webrisk.proto#L200}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::SearchHashesResponse,google/cloud/webrisk/v1/webrisk.proto#L209}
   ///
@@ -237,7 +242,7 @@ class WebRiskServiceClient {
   ///
   StatusOr<google::cloud::webrisk::v1::SearchHashesResponse> SearchHashes(
       google::cloud::webrisk::v1::SearchHashesRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Submission of a URI suspected of containing phishing content to
@@ -252,7 +257,8 @@ class WebRiskServiceClient {
   ///  the format "projects/{project_number}".
   /// @param submission  Required. The submission that contains the content of
   /// the phishing report.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::Submission,google/cloud/webrisk/v1/webrisk.proto#L335}
   ///
@@ -264,7 +270,7 @@ class WebRiskServiceClient {
   StatusOr<google::cloud::webrisk::v1::Submission> CreateSubmission(
       std::string const& parent,
       google::cloud::webrisk::v1::Submission const& submission,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a Submission of a URI suspected of containing phishing content to
@@ -276,7 +282,8 @@ class WebRiskServiceClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::webrisk::v1::CreateSubmissionRequest,google/cloud/webrisk/v1/webrisk.proto#L341}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::webrisk::v1::Submission,google/cloud/webrisk/v1/webrisk.proto#L335}
   ///
@@ -287,7 +294,7 @@ class WebRiskServiceClient {
   ///
   StatusOr<google::cloud::webrisk::v1::Submission> CreateSubmission(
       google::cloud::webrisk::v1::CreateSubmissionRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<WebRiskServiceConnection> connection_;

--- a/google/cloud/websecurityscanner/web_security_scanner_client.cc
+++ b/google/cloud/websecurityscanner/web_security_scanner_client.cc
@@ -26,10 +26,10 @@ namespace websecurityscanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WebSecurityScannerClient::WebSecurityScannerClient(
-    std::shared_ptr<WebSecurityScannerConnection> connection, Options options)
+    std::shared_ptr<WebSecurityScannerConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options),
+          std::move(opts),
           websecurityscanner_internal::WebSecurityScannerDefaultOptions(
               connection_->options()))) {}
 WebSecurityScannerClient::~WebSecurityScannerClient() = default;
@@ -38,36 +38,32 @@ StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>
 WebSecurityScannerClient::CreateScanConfig(
     google::cloud::websecurityscanner::v1::CreateScanConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateScanConfig(request);
 }
 
 Status WebSecurityScannerClient::DeleteScanConfig(
     google::cloud::websecurityscanner::v1::DeleteScanConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteScanConfig(request);
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>
 WebSecurityScannerClient::GetScanConfig(
     google::cloud::websecurityscanner::v1::GetScanConfigRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetScanConfig(request);
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::ScanConfig>
 WebSecurityScannerClient::ListScanConfigs(
     google::cloud::websecurityscanner::v1::ListScanConfigsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListScanConfigs(std::move(request));
 }
 
@@ -75,72 +71,64 @@ StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>
 WebSecurityScannerClient::UpdateScanConfig(
     google::cloud::websecurityscanner::v1::UpdateScanConfigRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateScanConfig(request);
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanRun>
 WebSecurityScannerClient::StartScanRun(
     google::cloud::websecurityscanner::v1::StartScanRunRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StartScanRun(request);
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanRun>
 WebSecurityScannerClient::GetScanRun(
     google::cloud::websecurityscanner::v1::GetScanRunRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetScanRun(request);
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::ScanRun>
 WebSecurityScannerClient::ListScanRuns(
     google::cloud::websecurityscanner::v1::ListScanRunsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListScanRuns(std::move(request));
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanRun>
 WebSecurityScannerClient::StopScanRun(
     google::cloud::websecurityscanner::v1::StopScanRunRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->StopScanRun(request);
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::CrawledUrl>
 WebSecurityScannerClient::ListCrawledUrls(
     google::cloud::websecurityscanner::v1::ListCrawledUrlsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListCrawledUrls(std::move(request));
 }
 
 StatusOr<google::cloud::websecurityscanner::v1::Finding>
 WebSecurityScannerClient::GetFinding(
     google::cloud::websecurityscanner::v1::GetFindingRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetFinding(request);
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::Finding>
 WebSecurityScannerClient::ListFindings(
     google::cloud::websecurityscanner::v1::ListFindingsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFindings(std::move(request));
 }
 
@@ -148,9 +136,8 @@ StatusOr<google::cloud::websecurityscanner::v1::ListFindingTypeStatsResponse>
 WebSecurityScannerClient::ListFindingTypeStats(
     google::cloud::websecurityscanner::v1::ListFindingTypeStatsRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListFindingTypeStats(request);
 }
 

--- a/google/cloud/websecurityscanner/web_security_scanner_client.h
+++ b/google/cloud/websecurityscanner/web_security_scanner_client.h
@@ -64,7 +64,7 @@ class WebSecurityScannerClient {
  public:
   explicit WebSecurityScannerClient(
       std::shared_ptr<WebSecurityScannerConnection> connection,
-      Options options = {});
+      Options opts = {});
   ~WebSecurityScannerClient();
 
   //@{
@@ -93,7 +93,8 @@ class WebSecurityScannerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::CreateScanConfigRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L142}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanConfig,google/cloud/websecurityscanner/v1/scan_config.proto#L31}
   ///
@@ -105,14 +106,15 @@ class WebSecurityScannerClient {
   StatusOr<google::cloud::websecurityscanner::v1::ScanConfig> CreateScanConfig(
       google::cloud::websecurityscanner::v1::CreateScanConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes an existing ScanConfig and its child resources.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::DeleteScanConfigRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L152}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   ///
   /// [google.cloud.websecurityscanner.v1.DeleteScanConfigRequest]:
   /// @googleapis_reference_link{google/cloud/websecurityscanner/v1/web_security_scanner.proto#L152}
@@ -120,14 +122,15 @@ class WebSecurityScannerClient {
   Status DeleteScanConfig(
       google::cloud::websecurityscanner::v1::DeleteScanConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a ScanConfig.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::GetScanConfigRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L159}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanConfig,google/cloud/websecurityscanner/v1/scan_config.proto#L31}
   ///
@@ -139,14 +142,15 @@ class WebSecurityScannerClient {
   StatusOr<google::cloud::websecurityscanner::v1::ScanConfig> GetScanConfig(
       google::cloud::websecurityscanner::v1::GetScanConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists ScanConfigs under a given project.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ListScanConfigsRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L166}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanConfig,google/cloud/websecurityscanner/v1/scan_config.proto#L31}
   ///
@@ -158,14 +162,15 @@ class WebSecurityScannerClient {
   StreamRange<google::cloud::websecurityscanner::v1::ScanConfig>
   ListScanConfigs(
       google::cloud::websecurityscanner::v1::ListScanConfigsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates a ScanConfig. This method support partial update of a ScanConfig.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::UpdateScanConfigRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L183}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanConfig,google/cloud/websecurityscanner/v1/scan_config.proto#L31}
   ///
@@ -177,14 +182,15 @@ class WebSecurityScannerClient {
   StatusOr<google::cloud::websecurityscanner::v1::ScanConfig> UpdateScanConfig(
       google::cloud::websecurityscanner::v1::UpdateScanConfigRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Start a ScanRun according to the given ScanConfig.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::StartScanRunRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L206}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanRun,google/cloud/websecurityscanner/v1/scan_run.proto#L33}
   ///
@@ -195,14 +201,15 @@ class WebSecurityScannerClient {
   ///
   StatusOr<google::cloud::websecurityscanner::v1::ScanRun> StartScanRun(
       google::cloud::websecurityscanner::v1::StartScanRunRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a ScanRun.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::GetScanRunRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L213}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanRun,google/cloud/websecurityscanner/v1/scan_run.proto#L33}
   ///
@@ -213,7 +220,7 @@ class WebSecurityScannerClient {
   ///
   StatusOr<google::cloud::websecurityscanner::v1::ScanRun> GetScanRun(
       google::cloud::websecurityscanner::v1::GetScanRunRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Lists ScanRuns under a given ScanConfig, in descending order of ScanRun
@@ -221,7 +228,8 @@ class WebSecurityScannerClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ListScanRunsRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L221}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanRun,google/cloud/websecurityscanner/v1/scan_run.proto#L33}
   ///
@@ -232,14 +240,15 @@ class WebSecurityScannerClient {
   ///
   StreamRange<google::cloud::websecurityscanner::v1::ScanRun> ListScanRuns(
       google::cloud::websecurityscanner::v1::ListScanRunsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Stops a ScanRun. The stopped ScanRun is returned.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::StopScanRunRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L248}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ScanRun,google/cloud/websecurityscanner/v1/scan_run.proto#L33}
   ///
@@ -250,14 +259,15 @@ class WebSecurityScannerClient {
   ///
   StatusOr<google::cloud::websecurityscanner::v1::ScanRun> StopScanRun(
       google::cloud::websecurityscanner::v1::StopScanRunRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List CrawledUrls under a given ScanRun.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ListCrawledUrlsRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L256}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::CrawledUrl,google/cloud/websecurityscanner/v1/crawled_url.proto#L30}
   ///
@@ -269,14 +279,15 @@ class WebSecurityScannerClient {
   StreamRange<google::cloud::websecurityscanner::v1::CrawledUrl>
   ListCrawledUrls(
       google::cloud::websecurityscanner::v1::ListCrawledUrlsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets a Finding.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::GetFindingRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L284}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::Finding,google/cloud/websecurityscanner/v1/finding.proto#L33}
   ///
@@ -287,14 +298,15 @@ class WebSecurityScannerClient {
   ///
   StatusOr<google::cloud::websecurityscanner::v1::Finding> GetFinding(
       google::cloud::websecurityscanner::v1::GetFindingRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List Findings under a given ScanRun.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ListFindingsRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L292}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::Finding,google/cloud/websecurityscanner/v1/finding.proto#L33}
   ///
@@ -305,14 +317,15 @@ class WebSecurityScannerClient {
   ///
   StreamRange<google::cloud::websecurityscanner::v1::Finding> ListFindings(
       google::cloud::websecurityscanner::v1::ListFindingsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// List all FindingTypeStats under a given ScanRun.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ListFindingTypeStatsRequest,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L326}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::websecurityscanner::v1::ListFindingTypeStatsResponse,google/cloud/websecurityscanner/v1/web_security_scanner.proto#L334}
   ///
@@ -325,7 +338,7 @@ class WebSecurityScannerClient {
   ListFindingTypeStats(
       google::cloud::websecurityscanner::v1::ListFindingTypeStatsRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<WebSecurityScannerConnection> connection_;

--- a/google/cloud/workflows/executions_client.cc
+++ b/google/cloud/workflows/executions_client.cc
@@ -26,17 +26,16 @@ namespace workflows {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 ExecutionsClient::ExecutionsClient(
-    std::shared_ptr<ExecutionsConnection> connection, Options options)
+    std::shared_ptr<ExecutionsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), workflows_internal::ExecutionsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), workflows_internal::ExecutionsDefaultOptions(
+                               connection_->options()))) {}
 ExecutionsClient::~ExecutionsClient() = default;
 
 StreamRange<google::cloud::workflows::executions::v1::Execution>
-ExecutionsClient::ListExecutions(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ExecutionsClient::ListExecutions(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::executions::v1::ListExecutionsRequest request;
   request.set_parent(parent);
   return connection_->ListExecutions(request);
@@ -45,9 +44,8 @@ ExecutionsClient::ListExecutions(std::string const& parent, Options options) {
 StreamRange<google::cloud::workflows::executions::v1::Execution>
 ExecutionsClient::ListExecutions(
     google::cloud::workflows::executions::v1::ListExecutionsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListExecutions(std::move(request));
 }
 
@@ -55,9 +53,8 @@ StatusOr<google::cloud::workflows::executions::v1::Execution>
 ExecutionsClient::CreateExecution(
     std::string const& parent,
     google::cloud::workflows::executions::v1::Execution const& execution,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::executions::v1::CreateExecutionRequest request;
   request.set_parent(parent);
   *request.mutable_execution() = execution;
@@ -68,16 +65,14 @@ StatusOr<google::cloud::workflows::executions::v1::Execution>
 ExecutionsClient::CreateExecution(
     google::cloud::workflows::executions::v1::CreateExecutionRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateExecution(request);
 }
 
 StatusOr<google::cloud::workflows::executions::v1::Execution>
-ExecutionsClient::GetExecution(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ExecutionsClient::GetExecution(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::executions::v1::GetExecutionRequest request;
   request.set_name(name);
   return connection_->GetExecution(request);
@@ -87,16 +82,14 @@ StatusOr<google::cloud::workflows::executions::v1::Execution>
 ExecutionsClient::GetExecution(
     google::cloud::workflows::executions::v1::GetExecutionRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetExecution(request);
 }
 
 StatusOr<google::cloud::workflows::executions::v1::Execution>
-ExecutionsClient::CancelExecution(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+ExecutionsClient::CancelExecution(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::executions::v1::CancelExecutionRequest request;
   request.set_name(name);
   return connection_->CancelExecution(request);
@@ -106,9 +99,8 @@ StatusOr<google::cloud::workflows::executions::v1::Execution>
 ExecutionsClient::CancelExecution(
     google::cloud::workflows::executions::v1::CancelExecutionRequest const&
         request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CancelExecution(request);
 }
 

--- a/google/cloud/workflows/executions_client.h
+++ b/google/cloud/workflows/executions_client.h
@@ -62,7 +62,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class ExecutionsClient {
  public:
   explicit ExecutionsClient(std::shared_ptr<ExecutionsConnection> connection,
-                            Options options = {});
+                            Options opts = {});
   ~ExecutionsClient();
 
   //@{
@@ -92,7 +92,8 @@ class ExecutionsClient {
   /// @param parent  Required. Name of the workflow for which the executions
   /// should be listed.
   ///  Format: projects/{project}/locations/{location}/workflows/{workflow}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -102,7 +103,7 @@ class ExecutionsClient {
   /// @googleapis_reference_link{google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
   StreamRange<google::cloud::workflows::executions::v1::Execution>
-  ListExecutions(std::string const& parent, Options options = {});
+  ListExecutions(std::string const& parent, Options opts = {});
 
   ///
   /// Returns a list of executions which belong to the workflow with
@@ -112,7 +113,8 @@ class ExecutionsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::executions::v1::ListExecutionsRequest,google/cloud/workflows/executions/v1/executions.proto#L205}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -124,7 +126,7 @@ class ExecutionsClient {
   StreamRange<google::cloud::workflows::executions::v1::Execution>
   ListExecutions(
       google::cloud::workflows::executions::v1::ListExecutionsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new execution using the latest revision of the given workflow.
@@ -134,7 +136,8 @@ class ExecutionsClient {
   ///  Format: projects/{project}/locations/{location}/workflows/{workflow}
   ///  The latest revision of the workflow will be used.
   /// @param execution  Required. Execution to be created.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -146,14 +149,15 @@ class ExecutionsClient {
   StatusOr<google::cloud::workflows::executions::v1::Execution> CreateExecution(
       std::string const& parent,
       google::cloud::workflows::executions::v1::Execution const& execution,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new execution using the latest revision of the given workflow.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::executions::v1::CreateExecutionRequest,google/cloud/workflows/executions/v1/executions.proto#L249}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -165,7 +169,7 @@ class ExecutionsClient {
   StatusOr<google::cloud::workflows::executions::v1::Execution> CreateExecution(
       google::cloud::workflows::executions::v1::CreateExecutionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Returns an execution of the given name.
@@ -173,7 +177,8 @@ class ExecutionsClient {
   /// @param name  Required. Name of the execution to be retrieved.
   ///  Format:
   ///  projects/{project}/locations/{location}/workflows/{workflow}/executions/{execution}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -183,14 +188,15 @@ class ExecutionsClient {
   /// @googleapis_reference_link{google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
   StatusOr<google::cloud::workflows::executions::v1::Execution> GetExecution(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Returns an execution of the given name.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::executions::v1::GetExecutionRequest,google/cloud/workflows/executions/v1/executions.proto#L267}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -202,7 +208,7 @@ class ExecutionsClient {
   StatusOr<google::cloud::workflows::executions::v1::Execution> GetExecution(
       google::cloud::workflows::executions::v1::GetExecutionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Cancels an execution of the given name.
@@ -210,7 +216,8 @@ class ExecutionsClient {
   /// @param name  Required. Name of the execution to be cancelled.
   ///  Format:
   ///  projects/{project}/locations/{location}/workflows/{workflow}/executions/{execution}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -220,14 +227,15 @@ class ExecutionsClient {
   /// @googleapis_reference_link{google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
   StatusOr<google::cloud::workflows::executions::v1::Execution> CancelExecution(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Cancels an execution of the given name.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::executions::v1::CancelExecutionRequest,google/cloud/workflows/executions/v1/executions.proto#L286}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::executions::v1::Execution,google/cloud/workflows/executions/v1/executions.proto#L80}
   ///
@@ -239,7 +247,7 @@ class ExecutionsClient {
   StatusOr<google::cloud::workflows::executions::v1::Execution> CancelExecution(
       google::cloud::workflows::executions::v1::CancelExecutionRequest const&
           request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<ExecutionsConnection> connection_;

--- a/google/cloud/workflows/workflows_client.cc
+++ b/google/cloud/workflows/workflows_client.cc
@@ -26,17 +26,16 @@ namespace workflows {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 WorkflowsClient::WorkflowsClient(
-    std::shared_ptr<WorkflowsConnection> connection, Options options)
+    std::shared_ptr<WorkflowsConnection> connection, Options opts)
     : connection_(std::move(connection)),
       options_(internal::MergeOptions(
-          std::move(options), workflows_internal::WorkflowsDefaultOptions(
-                                  connection_->options()))) {}
+          std::move(opts), workflows_internal::WorkflowsDefaultOptions(
+                               connection_->options()))) {}
 WorkflowsClient::~WorkflowsClient() = default;
 
 StreamRange<google::cloud::workflows::v1::Workflow>
-WorkflowsClient::ListWorkflows(std::string const& parent, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+WorkflowsClient::ListWorkflows(std::string const& parent, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::v1::ListWorkflowsRequest request;
   request.set_parent(parent);
   return connection_->ListWorkflows(request);
@@ -44,17 +43,14 @@ WorkflowsClient::ListWorkflows(std::string const& parent, Options options) {
 
 StreamRange<google::cloud::workflows::v1::Workflow>
 WorkflowsClient::ListWorkflows(
-    google::cloud::workflows::v1::ListWorkflowsRequest request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::cloud::workflows::v1::ListWorkflowsRequest request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->ListWorkflows(std::move(request));
 }
 
 StatusOr<google::cloud::workflows::v1::Workflow> WorkflowsClient::GetWorkflow(
-    std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::v1::GetWorkflowRequest request;
   request.set_name(name);
   return connection_->GetWorkflow(request);
@@ -62,9 +58,8 @@ StatusOr<google::cloud::workflows::v1::Workflow> WorkflowsClient::GetWorkflow(
 
 StatusOr<google::cloud::workflows::v1::Workflow> WorkflowsClient::GetWorkflow(
     google::cloud::workflows::v1::GetWorkflowRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->GetWorkflow(request);
 }
 
@@ -72,9 +67,8 @@ future<StatusOr<google::cloud::workflows::v1::Workflow>>
 WorkflowsClient::CreateWorkflow(
     std::string const& parent,
     google::cloud::workflows::v1::Workflow const& workflow,
-    std::string const& workflow_id, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    std::string const& workflow_id, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::v1::CreateWorkflowRequest request;
   request.set_parent(parent);
   *request.mutable_workflow() = workflow;
@@ -85,16 +79,14 @@ WorkflowsClient::CreateWorkflow(
 future<StatusOr<google::cloud::workflows::v1::Workflow>>
 WorkflowsClient::CreateWorkflow(
     google::cloud::workflows::v1::CreateWorkflowRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->CreateWorkflow(request);
 }
 
 future<StatusOr<google::cloud::workflows::v1::OperationMetadata>>
-WorkflowsClient::DeleteWorkflow(std::string const& name, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+WorkflowsClient::DeleteWorkflow(std::string const& name, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::v1::DeleteWorkflowRequest request;
   request.set_name(name);
   return connection_->DeleteWorkflow(request);
@@ -103,18 +95,16 @@ WorkflowsClient::DeleteWorkflow(std::string const& name, Options options) {
 future<StatusOr<google::cloud::workflows::v1::OperationMetadata>>
 WorkflowsClient::DeleteWorkflow(
     google::cloud::workflows::v1::DeleteWorkflowRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->DeleteWorkflow(request);
 }
 
 future<StatusOr<google::cloud::workflows::v1::Workflow>>
 WorkflowsClient::UpdateWorkflow(
     google::cloud::workflows::v1::Workflow const& workflow,
-    google::protobuf::FieldMask const& update_mask, Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    google::protobuf::FieldMask const& update_mask, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   google::cloud::workflows::v1::UpdateWorkflowRequest request;
   *request.mutable_workflow() = workflow;
   *request.mutable_update_mask() = update_mask;
@@ -124,9 +114,8 @@ WorkflowsClient::UpdateWorkflow(
 future<StatusOr<google::cloud::workflows::v1::Workflow>>
 WorkflowsClient::UpdateWorkflow(
     google::cloud::workflows::v1::UpdateWorkflowRequest const& request,
-    Options options) {
-  internal::OptionsSpan span(
-      internal::MergeOptions(std::move(options), options_));
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
   return connection_->UpdateWorkflow(request);
 }
 

--- a/google/cloud/workflows/workflows_client.h
+++ b/google/cloud/workflows/workflows_client.h
@@ -65,7 +65,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class WorkflowsClient {
  public:
   explicit WorkflowsClient(std::shared_ptr<WorkflowsConnection> connection,
-                           Options options = {});
+                           Options opts = {});
   ~WorkflowsClient();
 
   //@{
@@ -93,7 +93,8 @@ class WorkflowsClient {
   /// @param parent  Required. Project and location from which the workflows
   /// should be listed.
   ///  Format: projects/{project}/locations/{location}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -103,7 +104,7 @@ class WorkflowsClient {
   /// @googleapis_reference_link{google/cloud/workflows/v1/workflows.proto#L104}
   ///
   StreamRange<google::cloud::workflows::v1::Workflow> ListWorkflows(
-      std::string const& parent, Options options = {});
+      std::string const& parent, Options opts = {});
 
   ///
   /// Lists Workflows in a given project and location.
@@ -111,7 +112,8 @@ class WorkflowsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::v1::ListWorkflowsRequest,google/cloud/workflows/v1/workflows.proto#L186}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -122,7 +124,7 @@ class WorkflowsClient {
   ///
   StreamRange<google::cloud::workflows::v1::Workflow> ListWorkflows(
       google::cloud::workflows::v1::ListWorkflowsRequest request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Gets details of a single Workflow.
@@ -130,7 +132,8 @@ class WorkflowsClient {
   /// @param name  Required. Name of the workflow which information should be
   /// retrieved.
   ///  Format: projects/{project}/locations/{location}/workflows/{workflow}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -140,14 +143,15 @@ class WorkflowsClient {
   /// @googleapis_reference_link{google/cloud/workflows/v1/workflows.proto#L104}
   ///
   StatusOr<google::cloud::workflows::v1::Workflow> GetWorkflow(
-      std::string const& name, Options options = {});
+      std::string const& name, Options opts = {});
 
   ///
   /// Gets details of a single Workflow.
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::v1::GetWorkflowRequest,google/cloud/workflows/v1/workflows.proto#L236}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -158,7 +162,7 @@ class WorkflowsClient {
   ///
   StatusOr<google::cloud::workflows::v1::Workflow> GetWorkflow(
       google::cloud::workflows::v1::GetWorkflowRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Creates a new workflow. If a workflow with the specified name already
@@ -177,7 +181,8 @@ class WorkflowsClient {
   ///  * Must be between 1-64 characters.
   ///  * Must end with a number or a letter.
   ///  * Must be unique within the customer project and location.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -189,7 +194,7 @@ class WorkflowsClient {
   future<StatusOr<google::cloud::workflows::v1::Workflow>> CreateWorkflow(
       std::string const& parent,
       google::cloud::workflows::v1::Workflow const& workflow,
-      std::string const& workflow_id, Options options = {});
+      std::string const& workflow_id, Options opts = {});
 
   ///
   /// Creates a new workflow. If a workflow with the specified name already
@@ -198,7 +203,8 @@ class WorkflowsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::v1::CreateWorkflowRequest,google/cloud/workflows/v1/workflows.proto#L250}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -209,7 +215,7 @@ class WorkflowsClient {
   ///
   future<StatusOr<google::cloud::workflows::v1::Workflow>> CreateWorkflow(
       google::cloud::workflows::v1::CreateWorkflowRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Deletes a workflow with the specified name.
@@ -218,7 +224,8 @@ class WorkflowsClient {
   ///
   /// @param name  Required. Name of the workflow to be deleted.
   ///  Format: projects/{project}/locations/{location}/workflows/{workflow}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::OperationMetadata,google/cloud/workflows/v1/workflows.proto#L301}
   ///
@@ -228,7 +235,7 @@ class WorkflowsClient {
   /// @googleapis_reference_link{google/cloud/workflows/v1/workflows.proto#L301}
   ///
   future<StatusOr<google::cloud::workflows::v1::OperationMetadata>>
-  DeleteWorkflow(std::string const& name, Options options = {});
+  DeleteWorkflow(std::string const& name, Options opts = {});
 
   ///
   /// Deletes a workflow with the specified name.
@@ -237,7 +244,8 @@ class WorkflowsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::v1::DeleteWorkflowRequest,google/cloud/workflows/v1/workflows.proto#L277}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::OperationMetadata,google/cloud/workflows/v1/workflows.proto#L301}
   ///
@@ -249,7 +257,7 @@ class WorkflowsClient {
   future<StatusOr<google::cloud::workflows::v1::OperationMetadata>>
   DeleteWorkflow(
       google::cloud::workflows::v1::DeleteWorkflowRequest const& request,
-      Options options = {});
+      Options opts = {});
 
   ///
   /// Updates an existing workflow.
@@ -262,7 +270,8 @@ class WorkflowsClient {
   /// @param update_mask  List of fields to be updated. If not present, the
   /// entire workflow
   ///  will be updated.
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -273,7 +282,7 @@ class WorkflowsClient {
   ///
   future<StatusOr<google::cloud::workflows::v1::Workflow>> UpdateWorkflow(
       google::cloud::workflows::v1::Workflow const& workflow,
-      google::protobuf::FieldMask const& update_mask, Options options = {});
+      google::protobuf::FieldMask const& update_mask, Options opts = {});
 
   ///
   /// Updates an existing workflow.
@@ -284,7 +293,8 @@ class WorkflowsClient {
   ///
   /// @param request
   /// @googleapis_link{google::cloud::workflows::v1::UpdateWorkflowRequest,google/cloud/workflows/v1/workflows.proto#L291}
-  /// @param options  Optional. Operation options.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
   /// @return
   /// @googleapis_link{google::cloud::workflows::v1::Workflow,google/cloud/workflows/v1/workflows.proto#L104}
   ///
@@ -295,7 +305,7 @@ class WorkflowsClient {
   ///
   future<StatusOr<google::cloud::workflows::v1::Workflow>> UpdateWorkflow(
       google::cloud::workflows::v1::UpdateWorkflowRequest const& request,
-      Options options = {});
+      Options opts = {});
 
  private:
   std::shared_ptr<WorkflowsConnection> connection_;


### PR DESCRIPTION
The googleapis RPCs can define "method signatures" which decompose a
proto `request` object into its key parameters. The generator maps these
to overloads, and adds the `Options options` parameter. This does not
work when one of the arguments defined in the method signature is
already called `options`.  This changes the extract `Options options`
parameter to `Options opts`, which, as of this writing, does not have
any conflicts in the googleapis protos.

Part of the work for #8175 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8283)
<!-- Reviewable:end -->
