### PR TITLE
ci: deflake macOS Bazel builds

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -33,7 +33,7 @@ python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem
-curl --retry-all-errors -sSL --retry 10 -o /dev/shm/roots.pem https://pki.google.com/roots.pem
+ci/retry-command.sh 3 120 curl -sSL -o /dev/shm/roots.pem https://pki.google.com/roots.pem
 
 # Outputs a list of Bazel arguments that should be used when running
 # integration tests. These do not include the common `bazel::common_args`.

--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -33,7 +33,7 @@ python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
 
 # Some of the tests will need a valid roots.pem file.
 rm -f /dev/shm/roots.pem
-curl -sSL --retry 10 -o /dev/shm/roots.pem https://pki.google.com/roots.pem
+curl --retry-all-errors -sSL --retry 10 -o /dev/shm/roots.pem https://pki.google.com/roots.pem
 
 # Outputs a list of Bazel arguments that should be used when running
 # integration tests. These do not include the common `bazel::common_args`.

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -98,7 +98,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/kokoro-run-key.json"
 io::log_h1 "Getting roots.pem for gRPC"
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${KOKORO_GFILE_DIR}/roots.pem"
 rm -f "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
-curl -sSL --retry 10 -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
+curl -sSL --retry-all-errors --retry 10 -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
   https://pki.google.com/roots.pem
 
 io::log_h1 "Downloading cache"

--- a/ci/kokoro/macos/build.sh
+++ b/ci/kokoro/macos/build.sh
@@ -98,7 +98,7 @@ export GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_GFILE_DIR}/kokoro-run-key.json"
 io::log_h1 "Getting roots.pem for gRPC"
 export GRPC_DEFAULT_SSL_ROOTS_FILE_PATH="${KOKORO_GFILE_DIR}/roots.pem"
 rm -f "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}"
-curl -sSL --retry-all-errors --retry 10 -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
+ci/retry-command.sh 3 120 curl -sSL -o "${GRPC_DEFAULT_SSL_ROOTS_FILE_PATH}" \
   https://pki.google.com/roots.pem
 
 io::log_h1 "Downloading cache"

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -40,7 +40,7 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 mkdir -p "${vcpkg_dir}"
 io::log "Downloading vcpkg into ${vcpkg_dir}..."
 VCPKG_COMMIT="$(<ci/etc/vcpkg-commit.txt)"
-curl --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
+curl --retry-all-errors --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
 (
   cd "${vcpkg_dir}"

--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -40,7 +40,7 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 mkdir -p "${vcpkg_dir}"
 io::log "Downloading vcpkg into ${vcpkg_dir}..."
 VCPKG_COMMIT="$(<ci/etc/vcpkg-commit.txt)"
-curl --retry-all-errors --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
+ci/retry-command.sh 3 120 curl -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
 (
   cd "${vcpkg_dir}"

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -33,7 +33,7 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 mkdir -p "${vcpkg_dir}"
 io::log "Downloading vcpkg into ${vcpkg_dir}..."
 VCPKG_COMMIT="$(<ci/etc/vcpkg-commit.txt)"
-curl --retry-all-errors --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
+ci/retry-command.sh 3 120 curl -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
 (
   cd "${vcpkg_dir}"

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -33,7 +33,7 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 mkdir -p "${vcpkg_dir}"
 io::log "Downloading vcpkg into ${vcpkg_dir}..."
 VCPKG_COMMIT="$(<ci/etc/vcpkg-commit.txt)"
-curl --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
+curl --retry-all-errors --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
 (
   cd "${vcpkg_dir}"
@@ -46,11 +46,9 @@ curl --retry 3 -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.
 run_quickstart="false"
 readonly CONFIG_DIR="${KOKORO_GFILE_DIR:-/private/var/tmp}"
 readonly CREDENTIALS_FILE="${CONFIG_DIR}/kokoro-run-key.json"
-readonly ROOTS_PEM_SOURCE="https://pki.google.com/roots.pem"
 if [[ -r "${CREDENTIALS_FILE}" ]]; then
+  # The driver script (../build.sh) should have downloaded this file.
   if [[ -r "${CONFIG_DIR}/roots.pem" ]]; then
-    run_quickstart="true"
-  elif curl -sSL --retry 10 -o "${CONFIG_DIR}/roots.pem" "${ROOTS_PEM_SOURCE}"; then
     run_quickstart="true"
   fi
 fi
@@ -86,7 +84,6 @@ build_quickstart() {
       args+=("${line}")
     done < <(quickstart::arguments "${library}")
     env "GOOGLE_APPLICATION_CREDENTIALS=${CREDENTIALS_FILE}" \
-      "GRPC_DEFAULT_SSL_ROOTS_FILE_PATH=${CONFIG_DIR}/roots.pem" \
       "${binary_dir}/quickstart" "${args[@]}"
   fi
 }


### PR DESCRIPTION
Turns out there are more steps in both the Bazel and CMake builds that
needed deflaking. Also preemptively improve retry loop in the general
integration test script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8287)
<!-- Reviewable:end -->
