### PR TITLE
chore: fix west->east const

### DIFF
--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -18,7 +18,7 @@
 #include <iomanip>
 #include <sstream>
 
-const char kDescription[] =
+char const kDescription[] =
     R"""(Measure the latency of `Table::Apply()` and `Table::ReadRow()` on a
 long running program.
 

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -376,7 +376,7 @@ void CurlImpl::SetUrl(
     return;
   }
   url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());
-  const char* query_parameter_separator = InitialQueryParameterSeparator(url_);
+  char const* query_parameter_separator = InitialQueryParameterSeparator(url_);
   auto append_params = [&](RestRequest::HttpParameters const& parameters) {
     for (auto const& param : parameters) {
       absl::StrAppend(&url_, query_parameter_separator,

--- a/google/cloud/internal/non_constructible.h
+++ b/google/cloud/internal/non_constructible.h
@@ -31,7 +31,7 @@ namespace internal {
  */
 struct NonConstructible {
   NonConstructible() = delete;
-  NonConstructible(const NonConstructible&) = delete;
+  NonConstructible(NonConstructible const&) = delete;
   NonConstructible(NonConstructible&&) = delete;
 };
 

--- a/google/cloud/internal/status_payload_keys.cc
+++ b/google/cloud/internal/status_payload_keys.cc
@@ -20,7 +20,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 // These keys need to be unique, but there's no other required format.
-const char kStatusPayloadGrpcProto[] = "StatusProtoSerialized";
+char const kStatusPayloadGrpcProto[] = "StatusProtoSerialized";
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/status_payload_keys.h
+++ b/google/cloud/internal/status_payload_keys.h
@@ -26,7 +26,7 @@ namespace internal {
 // The key to use when setting/getting a `google::cloud::Status` payload
 // associated with a serialized `google::rpc::Status` protobuf. The value
 // should be serialized with `.SerializeAsString()`.
-extern const char kStatusPayloadGrpcProto[];
+extern char const kStatusPayloadGrpcProto[];
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session_test.cc
@@ -118,7 +118,7 @@ TEST_F(LoggingResumableUploadSessionTest, NextExpectedByte) {
 TEST_F(LoggingResumableUploadSessionTest, LastResponseOk) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
-  const StatusOr<ResumableUploadResponse> last_response(ResumableUploadResponse{
+  StatusOr<ResumableUploadResponse> const last_response(ResumableUploadResponse{
       "upload url", ResumableUploadResponse::kInProgress, 1, {}, {}});
   EXPECT_CALL(*mock, last_response()).WillOnce(ReturnRef(last_response));
 
@@ -135,7 +135,7 @@ TEST_F(LoggingResumableUploadSessionTest, LastResponseOk) {
 TEST_F(LoggingResumableUploadSessionTest, LastResponseBadStatus) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
 
-  const StatusOr<ResumableUploadResponse> last_response(
+  StatusOr<ResumableUploadResponse> const last_response(
       Status(StatusCode::kFailedPrecondition, "something bad"));
   EXPECT_CALL(*mock, last_response()).WillOnce(ReturnRef(last_response));
 

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -251,7 +251,7 @@ void RetryResumableUploadSession::AppendDebug(char const* action,
 }
 
 Status RetryResumableUploadSession::HandleUncommitError(
-    const char* caller, ResumableUploadResponse const& result) {
+    char const* caller, ResumableUploadResponse const& result) {
   std::stringstream os;
   os << caller << ": server previously confirmed " << committed_size_
      << " bytes as committed, but the current response only reports "


### PR DESCRIPTION
These were fixed using a new clang-format with
`--qualifier-alignment=right`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8289)
<!-- Reviewable:end -->
