### PR TITLE
impl(rest): add POST with form_data method

### DIFF
--- a/google/cloud/internal/rest_client.h
+++ b/google/cloud/internal/rest_client.h
@@ -22,6 +22,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace google {
@@ -58,6 +59,9 @@ class RestClient {
   virtual StatusOr<std::unique_ptr<RestResponse>> Post(
       RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) = 0;
+  virtual StatusOr<std::unique_ptr<RestResponse>> Post(
+      RestRequest request,
+      std::vector<std::pair<std::string, std::string>> const& form_data) = 0;
   virtual StatusOr<std::unique_ptr<RestResponse>> Put(
       RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) = 0;
@@ -85,6 +89,10 @@ class CurlRestClient : public RestClient {
   StatusOr<std::unique_ptr<RestResponse>> Post(
       RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;
+  StatusOr<std::unique_ptr<RestResponse>> Post(
+      RestRequest request,
+      std::vector<std::pair<std::string, std::string>> const& form_data)
+      override;
   StatusOr<std::unique_ptr<RestResponse>> Put(
       RestRequest const& request,
       std::vector<absl::Span<char const>> const& payload) override;


### PR DESCRIPTION
This adds an overload to RestClient::Post that accepts a collection of key/value pairs representing form data. The values of each pair are x-www-form-urlencoded and the all pairs are assembled into a payload such `key1=value1&key2=value2&keyN=valueN`. This addition was the result of preserving the libcurl encapsulation in `CurlImpl` and `curl_easy_escape` requiring an easy handle as an argument.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8291)
<!-- Reviewable:end -->
