### PR TITLE
refactor: enabled performance-move-const-arg clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,13 +18,6 @@
 #      avoiding C arrays often makes the code less readable, and std::array is
 #      not a drop-in replacement because it doesn't deduce the size.
 #
-#  -performance-move-const-arg: This warning requires the developer to
-#      know/care more about the implementation details of types/functions than
-#      should be necessary. For example, `A a; F(std::move(a));` will trigger a
-#      warning IFF `A` is a trivial type (and therefore the move is
-#      meaningless). It would also warn if `F` accepts by `const&`, which is
-#      another detail that the caller need not care about.
-#
 #  -readability-redundant-declaration: A friend declaration inside a class
 #      counts as a declaration, so if we also declare that friend outside the
 #      class in order to document it as part of the public API, that will
@@ -53,7 +46,6 @@ Checks: >
   -modernize-return-braced-init-list,
   -modernize-use-trailing-return-type,
   -modernize-avoid-c-arrays,
-  -performance-move-const-arg,
   -readability-braces-around-statements,
   -readability-identifier-length,
   -readability-magic-numbers,

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -34,7 +34,7 @@ GoldenKitchenSinkLogging::GoldenKitchenSinkLogging(
     std::shared_ptr<GoldenKitchenSinkStub> child,
     TracingOptions tracing_options,
     std::set<std::string> components)
-    : child_(std::move(child)), tracing_options_(std::move(tracing_options)),
+    : child_(std::move(child)), tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>

--- a/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_logging_decorator.cc
@@ -31,7 +31,7 @@ GoldenThingAdminLogging::GoldenThingAdminLogging(
     std::shared_ptr<GoldenThingAdminStub> child,
     TracingOptions tracing_options,
     std::set<std::string> components)
-    : child_(std::move(child)), tracing_options_(std::move(tracing_options)),
+    : child_(std::move(child)), tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::test::admin::database::v1::ListDatabasesResponse>

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -360,7 +360,7 @@ std::string FormatApiMethodSignatureParameters(
          {"<tbody>", "<!--<tbody>-->"},
          {"</tbody>", "<!--</tbody>-->"}});
     absl::StrAppendFormat(&parameter_comments, "  /// @param %s %s\n",
-                          FieldName(parameter_descriptor), std::move(comment));
+                          FieldName(parameter_descriptor), comment);
   }
   return parameter_comments;
 }
@@ -503,7 +503,7 @@ std::string FormatMethodCommentsMethodSignature(
   }
   auto parameter_comments =
       FormatApiMethodSignatureParameters(method, signature);
-  return FormatMethodComments(method, std::move(parameter_comments),
+  return FormatMethodComments(method, parameter_comments,
                               method_source_location);
 }
 
@@ -518,7 +518,7 @@ std::string FormatMethodCommentsProtobufRequest(
   google::protobuf::Descriptor const* input_type = method.input_type();
   auto parameter_comment = absl::StrFormat("  /// @param %s %s\n", "request",
                                            FormatDoxygenLink(*input_type));
-  return FormatMethodComments(method, std::move(parameter_comment),
+  return FormatMethodComments(method, parameter_comment,
                               method_source_location);
 }
 

--- a/generator/internal/logging_decorator_generator.cc
+++ b/generator/internal/logging_decorator_generator.cc
@@ -206,7 +206,7 @@ Status LoggingDecoratorGenerator::GenerateCc() {
     "    std::shared_ptr<$stub_class_name$> child,\n"
     "    TracingOptions tracing_options,\n"
     "    std::set<std::string> components)\n"
-    "    : child_(std::move(child)), tracing_options_(std::move(tracing_options)),\n"
+    "    : child_(std::move(child)), tracing_options_(tracing_options),\n"
     "      components_(std::move(components)) {}\n");
   // clang-format on
 

--- a/google/cloud/accessapproval/internal/access_approval_logging_decorator.cc
+++ b/google/cloud/accessapproval/internal/access_approval_logging_decorator.cc
@@ -31,7 +31,7 @@ AccessApprovalLogging::AccessApprovalLogging(
     std::shared_ptr<AccessApprovalStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::accessapproval::v1::ListApprovalRequestsResponse>

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_logging_decorator.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ AccessContextManagerLogging::AccessContextManagerLogging(
     std::shared_ptr<AccessContextManagerStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::identity::accesscontextmanager::v1::ListAccessPoliciesResponse>

--- a/google/cloud/apigateway/internal/api_gateway_logging_decorator.cc
+++ b/google/cloud/apigateway/internal/api_gateway_logging_decorator.cc
@@ -31,7 +31,7 @@ ApiGatewayServiceLogging::ApiGatewayServiceLogging(
     std::shared_ptr<ApiGatewayServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::apigateway::v1::ListGatewaysResponse>

--- a/google/cloud/apigeeconnect/internal/connection_logging_decorator.cc
+++ b/google/cloud/apigeeconnect/internal/connection_logging_decorator.cc
@@ -31,7 +31,7 @@ ConnectionServiceLogging::ConnectionServiceLogging(
     std::shared_ptr<ConnectionServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::apigeeconnect::v1::ListConnectionsResponse>

--- a/google/cloud/appengine/internal/applications_logging_decorator.cc
+++ b/google/cloud/appengine/internal/applications_logging_decorator.cc
@@ -31,7 +31,7 @@ ApplicationsLogging::ApplicationsLogging(
     std::shared_ptr<ApplicationsStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::Application>

--- a/google/cloud/appengine/internal/authorized_certificates_logging_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_logging_decorator.cc
@@ -31,7 +31,7 @@ AuthorizedCertificatesLogging::AuthorizedCertificatesLogging(
     std::shared_ptr<AuthorizedCertificatesStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListAuthorizedCertificatesResponse>

--- a/google/cloud/appengine/internal/authorized_domains_logging_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_domains_logging_decorator.cc
@@ -31,7 +31,7 @@ AuthorizedDomainsLogging::AuthorizedDomainsLogging(
     std::shared_ptr<AuthorizedDomainsStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListAuthorizedDomainsResponse>

--- a/google/cloud/appengine/internal/domain_mappings_logging_decorator.cc
+++ b/google/cloud/appengine/internal/domain_mappings_logging_decorator.cc
@@ -31,7 +31,7 @@ DomainMappingsLogging::DomainMappingsLogging(
     std::shared_ptr<DomainMappingsStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListDomainMappingsResponse>

--- a/google/cloud/appengine/internal/firewall_logging_decorator.cc
+++ b/google/cloud/appengine/internal/firewall_logging_decorator.cc
@@ -31,7 +31,7 @@ FirewallLogging::FirewallLogging(std::shared_ptr<FirewallStub> child,
                                  TracingOptions tracing_options,
                                  std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListIngressRulesResponse>

--- a/google/cloud/appengine/internal/instances_logging_decorator.cc
+++ b/google/cloud/appengine/internal/instances_logging_decorator.cc
@@ -31,7 +31,7 @@ InstancesLogging::InstancesLogging(std::shared_ptr<InstancesStub> child,
                                    TracingOptions tracing_options,
                                    std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListInstancesResponse>

--- a/google/cloud/appengine/internal/services_logging_decorator.cc
+++ b/google/cloud/appengine/internal/services_logging_decorator.cc
@@ -31,7 +31,7 @@ ServicesLogging::ServicesLogging(std::shared_ptr<ServicesStub> child,
                                  TracingOptions tracing_options,
                                  std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListServicesResponse>

--- a/google/cloud/appengine/internal/versions_logging_decorator.cc
+++ b/google/cloud/appengine/internal/versions_logging_decorator.cc
@@ -31,7 +31,7 @@ VersionsLogging::VersionsLogging(std::shared_ptr<VersionsStub> child,
                                  TracingOptions tracing_options,
                                  std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::appengine::v1::ListVersionsResponse>

--- a/google/cloud/artifactregistry/internal/artifact_registry_logging_decorator.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_logging_decorator.cc
@@ -31,7 +31,7 @@ ArtifactRegistryLogging::ArtifactRegistryLogging(
     std::shared_ptr<ArtifactRegistryStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::devtools::artifactregistry::v1::ListDockerImagesResponse>

--- a/google/cloud/asset/internal/asset_logging_decorator.cc
+++ b/google/cloud/asset/internal/asset_logging_decorator.cc
@@ -31,7 +31,7 @@ AssetServiceLogging::AssetServiceLogging(
     std::shared_ptr<AssetServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/assuredworkloads/internal/assured_workloads_logging_decorator.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_logging_decorator.cc
@@ -31,7 +31,7 @@ AssuredWorkloadsServiceLogging::AssuredWorkloadsServiceLogging(
     std::shared_ptr<AssuredWorkloadsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/automl/internal/auto_ml_logging_decorator.cc
+++ b/google/cloud/automl/internal/auto_ml_logging_decorator.cc
@@ -31,7 +31,7 @@ AutoMlLogging::AutoMlLogging(std::shared_ptr<AutoMlStub> child,
                              TracingOptions tracing_options,
                              std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/automl/internal/prediction_logging_decorator.cc
+++ b/google/cloud/automl/internal/prediction_logging_decorator.cc
@@ -31,7 +31,7 @@ PredictionServiceLogging::PredictionServiceLogging(
     std::shared_ptr<PredictionServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::automl::v1::PredictResponse>

--- a/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_logging_decorator.cc
@@ -32,7 +32,7 @@ BigQueryReadLogging::BigQueryReadLogging(
     std::shared_ptr<BigQueryReadStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>

--- a/google/cloud/bigquery/internal/connection_logging_decorator.cc
+++ b/google/cloud/bigquery/internal/connection_logging_decorator.cc
@@ -31,7 +31,7 @@ ConnectionServiceLogging::ConnectionServiceLogging(
     std::shared_ptr<ConnectionServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::bigquery::connection::v1::Connection>

--- a/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/admin_backup_integration_test.cc
@@ -104,8 +104,7 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   btadmin::Backup b;
   b.set_source_table(table_name);
   *b.mutable_expire_time() = expire_time;
-  auto backup =
-      client_.CreateBackup(cluster_name, backup_id, std::move(b)).get();
+  auto backup = client_.CreateBackup(cluster_name, backup_id, b).get();
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(backup->name(), backup_name);
 
@@ -144,7 +143,7 @@ TEST_F(AdminBackupIntegrationTest, CreateListGetUpdateRestoreDeleteBackup) {
   r.set_parent(instance_name);
   r.set_table_id(table_id);
   r.set_backup(backup_name);
-  auto table = client_.RestoreTable(std::move(r)).get();
+  auto table = client_.RestoreTable(r).get();
   EXPECT_STATUS_OK(table);
 
   // Verify the restore

--- a/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
@@ -121,8 +121,8 @@ btadmin::CreateInstanceRequest IntegrationTestConfig(
     btadmin::Instance::Type type = btadmin::Instance::DEVELOPMENT,
     int32_t serve_nodes = 0) {
   // The description cannot exceed 30 characters
-  auto const display_name = ("IT " + instance_id).substr(0, 30);
-  auto const project_name = Project(project).FullName();
+  auto display_name = ("IT " + instance_id).substr(0, 30);
+  auto project_name = Project(project).FullName();
 
   btadmin::Cluster c;
   c.set_location(project_name + "/locations/" + location);
@@ -261,7 +261,7 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   req_1.set_ignore_warnings(true);
   req_1.set_name(name_1);
 
-  ASSERT_STATUS_OK(client_.DeleteAppProfile(std::move(req_1)));
+  ASSERT_STATUS_OK(client_.DeleteAppProfile(req_1));
   profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
   EXPECT_THAT(*profiles, Not(Contains(name_1)));
@@ -271,13 +271,13 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteAppProfile) {
   req_2.set_ignore_warnings(true);
   req_2.set_name(name_2);
 
-  ASSERT_STATUS_OK(client_.DeleteAppProfile(std::move(req_2)));
+  ASSERT_STATUS_OK(client_.DeleteAppProfile(req_2));
   profiles = profile_names(client_.ListAppProfiles(instance_name));
   ASSERT_STATUS_OK(profiles);
   EXPECT_THAT(*profiles, Not(Contains(name_1)));
   EXPECT_THAT(*profiles, Not(Contains(name_2)));
 
-  ASSERT_STATUS_OK(client_.DeleteInstance(std::move(instance_name)));
+  ASSERT_STATUS_OK(client_.DeleteInstance(instance_name));
 }
 
 /// @test Verify that Instance CRUD operations work as expected.

--- a/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
@@ -78,7 +78,7 @@ TEST_F(TableAdminIntegrationTest, TableListWithMultipleTables) {
     std::string table_id = RandomTableId();
     EXPECT_STATUS_OK(client_.CreateTable(instance_name, table_id, {}));
     expected_tables.emplace_back(
-        bigtable::TableName(project_id(), instance_id(), std::move(table_id)));
+        bigtable::TableName(project_id(), instance_id(), table_id));
   }
   auto tables = ListTables();
   ASSERT_STATUS_OK(tables);
@@ -124,8 +124,8 @@ TEST_F(TableAdminIntegrationTest, DropRowsByPrefix) {
   // Delete all the records for a row
   btadmin::DropRowRangeRequest r;
   r.set_name(table.table_name());
-  r.set_row_key_prefix(std::move(row_key1_prefix));
-  EXPECT_STATUS_OK(client_.DropRowRange(std::move(r)));
+  r.set_row_key_prefix(row_key1_prefix);
+  EXPECT_STATUS_OK(client_.DropRowRange(r));
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
 
   CheckEqualUnordered(expected_cells, actual_cells);
@@ -151,7 +151,7 @@ TEST_F(TableAdminIntegrationTest, DropAllRows) {
   btadmin::DropRowRangeRequest r;
   r.set_name(table.table_name());
   r.set_delete_all_data_from_table(true);
-  EXPECT_STATUS_OK(client_.DropRowRange(std::move(r)));
+  EXPECT_STATUS_OK(client_.DropRowRange(r));
   auto actual_cells = ReadRows(table, bigtable::Filter::PassAllFilter());
 
   ASSERT_TRUE(actual_cells.empty());
@@ -180,12 +180,12 @@ TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTable) {
   auto& families = *t.mutable_column_families();
   *families["fam"].mutable_gc_rule() = std::move(gc_fam);
   *families["foo"].mutable_gc_rule() = std::move(gc_foo);
-  for (auto&& split : {"a1000", "a2000", "b3000", "m5000"}) {
-    r.add_initial_splits()->set_key(std::move(split));
+  for (auto const& split : {"a1000", "a2000", "b3000", "m5000"}) {
+    r.add_initial_splits()->set_key(split);
   }
 
   // Create table
-  ASSERT_STATUS_OK(client_.CreateTable(std::move(r)));
+  ASSERT_STATUS_OK(client_.CreateTable(r));
   bigtable::Table table(data_client_, table_id);
 
   // List tables
@@ -274,7 +274,7 @@ TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
   // be production clusters (and therefore have at least 3 nodes each), and
   // they must be in different zones. Also, the display name cannot be longer
   // than 30 characters.
-  auto const display_name = ("IT " + id).substr(0, 30);
+  auto display_name = ("IT " + id).substr(0, 30);
 
   btadmin::Instance in;
   in.set_display_name(std::move(display_name));
@@ -293,7 +293,7 @@ TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
 
   // Create the new instance.
   auto instance = instance_admin_client
-                      .CreateInstance(project_name, id, std::move(in),
+                      .CreateInstance(project_name, id, in,
                                       {{id + "-c1", std::move(c1)},
                                        {id + "-c2", std::move(c2)}})
                       .get();
@@ -309,8 +309,7 @@ TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
   *families[family].mutable_gc_rule() = std::move(gc);
 
   // Create the new table.
-  auto table_created =
-      client_.CreateTable(instance_name, random_table_id, std::move(t));
+  auto table_created = client_.CreateTable(instance_name, random_table_id, t);
   ASSERT_STATUS_OK(table_created);
 
   // We need to mutate the data in the table and then wait for those mutations
@@ -410,12 +409,12 @@ TEST_F(TableAdminIntegrationTest, CreateListGetDeleteTableWithLogging) {
   auto& families = *t.mutable_column_families();
   *families["fam"].mutable_gc_rule() = std::move(gc_fam);
   *families["foo"].mutable_gc_rule() = std::move(gc_foo);
-  for (auto&& split : {"a1000", "a2000", "b3000", "m5000"}) {
-    r.add_initial_splits()->set_key(std::move(split));
+  for (auto const& split : {"a1000", "a2000", "b3000", "m5000"}) {
+    r.add_initial_splits()->set_key(split);
   }
 
   // Create table
-  ASSERT_STATUS_OK(client.CreateTable(std::move(r)));
+  ASSERT_STATUS_OK(client.CreateTable(r));
   bigtable::Table table(data_client_, table_id);
 
   // List tables

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_logging_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_logging_decorator.cc
@@ -31,7 +31,7 @@ BigtableInstanceAdminLogging::BigtableInstanceAdminLogging(
     std::shared_ptr<BigtableInstanceAdminStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_logging_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_logging_decorator.cc
@@ -31,7 +31,7 @@ BigtableTableAdminLogging::BigtableTableAdminLogging(
     std::shared_ptr<BigtableTableAdminStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::bigtable::admin::v2::Table>

--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -411,8 +411,8 @@ std::shared_ptr<AdminClient> MakeAdminClient(std::string project,
       std::move(project), std::move(options));
   if (tracing_enabled) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    client = std::make_shared<internal::LoggingAdminClient>(
-        std::move(client), std::move(tracing_options));
+    client = std::make_shared<internal::LoggingAdminClient>(std::move(client),
+                                                            tracing_options);
   }
   return client;
 }

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -242,7 +242,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
     // assert(!whole_op_finished_);
     // assert(!continue_reading_);
     // assert(status_.ok());
-    status_ = ConsumeResponse(std::move(response));
+    status_ = ConsumeResponse(response);
     // We've processed the response.
     //
     // If there were errors (e.g. malformed response from the server), we should

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -115,7 +115,7 @@ std::string Benchmark::CreateTable() {
   auto& families = *r.mutable_table()->mutable_column_families();
   *families[kColumnFamily].mutable_gc_rule() = std::move(gc);
 
-  (void)admin.CreateTable(std::move(r));
+  (void)admin.CreateTable(r);
   return options_.table_id;
 }
 

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -174,7 +174,7 @@ int main(int argc, char* argv[]) {
     *families[options->column_family].mutable_gc_rule() = std::move(gc);
 
     std::cout << "# Creating Table\n";
-    auto table = admin.CreateTable(std::move(r));
+    auto table = admin.CreateTable(r);
     if (!table) {
       std::cout << table.status() << std::endl;
       return 1;
@@ -185,7 +185,7 @@ int main(int argc, char* argv[]) {
     r.set_name(
         cbt::TableName(options->project_id, options->instance_id, table_id));
     r.set_view(google::bigtable::admin::v2::Table_View_NAME_ONLY);
-    auto table = admin.GetTable(std::move(r));
+    auto table = admin.GetTable(r);
     if (!table) {
       std::cout << "Error trying to get Table " << table_id << ":\n"
                 << table.status() << std::endl;

--- a/google/cloud/bigtable/client_options_test.cc
+++ b/google/cloud/bigtable/client_options_test.cc
@@ -578,8 +578,7 @@ TEST(ClientOptionsTest, CustomBackgroundThreads) {
   cq = CompletionQueue();
   client_options = ClientOptions().DisableBackgroundThreads(cq);
   auto opts = internal::MakeOptions(std::move(client_options));
-  background =
-      google::cloud::internal::MakeBackgroundThreadsFactory(std::move(opts))();
+  background = google::cloud::internal::MakeBackgroundThreadsFactory(opts)();
 
   check(cq, std::move(background));
 }

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -188,8 +188,8 @@ std::shared_ptr<DataClient> MakeDataClient(std::string project_id,
       std::move(project_id), std::move(instance_id), std::move(options));
   if (tracing_enabled) {
     GCP_LOG(INFO) << "Enabled logging for gRPC calls";
-    client = std::make_shared<internal::LoggingDataClient>(
-        std::move(client), std::move(tracing_options));
+    client = std::make_shared<internal::LoggingDataClient>(std::move(client),
+                                                           tracing_options);
   }
   return client;
 }

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -134,7 +134,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto& families = *t.mutable_column_families();
   *families["fam"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   auto profile_id = "hw-app-profile-" +
@@ -146,7 +146,7 @@ void RunAll(std::vector<std::string> const& argv) {
   google::bigtable::admin::v2::AppProfile ap;
   ap.mutable_multi_cluster_routing_use_any()->Clear();
   auto profile = instance_admin.CreateAppProfile(
-      cbt::InstanceName(project_id, instance_id), profile_id, std::move(ap));
+      cbt::InstanceName(project_id, instance_id), profile_id, ap);
   if (!profile) throw std::runtime_error(profile.status().message());
 
   std::cout << "\nRunning the AppProfile hello world example" << std::endl;
@@ -155,7 +155,7 @@ void RunAll(std::vector<std::string> const& argv) {
   google::bigtable::admin::v2::DeleteAppProfileRequest req;
   req.set_name(cbt::AppProfileName(project_id, instance_id, profile_id));
   req.set_ignore_warnings(true);
-  instance_admin.DeleteAppProfile(std::move(req));
+  instance_admin.DeleteAppProfile(req);
   admin.DeleteTable(schema->name());
 }
 

--- a/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
@@ -103,7 +103,7 @@ void BigtableHelloInstance(std::vector<std::string> const& argv) {
 
     future<void> creation_done =
         instance_admin
-            .CreateInstance(project_name, instance_id, std::move(in),
+            .CreateInstance(project_name, instance_id, in,
                             {{cluster_id, std::move(c)}})
             .then(
                 [instance_id](

--- a/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
@@ -71,7 +71,7 @@ void HelloWorldTableAdmin(std::vector<std::string> const& argv) {
   std::cout << "Creating a table:\n";
   std::string instance_name = cbt::InstanceName(project_id, instance_id);
   StatusOr<google::bigtable::admin::v2::Table> schema =
-      admin.CreateTable(instance_name, table_id, std::move(t));
+      admin.CreateTable(instance_name, table_id, t);
   std::cout << "DONE\n";
   //! [create table]
 
@@ -93,8 +93,7 @@ void HelloWorldTableAdmin(std::vector<std::string> const& argv) {
   google::bigtable::admin::v2::GetTableRequest get_req;
   get_req.set_name(schema->name());
   get_req.set_view(google::bigtable::admin::v2::Table::FULL);
-  StatusOr<google::bigtable::admin::v2::Table> table =
-      admin.GetTable(std::move(get_req));
+  StatusOr<google::bigtable::admin::v2::Table> table = admin.GetTable(get_req);
   if (!table) throw std::runtime_error(table.status().message());
   std::cout << "Table name : " << table->name() << "\n";
 
@@ -131,7 +130,7 @@ void HelloWorldTableAdmin(std::vector<std::string> const& argv) {
   google::bigtable::admin::v2::DropRowRangeRequest drop_req;
   drop_req.set_name(table->name());
   drop_req.set_delete_all_data_from_table(true);
-  google::cloud::Status status = admin.DropRowRange(std::move(drop_req));
+  google::cloud::Status status = admin.DropRowRange(drop_req);
   if (!status.ok()) throw std::runtime_error(status.message());
   std::cout << "DONE\n";
   //! [drop all rows]

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -62,7 +62,7 @@ void BigtableHelloWorld(std::vector<std::string> const& argv) {
   // Create a table.
   std::string instance_name = cbt::InstanceName(project_id, instance_id);
   StatusOr<google::bigtable::admin::v2::Table> schema =
-      table_admin.CreateTable(instance_name, table_id, std::move(t));
+      table_admin.CreateTable(instance_name, table_id, t);
   //! [create table]
 
   // Create an object to access the Cloud Bigtable Data API.

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -55,8 +55,8 @@ void CreateInstance(
         {cluster_id, std::move(cluster)}};
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.CreateInstance(project_name, instance_id, std::move(in),
-                                      std::move(cluster_map));
+        instance_admin.CreateInstance(project_name, instance_id, in,
+                                      cluster_map);
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.
     std::cout << "Waiting for instance creation to complete " << std::flush;
@@ -98,8 +98,8 @@ void CreateDevInstance(
         {cluster_id, std::move(cluster)}};
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.CreateInstance(project_name, instance_id, std::move(in),
-                                      std::move(cluster_map));
+        instance_admin.CreateInstance(project_name, instance_id, in,
+                                      cluster_map);
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.
     std::cout << "Waiting for instance creation to complete " << std::flush;
@@ -147,8 +147,8 @@ void CreateReplicatedInstance(
         {c1, std::move(cluster1)}, {c2, std::move(cluster2)}};
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.CreateInstance(project_name, instance_id, std::move(in),
-                                      std::move(cluster_map));
+        instance_admin.CreateInstance(project_name, instance_id, in,
+                                      cluster_map);
     // Show how to perform additional work while the long running operation
     // completes. The application could use future.then() instead.
     std::cout << "Waiting for instance creation to complete " << std::flush;
@@ -182,8 +182,7 @@ void UpdateInstance(
     mask.add_paths("display_name");
 
     future<StatusOr<google::bigtable::admin::v2::Instance>> instance_future =
-        instance_admin.PartialUpdateInstance(std::move(*instance),
-                                             std::move(mask));
+        instance_admin.PartialUpdateInstance(*instance, mask);
     instance_future
         .then([](future<StatusOr<google::bigtable::admin::v2::Instance>> f) {
           auto updated_instance = f.get();
@@ -310,7 +309,7 @@ void CreateCluster(
     c.set_default_storage_type(google::bigtable::admin::v2::HDD);
 
     future<StatusOr<google::bigtable::admin::v2::Cluster>> cluster_future =
-        instance_admin.CreateCluster(instance_name, cluster_id, std::move(c));
+        instance_admin.CreateCluster(instance_name, cluster_id, c);
 
     // Applications can wait asynchronously, in this example we just block.
     auto cluster = cluster_future.get();
@@ -403,8 +402,7 @@ void UpdateCluster(
     // Set the desired cluster configuration.
     cluster->set_serve_nodes(4);
 
-    auto modified_cluster =
-        instance_admin.UpdateCluster(std::move(*cluster)).get();
+    auto modified_cluster = instance_admin.UpdateCluster(*cluster).get();
     if (!modified_cluster) {
       throw std::runtime_error(modified_cluster.status().message());
     }
@@ -470,8 +468,7 @@ void CreateAppProfile(
     ap.mutable_multi_cluster_routing_use_any()->Clear();
 
     StatusOr<google::bigtable::admin::v2::AppProfile> profile =
-        instance_admin.CreateAppProfile(instance_name, profile_id,
-                                        std::move(ap));
+        instance_admin.CreateAppProfile(instance_name, profile_id, ap);
     if (!profile) throw std::runtime_error(profile.status().message());
     std::cout << "New profile created with name=" << profile->name() << "\n";
   }
@@ -495,8 +492,7 @@ void CreateAppProfileCluster(
     ap.mutable_single_cluster_routing()->set_cluster_id(cluster_id);
 
     StatusOr<google::bigtable::admin::v2::AppProfile> profile =
-        instance_admin.CreateAppProfile(instance_name, profile_id,
-                                        std::move(ap));
+        instance_admin.CreateAppProfile(instance_name, profile_id, ap);
     if (!profile) throw std::runtime_error(profile.status().message());
     std::cout << "New profile created with name=" << profile->name() << "\n";
   }
@@ -548,7 +544,7 @@ void UpdateAppProfileDescription(
     mask.add_paths("description");
 
     future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
-        instance_admin.UpdateAppProfile(std::move(profile), std::move(mask));
+        instance_admin.UpdateAppProfile(profile, mask);
     auto modified_profile = profile_future.get();
     if (!modified_profile)
       throw std::runtime_error(modified_profile.status().message());
@@ -580,7 +576,7 @@ void UpdateAppProfileRoutingAny(
     req.set_ignore_warnings(true);
 
     future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
-        instance_admin.UpdateAppProfile(std::move(req));
+        instance_admin.UpdateAppProfile(req);
     auto modified_profile = profile_future.get();
     if (!modified_profile)
       throw std::runtime_error(modified_profile.status().message());
@@ -613,7 +609,7 @@ void UpdateAppProfileRoutingSingleCluster(
     req.set_ignore_warnings(true);
 
     future<StatusOr<google::bigtable::admin::v2::AppProfile>> profile_future =
-        instance_admin.UpdateAppProfile(std::move(req));
+        instance_admin.UpdateAppProfile(req);
     auto modified_profile = profile_future.get();
     if (!modified_profile)
       throw std::runtime_error(modified_profile.status().message());
@@ -690,7 +686,7 @@ void DeleteAppProfile(std::vector<std::string> const& argv) {
     req.set_name(profile_name);
     req.set_ignore_warnings(ignore_warnings);
 
-    Status status = instance_admin.DeleteAppProfile(std::move(req));
+    Status status = instance_admin.DeleteAppProfile(req);
     if (!status.ok()) throw std::runtime_error(status.message());
     std::cout << "Application Profile deleted\n";
   }
@@ -788,7 +784,7 @@ void TestIamPermissions(std::vector<std::string> const& argv) {
     std::cout << "]\n";
   }
   //! [test iam permissions]
-  (std::move(instance_admin), std::move(resource_name), std::move(permissions));
+  (std::move(instance_admin), resource_name, permissions);
 }
 
 void RunAll(std::vector<std::string> const& argv) {

--- a/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_table_admin_backup_snippets.cc
@@ -52,7 +52,7 @@ void CreateBackup(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
     b.mutable_expire_time()->set_seconds(absl::ToUnixSeconds(t));
 
     future<StatusOr<google::bigtable::admin::v2::Backup>> backup_future =
-        admin.CreateBackup(cluster_name, backup_id, std::move(b));
+        admin.CreateBackup(cluster_name, backup_id, b);
     auto backup = backup_future.get();
     if (!backup) throw std::runtime_error(backup.status().message());
     std::cout << "Backup successfully created: " << backup->DebugString()
@@ -157,7 +157,7 @@ void UpdateBackup(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
     mask.add_paths("expire_time");
 
     StatusOr<google::bigtable::admin::v2::Backup> backup =
-        admin.UpdateBackup(std::move(b), std::move(mask));
+        admin.UpdateBackup(b, mask);
     if (!backup) throw std::runtime_error(backup.status().message());
     std::cout << backup->name() << " details=\n"
               << backup->DebugString() << "\n";
@@ -187,7 +187,7 @@ void RestoreTable(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
     r.set_backup(backup_name);
 
     future<StatusOr<google::bigtable::admin::v2::Table>> table_future =
-        admin.RestoreTable(std::move(r));
+        admin.RestoreTable(r);
     auto table = table_future.get();
     if (!table) throw std::runtime_error(table.status().message());
     std::cout << "Table successfully restored: " << table->DebugString()
@@ -220,7 +220,7 @@ void RestoreTableFromInstance(
     r.set_backup(backup_name);
 
     future<StatusOr<google::bigtable::admin::v2::Table>> table_future =
-        admin.RestoreTable(std::move(r));
+        admin.RestoreTable(r);
     auto table = table_future.get();
     if (!table) throw std::runtime_error(table.status().message());
     std::cout << "Table successfully restored: " << table->DebugString()
@@ -337,7 +337,7 @@ void RunAll(std::vector<std::string> const& argv) {
   *families["foo"].mutable_gc_rule() = std::move(gc2);
 
   auto table = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                 table_id, std::move(t));
+                                 table_id, t);
   if (!table) throw std::runtime_error(table.status().message());
 
   std::cout << "\nRunning CreateBackup() example" << std::endl;

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -288,7 +288,7 @@ void AsyncReadModifyWrite(google::cloud::bigtable::Table table,
   namespace cbt = ::google::cloud::bigtable;
   using ::google::cloud::future;
   using ::google::cloud::StatusOr;
-  [](cbt::Table table, std::string const& row_key) {
+  [](cbt::Table table, std::string row_key) {
     future<StatusOr<cbt::Row>> row_future = table.AsyncReadModifyWriteRow(
         std::move(row_key),
         cbt::ReadModifyWriteRule::AppendValue("fam", "list", ";element"));
@@ -348,7 +348,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto& families = *t.mutable_column_families();
   *families["fam"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id,

--- a/google/cloud/bigtable/examples/data_filter_snippets.cc
+++ b/google/cloud/bigtable/examples/data_filter_snippets.cc
@@ -578,7 +578,7 @@ void RunAll(std::vector<std::string> const& argv) {
   *families["cell_plan"].mutable_gc_rule() = gc;
   *families["stats_summary"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id);

--- a/google/cloud/bigtable/examples/data_snippets.cc
+++ b/google/cloud/bigtable/examples/data_snippets.cc
@@ -358,7 +358,7 @@ void MutateDeleteColumns(std::vector<std::string> const& argv) {
     std::cout << "Columns successfully deleted from row\n";
   }
   // [END bigtable_mutate_delete_columns]
-  (std::move(table), row_key, std::move(columns));
+  (std::move(table), row_key, columns);
 }
 
 void MutateDeleteRows(google::cloud::bigtable::Table table,
@@ -383,7 +383,7 @@ void MutateDeleteRows(google::cloud::bigtable::Table table,
     }
   }
   // [END bigtable_mutate_delete_rows]
-  (std::move(table), std::move(argv));
+  (std::move(table), argv);
 }
 
 void MutateDeleteRowsCommand(std::vector<std::string> const& argv) {
@@ -402,7 +402,7 @@ void MutateDeleteRowsCommand(std::vector<std::string> const& argv) {
   google::cloud::bigtable::Table table(
       google::cloud::bigtable::MakeDataClient(project_id, instance_id),
       table_id);
-  MutateDeleteRows(table, std::move(rows));
+  MutateDeleteRows(table, rows);
 }
 
 void MutateInsertUpdateRows(google::cloud::bigtable::Table table,
@@ -449,7 +449,7 @@ void MutateInsertUpdateRows(google::cloud::bigtable::Table table,
     std::cout << "Row successfully updated\n";
   }
   // [END bigtable_insert_update_rows]
-  (std::move(table), row_key, std::move(mutations));
+  (std::move(table), row_key, mutations);
 }
 
 void MutateInsertUpdateRowsCommand(std::vector<std::string> const& argv) {
@@ -470,7 +470,7 @@ void MutateInsertUpdateRowsCommand(std::vector<std::string> const& argv) {
   google::cloud::bigtable::Table table(
       google::cloud::bigtable::MakeDataClient(project_id, instance_id),
       table_id);
-  MutateInsertUpdateRows(table, std::move(rows));
+  MutateInsertUpdateRows(table, rows);
 }
 
 void RenameColumn(google::cloud::bigtable::Table table,
@@ -493,9 +493,8 @@ void RenameColumn(google::cloud::bigtable::Table table,
       auto timestamp_in_milliseconds =
           std::chrono::duration_cast<std::chrono::milliseconds>(
               cell.timestamp());
-      mutation.emplace_back(cbt::SetCell(family, new_name,
-                                         timestamp_in_milliseconds,
-                                         std::move(cell).value()));
+      mutation.emplace_back(cbt::SetCell(
+          family, new_name, timestamp_in_milliseconds, cell.value()));
     }
     mutation.emplace_back(cbt::DeleteFromColumn("fam", old_name));
 
@@ -720,7 +719,7 @@ void RunMutateExamples(
   auto& families = *t.mutable_column_families();
   *families["fam"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id,
@@ -750,7 +749,7 @@ void RunWriteExamples(
   auto& families = *t.mutable_column_families();
   *families["stats_summary"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id,
@@ -783,7 +782,7 @@ void RunDataExamples(
   auto& families = *t.mutable_column_families();
   *families["fam"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id,

--- a/google/cloud/bigtable/examples/read_snippets.cc
+++ b/google/cloud/bigtable/examples/read_snippets.cc
@@ -368,7 +368,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto& families = *t.mutable_column_families();
   *families["stats_summary"].mutable_gc_rule() = std::move(gc);
   auto schema = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                  table_id, std::move(t));
+                                  table_id, t);
   if (!schema) throw std::runtime_error(schema.status().message());
 
   cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id);

--- a/google/cloud/bigtable/examples/table_admin_iam_policy_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_iam_policy_snippets.cc
@@ -113,8 +113,7 @@ void TestIamPermissions(std::vector<std::string> const& argv) {
     std::cout << "]\n";
   }
   //! [test iam permissions]
-  (std::move(admin), std::move(project_id), std::move(instance_id),
-   std::move(table_id), std::move(permissions));
+  (std::move(admin), project_id, instance_id, table_id, permissions);
 }
 
 void RunAll(std::vector<std::string> const& argv) {
@@ -163,7 +162,7 @@ void RunAll(std::vector<std::string> const& argv) {
   *families["foo"].mutable_gc_rule() = std::move(gc2);
 
   auto table = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                 table_id, std::move(t));
+                                 table_id, t);
   if (!table) throw std::runtime_error(table.status().message());
 
   std::cout << "\nRunning GetIamPolicy() example" << std::endl;

--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -46,7 +46,7 @@ void CreateTable(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
     *families["fam"].mutable_gc_rule() = std::move(gc);
 
     StatusOr<google::bigtable::admin::v2::Table> schema =
-        admin.CreateTable(instance_name, table_id, std::move(t));
+        admin.CreateTable(instance_name, table_id, t);
     if (!schema) throw std::runtime_error(schema.status().message());
     std::cout << "Table successfully created: " << schema->DebugString()
               << "\n";
@@ -94,8 +94,7 @@ void GetTable(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
     r.set_name(table_name);
     r.set_view(google::bigtable::admin::v2::Table::FULL);
 
-    StatusOr<google::bigtable::admin::v2::Table> table =
-        admin.GetTable(std::move(r));
+    StatusOr<google::bigtable::admin::v2::Table> table = admin.GetTable(r);
     if (!table) throw std::runtime_error(table.status().message());
     std::cout << table->name() << " details=\n" << table->DebugString() << "\n";
   }
@@ -118,8 +117,7 @@ void CheckTableExists(
     r.set_name(table_name);
     r.set_view(google::bigtable::admin::v2::Table::NAME_ONLY);
 
-    StatusOr<google::bigtable::admin::v2::Table> table =
-        admin.GetTable(std::move(r));
+    StatusOr<google::bigtable::admin::v2::Table> table = admin.GetTable(r);
     if (!table) {
       if (table.status().code() == google::cloud::StatusCode::kNotFound) {
         std::cout << "Table " << table_id << " does not exist\n";
@@ -158,7 +156,7 @@ void GetOrCreateTable(
       if (!table) throw std::runtime_error(table.status().message());
       // The schema returned by a `CreateTable()` request does not include all
       // the metadata for a table, we need to explicitly request the rest:
-      table = admin.GetTable(std::move(r));
+      table = admin.GetTable(r);
     }
     if (!table) throw std::runtime_error(table.status().message());
     std::cout << "Table metadata: " << table->DebugString() << "\n";
@@ -427,8 +425,7 @@ void GetFamilyMetadata(
     r.set_name(table_name);
     r.set_view(google::bigtable::admin::v2::Table::FULL);
 
-    StatusOr<google::bigtable::admin::v2::Table> schema =
-        admin.GetTable(std::move(r));
+    StatusOr<google::bigtable::admin::v2::Table> schema = admin.GetTable(r);
 
     if (!schema) throw std::runtime_error(schema.status().message());
     auto pos = schema->column_families().find(family_name);
@@ -461,8 +458,7 @@ void GetOrCreateFamily(
     r.set_name(table_name);
     r.set_view(google::bigtable::admin::v2::Table::FULL);
 
-    StatusOr<google::bigtable::admin::v2::Table> schema =
-        admin.GetTable(std::move(r));
+    StatusOr<google::bigtable::admin::v2::Table> schema = admin.GetTable(r);
 
     if (!schema) throw std::runtime_error(schema.status().message());
     auto pos = schema->column_families().find(family_name);
@@ -535,8 +531,7 @@ void CheckFamilyExists(
     r.set_name(table_name);
     r.set_view(google::bigtable::admin::v2::Table::FULL);
 
-    StatusOr<google::bigtable::admin::v2::Table> schema =
-        admin.GetTable(std::move(r));
+    StatusOr<google::bigtable::admin::v2::Table> schema = admin.GetTable(r);
 
     if (!schema) throw std::runtime_error(schema.status().message());
     auto pos = schema->column_families().find(family_name);
@@ -565,8 +560,7 @@ void ListColumnFamilies(
     r.set_name(table_name);
     r.set_view(google::bigtable::admin::v2::Table::FULL);
 
-    StatusOr<google::bigtable::admin::v2::Table> schema =
-        admin.GetTable(std::move(r));
+    StatusOr<google::bigtable::admin::v2::Table> schema = admin.GetTable(r);
 
     if (!schema) throw std::runtime_error(schema.status().message());
     for (auto const& kv : schema->column_families()) {
@@ -624,7 +618,7 @@ void DropAllRows(google::cloud::bigtable_admin::BigtableTableAdminClient admin,
     r.set_name(table_name);
     r.set_delete_all_data_from_table(true);
 
-    Status status = admin.DropRowRange(std::move(r));
+    Status status = admin.DropRowRange(r);
     if (!status.ok()) throw std::runtime_error(status.message());
     std::cout << "All rows successfully deleted\n";
   }
@@ -650,7 +644,7 @@ void DropRowsByPrefix(
     r.set_name(table_name);
     r.set_row_key_prefix(prefix);
 
-    Status status = admin.DropRowRange(std::move(r));
+    Status status = admin.DropRowRange(r);
     if (!status.ok()) throw std::runtime_error(status.message());
     std::cout << "All rows starting with " << prefix
               << " successfully deleted\n";
@@ -793,7 +787,7 @@ void RunAll(std::vector<std::string> const& argv) {
   *families["foo"].mutable_gc_rule() = std::move(gc2);
 
   auto table_1 = admin.CreateTable(cbt::InstanceName(project_id, instance_id),
-                                   table_id_1, std::move(t));
+                                   table_id_1, t);
   if (!table_1) throw std::runtime_error(table_1.status().message());
 
   std::cout << "\nRunning ListTables() example" << std::endl;

--- a/google/cloud/bigtable/instance_update_config.h
+++ b/google/cloud/bigtable/instance_update_config.h
@@ -66,13 +66,13 @@ class InstanceUpdateConfig {
   //@}
 
   InstanceUpdateConfig& set_type(InstanceType type) {
-    proto_.mutable_instance()->set_type(std::move(type));
+    proto_.mutable_instance()->set_type(type);
     AddPathIfNotPresent("type");
     return *this;
   }
 
   InstanceUpdateConfig& set_state(StateType state) {
-    proto_.mutable_instance()->set_state(std::move(state));
+    proto_.mutable_instance()->set_state(state);
     AddPathIfNotPresent("state");
     return *this;
   }

--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -93,7 +93,7 @@ void AsyncRetryBulkApply::OnFinish(CompletionQueue cq, Status const& status) {
   cq.MakeRelativeTimer(rpc_backoff_policy_->OnCompletion(status))
       .then([self, cq](TimerFuture result) {
         if (result.get()) {
-          self->StartIteration(std::move(cq));
+          self->StartIteration(cq);
         } else {
           self->SetPromise();
         }

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -98,7 +98,7 @@ void AsyncRowSampler::OnFinish(Status const& status) {
     return;
   }
   if (!rpc_retry_policy_->OnFailure(status)) {
-    promise_.set_value(std::move(status));
+    promise_.set_value(status);
     return;
   }
 
@@ -106,7 +106,7 @@ void AsyncRowSampler::OnFinish(Status const& status) {
 
   samples_.clear();
   auto self = this->shared_from_this();
-  auto delay = rpc_backoff_policy_->OnCompletion(std::move(status));
+  auto delay = rpc_backoff_policy_->OnCompletion(status);
   cq_.MakeRelativeTimer(delay).then([self](TimerFuture result) {
     if (result.get()) {
       self->StartIteration();

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -59,7 +59,7 @@ struct RowKeySampleVectors {
     offset_bytes.reserve(samples.size());
     for (auto& sample : samples) {
       row_keys.emplace_back(std::move(sample.row_key));
-      offset_bytes.emplace_back(std::move(sample.offset_bytes));
+      offset_bytes.emplace_back(sample.offset_bytes);
     }
   }
 

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -127,7 +127,7 @@ Options DefaultOptions(Options opts) {
     // If the range is invalid, use the greater value as both the min and max
     auto const p = opts.get<MinConnectionRefreshOption>();
     if (p > opts.get<MaxConnectionRefreshOption>()) {
-      opts.set<MaxConnectionRefreshOption>(std::move(p));
+      opts.set<MaxConnectionRefreshOption>(p);
     }
   }
 

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -45,7 +45,7 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
   LoggingAdminClient(
       std::shared_ptr<google::cloud::bigtable::AdminClient> child,
       google::cloud::TracingOptions options)
-      : child_(std::move(child)), tracing_options_(std::move(options)) {}
+      : child_(std::move(child)), tracing_options_(options) {}
 
   std::string const& project() const override { return child_->project(); }
 

--- a/google/cloud/bigtable/internal/logging_data_client.h
+++ b/google/cloud/bigtable/internal/logging_data_client.h
@@ -37,7 +37,7 @@ class LoggingDataClient : public DataClient {
  public:
   LoggingDataClient(std::shared_ptr<google::cloud::bigtable::DataClient> child,
                     google::cloud::TracingOptions options)
-      : child_(std::move(child)), tracing_options_(std::move(options)) {}
+      : child_(std::move(child)), tracing_options_(options) {}
 
   std::string const& project_id() const override {
     return child_->project_id();

--- a/google/cloud/bigtable/internal/rowreaderiterator.h
+++ b/google/cloud/bigtable/internal/rowreaderiterator.h
@@ -59,7 +59,6 @@ class RowReaderIterator {
 
   value_type const& operator*() const& { return row_; }
   value_type& operator*() & { return row_; }
-  value_type const&& operator*() const&& { return std::move(row_); }
   value_type&& operator*() && { return std::move(row_); }
 
  private:

--- a/google/cloud/bigtable/mutation_batcher.cc
+++ b/google/cloud/bigtable/mutation_batcher.cc
@@ -182,7 +182,7 @@ bool MutationBatcher::FlushIfPossible(CompletionQueue cq) {
           // copying the `failed` vector.
           struct Functor {
             void operator()(CompletionQueue& cq) {
-              self->OnBulkApplyDone(cq, std::move(*batch), std::move(failed));
+              self->OnBulkApplyDone(cq, std::move(*batch), failed);
             }
 
             MutationBatcher* self;

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -172,7 +172,7 @@ TEST(MutationsTest, FailedMutation) {
   status.add_details()->PackFrom(retry);
   status.add_details()->PackFrom(debug_info);
 
-  FailedMutation fm(std::move(status), 27);
+  FailedMutation fm(status, 27);
   EXPECT_EQ(google::cloud::StatusCode::kFailedPrecondition, fm.status().code());
   EXPECT_EQ("something failed", fm.status().message());
   EXPECT_FALSE(fm.status().message().empty());

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -358,7 +358,7 @@ class TableAdmin {
         : cluster_id(std::move(cluster_id)),
           backup_id(std::move(backup_id)),
           table_name(std::move(table_id)),
-          expire_time(std::move(expire_time)) {}
+          expire_time(expire_time) {}
 
     google::bigtable::admin::v2::CreateBackupRequest AsProto(
         std::string instance_name) const;
@@ -439,7 +439,7 @@ class TableAdmin {
                        std::chrono::system_clock::time_point expire_time)
         : cluster_id(std::move(cluster_id)),
           backup_name(std::move(backup_id)),
-          expire_time(std::move(expire_time)) {}
+          expire_time(expire_time) {}
 
     google::bigtable::admin::v2::UpdateBackupRequest AsProto(
         std::string const& instance_name) const;

--- a/google/cloud/bigtable/table_admin_legacy_test.cc
+++ b/google/cloud/bigtable/table_admin_legacy_test.cc
@@ -670,7 +670,7 @@ TEST_F(TableAdminTest, UpdateBackupSimple) {
   TableAdmin::UpdateBackupParams params(
       "the-cluster", "the-backup",
       google::cloud::internal::ToChronoTimePoint(expire_time));
-  tested.UpdateBackup(std::move(params));
+  tested.UpdateBackup(params);
 }
 
 /**
@@ -690,7 +690,7 @@ TEST_F(TableAdminTest, UpdateBackupUnrecoverableFailures) {
   TableAdmin::UpdateBackupParams params(
       "the-cluster", "the-backup",
       google::cloud::internal::ToChronoTimePoint(expire_time));
-  EXPECT_FALSE(tested.UpdateBackup(std::move(params)));
+  EXPECT_FALSE(tested.UpdateBackup(params));
 }
 
 /**
@@ -711,7 +711,7 @@ TEST_F(TableAdminTest, UpdateBackupTooManyFailures) {
   TableAdmin::UpdateBackupParams params(
       "the-cluster", "the-backup",
       google::cloud::internal::ToChronoTimePoint(expire_time));
-  EXPECT_FALSE(tested.UpdateBackup(std::move(params)));
+  EXPECT_FALSE(tested.UpdateBackup(params));
 }
 
 /// @test Verify that bigtable::TableAdmin::DeleteBackup works as expected.
@@ -1418,7 +1418,7 @@ TEST_F(ValidContextMdAsyncTest, AsyncRestoreTable) {
           "google.bigtable.admin.v2.BigtableTableAdmin.RestoreTable"));
   bigtable::TableAdmin::RestoreTableParams params("restored-table",
                                                   "the-cluster", "the-backup");
-  FinishTest(table_admin_.AsyncRestoreTableImpl(cq_, std::move(params)));
+  FinishTest(table_admin_.AsyncRestoreTableImpl(cq_, params));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.cc
@@ -38,7 +38,7 @@ Status CleanupStaleTables(
   auto admin = bigtable_admin::BigtableTableAdminClient(std::move(c));
   auto tables = admin.ListTables(std::move(r));
   for (auto const& t : tables) {
-    if (!t) return std::move(t).status();
+    if (!t) return t.status();
     std::vector<std::string> const components = absl::StrSplit(t->name(), '/');
     if (components.empty()) continue;
     auto const id = components.back();
@@ -62,7 +62,7 @@ Status CleanupStaleBackups(
   auto admin = bigtable_admin::BigtableTableAdminClient(std::move(c));
   auto backups = admin.ListBackups(ClusterName(project_id, instance_id, "-"));
   for (auto const& b : backups) {
-    if (!b) return std::move(b).status();
+    if (!b) return b.status();
     std::vector<std::string> const components = absl::StrSplit(b->name(), '/');
     if (components.empty()) continue;
     auto const id = components.back();

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -76,8 +76,7 @@ void TableTestEnvironment::SetUp() {
 
   table_id_ = RandomTableId();
   ASSERT_STATUS_OK(TableAdminClient().CreateTable(
-      bigtable::InstanceName(project_id_, instance_id_), table_id_,
-      std::move(t)));
+      bigtable::InstanceName(project_id_, instance_id_), table_id_, t));
 }
 
 void TableTestEnvironment::TearDown() {
@@ -144,7 +143,7 @@ void TableIntegrationTest::SetUp() {
     google::bigtable::admin::v2::DropRowRangeRequest r;
     r.set_name(table.table_name());
     r.set_delete_all_data_from_table(true);
-    ASSERT_STATUS_OK(TableAdminClient().DropRowRange(std::move(r)));
+    ASSERT_STATUS_OK(TableAdminClient().DropRowRange(r));
     return;
   }
   auto failures = table.BulkApply(std::move(bulk));
@@ -230,10 +229,9 @@ std::vector<bigtable::Cell> TableIntegrationTest::GetCellsIgnoringTimestamp(
   std::vector<bigtable::Cell> return_cells;
   std::transform(cells.begin(), cells.end(), std::back_inserter(return_cells),
                  [](Cell& cell) {
-                   return bigtable::Cell(
-                       std::move(cell.row_key()), std::move(cell.family_name()),
-                       std::move(cell.column_qualifier()), 0,
-                       std::move(cell.value()), std::move(cell.labels()));
+                   return bigtable::Cell(cell.row_key(), cell.family_name(),
+                                         cell.column_qualifier(), 0,
+                                         cell.value(), cell.labels());
                  });
 
   return return_cells;

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -65,7 +65,7 @@ TEST_F(AdminIntegrationTest, TableListWithMultipleTables) {
     EXPECT_STATUS_OK(table_admin_->CreateTable(table_id, {}));
     ids.emplace_back(table_id);
     expected_tables.emplace_back(
-        bigtable::TableName(project_id(), instance_id(), std::move(table_id)));
+        bigtable::TableName(project_id(), instance_id(), table_id));
   }
   auto tables = table_admin_->ListTables(btadmin::Table::NAME_ONLY);
   ASSERT_STATUS_OK(tables);

--- a/google/cloud/billing/internal/budget_logging_decorator.cc
+++ b/google/cloud/billing/internal/budget_logging_decorator.cc
@@ -31,7 +31,7 @@ BudgetServiceLogging::BudgetServiceLogging(
     std::shared_ptr<BudgetServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::billing::budgets::v1::Budget>

--- a/google/cloud/billing/internal/cloud_billing_logging_decorator.cc
+++ b/google/cloud/billing/internal/cloud_billing_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudBillingLogging::CloudBillingLogging(
     std::shared_ptr<CloudBillingStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::billing::v1::BillingAccount>

--- a/google/cloud/billing/internal/cloud_catalog_logging_decorator.cc
+++ b/google/cloud/billing/internal/cloud_catalog_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudCatalogLogging::CloudCatalogLogging(
     std::shared_ptr<CloudCatalogStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::billing::v1::ListServicesResponse>

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_logging_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_logging_decorator.cc
@@ -31,7 +31,7 @@ BinauthzManagementServiceV1Logging::BinauthzManagementServiceV1Logging(
     std::shared_ptr<BinauthzManagementServiceV1Stub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_logging_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_logging_decorator.cc
@@ -31,7 +31,7 @@ SystemPolicyV1Logging::SystemPolicyV1Logging(
     std::shared_ptr<SystemPolicyV1Stub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_logging_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_logging_decorator.cc
@@ -31,7 +31,7 @@ ValidationHelperV1Logging::ValidationHelperV1Logging(
     std::shared_ptr<ValidationHelperV1Stub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::binaryauthorization::v1::

--- a/google/cloud/channel/internal/cloud_channel_logging_decorator.cc
+++ b/google/cloud/channel/internal/cloud_channel_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudChannelServiceLogging::CloudChannelServiceLogging(
     std::shared_ptr<CloudChannelServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::channel::v1::ListCustomersResponse>

--- a/google/cloud/cloudbuild/internal/cloud_build_logging_decorator.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudBuildLogging::CloudBuildLogging(std::shared_ptr<CloudBuildStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/composer/internal/environments_logging_decorator.cc
+++ b/google/cloud/composer/internal/environments_logging_decorator.cc
@@ -31,7 +31,7 @@ EnvironmentsLogging::EnvironmentsLogging(
     std::shared_ptr<EnvironmentsStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/composer/internal/image_versions_logging_decorator.cc
+++ b/google/cloud/composer/internal/image_versions_logging_decorator.cc
@@ -31,7 +31,7 @@ ImageVersionsLogging::ImageVersionsLogging(
     std::shared_ptr<ImageVersionsStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::orchestration::airflow::service::v1::

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_logging_decorator.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_logging_decorator.cc
@@ -31,7 +31,7 @@ ContactCenterInsightsLogging::ContactCenterInsightsLogging(
     std::shared_ptr<ContactCenterInsightsStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::contactcenterinsights::v1::Conversation>

--- a/google/cloud/container/internal/cluster_manager_logging_decorator.cc
+++ b/google/cloud/container/internal/cluster_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ ClusterManagerLogging::ClusterManagerLogging(
     std::shared_ptr<ClusterManagerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::container::v1::ListClustersResponse>

--- a/google/cloud/containeranalysis/internal/container_analysis_logging_decorator.cc
+++ b/google/cloud/containeranalysis/internal/container_analysis_logging_decorator.cc
@@ -31,7 +31,7 @@ ContainerAnalysisLogging::ContainerAnalysisLogging(
     std::shared_ptr<ContainerAnalysisStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisLogging::SetIamPolicy(

--- a/google/cloud/containeranalysis/internal/grafeas_logging_decorator.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_logging_decorator.cc
@@ -31,7 +31,7 @@ GrafeasLogging::GrafeasLogging(std::shared_ptr<GrafeasStub> child,
                                TracingOptions tracing_options,
                                std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<grafeas::v1::Occurrence> GrafeasLogging::GetOccurrence(

--- a/google/cloud/datacatalog/internal/data_catalog_logging_decorator.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_logging_decorator.cc
@@ -31,7 +31,7 @@ DataCatalogLogging::DataCatalogLogging(std::shared_ptr<DataCatalogStub> child,
                                        TracingOptions tracing_options,
                                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::datacatalog::v1::SearchCatalogResponse>

--- a/google/cloud/datacatalog/internal/policy_tag_manager_logging_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ PolicyTagManagerLogging::PolicyTagManagerLogging(
     std::shared_ptr<PolicyTagManagerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>

--- a/google/cloud/datacatalog/internal/policy_tag_manager_serialization_logging_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_serialization_logging_decorator.cc
@@ -31,7 +31,7 @@ PolicyTagManagerSerializationLogging::PolicyTagManagerSerializationLogging(
     std::shared_ptr<PolicyTagManagerSerializationStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>

--- a/google/cloud/datamigration/internal/data_migration_logging_decorator.cc
+++ b/google/cloud/datamigration/internal/data_migration_logging_decorator.cc
@@ -31,7 +31,7 @@ DataMigrationServiceLogging::DataMigrationServiceLogging(
     std::shared_ptr<DataMigrationServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::clouddms::v1::ListMigrationJobsResponse>

--- a/google/cloud/dataproc/internal/autoscaling_policy_logging_decorator.cc
+++ b/google/cloud/dataproc/internal/autoscaling_policy_logging_decorator.cc
@@ -31,7 +31,7 @@ AutoscalingPolicyServiceLogging::AutoscalingPolicyServiceLogging(
     std::shared_ptr<AutoscalingPolicyServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>

--- a/google/cloud/dataproc/internal/batch_controller_logging_decorator.cc
+++ b/google/cloud/dataproc/internal/batch_controller_logging_decorator.cc
@@ -31,7 +31,7 @@ BatchControllerLogging::BatchControllerLogging(
     std::shared_ptr<BatchControllerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/dataproc/internal/cluster_controller_logging_decorator.cc
+++ b/google/cloud/dataproc/internal/cluster_controller_logging_decorator.cc
@@ -31,7 +31,7 @@ ClusterControllerLogging::ClusterControllerLogging(
     std::shared_ptr<ClusterControllerStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/dataproc/internal/job_controller_logging_decorator.cc
+++ b/google/cloud/dataproc/internal/job_controller_logging_decorator.cc
@@ -31,7 +31,7 @@ JobControllerLogging::JobControllerLogging(
     std::shared_ptr<JobControllerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerLogging::SubmitJob(

--- a/google/cloud/dataproc/internal/workflow_template_logging_decorator.cc
+++ b/google/cloud/dataproc/internal/workflow_template_logging_decorator.cc
@@ -31,7 +31,7 @@ WorkflowTemplateServiceLogging::WorkflowTemplateServiceLogging(
     std::shared_ptr<WorkflowTemplateServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>

--- a/google/cloud/debugger/internal/controller2_logging_decorator.cc
+++ b/google/cloud/debugger/internal/controller2_logging_decorator.cc
@@ -31,7 +31,7 @@ Controller2Logging::Controller2Logging(std::shared_ptr<Controller2Stub> child,
                                        TracingOptions tracing_options,
                                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::devtools::clouddebugger::v2::RegisterDebuggeeResponse>

--- a/google/cloud/debugger/internal/debugger2_logging_decorator.cc
+++ b/google/cloud/debugger/internal/debugger2_logging_decorator.cc
@@ -31,7 +31,7 @@ Debugger2Logging::Debugger2Logging(std::shared_ptr<Debugger2Stub> child,
                                    TracingOptions tracing_options,
                                    std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::devtools::clouddebugger::v2::SetBreakpointResponse>

--- a/google/cloud/dlp/internal/dlp_logging_decorator.cc
+++ b/google/cloud/dlp/internal/dlp_logging_decorator.cc
@@ -31,7 +31,7 @@ DlpServiceLogging::DlpServiceLogging(std::shared_ptr<DlpServiceStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::privacy::dlp::v2::InspectContentResponse>

--- a/google/cloud/eventarc/internal/eventarc_logging_decorator.cc
+++ b/google/cloud/eventarc/internal/eventarc_logging_decorator.cc
@@ -31,7 +31,7 @@ EventarcLogging::EventarcLogging(std::shared_ptr<EventarcStub> child,
                                  TracingOptions tracing_options,
                                  std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::eventarc::v1::Trigger> EventarcLogging::GetTrigger(

--- a/google/cloud/eventarc/internal/publisher_logging_decorator.cc
+++ b/google/cloud/eventarc/internal/publisher_logging_decorator.cc
@@ -31,7 +31,7 @@ PublisherLogging::PublisherLogging(std::shared_ptr<PublisherStub> child,
                                    TracingOptions tracing_options,
                                    std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::eventarc::publishing::v1::

--- a/google/cloud/examples/grpc_credential_types.cc
+++ b/google/cloud/examples/grpc_credential_types.cc
@@ -305,7 +305,7 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
           argv.size() != arg_names.size()) {
         std::string usage = name;
         for (auto const& a : arg_names) usage += " <" + a + ">";
-        throw google::cloud::testing_util::Usage{std::move(usage)};
+        throw google::cloud::testing_util::Usage{usage};
       }
       auto client = google::cloud::iam::IAMCredentialsClient(
           google::cloud::iam::MakeIAMCredentialsConnection(

--- a/google/cloud/filestore/internal/cloud_filestore_manager_logging_decorator.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudFilestoreManagerLogging::CloudFilestoreManagerLogging(
     std::shared_ptr<CloudFilestoreManagerStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::filestore::v1::ListInstancesResponse>

--- a/google/cloud/functions/internal/cloud_functions_logging_decorator.cc
+++ b/google/cloud/functions/internal/cloud_functions_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudFunctionsServiceLogging::CloudFunctionsServiceLogging(
     std::shared_ptr<CloudFunctionsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::functions::v1::ListFunctionsResponse>

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -142,8 +142,7 @@ class promise final : private internal::promise_base<T> {
       : internal::promise_base<T>(std::move(cancellation_callback)) {}
 
   /// Creates a promise *without* a shared state.
-  explicit promise(null_promise_t x)
-      : internal::promise_base<T>(std::move(x)) {}
+  explicit promise(null_promise_t x) : internal::promise_base<T>(x) {}
 
   /// Constructs a new promise and transfer any shared state from @p rhs.
   // NOLINTNEXTLINE(performance-noexcept-move-constructor)

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -77,7 +77,7 @@ TEST(FutureTestBool, SetValueRefRef) {
   promise<bool> p;
   auto f = p.get_future();
   auto v = true;
-  p.set_value(std::move(v));
+  p.set_value(v);
   EXPECT_TRUE(f.get());
 }
 

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -138,7 +138,7 @@ class promise<void> final : private internal::promise_base<void> {
       : promise_base(std::move(cancellation_callback)) {}
 
   /// Creates a promise *without* a shared state.
-  explicit promise(null_promise_t x) : promise_base(std::move(x)) {}
+  explicit promise(null_promise_t x) : promise_base(x) {}
 
   /// Constructs a new promise and transfer any shared state from @p rhs.
   promise(promise&&) = default;

--- a/google/cloud/gameservices/internal/game_server_clusters_logging_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_logging_decorator.cc
@@ -31,7 +31,7 @@ GameServerClustersServiceLogging::GameServerClustersServiceLogging(
     std::shared_ptr<GameServerClustersServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::gaming::v1::ListGameServerClustersResponse>

--- a/google/cloud/gameservices/internal/game_server_configs_logging_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_logging_decorator.cc
@@ -31,7 +31,7 @@ GameServerConfigsServiceLogging::GameServerConfigsServiceLogging(
     std::shared_ptr<GameServerConfigsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::gaming::v1::ListGameServerConfigsResponse>

--- a/google/cloud/gameservices/internal/game_server_deployments_logging_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_logging_decorator.cc
@@ -31,7 +31,7 @@ GameServerDeploymentsServiceLogging::GameServerDeploymentsServiceLogging(
     std::shared_ptr<GameServerDeploymentsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::gaming::v1::ListGameServerDeploymentsResponse>

--- a/google/cloud/gameservices/internal/realms_logging_decorator.cc
+++ b/google/cloud/gameservices/internal/realms_logging_decorator.cc
@@ -31,7 +31,7 @@ RealmsServiceLogging::RealmsServiceLogging(
     std::shared_ptr<RealmsServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::gaming::v1::ListRealmsResponse>

--- a/google/cloud/gkehub/internal/gke_hub_logging_decorator.cc
+++ b/google/cloud/gkehub/internal/gke_hub_logging_decorator.cc
@@ -31,7 +31,7 @@ GkeHubLogging::GkeHubLogging(std::shared_ptr<GkeHubStub> child,
                              TracingOptions tracing_options,
                              std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::gkehub::v1::ListMembershipsResponse>

--- a/google/cloud/grpc_options_test.cc
+++ b/google/cloud/grpc_options_test.cc
@@ -260,7 +260,7 @@ TEST(GrpcClientContext, Configure) {
 
   grpc::ClientContext context;
   EXPECT_EQ(GRPC_COMPRESS_NONE, context.compression_algorithm());
-  internal::ConfigureContext(context, std::move(opts));
+  internal::ConfigureContext(context, opts);
   EXPECT_EQ(GRPC_COMPRESS_DEFLATE, context.compression_algorithm());
 }
 
@@ -276,7 +276,7 @@ TEST(GrpcClientContext, ConfigurePoll) {
   EXPECT_EQ(GRPC_COMPRESS_NONE, context.compression_algorithm());
   internal::ConfigureContext(context, opts);
   EXPECT_EQ(GRPC_COMPRESS_NONE, context.compression_algorithm());
-  internal::ConfigurePollContext(context, std::move(opts));
+  internal::ConfigurePollContext(context, opts);
   EXPECT_EQ(GRPC_COMPRESS_DEFLATE, context.compression_algorithm());
 }
 

--- a/google/cloud/iam/internal/iam_credentials_logging_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_logging_decorator.cc
@@ -31,7 +31,7 @@ IAMCredentialsLogging::IAMCredentialsLogging(
     std::shared_ptr<IAMCredentialsStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>

--- a/google/cloud/iam/internal/iam_logging_decorator.cc
+++ b/google/cloud/iam/internal/iam_logging_decorator.cc
@@ -31,7 +31,7 @@ IAMLogging::IAMLogging(std::shared_ptr<IAMStub> child,
                        TracingOptions tracing_options,
                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::iam::admin::v1::ListServiceAccountsResponse>

--- a/google/cloud/iam_bindings.h
+++ b/google/cloud/iam_bindings.h
@@ -46,10 +46,9 @@ class IamBindings {
   IamBindings() = default;
 
   GOOGLE_CLOUD_CPP_IAM_DEPRECATED explicit IamBindings(
-      // NOLINTNEXTLINE(performance-unnecessary-value-param)
-      std::vector<IamBinding> bindings) {
-    for (auto& it : bindings) {
-      bindings_.insert({std::move(it.role()), std::move(it.members())});
+      std::vector<IamBinding> const& bindings) {
+    for (auto const& it : bindings) {
+      bindings_.insert({it.role(), it.members()});
     }
   }
 

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_logging_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_logging_decorator.cc
@@ -31,7 +31,7 @@ IdentityAwareProxyAdminServiceLogging::IdentityAwareProxyAdminServiceLogging(
     std::shared_ptr<IdentityAwareProxyAdminServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::iam::v1::Policy>

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_logging_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_logging_decorator.cc
@@ -31,7 +31,7 @@ IdentityAwareProxyOAuthServiceLogging::IdentityAwareProxyOAuthServiceLogging(
     std::shared_ptr<IdentityAwareProxyOAuthServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::iap::v1::ListBrandsResponse>

--- a/google/cloud/ids/internal/ids_logging_decorator.cc
+++ b/google/cloud/ids/internal/ids_logging_decorator.cc
@@ -31,7 +31,7 @@ IDSLogging::IDSLogging(std::shared_ptr<IDSStub> child,
                        TracingOptions tracing_options,
                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::ids::v1::ListEndpointsResponse>

--- a/google/cloud/internal/async_long_running_operation.h
+++ b/google/cloud/internal/async_long_running_operation.h
@@ -132,7 +132,7 @@ future<StatusOr<ReturnType>> AsyncLongRunningOperation(
   auto loc = std::string{location};
   return AsyncPollingLoop(std::move(cq), std::move(operation), std::move(poll),
                           std::move(cancel), std::move(polling_policy),
-                          std::move(location))
+                          location)
       .then([value_extractor, loc](future<StatusOr<Operation>> g) {
         return value_extractor(g.get(), loc);
       });

--- a/google/cloud/internal/async_read_write_stream_auth.h
+++ b/google/cloud/internal/async_read_write_stream_auth.h
@@ -62,7 +62,7 @@ class AsyncStreamingReadWriteRpcAuth
   future<bool> Write(Request const& request,
                      grpc::WriteOptions options) override {
     std::lock_guard<std::mutex> g{state_->mu};
-    return state_->stream->Write(request, std::move(options));
+    return state_->stream->Write(request, options);
   }
 
   future<bool> WritesDone() override {

--- a/google/cloud/internal/async_read_write_stream_impl.h
+++ b/google/cloud/internal/async_read_write_stream_impl.h
@@ -104,9 +104,8 @@ class AsyncStreamingReadWriteRpcImpl
       void Cancel() override {}
     };
     auto op = std::make_shared<OnWrite>();
-    cq_->StartOperation(op, [&](void* tag) {
-      stream_->Write(request, std::move(options), tag);
-    });
+    cq_->StartOperation(
+        op, [&](void* tag) { stream_->Write(request, options, tag); });
     return op->p.get_future();
   }
 
@@ -133,7 +132,7 @@ class AsyncStreamingReadWriteRpcImpl
       grpc::Status status;
       bool Notify(bool /*ok*/) override {
         OptionsSpan span(options_);
-        p.set_value(MakeStatusFromRpcError(std::move(status)));
+        p.set_value(MakeStatusFromRpcError(status));
         return true;
       }
       void Cancel() override {}

--- a/google/cloud/internal/default_completion_queue_impl.cc
+++ b/google/cloud/internal/default_completion_queue_impl.cc
@@ -239,8 +239,7 @@ void DefaultCompletionQueueImpl::RunAsync(
 void DefaultCompletionQueueImpl::StartOperation(
     std::shared_ptr<AsyncGrpcOperation> op,
     absl::FunctionRef<void(void*)> start) {
-  StartOperation(std::unique_lock<std::mutex>(mu_), std::move(op),
-                 std::move(start));
+  StartOperation(std::unique_lock<std::mutex>(mu_), std::move(op), start);
 }
 
 grpc::CompletionQueue& DefaultCompletionQueueImpl::cq() { return cq_; }

--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -91,8 +91,7 @@ class AsyncAccessTokenGeneratorLogging : public MinimalIamCredentialsStub {
   AsyncAccessTokenGeneratorLogging(
       std::shared_ptr<MinimalIamCredentialsStub> child,
       TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+      : child_(std::move(child)), tracing_options_(tracing_options) {}
   ~AsyncAccessTokenGeneratorLogging() override = default;
 
   future<StatusOr<GenerateAccessTokenResponse>> AsyncGenerateAccessToken(

--- a/google/cloud/internal/rest_response.cc
+++ b/google/cloud/internal/rest_response.cc
@@ -197,7 +197,7 @@ Status AsStatus(HttpStatusCode http_status_code, std::string payload) {
   //   }
   // See  https://cloud.google.com/apis/design/errors#http_mapping
   auto error = json.value("error", nlohmann::json::object());
-  auto message = error.value("message", std::move(payload));
+  auto message = error.value("message", payload);
   auto details = error.value("details", nlohmann::json::object());
 
   if (!details.empty()) {

--- a/google/cloud/internal/streaming_read_rpc_logging.h
+++ b/google/cloud/internal/streaming_read_rpc_logging.h
@@ -44,7 +44,7 @@ class StreamingReadRpcLogging : public StreamingReadRpc<ResponseType> {
       std::unique_ptr<StreamingReadRpc<ResponseType>> reader,
       TracingOptions tracing_options, std::string request_id)
       : reader_(std::move(reader)),
-        tracing_options_(std::move(tracing_options)),
+        tracing_options_(tracing_options),
         request_id_(std::move(request_id)) {}
   ~StreamingReadRpcLogging() override = default;
 
@@ -73,7 +73,7 @@ class StreamingReadRpcLogging : public StreamingReadRpc<ResponseType> {
   class ResultVisitor {
    public:
     explicit ResultVisitor(TracingOptions tracing_options)
-        : tracing_options_(std::move(tracing_options)) {}
+        : tracing_options_(tracing_options) {}
 
     std::string operator()(Status const& status) {
       std::stringstream output;

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -95,7 +95,7 @@ class StreamingWriteRpcImpl
 
   bool Write(RequestType const& r, grpc::WriteOptions o) override {
     if (o.is_last_message()) has_last_message_ = true;
-    return stream_->Write(r, std::move(o));
+    return stream_->Write(r, o);
   }
 
   StatusOr<ResponseType> Close() override {

--- a/google/cloud/internal/streaming_write_rpc_logging.h
+++ b/google/cloud/internal/streaming_write_rpc_logging.h
@@ -39,7 +39,7 @@ class StreamingWriteRpcLogging
       std::unique_ptr<StreamingWriteRpc<RequestType, ResponseType>> stream,
       TracingOptions tracing_options, std::string request_id)
       : stream_(std::move(stream)),
-        tracing_options_(std::move(tracing_options)),
+        tracing_options_(tracing_options),
         request_id_(std::move(request_id)) {}
   ~StreamingWriteRpcLogging() override = default;
 
@@ -54,7 +54,7 @@ class StreamingWriteRpcLogging
     auto const prefix = std::string(__func__) + "(" + request_id_ + ")";
     GCP_LOG(DEBUG) << prefix << "() << "
                    << DebugString(request, tracing_options_);
-    auto success = stream_->Write(request, std::move(options));
+    auto success = stream_->Write(request, options);
     GCP_LOG(DEBUG) << prefix << "() >> " << (success ? "true" : "false");
     return success;
   }

--- a/google/cloud/internal/unified_grpc_credentials.cc
+++ b/google/cloud/internal/unified_grpc_credentials.cc
@@ -63,8 +63,8 @@ std::shared_ptr<GrpcAuthenticationStrategy> CreateAuthenticationStrategy(
           cfg.access_token(), std::move(options));
     }
     void visit(ImpersonateServiceAccountConfig& cfg) override {
-      result = GrpcImpersonateServiceAccount::Create(std::move(cq), cfg,
-                                                     std::move(options));
+      result =
+          GrpcImpersonateServiceAccount::Create(std::move(cq), cfg, options);
     }
     void visit(ServiceAccountConfig& cfg) override {
       result = absl::make_unique<GrpcServiceAccountAuthentication>(

--- a/google/cloud/iot/internal/device_manager_logging_decorator.cc
+++ b/google/cloud/iot/internal/device_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ DeviceManagerLogging::DeviceManagerLogging(
     std::shared_ptr<DeviceManagerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::iot::v1::DeviceRegistry>

--- a/google/cloud/kms/internal/key_management_logging_decorator.cc
+++ b/google/cloud/kms/internal/key_management_logging_decorator.cc
@@ -31,7 +31,7 @@ KeyManagementServiceLogging::KeyManagementServiceLogging(
     std::shared_ptr<KeyManagementServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::kms::v1::ListKeyRingsResponse>

--- a/google/cloud/kms_key_name.cc
+++ b/google/cloud/kms_key_name.cc
@@ -42,8 +42,7 @@ StatusOr<KmsKeyName> MakeKmsKeyName(std::string const& full_name) {
     return Status(StatusCode::kInvalidArgument,
                   "Improperly formatted KmsKeyName: " + full_name);
   }
-  return KmsKeyName(std::move(matches[1]), std::move(matches[2]),
-                    std::move(matches[3]), std::move(matches[4]));
+  return KmsKeyName(matches[1], matches[2], matches[3], matches[4]);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/language/internal/language_logging_decorator.cc
+++ b/google/cloud/language/internal/language_logging_decorator.cc
@@ -31,7 +31,7 @@ LanguageServiceLogging::LanguageServiceLogging(
     std::shared_ptr<LanguageServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>

--- a/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_logging_decorator.cc
@@ -32,7 +32,7 @@ LoggingServiceV2Logging::LoggingServiceV2Logging(
     std::shared_ptr<LoggingServiceV2Stub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 Status LoggingServiceV2Logging::DeleteLog(

--- a/google/cloud/managedidentities/internal/managed_identities_logging_decorator.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_logging_decorator.cc
@@ -31,7 +31,7 @@ ManagedIdentitiesServiceLogging::ManagedIdentitiesServiceLogging(
     std::shared_ptr<ManagedIdentitiesServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/memcache/internal/cloud_memcache_logging_decorator.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudMemcacheLogging::CloudMemcacheLogging(
     std::shared_ptr<CloudMemcacheStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::memcache::v1::ListInstancesResponse>

--- a/google/cloud/monitoring/internal/alert_policy_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/alert_policy_logging_decorator.cc
@@ -31,7 +31,7 @@ AlertPolicyServiceLogging::AlertPolicyServiceLogging(
     std::shared_ptr<AlertPolicyServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::ListAlertPoliciesResponse>

--- a/google/cloud/monitoring/internal/dashboards_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/dashboards_logging_decorator.cc
@@ -31,7 +31,7 @@ DashboardsServiceLogging::DashboardsServiceLogging(
     std::shared_ptr<DashboardsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>

--- a/google/cloud/monitoring/internal/group_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/group_logging_decorator.cc
@@ -31,7 +31,7 @@ GroupServiceLogging::GroupServiceLogging(
     std::shared_ptr<GroupServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::ListGroupsResponse>

--- a/google/cloud/monitoring/internal/metric_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/metric_logging_decorator.cc
@@ -31,7 +31,7 @@ MetricServiceLogging::MetricServiceLogging(
     std::shared_ptr<MetricServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::ListMonitoredResourceDescriptorsResponse>

--- a/google/cloud/monitoring/internal/metrics_scopes_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/metrics_scopes_logging_decorator.cc
@@ -31,7 +31,7 @@ MetricsScopesLogging::MetricsScopesLogging(
     std::shared_ptr<MetricsScopesStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::metricsscope::v1::MetricsScope>

--- a/google/cloud/monitoring/internal/notification_channel_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/notification_channel_logging_decorator.cc
@@ -31,7 +31,7 @@ NotificationChannelServiceLogging::NotificationChannelServiceLogging(
     std::shared_ptr<NotificationChannelServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::ListNotificationChannelDescriptorsResponse>

--- a/google/cloud/monitoring/internal/query_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/query_logging_decorator.cc
@@ -31,7 +31,7 @@ QueryServiceLogging::QueryServiceLogging(
     std::shared_ptr<QueryServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::QueryTimeSeriesResponse>

--- a/google/cloud/monitoring/internal/service_monitoring_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_logging_decorator.cc
@@ -31,7 +31,7 @@ ServiceMonitoringServiceLogging::ServiceMonitoringServiceLogging(
     std::shared_ptr<ServiceMonitoringServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::Service>

--- a/google/cloud/monitoring/internal/uptime_check_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/uptime_check_logging_decorator.cc
@@ -31,7 +31,7 @@ UptimeCheckServiceLogging::UptimeCheckServiceLogging(
     std::shared_ptr<UptimeCheckServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::monitoring::v3::ListUptimeCheckConfigsResponse>

--- a/google/cloud/networkmanagement/internal/reachability_logging_decorator.cc
+++ b/google/cloud/networkmanagement/internal/reachability_logging_decorator.cc
@@ -31,7 +31,7 @@ ReachabilityServiceLogging::ReachabilityServiceLogging(
     std::shared_ptr<ReachabilityServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::networkmanagement::v1::ListConnectivityTestsResponse>

--- a/google/cloud/notebooks/internal/managed_notebook_logging_decorator.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_logging_decorator.cc
@@ -31,7 +31,7 @@ ManagedNotebookServiceLogging::ManagedNotebookServiceLogging(
     std::shared_ptr<ManagedNotebookServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::notebooks::v1::ListRuntimesResponse>

--- a/google/cloud/notebooks/internal/notebook_logging_decorator.cc
+++ b/google/cloud/notebooks/internal/notebook_logging_decorator.cc
@@ -31,7 +31,7 @@ NotebookServiceLogging::NotebookServiceLogging(
     std::shared_ptr<NotebookServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::notebooks::v1::ListInstancesResponse>

--- a/google/cloud/orgpolicy/internal/org_policy_logging_decorator.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_logging_decorator.cc
@@ -31,7 +31,7 @@ OrgPolicyLogging::OrgPolicyLogging(std::shared_ptr<OrgPolicyStub> child,
                                    TracingOptions tracing_options,
                                    std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::orgpolicy::v2::ListConstraintsResponse>

--- a/google/cloud/osconfig/internal/agent_endpoint_logging_decorator.cc
+++ b/google/cloud/osconfig/internal/agent_endpoint_logging_decorator.cc
@@ -32,7 +32,7 @@ AgentEndpointServiceLogging::AgentEndpointServiceLogging(
     std::shared_ptr<AgentEndpointServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 std::unique_ptr<google::cloud::internal::StreamingReadRpc<

--- a/google/cloud/osconfig/internal/os_config_logging_decorator.cc
+++ b/google/cloud/osconfig/internal/os_config_logging_decorator.cc
@@ -31,7 +31,7 @@ OsConfigServiceLogging::OsConfigServiceLogging(
     std::shared_ptr<OsConfigServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::osconfig::v1::PatchJob>

--- a/google/cloud/oslogin/internal/os_login_logging_decorator.cc
+++ b/google/cloud/oslogin/internal/os_login_logging_decorator.cc
@@ -31,7 +31,7 @@ OsLoginServiceLogging::OsLoginServiceLogging(
     std::shared_ptr<OsLoginServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 Status OsLoginServiceLogging::DeletePosixAccount(

--- a/google/cloud/policytroubleshooter/internal/iam_checker_logging_decorator.cc
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_logging_decorator.cc
@@ -31,7 +31,7 @@ IamCheckerLogging::IamCheckerLogging(std::shared_ptr<IamCheckerStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>

--- a/google/cloud/privateca/internal/certificate_authority_logging_decorator.cc
+++ b/google/cloud/privateca/internal/certificate_authority_logging_decorator.cc
@@ -31,7 +31,7 @@ CertificateAuthorityServiceLogging::CertificateAuthorityServiceLogging(
     std::shared_ptr<CertificateAuthorityServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::security::privateca::v1::Certificate>

--- a/google/cloud/project.cc
+++ b/google/cloud/project.cc
@@ -41,7 +41,7 @@ StatusOr<Project> MakeProject(std::string const& full_name) {
     return Status(StatusCode::kInvalidArgument,
                   "Improperly formatted Project: " + full_name);
   }
-  return Project(std::move(matches[1]));
+  return Project(matches[1]);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/flow_controlled_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/flow_controlled_publisher_connection.cc
@@ -50,7 +50,7 @@ future<StatusOr<std::string>> FlowControlledPublisherConnection::Publish(
 }
 
 void FlowControlledPublisherConnection::Flush(FlushParams p) {
-  return child_->Flush(std::move(p));
+  return child_->Flush(p);
 }
 
 void FlowControlledPublisherConnection::ResumePublish(ResumePublishParams p) {

--- a/google/cloud/pubsub/internal/publisher_logging.h
+++ b/google/cloud/pubsub/internal/publisher_logging.h
@@ -29,8 +29,7 @@ class PublisherLogging : public PublisherStub {
  public:
   PublisherLogging(std::shared_ptr<PublisherStub> child,
                    TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+      : child_(std::move(child)), tracing_options_(tracing_options) {}
 
   StatusOr<google::pubsub::v1::Topic> CreateTopic(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/schema_logging.h
+++ b/google/cloud/pubsub/internal/schema_logging.h
@@ -32,8 +32,7 @@ class SchemaLogging : public SchemaStub {
  public:
   SchemaLogging(std::shared_ptr<SchemaStub> child,
                 TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+      : child_(std::move(child)), tracing_options_(tracing_options) {}
 
   StatusOr<google::pubsub::v1::Schema> CreateSchema(
       grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -81,7 +81,7 @@ class StreamingSubscriptionBatchSource
         max_deadline_time_(opts.get<pubsub::MaxDeadlineTimeOption>()),
         retry_policy_(opts.get<pubsub::RetryPolicyOption>()->clone()),
         backoff_policy_(opts.get<pubsub::BackoffPolicyOption>()->clone()),
-        ack_batching_config_(std::move(ack_batching_config)) {}
+        ack_batching_config_(ack_batching_config) {}
 
   ~StreamingSubscriptionBatchSource() override = default;
 

--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -204,7 +204,7 @@ LoggingAsyncPullStream::LoggingAsyncPullStream(
     std::shared_ptr<SubscriberStub::AsyncPullStream> child,
     TracingOptions tracing_options, std::string request_id)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       request_id_(std::move(request_id)) {}
 
 void LoggingAsyncPullStream::Cancel() {
@@ -254,12 +254,11 @@ future<bool> LoggingAsyncPullStream::Write(
                  << ", is_corked=" << options.is_corked()
                  << ", buffer_hint=" << options.get_buffer_hint()
                  << ", no_compression=" << options.get_no_compression() << "}";
-  return child_->Write(request, std::move(options))
-      .then([prefix](future<bool> f) {
-        auto r = f.get();
-        GCP_LOG(DEBUG) << prefix << " >> response=" << r;
-        return r;
-      });
+  return child_->Write(request, options).then([prefix](future<bool> f) {
+    auto r = f.get();
+    GCP_LOG(DEBUG) << prefix << " >> response=" << r;
+    return r;
+  });
 }
 
 future<bool> LoggingAsyncPullStream::WritesDone() {

--- a/google/cloud/pubsub/internal/subscriber_logging.h
+++ b/google/cloud/pubsub/internal/subscriber_logging.h
@@ -31,7 +31,7 @@ class SubscriberLogging : public SubscriberStub {
   SubscriberLogging(std::shared_ptr<SubscriberStub> child,
                     TracingOptions tracing_options, bool trace_streams)
       : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)),
+        tracing_options_(tracing_options),
         trace_streams_(trace_streams) {}
 
   StatusOr<google::pubsub::v1::Subscription> CreateSubscription(

--- a/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
+++ b/google/cloud/pubsub/internal/subscription_concurrency_control_test.cc
@@ -473,7 +473,7 @@ TEST_F(SubscriptionConcurrencyControlTest, MessageContents) {
   std::vector<std::pair<pubsub::Message, pubsub::AckHandler>> messages;
   auto handler = [&](pubsub::Message const& m, pubsub::AckHandler h) {
     std::lock_guard<std::mutex> lk(handler_mu);
-    messages.emplace_back(std::move(m), std::move(h));
+    messages.emplace_back(m, std::move(h));
     handler_cv.notify_one();
   };
   auto wait_message_count = [&](std::size_t n) {

--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -44,7 +44,7 @@ future<Status> CreateTestSubscriptionSession(
     pubsub::SubscriberConnection::SubscribeParams p) {
   opts = DefaultSubscriberOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return CreateSubscriptionSession(subscription, std::move(opts), mock, cq,
+  return CreateSubscriptionSession(subscription, opts, mock, cq,
                                    "test-client-id", std::move(p));
 }
 

--- a/google/cloud/pubsub/message.h
+++ b/google/cloud/pubsub/message.h
@@ -229,8 +229,8 @@ class MessageBuilder {
     using value_type =
         google::protobuf::Map<std::string, std::string>::value_type;
     google::protobuf::Map<std::string, std::string> tmp;
-    for (auto& kv : v) {
-      tmp.insert(value_type(std::move(kv.first), std::move(kv.second)));
+    for (auto const& kv : v) {
+      tmp.insert(value_type(kv.first, kv.second));
     }
     proto_.mutable_attributes()->swap(tmp);
     return *this;

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -48,7 +48,7 @@ class ContainingPublisherConnection : public PublisherConnection {
   future<StatusOr<std::string>> Publish(PublishParams p) override {
     return child_->Publish(std::move(p));
   }
-  void Flush(FlushParams p) override { child_->Flush(std::move(p)); }
+  void Flush(FlushParams p) override { child_->Flush(p); }
   void ResumePublish(ResumePublishParams p) override {
     child_->ResumePublish(std::move(p));
   }

--- a/google/cloud/pubsub/samples/pubsub_samples_common.cc
+++ b/google/cloud/pubsub/samples/pubsub_samples_common.cc
@@ -39,7 +39,7 @@ google::cloud::testing_util::Commands::value_type CreatePublisherCommand(
     argv.erase(argv.begin(), argv.begin() + 2);
     google::cloud::pubsub::Publisher client(
         google::cloud::pubsub::MakePublisherConnection(topic));
-    command(std::move(client), std::move(argv));
+    command(std::move(client), argv);
   };
   return google::cloud::testing_util::Commands::value_type{name,
                                                            std::move(adapter)};
@@ -63,7 +63,7 @@ google::cloud::testing_util::Commands::value_type CreateSubscriberCommand(
         google::cloud::pubsub::MakeSubscriberConnection(
             pubsub::Subscription(argv.at(0), argv.at(1))));
     argv.erase(argv.begin(), argv.begin() + 2);
-    command(std::move(client), std::move(argv));
+    command(std::move(client), argv);
   };
   return google::cloud::testing_util::Commands::value_type{name,
                                                            std::move(adapter)};
@@ -84,7 +84,7 @@ google::cloud::testing_util::Commands::value_type CreateTopicAdminCommand(
     }
     google::cloud::pubsub::TopicAdminClient client(
         google::cloud::pubsub::MakeTopicAdminConnection());
-    command(std::move(client), std::move(argv));
+    command(std::move(client), argv);
   };
   return google::cloud::testing_util::Commands::value_type{name,
                                                            std::move(adapter)};
@@ -106,7 +106,7 @@ CreateSubscriptionAdminCommand(std::string const& name,
     }
     google::cloud::pubsub::SubscriptionAdminClient client(
         google::cloud::pubsub::MakeSubscriptionAdminConnection());
-    command(std::move(client), std::move(argv));
+    command(std::move(client), argv);
   };
   return google::cloud::testing_util::Commands::value_type{name,
                                                            std::move(adapter)};
@@ -127,7 +127,7 @@ google::cloud::testing_util::Commands::value_type CreateSchemaAdminCommand(
     }
     google::cloud::pubsub::SchemaAdminClient client(
         google::cloud::pubsub::MakeSchemaAdminConnection());
-    command(std::move(client), std::move(argv));
+    command(std::move(client), argv);
   };
   return google::cloud::testing_util::Commands::value_type{name,
                                                            std::move(adapter)};

--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -212,8 +212,7 @@ void DeleteTopic(google::cloud::pubsub::TopicAdminClient client,
   namespace pubsub = ::google::cloud::pubsub;
   [](pubsub::TopicAdminClient client, std::string const& project_id,
      std::string const& topic_id) {
-    auto status = client.DeleteTopic(
-        pubsub::Topic(std::move(project_id), std::move(topic_id)));
+    auto status = client.DeleteTopic(pubsub::Topic(project_id, topic_id));
     // Note that kNotFound is a possible result when the library retries.
     if (status.code() == google::cloud::StatusCode::kNotFound) {
       std::cout << "The topic was not found\n";
@@ -287,8 +286,8 @@ void CreateSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& topic_id, std::string const& subscription_id) {
     auto sub = client.CreateSubscription(
-        pubsub::Topic(project_id, std::move(topic_id)),
-        pubsub::Subscription(project_id, std::move(subscription_id)));
+        pubsub::Topic(project_id, topic_id),
+        pubsub::Subscription(project_id, subscription_id));
     if (sub.status().code() == google::cloud::StatusCode::kAlreadyExists) {
       std::cout << "The subscription already exists\n";
       return;
@@ -336,8 +335,8 @@ void CreatePushSubscription(
      std::string const& topic_id, std::string const& subscription_id,
      std::string const& endpoint) {
     auto sub = client.CreateSubscription(
-        pubsub::Topic(project_id, std::move(topic_id)),
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Topic(project_id, topic_id),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::SubscriptionBuilder{}.set_push_config(
             pubsub::PushConfigBuilder{}.set_push_endpoint(endpoint)));
     if (sub.status().code() == google::cloud::StatusCode::kAlreadyExists) {
@@ -361,8 +360,8 @@ void CreateOrderingSubscription(
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& topic_id, std::string const& subscription_id) {
     auto sub = client.CreateSubscription(
-        pubsub::Topic(project_id, std::move(topic_id)),
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Topic(project_id, topic_id),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::SubscriptionBuilder{}.enable_message_ordering(true));
     if (sub.status().code() == google::cloud::StatusCode::kAlreadyExists) {
       std::cout << "The subscription already exists\n";
@@ -388,8 +387,8 @@ void CreateDeadLetterSubscription(
      std::string const& dead_letter_topic_id,
      int dead_letter_delivery_attempts) {
     auto sub = client.CreateSubscription(
-        pubsub::Topic(project_id, std::move(topic_id)),
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Topic(project_id, topic_id),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::SubscriptionBuilder{}.set_dead_letter_policy(
             pubsub::SubscriptionBuilder::MakeDeadLetterPolicy(
                 pubsub::Topic(project_id, dead_letter_topic_id),
@@ -426,7 +425,7 @@ void UpdateDeadLetterSubscription(
      std::string const& dead_letter_topic_id,
      int dead_letter_delivery_attempts) {
     auto sub = client.UpdateSubscription(
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::SubscriptionBuilder{}.set_dead_letter_policy(
             pubsub::SubscriptionBuilder::MakeDeadLetterPolicy(
                 pubsub::Topic(project_id, dead_letter_topic_id),
@@ -479,7 +478,7 @@ void RemoveDeadLetterPolicy(
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& subscription_id) {
     auto sub = client.UpdateSubscription(
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::SubscriptionBuilder{}.clear_dead_letter_policy());
     if (!sub) return;  // TODO(#4792) - emulator lacks UpdateSubscription()
 
@@ -497,7 +496,7 @@ void GetSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& subscription_id) {
     auto sub = client.GetSubscription(
-        pubsub::Subscription(project_id, std::move(subscription_id)));
+        pubsub::Subscription(project_id, subscription_id));
     if (!sub) throw std::runtime_error(sub.status().message());
 
     std::cout << "The subscription exists and its metadata is: "
@@ -514,7 +513,7 @@ void UpdateSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& subscription_id) {
     auto s = client.UpdateSubscription(
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::SubscriptionBuilder{}.set_ack_deadline(
             std::chrono::seconds(60)));
     if (!s) throw std::runtime_error(s.status().message());
@@ -552,8 +551,8 @@ void DeleteSubscription(google::cloud::pubsub::SubscriptionAdminClient client,
   namespace pubsub = ::google::cloud::pubsub;
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& subscription_id) {
-    auto status = client.DeleteSubscription(pubsub::Subscription(
-        std::move(project_id), std::move(subscription_id)));
+    auto status = client.DeleteSubscription(
+        pubsub::Subscription(project_id, subscription_id));
     // Note that kNotFound is a possible result when the library retries.
     if (status.code() == google::cloud::StatusCode::kNotFound) {
       std::cout << "The subscription was not found\n";
@@ -574,7 +573,7 @@ void ModifyPushConfig(google::cloud::pubsub::SubscriptionAdminClient client,
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& subscription_id, std::string const& endpoint) {
     auto status = client.ModifyPushSubscription(
-        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::Subscription(project_id, subscription_id),
         pubsub::PushConfigBuilder{}.set_push_endpoint(endpoint));
     if (!status.ok()) throw std::runtime_error(status.message());
 
@@ -591,9 +590,9 @@ void CreateSnapshot(google::cloud::pubsub::SubscriptionAdminClient client,
   namespace pubsub = ::google::cloud::pubsub;
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& subscription_id, std::string const& snapshot_id) {
-    auto snapshot = client.CreateSnapshot(
-        pubsub::Subscription(project_id, subscription_id),
-        pubsub::Snapshot(project_id, std::move(snapshot_id)));
+    auto snapshot =
+        client.CreateSnapshot(pubsub::Subscription(project_id, subscription_id),
+                              pubsub::Snapshot(project_id, snapshot_id));
     if (snapshot.status().code() == google::cloud::StatusCode::kAlreadyExists) {
       std::cout << "The snapshot already exists\n";
       return;
@@ -613,8 +612,8 @@ void GetSnapshot(google::cloud::pubsub::SubscriptionAdminClient client,
   namespace pubsub = ::google::cloud::pubsub;
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& snapshot_id) {
-    auto response = client.GetSnapshot(
-        pubsub::Snapshot(std::move(project_id), std::move(snapshot_id)));
+    auto response =
+        client.GetSnapshot(pubsub::Snapshot(project_id, snapshot_id));
     if (!response.ok()) throw std::runtime_error(response.status().message());
 
     std::cout << "The snapshot details are: " << response->DebugString()
@@ -663,8 +662,8 @@ void DeleteSnapshot(google::cloud::pubsub::SubscriptionAdminClient client,
   namespace pubsub = ::google::cloud::pubsub;
   [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
      std::string const& snapshot_id) {
-    auto status = client.DeleteSnapshot(
-        pubsub::Snapshot(std::move(project_id), std::move(snapshot_id)));
+    auto status =
+        client.DeleteSnapshot(pubsub::Snapshot(project_id, snapshot_id));
     // Note that kNotFound is a possible result when the library retries.
     if (status.code() == google::cloud::StatusCode::kNotFound) {
       std::cout << "The snapshot was not found\n";
@@ -2039,7 +2038,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning DeleteSubscription() sample [1]" << std::endl;
   // Move push_subscription_id to prevent accidentally using it below.
   DeleteSubscription(subscription_admin_client,
-                     {project_id, std::move(push_subscription_id)});
+                     {project_id, push_subscription_id});
 
   std::cout << "\nRunning CreateTopic() sample [4]" << std::endl;
   CreateTopic(topic_admin_client, {project_id, dead_letter_topic_id});
@@ -2211,7 +2210,7 @@ void AutoRun(std::vector<std::string> const& argv) {
 
   std::cout << "\nRunning DeleteSubscription() sample [2]" << std::endl;
   DeleteSubscription(subscription_admin_client,
-                     {project_id, std::move(dead_letter_subscription_id)});
+                     {project_id, dead_letter_subscription_id});
 
   std::cout << "\nRunning DeleteSubscription() sample [3] " << std::endl;
   DeleteSubscription(subscription_admin_client,

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -92,7 +92,7 @@ class SchemaAdminConnectionImpl : public pubsub::SchemaAdminConnection {
               request, function_name);
         };
     return internal::MakePaginationRange<pubsub::ListSchemasRange>(
-        std::move(request), list_functor,
+        request, list_functor,
         [](google::pubsub::v1::ListSchemasResponse response) {
           std::vector<google::pubsub::v1::Schema> items;
           items.reserve(response.schemas_size());

--- a/google/cloud/pubsub/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/schema_admin_connection_test.cc
@@ -43,8 +43,7 @@ std::shared_ptr<SchemaAdminConnection> MakeTestSchemaAdminConnection(
     std::shared_ptr<pubsub_internal::SchemaStub> mock, Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakeTestSchemaAdminConnection(std::move(opts),
-                                                        std::move(mock));
+  return pubsub_internal::MakeTestSchemaAdminConnection(opts, std::move(mock));
 }
 
 TEST(SchemaAdminConnectionTest, Create) {

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -44,7 +44,7 @@ MakeTestSubscriptionAdminConnection(
     std::shared_ptr<pubsub_internal::SubscriberStub> mock, Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakeTestSubscriptionAdminConnection(std::move(opts),
+  return pubsub_internal::MakeTestSubscriptionAdminConnection(opts,
                                                               std::move(mock));
 }
 

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -40,8 +40,7 @@ std::shared_ptr<pubsub::TopicAdminConnection> MakeTestTopicAdminConnection(
     std::shared_ptr<pubsub_internal::PublisherStub> mock, Options opts = {}) {
   opts = pubsub_internal::DefaultCommonOptions(
       pubsub_testing::MakeTestOptions(std::move(opts)));
-  return pubsub_internal::MakeTestTopicAdminConnection(std::move(opts),
-                                                       std::move(mock));
+  return pubsub_internal::MakeTestTopicAdminConnection(opts, std::move(mock));
 }
 
 TEST(TopicAdminConnectionTest, Create) {

--- a/google/cloud/pubsublite/internal/admin_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_logging_decorator.cc
@@ -31,7 +31,7 @@ AdminServiceLogging::AdminServiceLogging(
     std::shared_ptr<AdminServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceLogging::CreateTopic(

--- a/google/cloud/pubsublite/internal/cursor_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/cursor_logging_decorator.cc
@@ -32,7 +32,7 @@ CursorServiceLogging::CursorServiceLogging(
     std::shared_ptr<CursorServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/pubsublite/internal/partition_assignment_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/partition_assignment_logging_decorator.cc
@@ -32,7 +32,7 @@ PartitionAssignmentServiceLogging::PartitionAssignmentServiceLogging(
     std::shared_ptr<PartitionAssignmentServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/pubsublite/internal/publisher_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/publisher_logging_decorator.cc
@@ -32,7 +32,7 @@ PublisherServiceLogging::PublisherServiceLogging(
     std::shared_ptr<PublisherServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/pubsublite/internal/subscriber_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/subscriber_logging_decorator.cc
@@ -32,7 +32,7 @@ SubscriberServiceLogging::SubscriberServiceLogging(
     std::shared_ptr<SubscriberServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<

--- a/google/cloud/pubsublite/internal/topic_stats_logging_decorator.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_logging_decorator.cc
@@ -31,7 +31,7 @@ TopicStatsServiceLogging::TopicStatsServiceLogging(
     std::shared_ptr<TopicStatsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>

--- a/google/cloud/recommender/internal/recommender_logging_decorator.cc
+++ b/google/cloud/recommender/internal/recommender_logging_decorator.cc
@@ -31,7 +31,7 @@ RecommenderLogging::RecommenderLogging(std::shared_ptr<RecommenderStub> child,
                                        TracingOptions tracing_options,
                                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::recommender::v1::ListInsightsResponse>

--- a/google/cloud/redis/internal/cloud_redis_logging_decorator.cc
+++ b/google/cloud/redis/internal/cloud_redis_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudRedisLogging::CloudRedisLogging(std::shared_ptr<CloudRedisStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::redis::v1::ListInstancesResponse>

--- a/google/cloud/resourcemanager/internal/folders_logging_decorator.cc
+++ b/google/cloud/resourcemanager/internal/folders_logging_decorator.cc
@@ -31,7 +31,7 @@ FoldersLogging::FoldersLogging(std::shared_ptr<FoldersStub> child,
                                TracingOptions tracing_options,
                                std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::resourcemanager::v3::Folder> FoldersLogging::GetFolder(

--- a/google/cloud/resourcemanager/internal/organizations_logging_decorator.cc
+++ b/google/cloud/resourcemanager/internal/organizations_logging_decorator.cc
@@ -31,7 +31,7 @@ OrganizationsLogging::OrganizationsLogging(
     std::shared_ptr<OrganizationsStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::resourcemanager::v3::Organization>

--- a/google/cloud/resourcemanager/internal/projects_logging_decorator.cc
+++ b/google/cloud/resourcemanager/internal/projects_logging_decorator.cc
@@ -31,7 +31,7 @@ ProjectsLogging::ProjectsLogging(std::shared_ptr<ProjectsStub> child,
                                  TracingOptions tracing_options,
                                  std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::resourcemanager::v3::Project>

--- a/google/cloud/resourcesettings/internal/resource_settings_logging_decorator.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_logging_decorator.cc
@@ -31,7 +31,7 @@ ResourceSettingsServiceLogging::ResourceSettingsServiceLogging(
     std::shared_ptr<ResourceSettingsServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::resourcesettings::v1::ListSettingsResponse>

--- a/google/cloud/retail/internal/catalog_logging_decorator.cc
+++ b/google/cloud/retail/internal/catalog_logging_decorator.cc
@@ -31,7 +31,7 @@ CatalogServiceLogging::CatalogServiceLogging(
     std::shared_ptr<CatalogServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::retail::v2::ListCatalogsResponse>

--- a/google/cloud/retail/internal/completion_logging_decorator.cc
+++ b/google/cloud/retail/internal/completion_logging_decorator.cc
@@ -31,7 +31,7 @@ CompletionServiceLogging::CompletionServiceLogging(
     std::shared_ptr<CompletionServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::retail::v2::CompleteQueryResponse>

--- a/google/cloud/retail/internal/prediction_logging_decorator.cc
+++ b/google/cloud/retail/internal/prediction_logging_decorator.cc
@@ -31,7 +31,7 @@ PredictionServiceLogging::PredictionServiceLogging(
     std::shared_ptr<PredictionServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::retail::v2::PredictResponse>

--- a/google/cloud/retail/internal/product_logging_decorator.cc
+++ b/google/cloud/retail/internal/product_logging_decorator.cc
@@ -31,7 +31,7 @@ ProductServiceLogging::ProductServiceLogging(
     std::shared_ptr<ProductServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::retail::v2::Product>

--- a/google/cloud/retail/internal/search_logging_decorator.cc
+++ b/google/cloud/retail/internal/search_logging_decorator.cc
@@ -31,7 +31,7 @@ SearchServiceLogging::SearchServiceLogging(
     std::shared_ptr<SearchServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::retail::v2::SearchResponse>

--- a/google/cloud/retail/internal/user_event_logging_decorator.cc
+++ b/google/cloud/retail/internal/user_event_logging_decorator.cc
@@ -31,7 +31,7 @@ UserEventServiceLogging::UserEventServiceLogging(
     std::shared_ptr<UserEventServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::retail::v2::UserEvent>

--- a/google/cloud/scheduler/internal/cloud_scheduler_logging_decorator.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudSchedulerLogging::CloudSchedulerLogging(
     std::shared_ptr<CloudSchedulerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::scheduler::v1::ListJobsResponse>

--- a/google/cloud/secretmanager/internal/secret_manager_logging_decorator.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ SecretManagerServiceLogging::SecretManagerServiceLogging(
     std::shared_ptr<SecretManagerServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::secretmanager::v1::ListSecretsResponse>

--- a/google/cloud/securitycenter/internal/security_center_logging_decorator.cc
+++ b/google/cloud/securitycenter/internal/security_center_logging_decorator.cc
@@ -31,7 +31,7 @@ SecurityCenterLogging::SecurityCenterLogging(
     std::shared_ptr<SecurityCenterStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/servicecontrol/internal/quota_controller_logging_decorator.cc
+++ b/google/cloud/servicecontrol/internal/quota_controller_logging_decorator.cc
@@ -31,7 +31,7 @@ QuotaControllerLogging::QuotaControllerLogging(
     std::shared_ptr<QuotaControllerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>

--- a/google/cloud/servicecontrol/internal/service_controller_logging_decorator.cc
+++ b/google/cloud/servicecontrol/internal/service_controller_logging_decorator.cc
@@ -31,7 +31,7 @@ ServiceControllerLogging::ServiceControllerLogging(
     std::shared_ptr<ServiceControllerStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::api::servicecontrol::v1::CheckResponse>

--- a/google/cloud/servicedirectory/internal/lookup_logging_decorator.cc
+++ b/google/cloud/servicedirectory/internal/lookup_logging_decorator.cc
@@ -31,7 +31,7 @@ LookupServiceLogging::LookupServiceLogging(
     std::shared_ptr<LookupServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>

--- a/google/cloud/servicedirectory/internal/registration_logging_decorator.cc
+++ b/google/cloud/servicedirectory/internal/registration_logging_decorator.cc
@@ -31,7 +31,7 @@ RegistrationServiceLogging::RegistrationServiceLogging(
     std::shared_ptr<RegistrationServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::servicedirectory::v1::Namespace>

--- a/google/cloud/servicemanagement/internal/service_manager_logging_decorator.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_logging_decorator.cc
@@ -31,7 +31,7 @@ ServiceManagerLogging::ServiceManagerLogging(
     std::shared_ptr<ServiceManagerStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::api::servicemanagement::v1::ListServicesResponse>

--- a/google/cloud/serviceusage/internal/service_usage_logging_decorator.cc
+++ b/google/cloud/serviceusage/internal/service_usage_logging_decorator.cc
@@ -31,7 +31,7 @@ ServiceUsageLogging::ServiceUsageLogging(
     std::shared_ptr<ServiceUsageStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/shell/internal/cloud_shell_logging_decorator.cc
+++ b/google/cloud/shell/internal/cloud_shell_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudShellServiceLogging::CloudShellServiceLogging(
     std::shared_ptr<CloudShellServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::shell::v1::Environment>

--- a/google/cloud/spanner/admin/internal/database_admin_logging_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_logging_decorator.cc
@@ -31,7 +31,7 @@ DatabaseAdminLogging::DatabaseAdminLogging(
     std::shared_ptr<DatabaseAdminStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::spanner::admin::database::v1::ListDatabasesResponse>

--- a/google/cloud/spanner/admin/internal/instance_admin_logging_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_logging_decorator.cc
@@ -31,7 +31,7 @@ InstanceAdminLogging::InstanceAdminLogging(
     std::shared_ptr<InstanceAdminStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::spanner::admin::instance::v1::ListInstanceConfigsResponse>

--- a/google/cloud/spanner/backup.cc
+++ b/google/cloud/spanner/backup.cc
@@ -45,8 +45,7 @@ StatusOr<Backup> MakeBackup(std::string const& full_name) {
     return Status(StatusCode::kInvalidArgument,
                   "Improperly formatted Backup: " + full_name);
   }
-  return Backup(Instance(std::move(matches[1]), std::move(matches[2])),
-                std::move(matches[3]));
+  return Backup(Instance(matches[1], matches[2]), matches[3]);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -78,7 +78,7 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
       {"--instance=",
        [](Config& c, std::string v) { c.instance_id = std::move(v); }},
       {"--database=",
-       [](Config& c, std::string const& v) { c.database_id = std::move(v); }},
+       [](Config& c, std::string v) { c.database_id = std::move(v); }},
       {"--samples=",
        [](Config& c, std::string const& v) { c.samples = std::stoi(v); }},
       {"--iteration-duration=",

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -357,7 +357,7 @@ std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
     return spanner_internal::CreateDefaultSpannerStub(db, auth, opts, id++);
   });
   return std::make_shared<spanner_internal::ConnectionImpl>(
-      std::move(db), std::move(background), std::move(stubs), std::move(opts));
+      db, std::move(background), std::move(stubs), std::move(opts));
 }
 
 std::shared_ptr<Connection> MakeConnection(

--- a/google/cloud/spanner/commit_options.h
+++ b/google/cloud/spanner/commit_options.h
@@ -61,7 +61,7 @@ class CommitOptions {
   /// Set the priority of the `spanner::Client::Commit()` call.
   CommitOptions& set_request_priority(
       absl::optional<RequestPriority> request_priority) {
-    request_priority_ = std::move(request_priority);
+    request_priority_ = request_priority;
     return *this;
   }
 

--- a/google/cloud/spanner/database.cc
+++ b/google/cloud/spanner/database.cc
@@ -50,8 +50,7 @@ StatusOr<Database> MakeDatabase(std::string const& full_name) {
     return Status(StatusCode::kInvalidArgument,
                   "Improperly formatted Database: " + full_name);
   }
-  return Database(Instance(std::move(matches[1]), std::move(matches[2])),
-                  std::move(matches[3]));
+  return Database(Instance(matches[1], matches[2]), matches[3]);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -144,9 +144,9 @@ future<StatusOr<gcsa::Backup>> DatabaseAdminClient::CreateBackup(
   if (!expire_time_point) {
     expire_time_point = std::chrono::system_clock::time_point::max();
   }
-  return conn_->CreateBackup(
-      {std::move(db), std::move(backup_id), *std::move(expire_time_point),
-       expire_time, std::move(version_time), std::move(encryption_config)});
+  return conn_->CreateBackup({std::move(db), std::move(backup_id),
+                              *std::move(expire_time_point), expire_time,
+                              version_time, std::move(encryption_config)});
 }
 
 future<StatusOr<gcsa::Backup>> DatabaseAdminClient::CreateBackup(

--- a/google/cloud/spanner/instance.cc
+++ b/google/cloud/spanner/instance.cc
@@ -48,7 +48,7 @@ StatusOr<Instance> MakeInstance(std::string const& full_name) {
     return Status(StatusCode::kInvalidArgument,
                   "Improperly formatted Instance: " + full_name);
   }
-  return Instance(Project(std::move(matches[1])), std::move(matches[2]));
+  return Instance(Project(matches[1]), matches[2]);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/integration_tests/client_stress_test.cc
+++ b/google/cloud/spanner/integration_tests/client_stress_test.cc
@@ -298,7 +298,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   if (config->show_help) return 0;
-  spanner::config = std::move(*config);
+  spanner::config = *config;
 
   return RUN_ALL_TESTS();
 }

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -798,8 +798,7 @@ ConnectionImpl::PartitionQueryImpl(
   *request.mutable_params() = std::move(*sql_statement.mutable_params());
   *request.mutable_param_types() =
       std::move(*sql_statement.mutable_param_types());
-  *request.mutable_partition_options() =
-      ToProto(std::move(params.partition_options));
+  *request.mutable_partition_options() = ToProto(params.partition_options);
 
   auto stub = session_pool_->GetStub(*session);
   for (;;) {

--- a/google/cloud/spanner/internal/database_admin_logging.h
+++ b/google/cloud/spanner/internal/database_admin_logging.h
@@ -33,8 +33,7 @@ class DatabaseAdminLogging : public DatabaseAdminStub {
  public:
   DatabaseAdminLogging(std::shared_ptr<DatabaseAdminStub> child,
                        TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+      : child_(std::move(child)), tracing_options_(tracing_options) {}
 
   ~DatabaseAdminLogging() override = default;
 

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -220,7 +220,7 @@ TEST(Options, OverrideTracingOptions) {
       ",single_line_mode=F"
       ",use_short_repeated_primitives=n"
       ",truncate_string_field_longer_than=256");
-  auto opts = Options{}.set<GrpcTracingOptionsOption>(std::move(options));
+  auto opts = Options{}.set<GrpcTracingOptionsOption>(options);
   opts = spanner_internal::DefaultOptions(std::move(opts));
   options = opts.get<GrpcTracingOptionsOption>();
   EXPECT_NE(options, TracingOptions{});

--- a/google/cloud/spanner/internal/instance_admin_logging.h
+++ b/google/cloud/spanner/internal/instance_admin_logging.h
@@ -33,8 +33,7 @@ class InstanceAdminLogging : public InstanceAdminStub {
  public:
   InstanceAdminLogging(std::shared_ptr<InstanceAdminStub> child,
                        TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+      : child_(std::move(child)), tracing_options_(tracing_options) {}
 
   ~InstanceAdminLogging() override = default;
 

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -30,7 +30,7 @@ class LoggingResultSetReader : public PartialResultSetReader {
  public:
   LoggingResultSetReader(std::unique_ptr<PartialResultSetReader> impl,
                          TracingOptions tracing_options)
-      : impl_(std::move(impl)), tracing_options_(std::move(tracing_options)) {}
+      : impl_(std::move(impl)), tracing_options_(tracing_options) {}
   ~LoggingResultSetReader() override = default;
 
   void TryCancel() override;

--- a/google/cloud/spanner/internal/logging_spanner_stub.h
+++ b/google/cloud/spanner/internal/logging_spanner_stub.h
@@ -33,8 +33,7 @@ class LoggingSpannerStub : public SpannerStub {
  public:
   LoggingSpannerStub(std::shared_ptr<SpannerStub> child,
                      TracingOptions tracing_options)
-      : child_(std::move(child)),
-        tracing_options_(std::move(tracing_options)) {}
+      : child_(std::move(child)), tracing_options_(tracing_options) {}
   ~LoggingSpannerStub() override = default;
 
   StatusOr<google::spanner::v1::Session> CreateSession(

--- a/google/cloud/spanner/internal/spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/spanner_stub_test.cc
@@ -38,7 +38,7 @@ TEST(SpannerStub, CreateDefaultStub) {
   auto auth =
       internal::CreateAuthenticationStrategy(opts.get<GrpcCredentialOption>());
   auto stub = CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"),
-                                       std::move(auth), std::move(opts),
+                                       std::move(auth), opts,
                                        /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 }
@@ -53,7 +53,7 @@ TEST(SpannerStub, CreateDefaultStubWithLogging) {
   auto auth =
       internal::CreateAuthenticationStrategy(opts.get<GrpcCredentialOption>());
   auto stub = CreateDefaultSpannerStub(spanner::Database("foo", "bar", "baz"),
-                                       std::move(auth), std::move(opts),
+                                       std::move(auth), opts,
                                        /*channel_id=*/0);
   EXPECT_NE(stub, nullptr);
 

--- a/google/cloud/spanner/query_options.h
+++ b/google/cloud/spanner/query_options.h
@@ -85,7 +85,7 @@ class QueryOptions {
 
   /// Sets the request priority.
   QueryOptions& set_request_priority(absl::optional<RequestPriority> priority) {
-    request_priority_ = std::move(priority);
+    request_priority_ = priority;
     return *this;
   }
 

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -556,8 +556,7 @@ void UpdateDatabaseWithDefaultLeader(
   statements.push_back("ALTER DATABASE `" + database_id + "` " +
                        "SET OPTIONS (default_leader='" + default_leader + "')");
   auto metadata =
-      client.UpdateDatabaseDdl(database.FullName(), std::move(statements))
-          .get();
+      client.UpdateDatabaseDdl(database.FullName(), statements).get();
   if (!metadata) throw std::runtime_error(metadata.status().message());
   std::cout << "`default_leader` altered, new DDL metadata:\n"
             << metadata->DebugString();
@@ -2290,7 +2289,7 @@ void QueryWithQueryOptions(google::cloud::spanner::Client client) {
   auto opts = spanner::QueryOptions()
                   .set_optimizer_version("1")
                   .set_optimizer_statistics_package("latest");
-  auto rows = client.ExecuteQuery(std::move(sql), std::move(opts));
+  auto rows = client.ExecuteQuery(std::move(sql), opts);
 
   using RowType = std::tuple<std::int64_t, std::string>;
   for (auto const& row : spanner::StreamOf<RowType>(rows)) {
@@ -2541,7 +2540,7 @@ void DmlWriteThenRead(google::cloud::spanner::Client client) {
             "SELECT FirstName, LastName FROM Singers where SingerId = 11");
         using RowType = std::tuple<std::string, std::string>;
         auto rows = client.ExecuteQuery(std::move(txn), std::move(select));
-        for (auto const& row : spanner::StreamOf<RowType>(rows)) {
+        for (auto& row : spanner::StreamOf<RowType>(rows)) {
           if (!row) return std::move(row).status();
           std::cout << "FirstName: " << std::get<0>(*row) << "\t";
           std::cout << "LastName: " << std::get<1>(*row) << "\n";
@@ -3579,7 +3578,7 @@ int RunOneCommand(std::vector<std::string> argv) {
   }
 
   // Run the command.
-  command->second(std::move(argv));
+  command->second(argv);
   return 0;
 }
 

--- a/google/cloud/spanner/session_pool_options.h
+++ b/google/cloud/spanner/session_pool_options.h
@@ -119,7 +119,7 @@ class SessionPoolOptions {
 
   /// Set whether to block or fail on pool exhaustion.
   SessionPoolOptions& set_action_on_exhaustion(ActionOnExhaustion action) {
-    opts_.set<SessionPoolActionOnExhaustionOption>(std::move(action));
+    opts_.set<SessionPoolActionOnExhaustionOption>(action);
     return *this;
   }
 
@@ -138,7 +138,7 @@ class SessionPoolOptions {
    * to be made to refresh the sessions) should suffice.
    */
   SessionPoolOptions& set_keep_alive_interval(std::chrono::seconds interval) {
-    opts_.set<SessionPoolKeepAliveIntervalOption>(std::move(interval));
+    opts_.set<SessionPoolKeepAliveIntervalOption>(interval);
     return *this;
   }
 

--- a/google/cloud/spanner/testing/cleanup_stale_databases.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.cc
@@ -35,7 +35,7 @@ Status CleanupStaleDatabases(
   auto const expired = RandomDatabasePrefix(tp);
   std::regex re(RandomDatabasePrefixRegex());
   for (auto const& db : admin_client.ListDatabases(instance.FullName())) {
-    if (!db) return std::move(db).status();
+    if (!db) return db.status();
     auto id = spanner::MakeDatabase(db->name())->database_id();
     // Skip databases that do not look like a randomly created DB.
     if (!std::regex_match(id, re)) continue;

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -195,13 +195,11 @@ class Value {
   /// @copydoc Value(bool)
   explicit Value(Numeric v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
-  explicit Value(Timestamp v) : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(Timestamp v) : Value(PrivateConstructor{}, v) {}
   /// @copydoc Value(bool)
-  explicit Value(CommitTimestamp v)
-      : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(CommitTimestamp v) : Value(PrivateConstructor{}, v) {}
   /// @copydoc Value(bool)
-  explicit Value(absl::CivilDay v)
-      : Value(PrivateConstructor{}, std::move(v)) {}
+  explicit Value(absl::CivilDay v) : Value(PrivateConstructor{}, v) {}
 
   /**
    * Constructs an instance from common C++ literal types that closely, though

--- a/google/cloud/status_or_test.cc
+++ b/google/cloud/status_or_test.cc
@@ -100,7 +100,7 @@ TEST(StatusOrTest, ValueConstructor) {
 }
 
 TEST(StatusOrTest, ValueConstAccessors) {
-  StatusOr<int> const actual(42);
+  StatusOr<int> actual(42);
   EXPECT_STATUS_OK(actual);
   EXPECT_EQ(42, actual.value());
   EXPECT_EQ(42, std::move(actual).value());
@@ -147,7 +147,7 @@ TEST(StatusOrTest, ValueAccessorConstThrows) {
 }
 
 TEST(StatusOrTest, StatusConstAccessors) {
-  StatusOr<int> const actual(Status(StatusCode::kInternal, "BAD"));
+  StatusOr<int> actual(Status(StatusCode::kInternal, "BAD"));
   EXPECT_EQ(StatusCode::kInternal, actual.status().code());
   EXPECT_EQ(StatusCode::kInternal, std::move(actual).status().code());
 }
@@ -163,7 +163,7 @@ TEST(StatusOrTest, ValueConstDeference) {
   StatusOr<std::string> const actual("42");
   EXPECT_STATUS_OK(actual);
   EXPECT_EQ("42", *actual);
-  EXPECT_EQ("42", std::move(actual).value());
+  EXPECT_EQ("42", actual.value());
 }
 
 TEST(StatusOrTest, ValueArrow) {

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -801,7 +801,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return retention_policy_;
   }
   BucketMetadata& set_retention_policy(BucketRetentionPolicy v) {
-    retention_policy_ = std::move(v);
+    retention_policy_ = v;
     return *this;
   }
 
@@ -862,7 +862,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return *this;
   }
   BucketMetadata& set_versioning(absl::optional<BucketVersioning> v) {
-    versioning_ = std::move(v);
+    versioning_ = v;
     return *this;
   }
   //@}

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -485,7 +485,7 @@ ScopedDeleter::~ScopedDeleter() {
 
 void ScopedDeleter::Add(ObjectMetadata const& object) {
   auto generation = object.generation();
-  Add(std::move(object).name(), generation);
+  Add(object.name(), generation);
 }
 
 void ScopedDeleter::Add(std::string object_name, std::int64_t generation) {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3366,7 +3366,7 @@ struct DeleteApplyHelper {
 struct InsertObjectApplyHelper {
   template <typename... Options>
   StatusOr<ObjectMetadata> operator()(Options... options) const {
-    return client.InsertObject(bucket_name, object_name, std::move(contents),
+    return client.InsertObject(bucket_name, object_name, contents,
                                std::move(options)...);
   }
 
@@ -3453,9 +3453,8 @@ namespace internal {
 struct ComposeApplyHelper {
   template <typename... Options>
   StatusOr<ObjectMetadata> operator()(Options... options) const {
-    return client.ComposeObject(
-        std::move(bucket_name), std::move(source_objects),
-        std::move(destination_object_name), std::move(options)...);
+    return client.ComposeObject(bucket_name, source_objects,
+                                destination_object_name, std::move(options)...);
   }
 
   Client& client;

--- a/google/cloud/storage/client_options.h
+++ b/google/cloud/storage/client_options.h
@@ -425,7 +425,7 @@ class ClientOptions {
    *     instead.
    */
   ClientOptions& set_download_stall_timeout(std::chrono::seconds v) {
-    opts_.set<TransferStallTimeoutOption>(std::move(v));
+    opts_.set<TransferStallTimeoutOption>(v);
     return *this;
   }
   //@}

--- a/google/cloud/storage/examples/storage_bucket_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_acl_samples.cc
@@ -295,7 +295,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
   examples::Example example({
       make_entry("list-bucket-acl", {}, ListBucketAcl),

--- a/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_default_kms_key_samples.cc
@@ -146,7 +146,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
   examples::Example example({
       make_entry("add-bucket-default-kms-key", {"<kms-key-name>"},

--- a/google/cloud/storage/examples/storage_bucket_iam_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_iam_samples.cc
@@ -221,7 +221,7 @@ void TestBucketIamPermissions(google::cloud::storage::Client client,
     std::cout << "\n";
   }
   //! [test bucket iam permissions]
-  (std::move(client), std::move(bucket_name), std::move(permissions));
+  (std::move(client), bucket_name, permissions);
 }
 
 void NativeSetBucketPublicIam(google::cloud::storage::Client client,
@@ -276,7 +276,7 @@ void RunAll(std::vector<std::string> const& argv) {
     gcs::UniformBucketLevelAccess ubla;
     ubla.enabled = true;
     gcs::BucketIamConfiguration result;
-    result.uniform_bucket_level_access = std::move(ubla);
+    result.uniform_bucket_level_access = ubla;
     return result;
   };
   auto bucket_metadata =
@@ -343,7 +343,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
   examples::Example example({
       make_entry("native-get-bucket-iam-policy", {}, NativeGetBucketIamPolicy),

--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -278,8 +278,8 @@ void EnableUniformBucketLevelAccess(google::cloud::storage::Client client,
     configuration.uniform_bucket_level_access =
         gcs::UniformBucketLevelAccess{true, {}};
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
-                         std::move(configuration)));
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetIamConfiguration(configuration));
 
     if (!updated_metadata) {
       throw std::runtime_error(updated_metadata.status().message());
@@ -304,8 +304,8 @@ void DisableUniformBucketLevelAccess(google::cloud::storage::Client client,
     configuration.uniform_bucket_level_access =
         gcs::UniformBucketLevelAccess{false, {}};
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
-                         std::move(configuration)));
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetIamConfiguration(configuration));
 
     if (!updated_metadata) {
       throw std::runtime_error(updated_metadata.status().message());
@@ -363,8 +363,8 @@ void SetPublicAccessPreventionEnforced(google::cloud::storage::Client client,
     configuration.public_access_prevention =
         gcs::PublicAccessPreventionEnforced();
     StatusOr<gcs::BucketMetadata> updated_metadata = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
-                         std::move(configuration)));
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetIamConfiguration(configuration));
 
     if (!updated_metadata) {
       throw std::runtime_error(updated_metadata.status().message());
@@ -388,8 +388,8 @@ void SetPublicAccessPreventionInherited(google::cloud::storage::Client client,
     configuration.public_access_prevention =
         gcs::PublicAccessPreventionInherited();
     auto updated = client.PatchBucket(
-        bucket_name, gcs::BucketMetadataPatchBuilder().SetIamConfiguration(
-                         std::move(configuration)));
+        bucket_name,
+        gcs::BucketMetadataPatchBuilder().SetIamConfiguration(configuration));
     if (!updated) throw std::runtime_error(updated.status().message());
 
     std::cout << "Public Access Prevention is set to 'inherited' for "
@@ -709,7 +709,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_default_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_default_object_acl_samples.cc
@@ -246,7 +246,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_event_based_hold_samples.cc
+++ b/google/cloud/storage/examples/storage_event_based_hold_samples.cc
@@ -152,7 +152,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -58,7 +58,7 @@ Commands::value_type CreateCommandEntry(
       throw Usage{std::move(os).str()};
     }
     auto client = google::cloud::storage::Client();
-    command(std::move(client), std::move(argv));
+    command(std::move(client), argv);
   };
   return {name, std::move(adapter)};
 }

--- a/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
+++ b/google/cloud/storage/examples/storage_lifecycle_management_samples.cc
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_object_acl_samples.cc
+++ b/google/cloud/storage/examples/storage_object_acl_samples.cc
@@ -319,7 +319,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_object_cmek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_cmek_samples.cc
@@ -169,7 +169,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), {"<bucket-name>", "<object-name>"});
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
   examples::Example example({
       make_entry("write-object-with-kms-key", {"<kms-key-name>"},

--- a/google/cloud/storage/examples/storage_object_csek_samples.cc
+++ b/google/cloud/storage/examples/storage_object_csek_samples.cc
@@ -145,7 +145,7 @@ void ComposeObjectFromEncryptedObjects(google::cloud::storage::Client client,
   }
   //! [compose object csek]
   (std::move(client), bucket_name, destination_object_name, base64_aes256_key,
-   std::move(compose_objects));
+   compose_objects);
 }
 
 void CopyEncryptedObject(google::cloud::storage::Client client,
@@ -275,7 +275,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), {"<bucket-name>", "<object-name>"});
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_object_preconditions_samples.cc
+++ b/google/cloud/storage/examples/storage_object_preconditions_samples.cc
@@ -173,7 +173,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
+++ b/google/cloud/storage/examples/storage_object_resumable_write_samples.cc
@@ -180,7 +180,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), {"<bucket-name>", "<object-name>"});
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_object_rewrite_samples.cc
+++ b/google/cloud/storage/examples/storage_object_rewrite_samples.cc
@@ -259,7 +259,7 @@ int main(int argc, char* argv[]) {
         arg_names.begin(),
         {"<source-bucket-name>", "<source-object-name>",
          "<destination-bucket-name>", "<destination-object-name>"});
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
   examples::Example example({
       make_entry("rewrite-object", {}, RewriteObject),

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -113,7 +113,7 @@ void InsertObject(google::cloud::storage::Client client,
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::string const& contents) {
     StatusOr<gcs::ObjectMetadata> object_metadata =
-        client.InsertObject(bucket_name, object_name, std::move(contents));
+        client.InsertObject(bucket_name, object_name, contents);
 
     if (!object_metadata) {
       throw std::runtime_error(object_metadata.status().message());
@@ -140,9 +140,8 @@ void InsertObjectStrictIdempotency(google::cloud::storage::Client,
     auto client =
         gcs::Client(google::cloud::Options{}.set<gcs::IdempotencyPolicyOption>(
             gcs::StrictIdempotencyPolicy().clone()));
-    StatusOr<gcs::ObjectMetadata> object_metadata =
-        client.InsertObject(bucket_name, object_name, std::move(contents),
-                            gcs::IfGenerationMatch(0));
+    StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
+        bucket_name, object_name, contents, gcs::IfGenerationMatch(0));
 
     if (!object_metadata) {
       throw std::runtime_error(object_metadata.status().message());
@@ -170,9 +169,8 @@ void InsertObjectModifiedRetry(google::cloud::storage::Client,
         gcs::Client(google::cloud::Options{}.set<gcs::RetryPolicyOption>(
             gcs::LimitedErrorCountRetryPolicy(3).clone()));
 
-    StatusOr<gcs::ObjectMetadata> object_metadata =
-        client.InsertObject(bucket_name, object_name, std::move(contents),
-                            gcs::IfGenerationMatch(0));
+    StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
+        bucket_name, object_name, contents, gcs::IfGenerationMatch(0));
 
     if (!object_metadata) {
       throw std::runtime_error(object_metadata.status().message());
@@ -198,7 +196,7 @@ void InsertObjectMultipart(google::cloud::storage::Client client,
     // requires a multipart upload, the library prefers simple uploads unless
     // required as in this case.
     StatusOr<gcs::ObjectMetadata> object_metadata = client.InsertObject(
-        bucket_name, object_name, std::move(contents),
+        bucket_name, object_name, contents,
         gcs::WithObjectMetadata(
             gcs::ObjectMetadata().set_content_type(content_type)));
 
@@ -500,8 +498,7 @@ void ComposeObject(google::cloud::storage::Client client,
               << "\nFull metadata: " << *composed_object << "\n";
   }
   //! [compose object] [END storage_compose_file]
-  (std::move(client), bucket_name, destination_object_name,
-   std::move(compose_objects));
+  (std::move(client), bucket_name, destination_object_name, compose_objects);
 }
 
 void ComposeObjectFromMany(google::cloud::storage::Client client,
@@ -537,8 +534,7 @@ void ComposeObjectFromMany(google::cloud::storage::Client client,
               << "\nFull metadata: " << *composed_object << "\n";
   }
   //! [compose object from many] [END storage_compose_file_from_many]
-  (std::move(client), bucket_name, destination_object_name,
-   std::move(compose_objects));
+  (std::move(client), bucket_name, destination_object_name, compose_objects);
 }
 
 void ChangeObjectStorageClass(google::cloud::storage::Client client,
@@ -762,7 +758,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_policy_doc_samples.cc
+++ b/google/cloud/storage/examples/storage_policy_doc_samples.cc
@@ -36,8 +36,8 @@ void CreateSignedPolicyDocumentV2(google::cloud::storage::Client client,
                     gcs::PolicyDocumentCondition::StartsWith("key", ""),
                     gcs::PolicyDocumentCondition::ExactMatchObject(
                         "acl", "bucket-owner-read"),
-                    gcs::PolicyDocumentCondition::ExactMatchObject(
-                        "bucket", std::move(bucket_name)),
+                    gcs::PolicyDocumentCondition::ExactMatchObject("bucket",
+                                                                   bucket_name),
                     gcs::PolicyDocumentCondition::ExactMatch("Content-Type",
                                                              "image/jpeg"),
                     gcs::PolicyDocumentCondition::ContentLengthRange(0,
@@ -63,7 +63,7 @@ void CreateSignedPolicyDocumentV4(google::cloud::storage::Client client,
     StatusOr<gcs::PolicyDocumentV4Result> document =
         client.GenerateSignedPostPolicyV4(
             gcs::PolicyDocumentV4{
-                std::move(bucket_name),
+                bucket_name,
                 "scan_0001.jpg",
                 std::chrono::minutes(15),
                 std::chrono::system_clock::now(),

--- a/google/cloud/storage/examples/storage_retention_policy_samples.cc
+++ b/google/cloud/storage/examples/storage_retention_policy_samples.cc
@@ -210,7 +210,7 @@ int main(int argc, char* argv[]) {
                        std::vector<std::string> arg_names,
                        examples::ClientCommand const& cmd) {
     arg_names.insert(arg_names.begin(), "<bucket-name>");
-    return examples::CreateCommandEntry(name, std::move(arg_names), cmd);
+    return examples::CreateCommandEntry(name, arg_names, cmd);
   };
 
   examples::Example example({

--- a/google/cloud/storage/examples/storage_service_account_samples.cc
+++ b/google/cloud/storage/examples/storage_service_account_samples.cc
@@ -180,7 +180,7 @@ void UpdateHmacKey(google::cloud::storage::Client client,
   [](gcs::Client client, std::string const& access_id,
      std::string const& state) {
     StatusOr<gcs::HmacKeyMetadata> updated = client.UpdateHmacKey(
-        access_id, gcs::HmacKeyMetadata().set_state(std::move(state)));
+        access_id, gcs::HmacKeyMetadata().set_state(state));
     if (!updated) throw std::runtime_error(updated.status().message());
 
     std::cout << "The updated HMAC key metadata is: " << *updated << "\n";

--- a/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v2_samples.cc
@@ -27,7 +27,7 @@ void CreateGetSignedUrlV2(google::cloud::storage::Client client,
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::string const& signing_account) {
     StatusOr<std::string> signed_url = client.CreateV2SignedUrl(
-        "GET", std::move(bucket_name), std::move(object_name),
+        "GET", bucket_name, object_name,
         gcs::ExpirationTime(std::chrono::system_clock::now() +
                             std::chrono::minutes(15)),
         gcs::SigningAccount(signing_account));
@@ -49,7 +49,7 @@ void CreatePutSignedUrlV2(google::cloud::storage::Client client,
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::string const& signing_account) {
     StatusOr<std::string> signed_url = client.CreateV2SignedUrl(
-        "PUT", std::move(bucket_name), std::move(object_name),
+        "PUT", bucket_name, object_name,
         gcs::ExpirationTime(std::chrono::system_clock::now() +
                             std::chrono::minutes(15)),
         gcs::ContentType("application/octet-stream"),

--- a/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
+++ b/google/cloud/storage/examples/storage_signed_url_v4_samples.cc
@@ -27,7 +27,7 @@ void CreateGetSignedUrlV4(google::cloud::storage::Client client,
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::string const& signing_account) {
     StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
-        "GET", std::move(bucket_name), std::move(object_name),
+        "GET", bucket_name, object_name,
         gcs::SignedUrlDuration(std::chrono::minutes(15)),
         gcs::SigningAccount(signing_account));
 
@@ -48,7 +48,7 @@ void CreatePutSignedUrlV4(google::cloud::storage::Client client,
   [](gcs::Client client, std::string const& bucket_name,
      std::string const& object_name, std::string const& signing_account) {
     StatusOr<std::string> signed_url = client.CreateV4SignedUrl(
-        "PUT", std::move(bucket_name), std::move(object_name),
+        "PUT", bucket_name, object_name,
         gcs::SignedUrlDuration(std::chrono::minutes(15)),
         gcs::AddExtensionHeader("content-type", "application/octet-stream"),
         gcs::SigningAccount(signing_account));

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -90,8 +90,7 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   auto agents = options.get<UserAgentProductsOption>();
   agents.push_back(user_agent_prefix_);
   user_agent_prefix_ = absl::StrJoin(agents, " ");
-  http_version_ =
-      std::move(options.get<storage_experimental::HttpVersionOption>());
+  http_version_ = options.get<storage_experimental::HttpVersionOption>();
   transfer_stall_timeout_ = options.get<TransferStallTimeoutOption>();
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
   return *this;

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -245,7 +245,7 @@ BucketIamConfiguration GrpcBucketMetadataParser::FromProto(
     ubla.enabled = rhs.uniform_bucket_level_access().enabled();
     ubla.locked_time = google::cloud::internal::ToChronoTimePoint(
         rhs.uniform_bucket_level_access().lock_time());
-    result.uniform_bucket_level_access = std::move(ubla);
+    result.uniform_bucket_level_access = ubla;
   }
   return result;
 }

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -52,7 +52,7 @@ StatusOr<ReadSourceResult> GrpcObjectReadSource::Read(char* buf,
   using BufferUpdater = absl::FunctionRef<absl::string_view(absl::string_view)>;
   struct Visitor {
     Visitor(GrpcObjectReadSource& source, BufferUpdater update)
-        : self(source), update_buf(std::move(update)) {
+        : self(source), update_buf(update) {
       result.response.status_code = HttpStatusCode::kContinue;
     }
 

--- a/google/cloud/storage/internal/lifecycle_rule_parser.cc
+++ b/google/cloud/storage/internal/lifecycle_rule_parser.cc
@@ -45,7 +45,7 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
             StatusCode::kInvalidArgument,
             "Cannot parse createdBefore value (" + date + ") as a date");
       }
-      result.condition_.created_before.emplace(std::move(day));
+      result.condition_.created_before.emplace(day);
     }
     if (condition.count("isLive") != 0) {
       auto is_live = internal::ParseBoolField(condition, "isLive");
@@ -77,7 +77,7 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
             StatusCode::kInvalidArgument,
             "Cannot parse noncurrentTimeBefore value (" + date + ") as a date");
       }
-      result.condition_.noncurrent_time_before.emplace(std::move(day));
+      result.condition_.noncurrent_time_before.emplace(day);
     }
     if (condition.count("daysSinceCustomTime") != 0) {
       auto v = internal::ParseIntField(condition, "daysSinceCustomTime");
@@ -92,7 +92,7 @@ StatusOr<LifecycleRule> LifecycleRuleParser::FromJson(
             StatusCode::kInvalidArgument,
             "Cannot parse customTimeBefore value (" + date + ") as a date");
       }
-      result.condition_.custom_time_before.emplace(std::move(day));
+      result.condition_.custom_time_before.emplace(day);
     }
   }
   return result;

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -56,7 +56,7 @@ struct ReadSourceResult {
 
   ReadSourceResult() = default;
   ReadSourceResult(std::size_t b, HttpResponse r)
-      : bytes_received(std::move(b)), response(std::move(r)) {}
+      : bytes_received(b), response(std::move(r)) {}
 };
 
 /**

--- a/google/cloud/storage/internal/object_read_streambuf.cc
+++ b/google/cloud/storage/internal/object_read_streambuf.cc
@@ -196,10 +196,10 @@ std::streamsize ObjectReadStreambuf::xsgetn(char* s, std::streamsize count) {
   for (auto const& kv : read->response.headers) {
     headers_.emplace(kv.first, kv.second);
   }
-  if (!generation_) generation_ = std::move(read->generation);
-  if (!metageneration_) metageneration_ = std::move(read->metageneration);
+  if (!generation_) generation_ = read->generation;
+  if (!metageneration_) metageneration_ = read->metageneration;
   if (!storage_class_) storage_class_ = std::move(read->storage_class);
-  if (!size_) size_ = std::move(read->size);
+  if (!size_) size_ = read->size;
   return run_validator_if_closed(Status());
 }
 

--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -166,7 +166,7 @@ void PolicyDocumentV4Request::SetOption(AddExtensionFieldOption const& o) {
     return;
   }
   extension_fields_.emplace_back(
-      std::make_pair(std::move(o.value().first), std::move(o.value().second)));
+      std::make_pair(o.value().first, o.value().second));
 }
 
 void PolicyDocumentV4Request::SetOption(PredefinedAcl const& o) {

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -144,7 +144,7 @@ RetryResumableUploadSession::UploadGenericChunk(char const* caller,
       // switch to calling ResetSession().
       last_status = std::move(result).status();
       if (!retry_policy->OnFailure(last_status)) {
-        return ReturnError(std::move(last_status), *retry_policy, __func__);
+        return ReturnError(last_status, *retry_policy, __func__);
       }
 
       auto delay = backoff_policy->OnCompletion();
@@ -217,7 +217,7 @@ StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {
     }
     last_status = std::move(result).status();
     if (!retry_policy->OnFailure(last_status)) {
-      return ReturnError(std::move(last_status), *retry_policy, __func__);
+      return ReturnError(last_status, *retry_policy, __func__);
     }
     auto delay = backoff_policy->OnCompletion();
     std::this_thread::sleep_for(delay);

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -33,7 +33,7 @@ StorageLogging::StorageLogging(std::shared_ptr<StorageStub> child,
                                TracingOptions tracing_options,
                                std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::storage::v2::Bucket> StorageLogging::GetBucket(

--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -49,7 +49,7 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
   if (config.empty() || config == "default" || config == "none") {
     // Just configure for the regular path.
     args.SetInt("grpc.channel_id", channel_id);
-    return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
+    return auth.CreateChannel(options.get<EndpointOption>(), args);
   }
   std::set<absl::string_view> settings = absl::StrSplit(config, ',');
   auto const dp = settings.count("dp") != 0 || settings.count("alts") != 0;
@@ -72,9 +72,9 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
         grpc::CompositeChannelCredentials(
             grpc::experimental::AltsCredentials(alts_opts),
             grpc::GoogleComputeEngineCredentials()),
-        std::move(args));
+        args);
   }
-  return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
+  return auth.CreateChannel(options.get<EndpointOption>(), args);
 }
 
 }  // namespace

--- a/google/cloud/storage/lifecycle_rule.cc
+++ b/google/cloud/storage/lifecycle_rule.cc
@@ -123,7 +123,7 @@ void LifecycleRule::MergeConditions(LifecycleRuleCondition& result,
       result.created_before =
           std::max(*result.created_before, *rhs.created_before);
     } else {
-      result.created_before.emplace(std::move(*rhs.created_before));
+      result.created_before.emplace(*rhs.created_before);
     }
   }
   if (rhs.is_live.has_value()) {

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -174,19 +174,19 @@ class LifecycleRule {
    */
   static LifecycleRuleCondition MaxAge(std::int32_t days) {
     LifecycleRuleCondition result;
-    result.age.emplace(std::move(days));
+    result.age.emplace(days);
     return result;
   }
 
   static LifecycleRuleCondition CreatedBefore(absl::CivilDay date) {
     LifecycleRuleCondition result;
-    result.created_before.emplace(std::move(date));
+    result.created_before.emplace(date);
     return result;
   }
 
   static LifecycleRuleCondition IsLive(bool value) {
     LifecycleRuleCondition result;
-    result.is_live.emplace(std::move(value));
+    result.is_live.emplace(value);
     return result;
   }
 
@@ -200,7 +200,7 @@ class LifecycleRule {
 
   static LifecycleRuleCondition MatchesStorageClasses(
       std::initializer_list<std::string> list) {
-    std::vector<std::string> classes(std::move(list));
+    std::vector<std::string> classes(list);
     LifecycleRuleCondition result;
     result.matches_storage_class.emplace(std::move(classes));
     return result;
@@ -246,7 +246,7 @@ class LifecycleRule {
 
   static LifecycleRuleCondition NumNewerVersions(std::int32_t days) {
     LifecycleRuleCondition result;
-    result.num_newer_versions.emplace(std::move(days));
+    result.num_newer_versions.emplace(days);
     return result;
   }
 

--- a/google/cloud/storage/policy_document.h
+++ b/google/cloud/storage/policy_document.h
@@ -153,8 +153,8 @@ struct PolicyDocumentV4 {
                    std::vector<PolicyDocumentCondition> conditions = {})
       : bucket(std::move(bucket)),
         object(std::move(object)),
-        expiration(std::move(expiration)),
-        timestamp(std::move(timestamp)),
+        expiration(expiration),
+        timestamp(timestamp),
         conditions(std::move(conditions)) {}
 
   std::string bucket;

--- a/google/cloud/storage/tests/object_compose_many_integration_test.cc
+++ b/google/cloud/storage/tests/object_compose_many_integration_test.cc
@@ -46,7 +46,7 @@ TEST_F(ObjectComposeManyIntegrationTest, ComposeMany) {
   std::vector<ComposeSourceObject> source_objs;
   std::string expected;
   for (int i = 0; i != 33; ++i) {
-    std::string const object_name = prefix + ".src-" + std::to_string(i);
+    std::string object_name = prefix + ".src-" + std::to_string(i);
     std::string content = std::to_string(i);
     expected += content;
     StatusOr<ObjectMetadata> insert_meta = client->InsertObject(

--- a/google/cloud/storagetransfer/internal/storage_transfer_logging_decorator.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_logging_decorator.cc
@@ -31,7 +31,7 @@ StorageTransferServiceLogging::StorageTransferServiceLogging(
     std::shared_ptr<StorageTransferServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::storagetransfer::v1::GoogleServiceAccount>

--- a/google/cloud/talent/internal/company_logging_decorator.cc
+++ b/google/cloud/talent/internal/company_logging_decorator.cc
@@ -31,7 +31,7 @@ CompanyServiceLogging::CompanyServiceLogging(
     std::shared_ptr<CompanyServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::talent::v4::Company>

--- a/google/cloud/talent/internal/completion_logging_decorator.cc
+++ b/google/cloud/talent/internal/completion_logging_decorator.cc
@@ -31,7 +31,7 @@ CompletionLogging::CompletionLogging(std::shared_ptr<CompletionStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::talent::v4::CompleteQueryResponse>

--- a/google/cloud/talent/internal/event_logging_decorator.cc
+++ b/google/cloud/talent/internal/event_logging_decorator.cc
@@ -31,7 +31,7 @@ EventServiceLogging::EventServiceLogging(
     std::shared_ptr<EventServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::talent::v4::ClientEvent>

--- a/google/cloud/talent/internal/job_logging_decorator.cc
+++ b/google/cloud/talent/internal/job_logging_decorator.cc
@@ -31,7 +31,7 @@ JobServiceLogging::JobServiceLogging(std::shared_ptr<JobServiceStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceLogging::CreateJob(

--- a/google/cloud/talent/internal/tenant_logging_decorator.cc
+++ b/google/cloud/talent/internal/tenant_logging_decorator.cc
@@ -31,7 +31,7 @@ TenantServiceLogging::TenantServiceLogging(
     std::shared_ptr<TenantServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceLogging::CreateTenant(

--- a/google/cloud/tasks/internal/cloud_tasks_logging_decorator.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_logging_decorator.cc
@@ -31,7 +31,7 @@ CloudTasksLogging::CloudTasksLogging(std::shared_ptr<CloudTasksStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::tasks::v2::ListQueuesResponse>

--- a/google/cloud/texttospeech/internal/text_to_speech_logging_decorator.cc
+++ b/google/cloud/texttospeech/internal/text_to_speech_logging_decorator.cc
@@ -31,7 +31,7 @@ TextToSpeechLogging::TextToSpeechLogging(
     std::shared_ptr<TextToSpeechStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>

--- a/google/cloud/tpu/internal/tpu_logging_decorator.cc
+++ b/google/cloud/tpu/internal/tpu_logging_decorator.cc
@@ -31,7 +31,7 @@ TpuLogging::TpuLogging(std::shared_ptr<TpuStub> child,
                        TracingOptions tracing_options,
                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::tpu::v1::ListNodesResponse> TpuLogging::ListNodes(

--- a/google/cloud/trace/internal/trace_logging_decorator.cc
+++ b/google/cloud/trace/internal/trace_logging_decorator.cc
@@ -31,7 +31,7 @@ TraceServiceLogging::TraceServiceLogging(
     std::shared_ptr<TraceServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 Status TraceServiceLogging::BatchWriteSpans(

--- a/google/cloud/translate/internal/translation_logging_decorator.cc
+++ b/google/cloud/translate/internal/translation_logging_decorator.cc
@@ -31,7 +31,7 @@ TranslationServiceLogging::TranslationServiceLogging(
     std::shared_ptr<TranslationServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::translation::v3::TranslateTextResponse>

--- a/google/cloud/videointelligence/internal/video_intelligence_logging_decorator.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_logging_decorator.cc
@@ -31,7 +31,7 @@ VideoIntelligenceServiceLogging::VideoIntelligenceServiceLogging(
     std::shared_ptr<VideoIntelligenceServiceStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/vision/internal/image_annotator_logging_decorator.cc
+++ b/google/cloud/vision/internal/image_annotator_logging_decorator.cc
@@ -31,7 +31,7 @@ ImageAnnotatorLogging::ImageAnnotatorLogging(
     std::shared_ptr<ImageAnnotatorStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>

--- a/google/cloud/vision/internal/product_search_logging_decorator.cc
+++ b/google/cloud/vision/internal/product_search_logging_decorator.cc
@@ -31,7 +31,7 @@ ProductSearchLogging::ProductSearchLogging(
     std::shared_ptr<ProductSearchStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::vision::v1::ProductSet>

--- a/google/cloud/vmmigration/internal/vm_migration_logging_decorator.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_logging_decorator.cc
@@ -31,7 +31,7 @@ VmMigrationLogging::VmMigrationLogging(std::shared_ptr<VmMigrationStub> child,
                                        TracingOptions tracing_options,
                                        std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::vmmigration::v1::ListSourcesResponse>

--- a/google/cloud/vpcaccess/internal/vpc_access_logging_decorator.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_logging_decorator.cc
@@ -31,7 +31,7 @@ VpcAccessServiceLogging::VpcAccessServiceLogging(
     std::shared_ptr<VpcAccessServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 future<StatusOr<google::longrunning::Operation>>

--- a/google/cloud/webrisk/internal/web_risk_logging_decorator.cc
+++ b/google/cloud/webrisk/internal/web_risk_logging_decorator.cc
@@ -31,7 +31,7 @@ WebRiskServiceLogging::WebRiskServiceLogging(
     std::shared_ptr<WebRiskServiceStub> child, TracingOptions tracing_options,
     std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_logging_decorator.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_logging_decorator.cc
@@ -31,7 +31,7 @@ WebSecurityScannerLogging::WebSecurityScannerLogging(
     std::shared_ptr<WebSecurityScannerStub> child,
     TracingOptions tracing_options, std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>

--- a/google/cloud/workflows/internal/executions_logging_decorator.cc
+++ b/google/cloud/workflows/internal/executions_logging_decorator.cc
@@ -31,7 +31,7 @@ ExecutionsLogging::ExecutionsLogging(std::shared_ptr<ExecutionsStub> child,
                                      TracingOptions tracing_options,
                                      std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::workflows::executions::v1::ListExecutionsResponse>

--- a/google/cloud/workflows/internal/workflows_logging_decorator.cc
+++ b/google/cloud/workflows/internal/workflows_logging_decorator.cc
@@ -31,7 +31,7 @@ WorkflowsLogging::WorkflowsLogging(std::shared_ptr<WorkflowsStub> child,
                                    TracingOptions tracing_options,
                                    std::set<std::string> components)
     : child_(std::move(child)),
-      tracing_options_(std::move(tracing_options)),
+      tracing_options_(tracing_options),
       components_(std::move(components)) {}
 
 StatusOr<google::cloud::workflows::v1::ListWorkflowsResponse>


### PR DESCRIPTION
This enables a handful of "remove std::move()" suggestions:
- std::move of the const variable/expression has no effect
- std::move of the trivially-copyable type has no effect
- passing result of std::move as a const& argument; no move will happen

In a few cases we remove the `const` from the variable so that the
move does have an effect (which is a performance win).  But otherwise,
eliminating all the no-op moves makes the code easier to understand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8306)
<!-- Reviewable:end -->
