### PR TITLE
test(asset): enable quickstart in CI

### DIFF
--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -135,6 +135,20 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_asset_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(asset_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(asset_quickstart
+                          PRIVATE google-cloud-cpp::experimental-asset)
+    google_cloud_cpp_add_common_options(asset_quickstart)
+    add_test(
+        NAME asset_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:asset_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(asset_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/asset/README.md
+++ b/google/cloud/asset/README.md
@@ -55,7 +55,10 @@ int main(int argc, char* argv[]) try {
   auto client = asset::AssetServiceClient(asset::MakeAssetServiceConnection());
 
   auto const project = google::cloud::Project(argv[1]);
-  for (auto a : client.ListAssets(project.FullName())) {
+  google::cloud::asset::v1::ListAssetsRequest request;
+  request.set_parent(project.FullName());
+  request.add_asset_types("storage.googleapis.com/Bucket");
+  for (auto a : client.ListAssets(request)) {
     if (!a) throw std::runtime_error(a.status().message());
     std::cout << a->DebugString() << "\n";
   }

--- a/google/cloud/asset/quickstart/quickstart.cc
+++ b/google/cloud/asset/quickstart/quickstart.cc
@@ -27,7 +27,10 @@ int main(int argc, char* argv[]) try {
   auto client = asset::AssetServiceClient(asset::MakeAssetServiceConnection());
 
   auto const project = google::cloud::Project(argv[1]);
-  for (auto a : client.ListAssets(project.FullName())) {
+  google::cloud::asset::v1::ListAssetsRequest request;
+  request.set_parent(project.FullName());
+  request.add_asset_types("storage.googleapis.com/Bucket");
+  for (auto a : client.ListAssets(request)) {
     if (!a) throw std::runtime_error(a.status().message());
     std::cout << a->DebugString() << "\n";
   }


### PR DESCRIPTION
Querying all the assets in our test project takes 2.5 minutes, and it
will only get slower. I made the quickstart a little more complicated,
but runs faster.

Part of the work for #7936

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8318)
<!-- Reviewable:end -->
