### PR TITLE
test(spanner): disable DataTypeIntegrationTest.JsonMaxNesting

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -445,7 +445,7 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 }
 
 // Verify maximum JSON nesting.
-TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
+TEST_F(DataTypeIntegrationTest, DISABLED_JsonMaxNesting) {
   // TODO(#6873): Remove this check when the emulator supports JSON.
   if (UsingEmulator()) GTEST_SKIP();
 


### PR DESCRIPTION
Apparently this is causing a request-of-death in the production
backend due to an updated nlohmann JSON library, so let's disable
it for now.