### PR TITLE
feat(common): Add converting constructors for future

### DIFF
--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/future_then_meta.h"
+#include "google/cloud/internal/utility.h"
 #include "google/cloud/version.h"
 
 namespace google {
@@ -64,8 +65,9 @@ class future final : private internal::future_base<T> {
    * Creates a future from a future whose result type is convertible to this
    * future's result type.
    */
-  template <class U,
-            typename Enable = std::enable_if<std::is_constructible<T, U>{}>>
+  // NOLINTNEXTLINE(google-explicit-constructor)
+  template <class U, typename Enable = internal::enable_if_t<
+                         std::is_constructible<T, U>::value>>
   future(future<U>&& rhs)
       : future<T>(rhs.then([](future<U> other) { return T(other.get()); })) {}
 

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -65,10 +65,9 @@ class future final : private internal::future_base<T> {
    * Creates a future from a future whose result type is convertible to this
    * future's result type.
    */
-  // NOLINTNEXTLINE(google-explicit-constructor)
   template <class U, typename Enable = internal::enable_if_t<
                          std::is_constructible<T, U>::value>>
-  future(future<U>&& rhs)
+  explicit future(future<U>&& rhs)
       : future<T>(rhs.then([](future<U> other) { return T(other.get()); })) {}
 
   /**

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -24,8 +24,8 @@
 #include "google/cloud/internal/future_fwd.h"
 #include "google/cloud/internal/future_impl.h"
 #include "google/cloud/internal/future_then_meta.h"
-#include "google/cloud/internal/utility.h"
 #include "google/cloud/version.h"
+#include "absl/meta/type_traits.h"
 
 namespace google {
 namespace cloud {
@@ -65,8 +65,8 @@ class future final : private internal::future_base<T> {
    * Creates a future from a future whose result type is convertible to this
    * future's result type.
    */
-  template <class U, typename Enable = internal::enable_if_t<
-                         std::is_constructible<T, U>::value>>
+  template <class U, typename Enable =
+                         absl::enable_if_t<std::is_constructible<T, U>::value>>
   explicit future(future<U>&& rhs)
       : future<T>(rhs.then([](future<U> other) { return T(other.get()); })) {}
 

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -61,6 +61,15 @@ class future final : private internal::future_base<T> {
   future(future<future<T>>&& rhs) noexcept(false);
 
   /**
+   * Creates a future from a future whose result type is convertible to this
+   * future's result type.
+   */
+  template <class U,
+            typename Enable = std::enable_if<std::is_constructible<T, U>{}>>
+  future(future<U>&& rhs)
+      : future<T>(rhs.then([](future<U> other) { return T(other.get()); })) {}
+
+  /**
    * Waits until the shared state becomes ready, then retrieves the value stored
    * in the shared state.
    *

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -771,6 +771,9 @@ TEST(FutureTestConvertingConstructor, ConvertFuture) {
   future<FromInt> f0{p0.get_future()};
 }
 
+static_assert(!std::is_constructible<future<FromInt>, future<int*>>{},
+              "Should not compile.");
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -771,12 +771,6 @@ TEST(FutureTestConvertingConstructor, ConvertFuture) {
   future<FromInt> f0{p0.get_future()};
 }
 
-TEST(FutureTestConvertingConstructor, ConvertFutureThen) {
-  promise<int> p0;
-  future<FromInt> f0 =
-      p0.get_future().then([](future<int> f) -> future<FromInt> { return f; });
-}
-
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -762,13 +762,19 @@ TEST(FutureTestInt, CreateInvalid) {
 }
 
 struct FromInt {
-  FromInt(int x) {}
+  explicit FromInt(int) {}
 };
 
 /// @test Verify we can create futures from convertible types.
 TEST(FutureTestConvertingConstructor, ConvertFuture) {
   promise<int> p0;
   future<FromInt> f0{p0.get_future()};
+}
+
+TEST(FutureTestConvertingConstructor, ConvertFutureThen) {
+  promise<int> p0;
+  future<FromInt> f0 =
+      p0.get_future().then([](future<int> f) -> future<FromInt> { return f; });
 }
 
 }  // namespace

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/future_generic.h"
+#include "google/cloud/future.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/expect_future_error.h"
 #include "google/cloud/testing_util/scoped_thread.h"
@@ -759,6 +759,16 @@ TEST(FutureTestInt, CreateInvalid) {
   promise<int> p0(null_promise_t{});
 
   ExpectFutureError([&] { p0.set_value(42); }, std::future_errc::no_state);
+}
+
+struct FromInt {
+  FromInt(int x) {}
+};
+
+/// @test Verify we can create futures from convertible types.
+TEST(FutureTestConvertingConstructor, ConvertFuture) {
+  promise<int> p0;
+  future<FromInt> f0{p0.get_future()};
 }
 
 }  // namespace

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -65,7 +65,7 @@ class future<void> final : private internal::future_base<void> {
    * future's result type.
    */
   template <class T>
-  future(future<T>&& rhs) : future<void>(rhs.then([](future<T>) {})) {}
+  explicit future(future<T>&& rhs) : future<void>(rhs.then([](future<T>) {})) {}
 
   /**
    * Waits until the shared state becomes ready, then retrieves the value stored

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -61,6 +61,13 @@ class future<void> final : private internal::future_base<void> {
   future(future<future<void>>&& rhs) noexcept(false);
 
   /**
+   * Creates a future from a future whose result type is convertible to this
+   * future's result type.
+   */
+  template <class T>
+  future(future<T>&& rhs) : future<void>(rhs.then([](future<T>) {})) {}
+
+  /**
    * Waits until the shared state becomes ready, then retrieves the value stored
    * in the shared state.
    *

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/future_void.h"
+#include "google/cloud/future.h"
 #include "google/cloud/testing_util/chrono_literals.h"
 #include "google/cloud/testing_util/expect_future_error.h"
 #include "google/cloud/testing_util/scoped_thread.h"
@@ -720,6 +720,12 @@ TEST(FutureTestVoid, CreateInvalid) {
   promise<void> p0(null_promise_t{});
 
   ExpectFutureError([&] { p0.set_value(); }, std::future_errc::no_state);
+}
+
+/// @test Verify we can create futures from convertible types.
+TEST(FutureTestVoid, ConvertFuture) {
+  promise<int> p0;
+  future<void> f0{p0.get_future()};
 }
 
 }  // namespace

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -89,12 +89,6 @@ using make_integer_sequence =
 template <size_t N>
 using make_index_sequence = make_integer_sequence<size_t, N>;
 
-/**
- * Backport of std::enable_if_t from c++14
- */
-template <bool Enable, typename T = void>
-using enable_if_t = typename std::enable_if<Enable, T>::type;
-
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/internal/utility.h
+++ b/google/cloud/internal/utility.h
@@ -89,6 +89,12 @@ using make_integer_sequence =
 template <size_t N>
 using make_index_sequence = make_integer_sequence<size_t, N>;
 
+/**
+ * Backport of std::enable_if_t from c++14
+ */
+template <bool Enable, typename T = void>
+using enable_if_t = typename std::enable_if<Enable, T>::type;
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud


### PR DESCRIPTION
When the value type of a future is convertible to the value type of another, this allows the futures to interconvert.

This is useful with, for example, make_ready_future, where one could return `make_ready_future(absl::nullopt)` for a return type of `future<absl::optional<Result>>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8329)
<!-- Reviewable:end -->
