### PR TITLE
impl(bigtable): table admin connection logic

### DIFF
--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ADMIN_CLIENT_H
 
+#include "google/cloud/bigtable/admin/bigtable_table_admin_connection.h"
 #include "google/cloud/bigtable/client_options.h"
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.grpc.pb.h>
@@ -87,7 +88,6 @@ class AdminClient {
   // them protected, so the mock classes can override them, and then make the
   // classes that do use them friends.
  protected:
-  friend class TableAdmin;
   template <typename Client, typename Response>
   friend class internal::AsyncLongrunningOperation;
   friend class internal::LoggingAdminClient;
@@ -291,6 +291,18 @@ class AdminClient {
                     google::longrunning::GetOperationRequest const& request,
                     grpc::CompletionQueue* cq) = 0;
   //@}
+
+ private:
+  friend class TableAdmin;
+
+  // TODO(#7530): Make this a pure virtual function, when we break the class.
+  virtual std::shared_ptr<bigtable_admin::BigtableTableAdminConnection>
+  connection() {
+    return nullptr;
+  }
+
+  // TODO(#7530): Make this a pure virtual function, when we break the class.
+  virtual CompletionQueue cq() { return {}; }
 };
 
 /// Create a new table admin client configured via @p options.

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -13,49 +13,78 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/table_admin.h"
-#include "google/cloud/bigtable/resource_names.h"
-#include "google/cloud/bigtable/testing/mock_admin_client.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_connection.h"
+#include "google/cloud/bigtable/admin/mocks/mock_bigtable_table_admin_connection.h"
+#include "google/cloud/testing_util/async_sequencer.h"
+#include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// Helper class for checking that the legacy API still functions correctly
+class TableAdminTester {
+ public:
+  static TableAdmin MakeTestTableAdmin(
+      std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> conn,
+      std::string const& kProjectId, std::string const& kInstanceId) {
+    return TableAdmin(std::move(conn), kProjectId, kInstanceId);
+  }
+
+  static std::shared_ptr<bigtable_admin::BigtableTableAdminConnection>
+  Connection(TableAdmin const& admin) {
+    return admin.connection_;
+  }
+};
+
 namespace {
 
-using ::testing::ReturnRef;
-
-using MockAdminClient = ::google::cloud::bigtable::testing::MockAdminClient;
+using MockConnection =
+    ::google::cloud::bigtable_admin_mocks::MockBigtableTableAdminConnection;
 
 auto const* const kProjectId = "the-project";
 auto const* const kInstanceId = "the-instance";
 auto const* const kInstanceName = "projects/the-project/instances/the-instance";
 
+Options TestOptions() {
+  return Options{}.set<GrpcCredentialOption>(
+      grpc::InsecureChannelCredentials());
+}
+
 class TableAdminTest : public ::testing::Test {
  protected:
-  void SetUp() override {
-    EXPECT_CALL(*client_, project()).WillRepeatedly(ReturnRef(project_id_));
-  }
-
-  std::string project_id_ = kProjectId;
-  std::shared_ptr<MockAdminClient> client_ =
-      std::make_shared<MockAdminClient>();
+  std::shared_ptr<MockConnection> connection_ =
+      std::make_shared<MockConnection>();
 };
 
 TEST_F(TableAdminTest, ResourceNames) {
-  TableAdmin tested(client_, kInstanceId);
-  EXPECT_EQ(kProjectId, tested.project());
-  EXPECT_EQ(kInstanceId, tested.instance_id());
-  EXPECT_EQ(kInstanceName, tested.instance_name());
+  auto admin = TableAdminTester::MakeTestTableAdmin(connection_, kProjectId,
+                                                    kInstanceId);
+  EXPECT_EQ(kProjectId, admin.project());
+  EXPECT_EQ(kInstanceId, admin.instance_id());
+  EXPECT_EQ(kInstanceName, admin.instance_name());
 }
 
 TEST_F(TableAdminTest, WithNewTarget) {
-  auto admin = TableAdmin(client_, kInstanceId);
+  auto admin = TableAdminTester::MakeTestTableAdmin(connection_, kProjectId,
+                                                    kInstanceId);
   auto other_admin = admin.WithNewTarget("other-project", "other-instance");
   EXPECT_EQ(other_admin.project(), "other-project");
   EXPECT_EQ(other_admin.instance_id(), "other-instance");
   EXPECT_EQ(other_admin.instance_name(),
             InstanceName("other-project", "other-instance"));
+}
+
+TEST_F(TableAdminTest, LegacyConstructorSharesConnection) {
+  auto admin_client = MakeAdminClient(kProjectId, TestOptions());
+  auto admin_1 = TableAdmin(admin_client, kInstanceId);
+  auto admin_2 = TableAdmin(admin_client, kInstanceId);
+  auto conn_1 = TableAdminTester::Connection(admin_1);
+  auto conn_2 = TableAdminTester::Connection(admin_2);
+
+  EXPECT_EQ(conn_1, conn_2);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #7530 

The analog of #8061, but for `TableAdmin`. The main differences are that:
1. `TableAdmin` requires a CQ, whereas `InstanceAdmin` did not.
2. In `InstanceAdmin`, I added a new public constructor that takes in a Connection class ([code](https://github.com/googleapis/google-cloud-cpp/blob/089d318a9d630ebab12d9736dadd59c5f99a1df0/google/cloud/bigtable/instance_admin.h#L130-L134)). I thought this was needed for cheap `InstanceAdmin` creation, with a different project id. Now we get cheap client creation via the `WithNewTarget()` methods. So making the new constructor public is unnecessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8338)
<!-- Reviewable:end -->
