### PR TITLE
cleanup(bigtable): silly test cleanup

### DIFF
--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -51,6 +51,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::An;
 using ::testing::Contains;
 using ::testing::ElementsAreArray;
+using ::testing::NotNull;
 using ::testing::Return;
 using ::testing::UnorderedElementsAreArray;
 
@@ -152,6 +153,7 @@ TEST_F(InstanceAdminTest, LegacyConstructorSharesConnection) {
   auto conn_2 = InstanceAdminTester::Connection(admin_2);
 
   EXPECT_EQ(conn_1, conn_2);
+  EXPECT_THAT(conn_1, NotNull());
 }
 
 TEST_F(InstanceAdminTest, LegacyConstructorDefaultsPolicies) {

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -258,6 +258,13 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
     return child_->BackgroundThreadsFactory();
   }
 
+  std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection()
+      override {
+    return child_->connection();
+  }
+
+  CompletionQueue cq() override { return child_->cq(); }
+
   std::shared_ptr<google::cloud::bigtable::AdminClient> child_;
   google::cloud::TracingOptions tracing_options_;
 };

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -41,6 +41,7 @@ class TableAdminTester {
 
 namespace {
 
+using ::testing::NotNull;
 using MockConnection =
     ::google::cloud::bigtable_admin_mocks::MockBigtableTableAdminConnection;
 
@@ -55,21 +56,24 @@ Options TestOptions() {
 
 class TableAdminTest : public ::testing::Test {
  protected:
+  TableAdmin DefaultTableAdmin() {
+    return TableAdminTester::MakeTestTableAdmin(connection_, kProjectId,
+                                                kInstanceId);
+  }
+
   std::shared_ptr<MockConnection> connection_ =
       std::make_shared<MockConnection>();
 };
 
 TEST_F(TableAdminTest, ResourceNames) {
-  auto admin = TableAdminTester::MakeTestTableAdmin(connection_, kProjectId,
-                                                    kInstanceId);
+  auto admin = DefaultTableAdmin();
   EXPECT_EQ(kProjectId, admin.project());
   EXPECT_EQ(kInstanceId, admin.instance_id());
   EXPECT_EQ(kInstanceName, admin.instance_name());
 }
 
 TEST_F(TableAdminTest, WithNewTarget) {
-  auto admin = TableAdminTester::MakeTestTableAdmin(connection_, kProjectId,
-                                                    kInstanceId);
+  auto admin = DefaultTableAdmin();
   auto other_admin = admin.WithNewTarget("other-project", "other-instance");
   EXPECT_EQ(other_admin.project(), "other-project");
   EXPECT_EQ(other_admin.instance_id(), "other-instance");
@@ -85,6 +89,7 @@ TEST_F(TableAdminTest, LegacyConstructorSharesConnection) {
   auto conn_2 = TableAdminTester::Connection(admin_2);
 
   EXPECT_EQ(conn_1, conn_2);
+  EXPECT_THAT(conn_1, NotNull());
 }
 
 }  // namespace


### PR DESCRIPTION
`AdminClient` is in a transition state. The base class has these non pure virtual functions: https://github.com/googleapis/google-cloud-cpp/blob/6b6de2af1a62972a1e0144e2d4d7c2448d956294/google/cloud/bigtable/admin_client.h#L298-L305

I did not realize that the `AdminClient` in certain tests was a `LoggingAdminClient`, which called the non-pure base function and returned a `nullptr` for a connection. This escaped my tests which only checked that two connections were equal.

Soon, `LoggingAdminClient` will be deleted. But for now, I will have it return the `DefaultAdminClient`s CQ and Connection, so my tests will pass in this transition state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8341)
<!-- Reviewable:end -->
