### PR TITLE
ci: run the quickstarts in their own build

### DIFF
--- a/ci/cloudbuild/builds/quickstart-production.sh
+++ b/ci/cloudbuild/builds/quickstart-production.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,8 +36,9 @@ cmake "${cmake_args[@]}" \
 cmake --build cmake-out
 mapfile -t ctest_args < <(ctest::common_args)
 env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
-cmake --install cmake-out
 
-# Tests the installed artifacts by building and running the quickstarts.
-quickstart::build_cmake_and_make "${INSTALL_PREFIX}"
-quickstart::run_cmake_and_make "${INSTALL_PREFIX}"
+# Verify the quickstart programs for generated libraries run. Note
+# that most of these run against production, and are therefore
+# integration tests with the usual flakiness issues.
+io::log_h2 "Running all other quickstart programs"
+env -C cmake-out ctest "${ctest_args[@]}" -L "quickstart"

--- a/ci/cloudbuild/triggers/quickstart-production-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: quickstart-production-ci
+substitutions:
+  _BUILD_NAME: quickstart-production
+  _DISTRO: fedora-34
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/quickstart-production-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: quickstart-production-pr
+substitutions:
+  _BUILD_NAME: quickstart-production
+  _DISTRO: fedora-34
+  _TRIGGER_TYPE: pr
+tags:
+- pr

--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -41,6 +41,7 @@ $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID="test-instance-c1"
 $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="us-west2-b"
 $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="us-west2-c"
 $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="bigtable-test-iam-sa@${env:GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+$env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_QUICKSTART_TABLE="quickstart"
 
 # Cloud Storage configuration parameters
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="cloud-cpp-testing-bucket"
@@ -55,6 +56,7 @@ $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME="projects/${env:GOOGLE_CLOUD_PROJE
 # Cloud Spanner configuration parameters
 $env:GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID="test-instance"
 $env:GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT="spanner-iam-test-sa@${env:GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+$env:GOOGLE_CLOUD_CPP_SPANNER_TEST_QUICKSTART_DATABASE="quickstart-db"
 #$env:GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT="staging-wrenchworks.sandbox.googleapis.com"
 
 # Cloud Pub/Sub configuration parameters

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -49,6 +49,7 @@ export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_CLUSTER_ID="test-instance-c1"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_A="us-west2-b"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_ZONE_B="us-west2-c"
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="bigtable-test-iam-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_QUICKSTART_TABLE="quickstart"
 
 # Cloud Storage configuration parameters
 # An existing bucket, used in small tests that do not change the bucket metadata.
@@ -71,6 +72,7 @@ export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME="${PROJECT_ROO
 # Cloud Spanner configuration parameters
 export GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID="test-instance"
 export GOOGLE_CLOUD_CPP_SPANNER_TEST_SERVICE_ACCOUNT="spanner-iam-test-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
+export GOOGLE_CLOUD_CPP_SPANNER_TEST_QUICKSTART_DATABASE="quickstart-db"
 #export GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT="staging-wrenchworks.sandbox.googleapis.com"
 
 # Cloud Pub/Sub configuration parameters

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -202,6 +202,19 @@ add_subdirectory(integration_tests)
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
+
+    add_executable(bigquery_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(bigquery_quickstart
+                          PRIVATE google-cloud-cpp::bigquery)
+    google_cloud_cpp_add_common_options(bigquery_quickstart)
+    add_test(
+        NAME bigquery_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:bigquery_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_BIGQUERY_TEST_QUICKSTART_TABLE)
+    set_tests_properties(bigquery_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -400,6 +400,20 @@ endif ()
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(examples)
+
+    add_executable(bigtable_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(bigtable_quickstart
+                          PRIVATE google-cloud-cpp::bigtable)
+    google_cloud_cpp_add_common_options(bigtable_quickstart)
+    add_test(
+        NAME bigtable_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:bigtable_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID
+            GOOGLE_CLOUD_CPP_BIGTABLE_TEST_QUICKSTART_TABLE)
+    set_tests_properties(bigtable_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Export the CMake targets to make it easy to create configuration files.

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -127,6 +127,16 @@ add_subdirectory(integration_tests)
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
+
+    add_executable(iam_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(iam_quickstart PRIVATE google-cloud-cpp::iam)
+    google_cloud_cpp_add_common_options(iam_quickstart)
+    add_test(
+        NAME iam_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:iam_quickstart> GOOGLE_CLOUD_PROJECT)
+    set_tests_properties(iam_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/iam/README.md
+++ b/google/cloud/iam/README.md
@@ -34,6 +34,7 @@ this library.
 <!-- inject-quickstart-start -->
 ```cc
 #include "google/cloud/iam/iam_client.h"
+#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
@@ -43,23 +44,19 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  std::string const project_id = argv[1];
-
   // Create a namespace alias to make the code easier to read.
   namespace iam = ::google::cloud::iam;
   iam::IAMClient client(iam::MakeIAMConnection());
-  std::cout << "Service Accounts for project: " << project_id << "\n";
+  auto const project = google::cloud::Project(argv[1]);
+  std::cout << "Service Accounts for project: " << project.project_id() << "\n";
   int count = 0;
-  for (auto const& service_account :
-       client.ListServiceAccounts("projects/" + project_id)) {
-    if (!service_account) {
-      throw std::runtime_error(service_account.status().message());
-    }
-    std::cout << service_account->name() << "\n";
+  for (auto const& sa : client.ListServiceAccounts(project.FullName())) {
+    if (!sa) throw std::runtime_error(sa.status().message());
+    std::cout << sa->name() << "\n";
     ++count;
   }
-
   if (count == 0) std::cout << "No Service Accounts found.\n";
+
   return 0;
 } catch (std::exception const& ex) {
   std::cerr << "Standard exception raised: " << ex.what() << "\n";

--- a/google/cloud/iam/quickstart/quickstart.cc
+++ b/google/cloud/iam/quickstart/quickstart.cc
@@ -14,6 +14,7 @@
 
 //! [START iam_quickstart]
 #include "google/cloud/iam/iam_client.h"
+#include "google/cloud/project.h"
 #include <iostream>
 #include <stdexcept>
 
@@ -23,23 +24,19 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  std::string const project_id = argv[1];
-
   // Create a namespace alias to make the code easier to read.
   namespace iam = ::google::cloud::iam;
   iam::IAMClient client(iam::MakeIAMConnection());
-  std::cout << "Service Accounts for project: " << project_id << "\n";
+  auto const project = google::cloud::Project(argv[1]);
+  std::cout << "Service Accounts for project: " << project.project_id() << "\n";
   int count = 0;
-  for (auto const& service_account :
-       client.ListServiceAccounts("projects/" + project_id)) {
-    if (!service_account) {
-      throw std::runtime_error(service_account.status().message());
-    }
-    std::cout << service_account->name() << "\n";
+  for (auto const& sa : client.ListServiceAccounts(project.FullName())) {
+    if (!sa) throw std::runtime_error(sa.status().message());
+    std::cout << sa->name() << "\n";
     ++count;
   }
-
   if (count == 0) std::cout << "No Service Accounts found.\n";
+
   return 0;
 } catch (std::exception const& ex) {
   std::cerr << "Standard exception raised: " << ex.what() << "\n";

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -325,6 +325,18 @@ endif (BUILD_TESTING)
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
+
+    add_executable(pubsub_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(pubsub_quickstart PRIVATE google-cloud-cpp::pubsub)
+    google_cloud_cpp_add_common_options(pubsub_quickstart)
+    add_test(
+        NAME pubsub_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:pubsub_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_PUBSUB_TEST_QUICKSTART_TOPIC)
+    set_tests_properties(pubsub_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -438,6 +438,19 @@ endif (BUILD_TESTING)
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(samples)
+
+    add_executable(spanner_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(spanner_quickstart PRIVATE google-cloud-cpp::spanner)
+    google_cloud_cpp_add_common_options(spanner_quickstart)
+    add_test(
+        NAME spanner_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:spanner_quickstart> GOOGLE_CLOUD_PROJECT
+            GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID
+            GOOGLE_CLOUD_CPP_SPANNER_TEST_QUICKSTART_DATABASE)
+    set_tests_properties(spanner_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 # Export the CMake targets to make it easy to create configuration files.

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -654,6 +654,18 @@ endif ()
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
     add_subdirectory(examples)
+
+    add_executable(storage_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(storage_quickstart PRIVATE google-cloud-cpp::storage)
+    google_cloud_cpp_add_common_options(storage_quickstart)
+    add_test(
+        NAME storage_quickstart
+        COMMAND
+            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+            $<TARGET_FILE:storage_quickstart>
+            GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME)
+    set_tests_properties(storage_quickstart
+                         PROPERTIES LABELS "integration-test;quickstart")
 endif ()
 
 install(


### PR DESCRIPTION
I was hijacking the `shared` build to run the quickstart programs. This
moves the running of those programs to their own build, and adds drivers
for any quickstarts that predate the effort to run generated
quickstarts. It seems simpler to have one mechanism to run all of them.

Part of the work for #6221

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8342)
<!-- Reviewable:end -->
