### PR TITLE
ci: use DOCKER_BUILDKIT

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -306,9 +306,7 @@ if [[ "${DOCKER_FLAG}" = "true" ]]; then
     "--build-arg=NCPU=$(nproc)"
     -f "ci/cloudbuild/dockerfiles/${DISTRO_FLAG}.Dockerfile"
   )
-  if [[ "${TRIGGER_TYPE}" == "manual" ]]; then
-    build_flags+=("--quiet")
-  fi
+  export DOCKER_BUILDKIT=1
   io::run docker build "${build_flags[@]}" ci
   io::log_h2 "Starting docker container: ${image}"
   run_flags=(


### PR DESCRIPTION
Since version 18, docker has an improved build engine called "buildkit",
that we can optionally enable by setting an environment variable.
AFAIKT, this new building engine is strictly better, and in particular
its output is much less verbose, but is still very informative about
what is happening and the progress being made. For example, the output
from a clean build of the `gcb-checkers` image is:

```
2022-02-11T15:31:02Z (+0s)
--------------------------------------------------
|   Building docker image: gcb-checkers:latest   |
--------------------------------------------------
2022-02-11T15:31:02Z (+0s): + docker build -t gcb-checkers:latest --build-arg=NCPU=96 -f ci/cloudbuild/dockerfiles/checkers.Dockerfile ci
[+] Building 214.5s (12/12) FINISHED
 => [internal] load build definition from checkers.Dockerfile                                                                            0.0s
 => => transferring dockerfile: 1.64kB                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                        0.0s
 => => transferring context: 35B                                                                                                         0.0s
 => [internal] load metadata for docker.io/library/fedora:34                                                                             0.0s
 => CACHED [1/8] FROM docker.io/library/fedora:34                                                                                        0.0s
 => [2/8] RUN dnf makecache &&     dnf install -y         cargo         clang-tools-extra         diffutils         findutils           69.7s
 => [3/8] RUN curl -L -o /usr/bin/buildifier https://github.com/bazelbuild/buildtools/releases/download/0.29.0/buildifier &&     chmod   1.1s
 => [4/8] RUN curl -L -o /usr/local/bin/shfmt https://github.com/mvdan/sh/releases/download/v3.1.0/shfmt_v3.1.0_linux_amd64 &&     chmo  1.2s
 => [5/8] RUN pip3 install --upgrade pip                                                                                                 3.2s
 => [6/8] RUN pip3 install cmake_format==0.6.8                                                                                           2.4s
 => [7/8] RUN pip3 install black==19.3b0                                                                                                 2.7s
 => [8/8] RUN cargo install typos-cli --version 1.3.9 --root /usr/local                                                                128.7s
 => exporting to image                                                                                                                   5.4s
 => => exporting layers                                                                                                                  5.4s
 => => writing image sha256:4681a3b2cb3206c0a68dadc83a9b95eec0d97971d97f4d6824de1ca5b3dd177e                                             0.0s
 => => naming to docker.io/library/gcb-checkers:latest                                                                                   0.0s

2022-02-11T15:34:37Z (+215s)

```

See also: https://docs.docker.com/develop/develop-images/build_enhancements/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8347)
<!-- Reviewable:end -->
