### PR TITLE
chore: log links are bulleted lines

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -209,8 +209,8 @@ if [[ "${LOCAL_FLAG}" = "true" ]]; then
     # link may be publicly accessible. In manual builds this information is
     # never useful (both are "none").
     io::log_h1 "Log Links"
-    printf "GCB: %s\n" "${CONSOLE_LOG_URL:-none}"
-    printf "Raw: %s\n" "${RAW_LOG_URL:-none}"
+    printf "* GCB: %s\n" "${CONSOLE_LOG_URL:-none}"
+    printf "* Raw: %s\n" "${RAW_LOG_URL:-none}"
   fi
 
   if [[ "${TRIGGER_TYPE}" != "manual" || "${VERBOSE_FLAG}" == "true" ]]; then


### PR DESCRIPTION
Outputting the links to log files with a leading asterisk will make them
paste into GH issues as two bullets, which will be a bit nicer to read.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8349)
<!-- Reviewable:end -->
