### PR TITLE
fix(spanner): add Options save/restore to PartialResultSetSource

### DIFF
--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -84,6 +84,7 @@ PartialResultSetSource::~PartialResultSetSource() {
     // If there is actual data in the streaming RPC Finish() can deadlock, so
     // before trying to read the final status we need to cancel the streaming
     // RPC.
+    internal::OptionsSpan span(options_);
     reader_->TryCancel();
     // The user didn't iterate over all the data; finish the stream on their
     // behalf, but we have no way to communicate error status.
@@ -95,6 +96,7 @@ PartialResultSetSource::~PartialResultSetSource() {
 }
 
 Status PartialResultSetSource::ReadFromStream() {
+  internal::OptionsSpan span(options_);
   auto result_set = reader_->Read();
   if (!result_set) {
     // Read() returns false for end of stream, whether we read all the data or

--- a/google/cloud/spanner/internal/partial_result_set_source.h
+++ b/google/cloud/spanner/internal/partial_result_set_source.h
@@ -19,6 +19,7 @@
 #include "google/cloud/spanner/results.h"
 #include "google/cloud/spanner/value.h"
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
@@ -60,10 +61,11 @@ class PartialResultSetSource : public ResultSourceInterface {
  private:
   explicit PartialResultSetSource(
       std::unique_ptr<PartialResultSetReader> reader)
-      : reader_(std::move(reader)) {}
+      : options_(internal::CurrentOptions()), reader_(std::move(reader)) {}
 
   Status ReadFromStream();
 
+  Options options_;
   std::unique_ptr<PartialResultSetReader> reader_;
   absl::optional<google::spanner::v1::ResultSetMetadata> metadata_;
   absl::optional<google::spanner::v1::ResultSetStats> stats_;

--- a/google/cloud/spanner/results.h
+++ b/google/cloud/spanner/results.h
@@ -29,6 +29,7 @@ namespace google {
 namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 class ResultSourceInterface {
  public:
   virtual ~ResultSourceInterface() = default;
@@ -249,6 +250,7 @@ class ProfileDmlResult {
  private:
   std::unique_ptr<spanner_internal::ResultSourceInterface> source_;
 };
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner
 }  // namespace cloud


### PR DESCRIPTION
Save the options in force during `PartialResultSetSource` construction,
and then restore them over `PartialResultSetReader` calls.  This means
that `NextRow()`, `Finish()` and `TryCancel()` will have the right
options installed during any RPCs they execute.

Tighten up the test by installing a non-matching `OptionsSpan` before
any `NextRow()` calls are made, and by expecting no `TryCancel()`s in
cases that complete their enumeration.

This is the Spanner equivalent of #8256.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8355)
<!-- Reviewable:end -->
