### PR TITLE
doc: update stale warnings for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,23 +83,22 @@ option(GOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK
 # Help our users by giving them some guidance.
 if (APPLE
     AND GOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK
-    AND NOT DEFINED ENV{OPENSSL_ROOT_DIR})
+    AND NOT DEFINED OPENSSL_ROOT_DIR)
     message(
-        FATAL_ERROR
-            [===[
-The Google Cloud C++ client libraries use the native OpenSSL library. In most
-macOS systems, you need to set the OPENSSL_ROOT_DIR environment variable to find
-this dependency, for example:
-
-export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
-
-You have not set this environment variable. Most likely, this will result in a
-broken build with fairly obscure error messages. If your environment does not
-require setting OPENSSL_ROOT_DIR, you can disable this check using:
-
-cmake -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF ...
-
-]===])
+        WARNING
+            "The Google Cloud C++ client libraries use the native OpenSSL "
+            "library. In most macOS systems, you need to set the "
+            "OPENSSL_ROOT_DIR environment variable to find this dependency, "
+            "for example:"
+            "\n"
+            "    cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl ..."
+            "\n"
+            "You have not set this variable. Most likely, this will result in "
+            "a broken build with fairly obscure error messages. If your "
+            "environment does not require setting OPENSSL_ROOT_DIR, you can "
+            "disable this check using:"
+            "\n"
+            "    cmake -DGOOGLE_CLOUD_CPP_ENABLE_MACOS_OPENSSL_CHECK=OFF ...")
 endif ()
 
 # If ccache is installed use it for the build.


### PR DESCRIPTION
We have not needed the `OPENSSL_ROOT_DIR` environment variable set for a
long time, since we stopped doing super builds of gRPC at least.

Turn the message to a `WARNING`, as ee do recommend setting the CMake
variable of the same name on Apple, because the default OpenSSL is not
functional.

Let CMake format the message because it does a better job: it uses the
terminal width to break lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8358)
<!-- Reviewable:end -->
