### PR TITLE
ci: cache test results in `integration-production`

### DIFF
--- a/ci/cloudbuild/builds/integration-production.sh
+++ b/ci/cloudbuild/builds/integration-production.sh
@@ -38,5 +38,6 @@ excluded_rules=(
 
 io::log_h2 "Running the integration tests against prod"
 mapfile -t integration_args < <(integration::bazel_args)
-bazel test "${args[@]}" "${integration_args[@]}" \
+io::run bazel test "${args[@]}" "${integration_args[@]}" \
+  --cache_test_results="auto" \
   --test_tag_filters="integration-test" -- ... "${excluded_rules[@]}"


### PR DESCRIPTION
This will reduce the noise caused by some integration tests that are
flaking too much.

Workaround for #8128

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8363)
<!-- Reviewable:end -->
