### PR TITLE
cleanup(bigtable): simplify admin client params

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -134,7 +134,7 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
                 : absl::make_optional(options.get<UserProjectOption>())),
         impl_(options) {
     auto params = bigtable_internal::AdminClientParams(std::move(options));
-    cq_ = std::move(params.cq);
+    cq_ = params.options.get<GrpcCompletionQueueOption>();
     background_threads_ = std::move(params.background_threads);
     connection_ = bigtable_admin::MakeBigtableTableAdminConnection(
         std::move(params.options));

--- a/google/cloud/bigtable/internal/admin_client_params.h
+++ b/google/cloud/bigtable/internal/admin_client_params.h
@@ -41,11 +41,12 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * Otherwise, we will create and store the background threads
  * in this class. Then we will tell the Connection to use our threads for
  * its background work.
+ *
+ * The CQ will be stored in `options` as a `GrpcCompletionQueueOption`.
  */
 struct AdminClientParams {
   explicit AdminClientParams(Options opts);
 
-  CompletionQueue cq;
   std::unique_ptr<BackgroundThreads> background_threads;
   Options options;
 };

--- a/google/cloud/bigtable/internal/admin_client_params_test.cc
+++ b/google/cloud/bigtable/internal/admin_client_params_test.cc
@@ -37,7 +37,6 @@ TEST(AdminClientParams, WithSuppliedThreads) {
 
   EXPECT_THAT(p.background_threads, IsNull());
   ASSERT_TRUE(p.options.has<GrpcCompletionQueueOption>());
-  EXPECT_TRUE(SameCQ(user_cq, p.cq));
   EXPECT_TRUE(SameCQ(user_cq, p.options.get<GrpcCompletionQueueOption>()));
 }
 
@@ -46,8 +45,8 @@ TEST(AdminClientParams, WithoutSuppliedThreads) {
 
   ASSERT_THAT(p.background_threads, NotNull());
   ASSERT_TRUE(p.options.has<GrpcCompletionQueueOption>());
-  EXPECT_TRUE(SameCQ(p.cq, p.background_threads->cq()));
-  EXPECT_TRUE(SameCQ(p.cq, p.options.get<GrpcCompletionQueueOption>()));
+  EXPECT_TRUE(SameCQ(p.background_threads->cq(),
+                     p.options.get<GrpcCompletionQueueOption>()));
 }
 
 }  // namespace


### PR DESCRIPTION
Simplify the logic a bit. It is an invariant of the struct that the `options` field will have the `GrpcCompletionQueueOption` set. (we test for this). So there is no need to have a separate `cq` field.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8366)
<!-- Reviewable:end -->
