### PR TITLE
test: enable oslogin and shell quickstarts in CI

### DIFF
--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -110,6 +110,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_oslogin_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(oslogin_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(oslogin_quickstart
+                          PRIVATE google-cloud-cpp::experimental-oslogin)
+    google_cloud_cpp_add_common_options(oslogin_quickstart)
+    add_test(
+        NAME oslogin_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:oslogin_quickstart> "invalid@example.com")
+    set_tests_properties(
+        oslogin_quickstart
+        PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
+                   "Permanent error in GetLoginProfile:")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -110,6 +110,22 @@ target_include_directories(
 target_compile_options(google_cloud_cpp_shell_mocks
                        INTERFACE ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
+include(CTest)
+if (BUILD_TESTING)
+    add_executable(shell_quickstart "quickstart/quickstart.cc")
+    target_link_libraries(shell_quickstart
+                          PRIVATE google-cloud-cpp::experimental-shell)
+    google_cloud_cpp_add_common_options(shell_quickstart)
+    add_test(
+        NAME shell_quickstart
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:shell_quickstart> "invalid@example.com")
+    set_tests_properties(
+        shell_quickstart
+        PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
+                   "Permanent error in GetEnvironment:")
+endif ()
+
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
 


### PR DESCRIPTION
I think the best we can do for these services is run them, and verify we
get some kind of error.

These services are intended for *users* to retrieve their preferences
from GCP.  They cannot be used from service accounts, and only the user
can access their preferences.  That all sounds fine. Our integration
tests authenticate with a service account (as they should), and thus
cannot retrieve their own preferences (they are not a user). Even if we
created a demo or fake user, the service accounts cannot access the
preferences for such users, and I do not think we would want to do that
anyway.

Part of the work for #7936

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8371)
<!-- Reviewable:end -->
