### PR TITLE
ci: exclude any googleapis.patch from whitespace fixing

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -122,7 +122,7 @@ time {
   expressions=("-e" "'s/[[:blank:]]\+$//'")
   # Removes trailing blank lines (see http://sed.sourceforge.net/sed1line.txt)
   expressions+=("-e" "':x;/^\n*$/{\$d;N;bx;}'")
-  git ls-files -z | grep -zv '\.gz$' |
+  git ls-files -z | grep -zv '\.gz$' | grep -zv 'googleapis.patch$' |
     (xargs -P "$(nproc)" -n 50 -0 grep -ZPL "\b[D]O NOT EDIT\b" || true) |
     xargs -P "$(nproc)" -n 50 -0 bash -c "sed_edit ${expressions[*]} \"\$0\" \"\$@\""
 }


### PR DESCRIPTION
In a preview branch we may have merged a `googleapis.patch` file
to support a new feature that uses unreleased protos.  This patch
file often has lines that contain a single space because there are
empty context lines in the diff.  We do not want to trim those
trailing spaces, so exclude `googleapis.patch` from the process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8374)
<!-- Reviewable:end -->
