### PR TITLE
cleanup: move friend tester classes into internal

### DIFF
--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -41,6 +41,11 @@
 
 namespace google {
 namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class InstanceAdminTester;
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
@@ -750,7 +755,7 @@ class InstanceAdmin {
       std::vector<std::string> const& permissions);
 
  private:
-  friend class InstanceAdminTester;
+  friend class bigtable_internal::InstanceAdminTester;
 
   //@{
   /// @name Helper functions to implement constructors with changed policies.

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -22,22 +22,26 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 // Helper class for checking that the legacy API still functions correctly
 class InstanceAdminTester {
  public:
   static std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection>
-  Connection(InstanceAdmin const& admin) {
+  Connection(bigtable::InstanceAdmin const& admin) {
     return admin.connection_;
   }
 
-  static Options Policies(InstanceAdmin const& admin) {
+  static Options Policies(bigtable::InstanceAdmin const& admin) {
     return admin.policies_;
   }
 };
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 namespace btadmin = ::google::bigtable::admin::v2;
@@ -46,6 +50,7 @@ namespace iamproto = ::google::iam::v1;
 using ::google::cloud::bigtable::testing::MockBackoffPolicy;
 using ::google::cloud::bigtable::testing::MockPollingPolicy;
 using ::google::cloud::bigtable::testing::MockRetryPolicy;
+using ::google::cloud::bigtable_internal::InstanceAdminTester;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::An;

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -41,6 +41,11 @@
 
 namespace google {
 namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class TableAdminTester;
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /// The result of checking replication against a given token.
@@ -1042,7 +1047,7 @@ class TableAdmin {
   }
 
  private:
-  friend class TableAdminTester;
+  friend class bigtable_internal::TableAdminTester;
 
   explicit TableAdmin(
       std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection,

--- a/google/cloud/bigtable/table_admin_legacy_test.cc
+++ b/google/cloud/bigtable/table_admin_legacy_test.cc
@@ -31,28 +31,30 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class TableAdminTester {
  public:
   TableAdminTester() = default;
 
-  void SetTableAdmin(std::unique_ptr<TableAdmin> table_admin) {
+  void SetTableAdmin(std::unique_ptr<bigtable::TableAdmin> table_admin) {
     table_admin_ = std::move(table_admin);
   }
 
   future<StatusOr<google::bigtable::admin::v2::Backup>> AsyncCreateBackupImpl(
-      CompletionQueue& cq, TableAdmin::CreateBackupParams const& params) {
+      CompletionQueue& cq,
+      bigtable::TableAdmin::CreateBackupParams const& params) {
     return table_admin_->AsyncCreateBackupImpl(cq, params);
   };
 
   future<StatusOr<google::bigtable::admin::v2::Table>> AsyncRestoreTableImpl(
-      CompletionQueue& cq, TableAdmin::RestoreTableParams const& params) {
+      CompletionQueue& cq,
+      bigtable::TableAdmin::RestoreTableParams const& params) {
     return table_admin_->AsyncRestoreTableImpl(cq, params);
   }
 
-  future<StatusOr<Consistency>> AsyncWaitForConsistencyImpl(
+  future<StatusOr<bigtable::Consistency>> AsyncWaitForConsistencyImpl(
       CompletionQueue& cq, std::string const& table_id,
       std::string const& consistency_token) {
     return table_admin_->AsyncWaitForConsistencyImpl(cq, table_id,
@@ -60,13 +62,19 @@ class TableAdminTester {
   }
 
  private:
-  std::unique_ptr<TableAdmin> table_admin_;
+  std::unique_ptr<bigtable::TableAdmin> table_admin_;
 };
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 namespace btadmin = ::google::bigtable::admin::v2;
 
+using ::google::cloud::bigtable_internal::TableAdminTester;
+using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
@@ -75,7 +83,6 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _h;
 using ::google::cloud::testing_util::chrono_literals::operator"" _min;
 using ::google::cloud::testing_util::chrono_literals::operator"" _s;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::Not;
 using ::testing::Return;
 using ::testing::ReturnRef;

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -24,34 +24,45 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 // Helper class for checking that the legacy API still functions correctly
 class TableAdminTester {
  public:
-  static TableAdmin MakeTestTableAdmin(
+  static bigtable::TableAdmin MakeTestTableAdmin(
       std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> conn,
       CompletionQueue cq, std::string const& kProjectId,
       std::string const& kInstanceId) {
-    return TableAdmin(std::move(conn), std::move(cq), kProjectId, kInstanceId);
+    return bigtable::TableAdmin(std::move(conn), std::move(cq), kProjectId,
+                                kInstanceId);
   }
 
   static std::shared_ptr<bigtable_admin::BigtableTableAdminConnection>
-  Connection(TableAdmin const& admin) {
+  Connection(bigtable::TableAdmin const& admin) {
     return admin.connection_;
   }
 
-  static CompletionQueue CQ(TableAdmin const& admin) { return admin.cq_; }
+  static CompletionQueue CQ(bigtable::TableAdmin const& admin) {
+    return admin.cq_;
+  }
 
-  static Options Policies(TableAdmin const& admin) { return admin.policies_; }
+  static Options Policies(bigtable::TableAdmin const& admin) {
+    return admin.policies_;
+  }
 };
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 namespace {
 
 using ::google::cloud::bigtable::testing::MockBackoffPolicy;
 using ::google::cloud::bigtable::testing::MockPollingPolicy;
 using ::google::cloud::bigtable::testing::MockRetryPolicy;
+using ::google::cloud::bigtable_internal::TableAdminTester;
 using ::google::cloud::internal::ToChronoTimePoint;
 using ::testing::An;
 using ::testing::ElementsAre;

--- a/google/cloud/spanner/query_partition.h
+++ b/google/cloud/spanner/query_partition.h
@@ -26,6 +26,7 @@ namespace google {
 namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class QueryPartitionTester;
 struct QueryPartitionInternals;
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner_internal
@@ -113,7 +114,7 @@ class QueryPartition {
   ///@}
 
  private:
-  friend class QueryPartitionTester;
+  friend class spanner_internal::QueryPartitionTester;
   friend struct spanner_internal::QueryPartitionInternals;
   friend StatusOr<std::string> SerializeQueryPartition(
       QueryPartition const& query_partition);

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -20,15 +20,17 @@
 
 namespace google {
 namespace cloud {
-namespace spanner {
+namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class QueryPartitionTester {
  public:
   QueryPartitionTester() = default;
-  explicit QueryPartitionTester(QueryPartition partition)
+  explicit QueryPartitionTester(spanner::QueryPartition partition)
       : partition_(std::move(partition)) {}
-  SqlStatement const& Statement() const { return partition_.sql_statement(); }
+  spanner::SqlStatement const& Statement() const {
+    return partition_.sql_statement();
+  }
   std::string const& PartitionToken() const {
     return partition_.partition_token();
   }
@@ -39,14 +41,19 @@ class QueryPartitionTester {
   std::string const& TransactionTag() const {
     return partition_.transaction_tag();
   }
-  QueryPartition Partition() const { return partition_; }
+  spanner::QueryPartition Partition() const { return partition_; }
 
  private:
-  QueryPartition partition_;
+  spanner::QueryPartition partition_;
 };
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner_internal
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::spanner_internal::QueryPartitionTester;
 using ::google::cloud::spanner_testing::HasSessionAndTransaction;
 using ::google::cloud::testing_util::IsOk;
 using ::testing::Not;

--- a/google/cloud/spanner/read_partition.h
+++ b/google/cloud/spanner/read_partition.h
@@ -27,6 +27,7 @@ namespace google {
 namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class ReadPartitionTester;
 struct ReadPartitionInternals;
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner_internal
@@ -116,7 +117,7 @@ class ReadPartition {
   ///@}
 
  private:
-  friend class ReadPartitionTester;
+  friend class spanner_internal::ReadPartitionTester;
   friend struct spanner_internal::ReadPartitionInternals;
   friend StatusOr<std::string> SerializeReadPartition(
       ReadPartition const& read_partition);

--- a/google/cloud/spanner/read_partition_test.cc
+++ b/google/cloud/spanner/read_partition_test.cc
@@ -20,19 +20,19 @@
 
 namespace google {
 namespace cloud {
-namespace spanner {
+namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class ReadPartitionTester {
  public:
   ReadPartitionTester() = default;
-  explicit ReadPartitionTester(ReadPartition partition)
+  explicit ReadPartitionTester(spanner::ReadPartition partition)
       : partition_(std::move(partition)) {}
   std::string PartitionToken() const { return partition_.PartitionToken(); }
   std::string SessionId() const { return partition_.SessionId(); }
   std::string TransactionId() const { return partition_.TransactionId(); }
   std::string TransactionTag() const { return partition_.TransactionTag(); }
-  ReadPartition Partition() const { return partition_; }
+  spanner::ReadPartition Partition() const { return partition_; }
   std::string TableName() const { return partition_.TableName(); }
   google::spanner::v1::KeySet KeySet() const { return partition_.KeySet(); }
   std::vector<std::string> ColumnNames() const {
@@ -43,11 +43,16 @@ class ReadPartitionTester {
   }
 
  private:
-  ReadPartition partition_;
+  spanner::ReadPartition partition_;
 };
 
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner_internal
+namespace spanner {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::spanner_internal::ReadPartitionTester;
 using ::google::cloud::spanner_testing::HasSessionAndTransaction;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;


### PR DESCRIPTION
I am not labeling this as a breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8377)
<!-- Reviewable:end -->
