### PR TITLE
impl(bigtable): hold background threads in TableAdmin

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -446,6 +446,10 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
 
   CompletionQueue cq() override { return cq_; }
 
+  std::shared_ptr<BackgroundThreads> background_threads() override {
+    return background_threads_;
+  }
+
   google::cloud::BackgroundThreadsFactory BackgroundThreadsFactory() override {
     return impl_.BackgroundThreadsFactory();
   }
@@ -459,7 +463,7 @@ class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
   absl::optional<std::string> user_project_;
   internal::CommonClient<btadmin::BigtableTableAdmin> impl_;
   CompletionQueue cq_;
-  std::unique_ptr<BackgroundThreads> background_threads_;
+  std::shared_ptr<BackgroundThreads> background_threads_;
   std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection_;
 };
 

--- a/google/cloud/bigtable/admin_client.h
+++ b/google/cloud/bigtable/admin_client.h
@@ -303,6 +303,11 @@ class AdminClient {
 
   // TODO(#7530): Make this a pure virtual function, when we break the class.
   virtual CompletionQueue cq() { return {}; }
+
+  // TODO(#7530): Make this a pure virtual function, when we break the class.
+  virtual std::shared_ptr<BackgroundThreads> background_threads() {
+    return nullptr;
+  }
 };
 
 /// Create a new table admin client configured via @p options.

--- a/google/cloud/bigtable/internal/logging_admin_client.h
+++ b/google/cloud/bigtable/internal/logging_admin_client.h
@@ -265,6 +265,10 @@ class LoggingAdminClient : public google::cloud::bigtable::AdminClient {
 
   CompletionQueue cq() override { return child_->cq(); }
 
+  std::shared_ptr<BackgroundThreads> background_threads() override {
+    return child_->background_threads();
+  }
+
   std::shared_ptr<google::cloud::bigtable::AdminClient> child_;
   google::cloud::TracingOptions tracing_options_;
 };

--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -157,7 +157,7 @@ TableAdmin::CreateBackupParams::AsProto(std::string instance_name) const {
 
 StatusOr<google::bigtable::admin::v2::Backup> TableAdmin::CreateBackup(
     CreateBackupParams const& params) {
-  auto cq = background_threads_->cq();
+  auto cq = legacy_background_threads_->cq();
   return AsyncCreateBackupImpl(cq, params).get();
 }
 
@@ -332,7 +332,7 @@ TableAdmin::RestoreTableParams::AsProto(
 
 StatusOr<google::bigtable::admin::v2::Table> TableAdmin::RestoreTable(
     RestoreTableParams const& params) {
-  auto cq = background_threads_->cq();
+  auto cq = legacy_background_threads_->cq();
   return AsyncRestoreTableImpl(cq, params).get();
 }
 
@@ -357,7 +357,7 @@ google::bigtable::admin::v2::RestoreTableRequest AsProto(
 
 StatusOr<google::bigtable::admin::v2::Table> TableAdmin::RestoreTable(
     RestoreTableFromInstanceParams params) {
-  auto cq = background_threads_->cq();
+  auto cq = legacy_background_threads_->cq();
   return AsyncRestoreTableImpl(cq, std::move(params)).get();
 }
 
@@ -421,7 +421,7 @@ Status TableAdmin::DropRowsByPrefix(std::string const& table_id,
 
 google::cloud::future<StatusOr<Consistency>> TableAdmin::WaitForConsistency(
     std::string const& table_id, std::string const& consistency_token) {
-  auto cq = background_threads_->cq();
+  auto cq = legacy_background_threads_->cq();
   return AsyncWaitForConsistencyImpl(cq, table_id, consistency_token);
 }
 

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -152,6 +152,7 @@ class TableAdmin {
       : client_(std::move(client)),
         connection_(client_->connection()),
         cq_(client_->cq()),
+        background_threads_(client_->background_threads()),
         project_id_(client_->project()),
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),
@@ -164,7 +165,7 @@ class TableAdmin {
         policies_(bigtable_internal::MakeTableAdminOptions(
             retry_prototype_, backoff_prototype_, polling_prototype_)),
         metadata_update_policy_(instance_name(), MetadataParamTypes::PARENT),
-        background_threads_(client_->BackgroundThreadsFactory()()) {}
+        legacy_background_threads_(client_->BackgroundThreadsFactory()()) {}
 
   /**
    * Create a new TableAdmin using explicit policies to handle RPC errors.
@@ -198,6 +199,7 @@ class TableAdmin {
       : client_(std::move(client)),
         connection_(client_->connection()),
         cq_(client_->cq()),
+        background_threads_(client_->background_threads()),
         project_id_(client_->project()),
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),
@@ -208,7 +210,7 @@ class TableAdmin {
         polling_prototype_(
             DefaultPollingPolicy(internal::kBigtableTableAdminLimits)),
         metadata_update_policy_(instance_name(), MetadataParamTypes::PARENT),
-        background_threads_(client_->BackgroundThreadsFactory()()) {
+        legacy_background_threads_(client_->BackgroundThreadsFactory()()) {
     ChangePolicies(std::forward<Policies>(policies)...);
     policies_ = bigtable_internal::MakeTableAdminOptions(
         retry_prototype_, backoff_prototype_, polling_prototype_);
@@ -1137,6 +1139,7 @@ class TableAdmin {
   std::shared_ptr<AdminClient> client_;
   std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection_;
   CompletionQueue cq_;
+  std::shared_ptr<BackgroundThreads> background_threads_;
   std::string project_id_;
   std::string instance_id_;
   std::string instance_name_;
@@ -1145,7 +1148,7 @@ class TableAdmin {
   std::shared_ptr<PollingPolicy> polling_prototype_;
   Options policies_;
   bigtable::MetadataUpdatePolicy metadata_update_policy_;
-  std::shared_ptr<BackgroundThreads> background_threads_;
+  std::shared_ptr<BackgroundThreads> legacy_background_threads_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #7530

This is a fix of an impl. The background threads were stored only in the `AdminClient` which will be discarded if we drop the `TableAdmin::client_` member variable.

I considered continuing to store the `AdminClient` in `TableAdmin`. Instead of copying the `AdminClient`'s connection, CQ, and threads upon construction of `TableAdmin`, we could just use an accessor for the connection and CQ when we need it.

I don't feel strongly, but I decided to store the threads instead of storing the `AdminClient` because:
1. it is consistent with `InstanceAdmin`
2. one day we might make the [Connection constructor](https://github.com/googleapis/google-cloud-cpp/blob/7135f43e0397841548fcfd6564851be65dfe608d/google/cloud/bigtable/table_admin.h#L1052-L1054) public which will have no dependence on `AdminClient`.

Note that these are internal implementation choices, so no decision has to be final.