### PR TITLE
cleanup: use operator* instead of value for OK StatusOr's

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
@@ -78,7 +78,7 @@ class InstanceAdminIntegrationTest
     auto const project_name = Project(project_id_).FullName();
     auto sor = client.ListInstances(project_name);
     if (!sor) return std::move(sor).status();
-    auto resp = std::move(sor).value();
+    auto resp = *std::move(sor);
 
     std::vector<std::string> names;
     names.reserve(resp.instances_size());
@@ -95,7 +95,7 @@ class InstanceAdminIntegrationTest
     auto const instance_name = bigtable::InstanceName(project_id_, instance_id);
     auto sor = client_.ListClusters(instance_name);
     if (!sor) return std::move(sor).status();
-    auto resp = std::move(sor).value();
+    auto resp = *std::move(sor);
 
     std::vector<std::string> names;
     names.reserve(resp.clusters_size());

--- a/google/cloud/bigtable/instance_admin.cc
+++ b/google/cloud/bigtable/instance_admin.cc
@@ -38,7 +38,7 @@ StatusOr<InstanceList> InstanceAdmin::ListInstances() {
   request.set_parent(project_name());
   auto sor = connection_->ListInstances(request);
   if (!sor) return std::move(sor).status();
-  auto response = std::move(sor).value();
+  auto response = *std::move(sor);
   auto& instances = *response.mutable_instances();
   std::move(instances.begin(), instances.end(),
             std::back_inserter(result.instances));
@@ -116,7 +116,7 @@ StatusOr<ClusterList> InstanceAdmin::ListClusters(
   request.set_parent(InstanceName(instance_id));
   auto sor = connection_->ListClusters(request);
   if (!sor) return std::move(sor).status();
-  auto response = std::move(sor).value();
+  auto response = *std::move(sor);
   auto& clusters = *response.mutable_clusters();
   std::move(clusters.begin(), clusters.end(),
             std::back_inserter(result.clusters));
@@ -177,7 +177,7 @@ StatusOr<std::vector<btadmin::AppProfile>> InstanceAdmin::ListAppProfiles(
   auto sr = connection_->ListAppProfiles(request);
   for (auto& ap : sr) {
     if (!ap) return std::move(ap).status();
-    result.emplace_back(std::move(ap).value());
+    result.emplace_back(*std::move(ap));
   }
   return result;
 }
@@ -199,7 +199,7 @@ StatusOr<google::cloud::IamPolicy> InstanceAdmin::GetIamPolicy(
   request.set_resource(InstanceName(instance_id));
   auto sor = connection_->GetIamPolicy(request);
   if (!sor) return std::move(sor).status();
-  return ProtoToWrapper(std::move(sor).value());
+  return ProtoToWrapper(*std::move(sor));
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdmin::GetNativeIamPolicy(
@@ -230,7 +230,7 @@ StatusOr<google::cloud::IamPolicy> InstanceAdmin::SetIamPolicy(
   *request.mutable_policy() = std::move(policy);
   auto sor = connection_->SetIamPolicy(request);
   if (!sor) return std::move(sor).status();
-  return ProtoToWrapper(std::move(sor).value());
+  return ProtoToWrapper(*std::move(sor));
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdmin::SetIamPolicy(
@@ -253,7 +253,7 @@ StatusOr<std::vector<std::string>> InstanceAdmin::TestIamPermissions(
   }
   auto sor = connection_->TestIamPermissions(request);
   if (!sor) return std::move(sor).status();
-  auto response = std::move(sor).value();
+  auto response = *std::move(sor);
   std::vector<std::string> result;
   auto& ps = *response.mutable_permissions();
   std::move(ps.begin(), ps.end(), std::back_inserter(result));

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3048,7 +3048,7 @@ class Client {
     if (!result) {
       return std::move(result).status();
     }
-    return std::move(result).value().items;
+    return std::move(result.value().items);
   }
 
   /**

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -209,8 +209,7 @@ LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
     return std::move(result).status();
   }
   return std::unique_ptr<ResumableUploadSession>(
-      absl::make_unique<LoggingResumableUploadSession>(
-          std::move(result).value()));
+      absl::make_unique<LoggingResumableUploadSession>(*std::move(result)));
 }
 
 StatusOr<EmptyResponse> LoggingClient::DeleteResumableUpload(

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -375,7 +375,7 @@ RetryClient::CreateResumableSession(ResumableUploadRequest const& request) {
 
   return std::unique_ptr<ResumableUploadSession>(
       absl::make_unique<RetryResumableUploadSession>(
-          std::move(result).value(), std::move(retry_policy),
+          *std::move(result), std::move(retry_policy),
           std::move(backoff_policy)));
 }
 

--- a/google/cloud/storage/list_objects_and_prefixes_reader_test.cc
+++ b/google/cloud/storage/list_objects_and_prefixes_reader_test.cc
@@ -99,7 +99,7 @@ TEST(ListObjectsAndPrefixesReaderTest, Basic) {
   std::vector<ObjectOrPrefix> actual;
   for (auto&& object : reader) {
     ASSERT_STATUS_OK(object);
-    actual.emplace_back(std::move(object).value());
+    actual.emplace_back(*std::move(object));
   }
   EXPECT_THAT(actual, ContainerEq(expected));
 }

--- a/google/cloud/storage/list_objects_reader_test.cc
+++ b/google/cloud/storage/list_objects_reader_test.cc
@@ -85,7 +85,7 @@ TEST(ListObjectsReaderTest, Basic) {
   std::vector<ObjectMetadata> actual;
   for (auto&& object : reader) {
     ASSERT_STATUS_OK(object);
-    actual.emplace_back(std::move(object).value());
+    actual.emplace_back(*std::move(object));
   }
   EXPECT_THAT(actual, ContainerEq(expected));
 }

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -640,7 +640,8 @@ StatusOr<ResumableParallelUploadState> PrepareParallelUpload(
   if (resumable_session_id.empty()) {
     return ResumableParallelUploadState::CreateNew(
         std::move(client), bucket_name, object_name, num_shards, prefix,
-        extra_state_arg ? *std::move(extra_state_arg).payload() : std::string(),
+        extra_state_arg ? (*std::move(extra_state_arg)).payload()
+                        : std::string(),
         std::move(forwarded_args));
   }
   return ResumableParallelUploadState::Resume(

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -640,8 +640,7 @@ StatusOr<ResumableParallelUploadState> PrepareParallelUpload(
   if (resumable_session_id.empty()) {
     return ResumableParallelUploadState::CreateNew(
         std::move(client), bucket_name, object_name, num_shards, prefix,
-        extra_state_arg ? std::move(extra_state_arg).value().payload()
-                        : std::string(),
+        extra_state_arg ? *std::move(extra_state_arg).payload() : std::string(),
         std::move(forwarded_args));
   }
   return ResumableParallelUploadState::Resume(

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -52,7 +52,7 @@ class ObjectWriteStreambufIntegrationTest
     ASSERT_STATUS_OK(session);
 
     ObjectWriteStream writer(absl::make_unique<ObjectWriteStreambuf>(
-        std::move(session).value(),
+        *std::move(session),
         internal::ClientImplDetails::GetRawClient(*client)
             ->client_options()
             .upload_buffer_size(),


### PR DESCRIPTION
Note that `extra_state_arg` in `storage/parallel_upload.h` is an `absl::optional<>`, not a `StatusOr<>`. I am pretty sure we still want to change it though.

The one in `storage/client.h` I made look like all the other returns, e.g.: https://github.com/googleapis/google-cloud-cpp/blob/31819a04430bca3c0d782e09695787d832144983/google/cloud/storage/client.h#L1747

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8387)
<!-- Reviewable:end -->
