### PR TITLE
cleanup(generator): remove some unnecessary includes

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -25,7 +25,6 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
-#include "google/cloud/internal/resumable_streaming_read_rpc.h"
 #include <memory>
 
 namespace google {

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -229,13 +229,7 @@ Status ConnectionGenerator::GenerateCc() {
        vars("connection_impl_header_path"), vars("option_defaults_header_path"),
        vars("stub_factory_header_path"), "google/cloud/background_threads.h",
        "google/cloud/common_options.h", "google/cloud/grpc_options.h",
-       HasPaginatedMethod() ? "google/cloud/internal/pagination_range.h" : "",
-       HasLongrunningMethod()
-           ? "google/cloud/internal/async_long_running_operation.h"
-           : "",
-       HasStreamingReadMethod()
-           ? "google/cloud/internal/resumable_streaming_read_rpc.h"
-           : ""});
+       HasPaginatedMethod() ? "google/cloud/internal/pagination_range.h" : ""});
   CcSystemIncludes({"memory"});
 
   auto result = CcOpenNamespaces();

--- a/google/cloud/accesscontextmanager/access_context_manager_connection.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/apigateway/api_gateway_connection.cc
+++ b/google/cloud/apigateway/api_gateway_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/appengine/applications_connection.cc
+++ b/google/cloud/appengine/applications_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/appengine/domain_mappings_connection.cc
+++ b/google/cloud/appengine/domain_mappings_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/appengine/instances_connection.cc
+++ b/google/cloud/appengine/instances_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/appengine/services_connection.cc
+++ b/google/cloud/appengine/services_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/appengine/versions_connection.cc
+++ b/google/cloud/appengine/versions_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/asset/asset_connection.cc
+++ b/google/cloud/asset/asset_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/assuredworkloads/assured_workloads_connection.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/automl/auto_ml_connection.cc
+++ b/google/cloud/automl/auto_ml_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/automl/prediction_connection.cc
+++ b/google/cloud/automl/prediction_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/bigquery/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/bigquery_read_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/resumable_streaming_read_rpc.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/channel/cloud_channel_connection.cc
+++ b/google/cloud/channel/cloud_channel_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/cloudbuild/cloud_build_connection.cc
+++ b/google/cloud/cloudbuild/cloud_build_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/composer/environments_connection.cc
+++ b/google/cloud/composer/environments_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/contactcenterinsights/contact_center_insights_connection.cc
+++ b/google/cloud/contactcenterinsights/contact_center_insights_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/datamigration/data_migration_connection.cc
+++ b/google/cloud/datamigration/data_migration_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/dataproc/batch_controller_connection.cc
+++ b/google/cloud/dataproc/batch_controller_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/dataproc/cluster_controller_connection.cc
+++ b/google/cloud/dataproc/cluster_controller_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/dataproc/job_controller_connection.cc
+++ b/google/cloud/dataproc/job_controller_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/dataproc/workflow_template_connection.cc
+++ b/google/cloud/dataproc/workflow_template_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/eventarc/eventarc_connection.cc
+++ b/google/cloud/eventarc/eventarc_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/filestore/cloud_filestore_manager_connection.cc
+++ b/google/cloud/filestore/cloud_filestore_manager_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/functions/cloud_functions_connection.cc
+++ b/google/cloud/functions/cloud_functions_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/gameservices/game_server_clusters_connection.cc
+++ b/google/cloud/gameservices/game_server_clusters_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/gameservices/game_server_configs_connection.cc
+++ b/google/cloud/gameservices/game_server_configs_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/gameservices/game_server_deployments_connection.cc
+++ b/google/cloud/gameservices/game_server_deployments_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/gameservices/realms_connection.cc
+++ b/google/cloud/gameservices/realms_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/gkehub/gke_hub_connection.cc
+++ b/google/cloud/gkehub/gke_hub_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/ids/ids_connection.cc
+++ b/google/cloud/ids/ids_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/managedidentities/managed_identities_connection.cc
+++ b/google/cloud/managedidentities/managed_identities_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/memcache/cloud_memcache_connection.cc
+++ b/google/cloud/memcache/cloud_memcache_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/monitoring/metrics_scopes_connection.cc
+++ b/google/cloud/monitoring/metrics_scopes_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/networkmanagement/reachability_connection.cc
+++ b/google/cloud/networkmanagement/reachability_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/notebooks/managed_notebook_connection.cc
+++ b/google/cloud/notebooks/managed_notebook_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/notebooks/notebook_connection.cc
+++ b/google/cloud/notebooks/notebook_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/osconfig/agent_endpoint_connection.cc
+++ b/google/cloud/osconfig/agent_endpoint_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/resumable_streaming_read_rpc.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/privateca/certificate_authority_connection.cc
+++ b/google/cloud/privateca/certificate_authority_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/pubsublite/admin_connection.cc
+++ b/google/cloud/pubsublite/admin_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/redis/cloud_redis_connection.cc
+++ b/google/cloud/redis/cloud_redis_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/resourcemanager/folders_connection.cc
+++ b/google/cloud/resourcemanager/folders_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/resourcemanager/projects_connection.cc
+++ b/google/cloud/resourcemanager/projects_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/retail/completion_connection.cc
+++ b/google/cloud/retail/completion_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/retail/product_connection.cc
+++ b/google/cloud/retail/product_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/retail/user_event_connection.cc
+++ b/google/cloud/retail/user_event_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/securitycenter/security_center_connection.cc
+++ b/google/cloud/securitycenter/security_center_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/servicemanagement/service_manager_connection.cc
+++ b/google/cloud/servicemanagement/service_manager_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/serviceusage/service_usage_connection.cc
+++ b/google/cloud/serviceusage/service_usage_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/shell/cloud_shell_connection.cc
+++ b/google/cloud/shell/cloud_shell_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/spanner/admin/database_admin_connection.cc
+++ b/google/cloud/spanner/admin/database_admin_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/spanner/admin/instance_admin_connection.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/speech/speech_connection.cc
+++ b/google/cloud/speech/speech_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/storagetransfer/storage_transfer_connection.cc
+++ b/google/cloud/storagetransfer/storage_transfer_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/talent/job_connection.cc
+++ b/google/cloud/talent/job_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/tpu/tpu_connection.cc
+++ b/google/cloud/tpu/tpu_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/translate/translation_connection.cc
+++ b/google/cloud/translate/translation_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/videointelligence/video_intelligence_connection.cc
+++ b/google/cloud/videointelligence/video_intelligence_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/vision/image_annotator_connection.cc
+++ b/google/cloud/vision/image_annotator_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include <memory>
 
 namespace google {

--- a/google/cloud/vision/product_search_connection.cc
+++ b/google/cloud/vision/product_search_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/vmmigration/vm_migration_connection.cc
+++ b/google/cloud/vmmigration/vm_migration_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/vpcaccess/vpc_access_connection.cc
+++ b/google/cloud/vpcaccess/vpc_access_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 

--- a/google/cloud/workflows/workflows_connection.cc
+++ b/google/cloud/workflows/workflows_connection.cc
@@ -24,7 +24,6 @@
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/internal/async_long_running_operation.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
 


### PR DESCRIPTION
The generated "connection.cc" file does not need to include
either "google/cloud/internal/async_long_running_operation.h"
or "google/cloud/internal/resumable_streaming_read_rpc.h".
These are only used in "connection_impl.cc".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8388)
<!-- Reviewable:end -->
