### PR TITLE
fix(rest): formating headers

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -348,6 +348,7 @@ std::size_t CurlImpl::HeaderCallback(char* contents, std::size_t size,
 }
 
 void CurlImpl::SetHeader(std::string const& header) {
+  if (header.empty()) return;
   auto* new_headers = curl_slist_append(request_headers_.get(), header.c_str());
   (void)request_headers_.release();
   request_headers_.reset(new_headers);

--- a/google/cloud/internal/rest_client.cc
+++ b/google/cloud/internal/rest_client.cc
@@ -23,6 +23,8 @@
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/strip.h"
 
 namespace google {
 namespace cloud {
@@ -53,6 +55,15 @@ Status MakeRequestWithPayload(
   return impl.MakeRequest(http_method, payload);
 }
 
+std::string FormatHostHeaderValue(absl::string_view hostname) {
+  if (!absl::ConsumePrefix(&hostname, "https://")) {
+    absl::ConsumePrefix(&hostname, "http://");
+  }
+  std::vector<std::string> splits =
+      absl::StrSplit(hostname, absl::MaxSplits(absl::ByChar('/'), 1));
+  return splits[0];
+}
+
 }  // namespace
 
 std::string CurlRestClient::HostHeader(Options const& options,
@@ -66,7 +77,7 @@ std::string CurlRestClient::HostHeader(Options const& options,
   // or their own proxy, and need to provide the target's service host.
   auto const& endpoint = options.get<RestEndpointOption>();
   if (absl::StrContains(endpoint, "googleapis.com"))
-    return absl::StrCat("Host: ", default_endpoint);
+    return absl::StrCat("Host: ", FormatHostHeaderValue(default_endpoint));
   return {};
 }
 

--- a/google/cloud/internal/rest_client.cc
+++ b/google/cloud/internal/rest_client.cc
@@ -23,7 +23,6 @@
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/log.h"
 #include "absl/strings/match.h"
-#include "absl/strings/str_split.h"
 #include "absl/strings/strip.h"
 
 namespace google {
@@ -59,9 +58,7 @@ std::string FormatHostHeaderValue(absl::string_view hostname) {
   if (!absl::ConsumePrefix(&hostname, "https://")) {
     absl::ConsumePrefix(&hostname, "http://");
   }
-  std::vector<std::string> splits =
-      absl::StrSplit(hostname, absl::MaxSplits(absl::ByChar('/'), 1));
-  return splits[0];
+  return std::string(hostname.substr(0, hostname.find('/')));
 }
 
 }  // namespace

--- a/google/cloud/internal/rest_client_test.cc
+++ b/google/cloud/internal/rest_client_test.cc
@@ -41,6 +41,20 @@ TEST(HostHeader, OptionSetGoogleapis) {
   EXPECT_THAT(result, Eq("Host: endpoint.googleapis.com"));
 }
 
+TEST(HostHeader, OptionSetGoogleapisMisformatted) {
+  auto result = CurlRestClient::HostHeader(
+      Options{}.set<RestEndpointOption>("private.googleapis.com"),
+      "https://endpoint.googleapis.com");
+  EXPECT_THAT(result, Eq("Host: endpoint.googleapis.com"));
+}
+
+TEST(HostHeader, OptionSetGoogleapisMisformattedAgain) {
+  auto result = CurlRestClient::HostHeader(
+      Options{}.set<RestEndpointOption>("private.googleapis.com"),
+      "https://endpoint.googleapis.com/v1/");
+  EXPECT_THAT(result, Eq("Host: endpoint.googleapis.com"));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal


### PR DESCRIPTION
Some GCP services are very particular how the Host header is formatted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8391)
<!-- Reviewable:end -->
