### PR TITLE
refactor: include examples from top-level CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -277,6 +277,11 @@ include(CTest)
 # used in the depends condition of the next option.
 include(EnableCxxExceptions)
 
+if (BUILD_TESTING)
+    # Discover and add targets for the GTest::gtest and GTest::gmock libraries.
+    include(FindGMockWithTargets)
+endif ()
+
 # The examples use exception handling to simplify the code. Therefore they
 # cannot be compiled when exceptions are disabled, and applications cannot force
 # the flag.
@@ -305,6 +310,19 @@ function (google_cloud_cpp_enable_features)
                 continue()
             endif ()
             add_subdirectory(google/cloud/${feature})
+            if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
+                AND IS_DIRECTORY
+                    "${CMAKE_SOURCE_DIR}/google/cloud/${feature}/samples")
+                add_subdirectory(google/cloud/${feature}/samples)
+            endif ()
+            # Older libraries used examples/ to host their examples. The
+            # directory name cannot be easily changed as cloud.google.com
+            # references these files explicitly.
+            if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
+                AND IS_DIRECTORY
+                    "${CMAKE_SOURCE_DIR}/google/cloud/${feature}/examples")
+                add_subdirectory(google/cloud/${feature}/examples)
+            endif ()
         endif ()
     endforeach ()
 endfunction ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -18,14 +18,8 @@
 get_filename_component(GOOGLE_CLOUD_CPP_SUBPROJECT
                        "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
 
-# C++ Exceptions are enabled by default, but allow the user to turn them off.
-include(EnableCxxExceptions)
-
 # Get the destination directories based on the GNU recommendations.
 include(GNUInstallDirs)
-
-# Discover and add targets for the GTest::gtest and GTest::gmock libraries.
-include(FindGMockWithTargets)
 
 # Pick the right MSVC runtime libraries.
 include(SelectMSVCRuntime)

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -201,8 +201,6 @@ add_subdirectory(integration_tests)
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    add_subdirectory(samples)
-
     add_executable(bigquery_quickstart "quickstart/quickstart.cc")
     target_link_libraries(bigquery_quickstart
                           PRIVATE google-cloud-cpp::bigquery)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -387,8 +387,6 @@ endif ()
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    add_subdirectory(examples)
-
     add_executable(bigtable_quickstart "quickstart/quickstart.cc")
     target_link_libraries(bigtable_quickstart
                           PRIVATE google-cloud-cpp::bigtable)

--- a/google/cloud/examples/CMakeLists.txt
+++ b/google/cloud/examples/CMakeLists.txt
@@ -23,7 +23,6 @@ target_link_libraries(gcs2cbt google-cloud-cpp::bigtable
 google_cloud_cpp_add_common_options(gcs2cbt)
 
 if (BUILD_TESTING)
-    include(FindGMockWithTargets)
     include(FindCurlWithTargets)
     include(FindgRPC)
 

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -126,8 +126,6 @@ add_subdirectory(integration_tests)
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    add_subdirectory(samples)
-
     add_executable(iam_quickstart "quickstart/quickstart.cc")
     target_link_libraries(iam_quickstart PRIVATE google-cloud-cpp::iam)
     google_cloud_cpp_add_common_options(iam_quickstart)

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -324,8 +324,6 @@ endif (BUILD_TESTING)
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    add_subdirectory(samples)
-
     add_executable(pubsub_quickstart "quickstart/quickstart.cc")
     target_link_libraries(pubsub_quickstart PRIVATE google-cloud-cpp::pubsub)
     google_cloud_cpp_add_common_options(pubsub_quickstart)

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -437,8 +437,6 @@ endif (BUILD_TESTING)
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    add_subdirectory(samples)
-
     add_executable(spanner_quickstart "quickstart/quickstart.cc")
     target_link_libraries(spanner_quickstart PRIVATE google-cloud-cpp::spanner)
     google_cloud_cpp_add_common_options(spanner_quickstart)

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -653,8 +653,6 @@ endif ()
 # Examples are enabled if possible, but package maintainers may want to disable
 # compilation to speed up their builds.
 if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES)
-    add_subdirectory(examples)
-
     add_executable(storage_quickstart "quickstart/quickstart.cc")
     target_link_libraries(storage_quickstart PRIVATE google-cloud-cpp::storage)
     google_cloud_cpp_add_common_options(storage_quickstart)


### PR DESCRIPTION
This will allow us to add examples to a generated library, without
having to modify the generated `CMakeLists.txt` file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8392)
<!-- Reviewable:end -->
