### PR TITLE
cleanup(bigtable): remove sleep from table_admin_snippets

### DIFF
--- a/google/cloud/bigtable/examples/table_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/table_admin_snippets.cc
@@ -684,23 +684,13 @@ void WaitForConsistencyCheck(
           if (!is_consistent) {
             throw std::runtime_error(is_consistent.status().message());
           }
-          if (*is_consistent == cbt::Consistency::kConsistent) {
-            std::cout << "Table is consistent with token " << *consistency_token
-                      << "\n";
-          } else {
-            std::cout
-                << "Table is not yet consistent, Please try again later with"
-                << " the same token (" << *consistency_token << ")\n";
-          }
+          std::cout << "Table is consistent with token " << *consistency_token
+                    << "\n";
         });
     fut.get();  // simplify example by blocking until operation is done.
   }
   //! [wait for consistency check]
-  (old_admin, argv.at(2));
-
-  // TODO(#7740) - remove this sleep when lifetime issues are fixed.
-  // Extend the lifetime of old_admin long enough to avoid a crash.
-  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+  (std::move(old_admin), argv.at(2));
 }
 
 void CheckConsistency(


### PR DESCRIPTION
Fixes #7740 

Technically, this issue was closed by #8383, which resolved the lifetime issues by holding the background threads in `TableAdmin`, outside the `AsyncWaitForConsistencyImpl`. But we still needed to clean up the deflaking sleep in the test.

Also, simplify the printing of the output. It is now impossible to return an OK Status, that is `kInconsistent`. We [return a polling loop exhausted error](https://github.com/googleapis/google-cloud-cpp/blob/8cbde8d0217159156c20634c46f5ef8027f3dbfc/google/cloud/bigtable/internal/wait_for_consistency.cc#L104-L105) instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8393)
<!-- Reviewable:end -->
