### PR TITLE
fix: restore Options over deletion of StreamRange<T>::reader_

### DIFF
--- a/google/cloud/internal/resumable_streaming_read_rpc_test.cc
+++ b/google/cloud/internal/resumable_streaming_read_rpc_test.cc
@@ -42,9 +42,6 @@ struct FakeResponse {
   std::string token;
 };
 
-using MockReturnType =
-    std::unique_ptr<grpc::ClientReaderInterface<FakeResponse>>;
-
 using ReadReturn = absl::variant<Status, FakeResponse>;
 
 class MockStreamingReadRpc : public StreamingReadRpc<FakeResponse> {

--- a/google/cloud/internal/streaming_read_rpc_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_test.cc
@@ -38,9 +38,6 @@ struct FakeResponse {
   std::string value;
 };
 
-using MockReturnType =
-    std::unique_ptr<grpc::ClientReaderInterface<FakeResponse>>;
-
 class MockReader : public grpc::ClientReaderInterface<FakeResponse> {
  public:
   MOCK_METHOD(bool, Read, (FakeResponse*), (override));

--- a/google/cloud/internal/streaming_write_rpc_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_test.cc
@@ -35,9 +35,6 @@ struct FakeResponse {
   std::string value;
 };
 
-using MockReturnType =
-    std::unique_ptr<grpc::ClientReaderInterface<FakeResponse>>;
-
 class MockWriter : public grpc::ClientWriterInterface<FakeRequest> {
  public:
   MOCK_METHOD(bool, Write, (FakeRequest const&, grpc::WriteOptions),

--- a/google/cloud/stream_range.h
+++ b/google/cloud/stream_range.h
@@ -154,6 +154,11 @@ class StreamRange {
    */
   StreamRange() = default;
 
+  ~StreamRange() {
+    internal::OptionsSpan span(options_);
+    reader_ = nullptr;
+  }
+
   //@{
   // @name Move-only
   StreamRange(StreamRange const&) = delete;
@@ -226,8 +231,8 @@ class StreamRange {
     Next();
   }
 
-  internal::StreamReader<T> reader_;
   Options options_ = internal::CurrentOptions();
+  internal::StreamReader<T> reader_;
   StatusOr<T> current_;
   bool current_ok_ = false;
   bool is_end_ = true;


### PR DESCRIPTION
Restore the creation-time `Options` in the `StreamRange<T>` destructor
while explicitly clearing the `reader_` functor.  If the reader has not
reached the end of the range, then deleting it may send a best-effort,
out-of-band cancel on the call, and we should restore the options when
re-entering the library.  Add a test for the destructor case.  This is
a followup to #8256.

Also take this opportunity to delete some unused type aliases I stumbled
upon during this work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8403)
<!-- Reviewable:end -->
