### PR TITLE
test(common): deflake completion queue test

### DIFF
--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -696,14 +696,13 @@ TEST_P(RunAsyncTest, TortureBursts) {
   cq.Shutdown();
   for (auto& t : tasks) t.join();
 
-  // This test is largely here to trigger (now fixed) race conditions under TSAN
-  // and/or deadlocks under load. Just getting here is enough to declare
-  // success, but we should verify that at least some interesting stuff happened
-  EXPECT_GE(impl->thread_pool_hwm(), kThreads / 2);
-  EXPECT_GE(impl->run_async_pool_hwm(), kThreads / 2);
-  EXPECT_GE(impl->notify_counter(), kBurstCount);
   // At least one of the notifications should be avoided (thus _LT and not _LE):
   EXPECT_LT(impl->notify_counter(), kBurstCount * burst_size);
+
+  // This test is largely here to trigger (now fixed) race conditions under TSAN
+  // and/or deadlocks under load. Just getting here is enough to declare
+  // success.
+  GTEST_SUCCEED();
 }
 
 INSTANTIATE_TEST_SUITE_P(RunAsyncTest, RunAsyncTest,

--- a/google/cloud/completion_queue_test.cc
+++ b/google/cloud/completion_queue_test.cc
@@ -694,15 +694,13 @@ TEST_P(RunAsyncTest, TortureBursts) {
     burst(burst_size);
   }
   cq.Shutdown();
+
+  // This test is largely here to trigger (now fixed) race conditions under TSAN
+  // and/or deadlocks under load. If the threads join the test passed.
   for (auto& t : tasks) t.join();
 
   // At least one of the notifications should be avoided (thus _LT and not _LE):
   EXPECT_LT(impl->notify_counter(), kBurstCount * burst_size);
-
-  // This test is largely here to trigger (now fixed) race conditions under TSAN
-  // and/or deadlocks under load. Just getting here is enough to declare
-  // success.
-  GTEST_SUCCEED();
 }
 
 INSTANTIATE_TEST_SUITE_P(RunAsyncTest, RunAsyncTest,


### PR DESCRIPTION
As the comment says the checks were not needed. They were probably overly optimistic and lead to flakes.

Fixes #5440 (again?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8410)
<!-- Reviewable:end -->
