### PR TITLE
fix(pubsub): restore MakeSchemaAdminConnection overload

### DIFF
--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -196,6 +196,16 @@ std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(Options opts) {
       std::move(background), std::move(stub), std::move(opts));
 }
 
+std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
+    pubsub::ConnectionOptions const& options,
+    std::unique_ptr<pubsub::RetryPolicy const> retry_policy,
+    std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy) {
+  auto opts = internal::MakeOptions(options);
+  if (retry_policy) opts.set<RetryPolicyOption>(retry_policy->clone());
+  if (backoff_policy) opts.set<BackoffPolicyOption>(backoff_policy->clone());
+  return MakeSchemaAdminConnection(std::move(opts));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub
 

--- a/google/cloud/pubsub/schema_admin_connection.h
+++ b/google/cloud/pubsub/schema_admin_connection.h
@@ -102,7 +102,8 @@ class SchemaAdminConnection {
  *     existing code that calls `MakeSchemaAdminConnection({})` from breaking,
  *     due to ambiguity.
  *
- * @deprecated Please use `MakeSchemaAdminConnection()` instead.
+ * @deprecated Please use the `MakeSchemaAdminConnection` function that accepts
+ *     `google::cloud::Options` instead.
  */
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
     std::initializer_list<internal::NonConstructible>);


### PR DESCRIPTION
I removed the implementation by accident. It looked unused, and I
thought it was in the `pubsub_internal` namespace.  Good thing I caught
this before the release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8412)
<!-- Reviewable:end -->
