### PR TITLE
feat(GCS+gRPC): implement `UpdateBucket()`

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser.cc
@@ -272,6 +272,131 @@ GrpcBucketRequestParser::ToProto(PatchBucketRequest const& request) {
   return result;
 }
 
+StatusOr<google::storage::v2::UpdateBucketRequest>
+GrpcBucketRequestParser::ToProto(UpdateBucketRequest const& request) {
+  google::storage::v2::UpdateBucketRequest result;
+
+  auto& bucket = *result.mutable_bucket();
+  auto const& metadata = request.metadata();
+  bucket.set_name("projects/_/buckets/" + metadata.name());
+
+  // We set the update_mask for all fields, even if not present in `metadata` as
+  // "not present" implies the field should be cleared.
+
+  result.mutable_update_mask()->add_paths("storage_class");
+  bucket.set_storage_class(metadata.storage_class());
+  result.mutable_update_mask()->add_paths("rpo");
+  bucket.set_rpo(metadata.rpo());
+  result.mutable_update_mask()->add_paths("acl");
+  for (auto const& a : metadata.acl()) {
+    auto& acl = *bucket.add_acl();
+    acl.set_entity(a.entity());
+    acl.set_role(a.role());
+  }
+  result.mutable_update_mask()->add_paths("default_object_acl");
+  for (auto const& a : metadata.default_acl()) {
+    auto& acl = *bucket.add_default_object_acl();
+    acl.set_entity(a.entity());
+    acl.set_role(a.role());
+  }
+  result.mutable_update_mask()->add_paths("lifecycle");
+  if (metadata.has_lifecycle()) {
+    auto& lifecycle = *bucket.mutable_lifecycle();
+    // By construction, the PatchBuilder always includes the "rule"
+    // subobject.
+    for (auto const& r : metadata.lifecycle().rule) {
+      *lifecycle.add_rule() = GrpcBucketMetadataParser::ToProto(r);
+    }
+  }
+  result.mutable_update_mask()->add_paths("cors");
+  for (auto const& c : metadata.cors()) {
+    auto& cors = *bucket.add_cors();
+    cors.set_max_age_seconds(
+        static_cast<std::int32_t>(c.max_age_seconds.value_or(0)));
+    for (auto const& o : c.origin) {
+      cors.add_origin(o);
+    }
+    for (auto const& m : c.method) {
+      cors.add_method(m);
+    }
+    for (auto const& h : c.response_header) {
+      cors.add_response_header(h);
+    }
+  }
+  result.mutable_update_mask()->add_paths("default_event_based_hold");
+  bucket.set_default_event_based_hold(metadata.default_event_based_hold());
+  result.mutable_update_mask()->add_paths("labels");
+  for (auto const& kv : metadata.labels()) {
+    (*bucket.mutable_labels())[kv.first] = kv.second;
+  }
+  result.mutable_update_mask()->add_paths("website");
+  if (metadata.has_website()) {
+    auto const& w = metadata.website();
+    bucket.mutable_website()->set_main_page_suffix(w.main_page_suffix);
+    bucket.mutable_website()->set_not_found_page(w.not_found_page);
+  }
+  result.mutable_update_mask()->add_paths("versioning");
+  if (metadata.has_versioning()) {
+    bucket.mutable_versioning()->set_enabled(metadata.versioning()->enabled);
+  }
+  result.mutable_update_mask()->add_paths("logging");
+  if (metadata.has_logging()) {
+    bucket.mutable_logging()->set_log_bucket(metadata.logging().log_bucket);
+    bucket.mutable_logging()->set_log_object_prefix(
+        metadata.logging().log_object_prefix);
+  }
+  result.mutable_update_mask()->add_paths("encryption");
+  if (metadata.has_encryption()) {
+    bucket.mutable_encryption()->set_default_kms_key(
+        metadata.encryption().default_kms_key_name);
+  }
+  result.mutable_update_mask()->add_paths("billing");
+  if (metadata.has_billing()) {
+    bucket.mutable_billing()->set_requester_pays(
+        metadata.billing().requester_pays);
+  }
+  result.mutable_update_mask()->add_paths("retention_policy");
+  if (metadata.has_retention_policy()) {
+    bucket.mutable_retention_policy()->set_retention_period(
+        metadata.retention_policy().retention_period.count());
+  }
+  result.mutable_update_mask()->add_paths("iam_config");
+  if (metadata.has_iam_configuration()) {
+    auto& iam_config = *bucket.mutable_iam_config();
+    auto const& i = metadata.iam_configuration();
+    if (i.uniform_bucket_level_access.has_value()) {
+      iam_config.mutable_uniform_bucket_level_access()->set_enabled(
+          i.uniform_bucket_level_access->enabled);
+    }
+    if (i.public_access_prevention.has_value()) {
+      auto pap = i.public_access_prevention.value();
+      iam_config.set_public_access_prevention(
+          GrpcBucketMetadataParser::ToProtoPublicAccessPrevention(pap));
+    }
+  }
+
+  if (request.HasOption<IfMetagenerationMatch>()) {
+    result.set_if_metageneration_match(
+        request.GetOption<IfMetagenerationMatch>().value());
+  }
+  if (request.HasOption<IfMetagenerationNotMatch>()) {
+    result.set_if_metageneration_not_match(
+        request.GetOption<IfMetagenerationNotMatch>().value());
+  }
+  if (request.HasOption<PredefinedAcl>()) {
+    result.set_predefined_acl(GrpcPredefinedAclParser::ToProtoBucket(
+        request.GetOption<PredefinedAcl>()));
+  }
+  if (request.HasOption<PredefinedDefaultObjectAcl>()) {
+    result.set_predefined_default_object_acl(
+        GrpcPredefinedAclParser::ToProtoObject(
+            request.GetOption<PredefinedDefaultObjectAcl>()));
+  }
+  SetCommonParameters(result, request);
+
+  return result;
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/grpc_bucket_request_parser.h
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser.h
@@ -38,6 +38,8 @@ struct GrpcBucketRequestParser {
 
   static StatusOr<google::storage::v2::UpdateBucketRequest> ToProto(
       PatchBucketRequest const& request);
+  static StatusOr<google::storage::v2::UpdateBucketRequest> ToProto(
+      UpdateBucketRequest const& request);
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
@@ -311,6 +311,155 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
   EXPECT_THAT(*actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcBucketRequestParser, UpdateBucketRequestAllOptions) {
+  google::storage::v2::UpdateBucketRequest expected;
+  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+      R"pb(
+        bucket {
+          name: "projects/_/buckets/bucket-name"
+          storage_class: "NEARLINE"
+          rpo: "ASYNC_TURBO"
+          acl { entity: "allUsers" role: "READER" }
+          default_object_acl { entity: "user:test@example.com" role: "WRITER" }
+          lifecycle {
+            rule {
+              action { type: "Delete" }
+              condition {
+                age_days: 90
+                created_before { year: 2022 month: 2 day: 2 }
+                is_live: true
+                num_newer_versions: 7
+                matches_storage_class: "STANDARD"
+                days_since_custom_time: 42
+                days_since_noncurrent_time: 84
+                noncurrent_time_before { year: 2022 month: 2 day: 15 }
+              }
+            }
+          }
+          cors {
+            origin: "test-origin-0"
+            origin: "test-origin-1"
+            method: "GET"
+            method: "PUT"
+            response_header: "test-header-0"
+            response_header: "test-header-1"
+            max_age_seconds: 1800
+          }
+          cors { origin: "test-origin-0" origin: "test-origin-1" }
+          cors { method: "GET" method: "PUT" }
+          cors {
+            response_header: "test-header-0"
+            response_header: "test-header-1"
+          }
+          cors { max_age_seconds: 1800 }
+          default_event_based_hold: true
+          labels { key: "key0" value: "value0" }
+          website { main_page_suffix: "index.html" not_found_page: "404.html" }
+          versioning { enabled: true }
+          logging {
+            log_bucket: "test-log-bucket"
+            log_object_prefix: "test-log-prefix"
+          }
+          encryption { default_kms_key: "test-only-kms-key" }
+          billing { requester_pays: true }
+          retention_policy { retention_period: 123000 }
+          iam_config {
+            uniform_bucket_level_access { enabled: true }
+            public_access_prevention: ENFORCED
+          }
+        }
+        predefined_acl: BUCKET_ACL_PROJECT_PRIVATE
+        predefined_default_object_acl: OBJECT_ACL_PROJECT_PRIVATE
+        if_metageneration_match: 3
+        if_metageneration_not_match: 4
+        common_request_params: { user_project: "test-user-project" }
+        update_mask {}
+      )pb",
+      &expected));
+
+  UpdateBucketRequest req(
+      BucketMetadata{}
+          .set_name("bucket-name")
+          .set_storage_class("NEARLINE")
+          .set_rpo(RpoAsyncTurbo())
+          .set_acl(
+              {BucketAccessControl{}.set_entity("allUsers").set_role("READER")})
+          .set_default_acl({ObjectAccessControl{}
+                                .set_entity("user:test@example.com")
+                                .set_role("WRITER")})
+          .set_lifecycle(BucketLifecycle{{LifecycleRule(
+              LifecycleRule::ConditionConjunction(
+                  LifecycleRule::MaxAge(90),
+                  LifecycleRule::CreatedBefore(absl::CivilDay(2022, 2, 2)),
+                  LifecycleRule::IsLive(true),
+                  LifecycleRule::NumNewerVersions(7),
+                  LifecycleRule::MatchesStorageClassStandard(),
+                  LifecycleRule::DaysSinceCustomTime(42),
+                  LifecycleRule::DaysSinceNoncurrentTime(84),
+                  LifecycleRule::NoncurrentTimeBefore(
+                      absl::CivilDay(2022, 2, 15))),
+              LifecycleRule::Delete())}})
+          .set_cors({
+              CorsEntry{
+                  /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
+                  /*.method=*/{"GET", "PUT"},
+                  /*.origin=*/{"test-origin-0", "test-origin-1"},
+                  /*.response_header=*/{"test-header-0", "test-header-1"}},
+              CorsEntry{/*.max_age_seconds=*/absl::nullopt,
+                        /*.method=*/{},
+                        /*.origin=*/{"test-origin-0", "test-origin-1"},
+                        /*.response_header=*/{}},
+              CorsEntry{/*.max_age_seconds=*/absl::nullopt,
+                        /*.method=*/{"GET", "PUT"},
+                        /*.origin=*/{},
+                        /*.response_header=*/{}},
+              CorsEntry{
+                  /*.max_age_seconds=*/absl::nullopt,
+                  /*.method=*/{},
+                  /*.origin=*/{},
+                  /*.response_header=*/{"test-header-0", "test-header-1"}},
+              CorsEntry{
+                  /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
+                  /*.method=*/{},
+                  /*.origin=*/{},
+                  /*.response_header=*/{}},
+          })
+          .set_default_event_based_hold(true)
+          .upsert_label("key0", "value0")
+          .set_website(BucketWebsite{"index.html", "404.html"})
+          .set_versioning(BucketVersioning{true})
+          .set_logging(BucketLogging{"test-log-bucket", "test-log-prefix"})
+          .set_encryption(
+              BucketEncryption{/*.default_kms_key=*/"test-only-kms-key"})
+          .set_billing(BucketBilling{/*.requester_pays=*/true})
+          .set_retention_policy(std::chrono::seconds(123000))
+          .set_iam_configuration(BucketIamConfiguration{
+              /*.uniform_bucket_level_access=*/UniformBucketLevelAccess{true,
+                                                                        {}},
+              /*.public_access_prevention=*/PublicAccessPreventionEnforced()}));
+  req.set_multiple_options(
+      IfMetagenerationMatch(3), IfMetagenerationNotMatch(4),
+      PredefinedAcl("projectPrivate"),
+      PredefinedDefaultObjectAcl("projectPrivate"), Projection("full"),
+      UserProject("test-user-project"), QuotaUser("test-quota-user"),
+      UserIp("test-user-ip"));
+
+  auto actual = GrpcBucketRequestParser::ToProto(req);
+  ASSERT_STATUS_OK(actual);
+  // First check the paths, we do not care about their order, so checking them
+  // with IsProtoEqual does not work.
+  EXPECT_THAT(actual->update_mask().paths(),
+              UnorderedElementsAre(
+                  "storage_class", "rpo", "acl", "default_object_acl",
+                  "lifecycle", "cors", "default_event_based_hold", "labels",
+                  "website", "versioning", "logging", "encryption", "billing",
+                  "retention_policy", "iam_config"));
+
+  // Clear the paths, which we already compared, and test the rest
+  actual->mutable_update_mask()->clear_paths();
+  EXPECT_THAT(*actual, IsProtoEqual(expected));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -186,8 +186,15 @@ StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
   return EmptyResponse{};
 }
 
-StatusOr<BucketMetadata> GrpcClient::UpdateBucket(UpdateBucketRequest const&) {
-  return Status(StatusCode::kUnimplemented, __func__);
+StatusOr<BucketMetadata> GrpcClient::UpdateBucket(
+    UpdateBucketRequest const& request) {
+  auto proto = GrpcBucketRequestParser::ToProto(request);
+  if (!proto) return std::move(proto).status();
+  grpc::ClientContext context;
+  ApplyQueryParameters(context, request);
+  auto response = stub_->UpdateBucket(context, *proto);
+  if (!response) return std::move(response).status();
+  return GrpcBucketMetadataParser::FromProto(*response);
 }
 
 StatusOr<BucketMetadata> GrpcClient::PatchBucket(

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -141,6 +141,27 @@ TEST_F(GrpcClientTest, DeleteBucket) {
   EXPECT_EQ(response.status(), PermanentError());
 }
 
+TEST_F(GrpcClientTest, UpdateBucket) {
+  auto mock = std::make_shared<testing::MockStorageStub>();
+  EXPECT_CALL(*mock, UpdateBucket)
+      .WillOnce([this](
+                    grpc::ClientContext& context,
+                    google::storage::v2::UpdateBucketRequest const& request) {
+        auto metadata = GetMetadata(context);
+        EXPECT_THAT(metadata, UnorderedElementsAre(
+                                  Pair("x-goog-quota-user", "test-quota-user"),
+                                  Pair("x-goog-fieldmask", "field1,field2")));
+        EXPECT_THAT(request.bucket().name(), "projects/_/buckets/test-bucket");
+        return PermanentError();
+      });
+  auto client = CreateTestClient(mock);
+  auto response = client->UpdateBucket(
+      UpdateBucketRequest(BucketMetadata{}.set_name("test-bucket"))
+          .set_multiple_options(Fields("field1,field2"),
+                                QuotaUser("test-quota-user")));
+  EXPECT_EQ(response.status(), PermanentError());
+}
+
 TEST_F(GrpcClientTest, PatchBucket) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, UpdateBucket)

--- a/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
@@ -34,6 +34,7 @@ using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::Not;
 using ::testing::Pair;
+using ::testing::UnorderedElementsAre;
 
 // When GOOGLE_CLOUD_CPP_HAVE_GRPC is not set these tests compile, but they
 // actually just run against the regular GCS REST API. That is fine.
@@ -78,6 +79,12 @@ TEST_F(GrpcBucketMetadataIntegrationTest, ObjectMetadataCRUD) {
       bucket_name, BucketMetadataPatchBuilder{}.SetLabel("l0", "k0"));
   ASSERT_STATUS_OK(patch);
   EXPECT_THAT(patch->labels(), ElementsAre(Pair("l0", "k0")));
+
+  auto updated = client->UpdateBucket(
+      patch->name(), BucketMetadata(*patch).upsert_label("l1", "test-value"));
+  ASSERT_STATUS_OK(updated);
+  EXPECT_THAT(updated->labels(),
+              UnorderedElementsAre(Pair("l0", "k0"), Pair("l1", "test-value")));
 
   auto delete_status = client->DeleteBucket(bucket_name);
   ASSERT_STATUS_OK(delete_status);


### PR DESCRIPTION
Since this uses the same RPC as `PatchBucket()` I just needed to
implement the `ToProto()` helper, the RPC itself was easy after that.
As usual, I also implemented the unit and integration test for this new
RPC.

Fixes #4163 