### PR TITLE
fix(oauth2): compute engine credential query

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -654,10 +654,8 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
   using HttpMethod = CurlImpl::HttpMethod;
   handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodAsChar(method));
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
-  if (options_.has<CurlFollowLocationOption>()) {
-    handle_.SetOption(CURLOPT_FOLLOWLOCATION,
-                      options_.get<CurlFollowLocationOption>() ? 1L : 0L);
-  }
+  handle_.SetOption(CURLOPT_FOLLOWLOCATION,
+                    options_.get<CurlFollowLocationOption>() ? 1L : 0L);
 
   if (method == HttpMethod::kGet) {
     handle_.SetOption(CURLOPT_NOPROGRESS, 1L);

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -654,6 +654,7 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
   using HttpMethod = CurlImpl::HttpMethod;
   handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodAsChar(method));
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
+  handle_.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
 
   if (method == HttpMethod::kGet) {
     handle_.SetOption(CURLOPT_NOPROGRESS, 1L);

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -654,7 +654,10 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
   using HttpMethod = CurlImpl::HttpMethod;
   handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodAsChar(method));
   handle_.SetOption(CURLOPT_UPLOAD, 0L);
-  handle_.SetOption(CURLOPT_FOLLOWLOCATION, 1L);
+  if (options_.has<CurlFollowLocationOption>()) {
+    handle_.SetOption(CURLOPT_FOLLOWLOCATION,
+                      options_.get<CurlFollowLocationOption>() ? 1L : 0L);
+  }
 
   if (method == HttpMethod::kGet) {
     handle_.SetOption(CURLOPT_NOPROGRESS, 1L);

--- a/google/cloud/internal/curl_options.h
+++ b/google/cloud/internal/curl_options.h
@@ -117,10 +117,18 @@ struct MaximumCurlSocketSendSizeOption {
   using Type = std::size_t;
 };
 
+/**
+ * Issue a new request to any Location header specified in a HTTP 3xx response.
+ */
+struct CurlFollowLocationOption {
+  using Type = bool;
+};
+
 using CurlOptionList = ::google::cloud::OptionList<
     ConnectionPoolSizeOption, EnableCurlSslLockingOption,
     EnableCurlSigpipeHandlerOption, MaximumCurlSocketRecvSizeOption,
-    MaximumCurlSocketSendSizeOption, CAPathOption, HttpVersionOption>;
+    MaximumCurlSocketSendSizeOption, CAPathOption, HttpVersionOption,
+    CurlFollowLocationOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/internal/oauth2_compute_engine_credentials.h"
 #include "google/cloud/internal/compute_engine_util.h"
+#include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/oauth2_credential_constants.h"
 #include "google/cloud/internal/oauth2_credentials.h"
@@ -91,6 +92,7 @@ ComputeEngineCredentials::ComputeEngineCredentials(
       service_account_email_(std::move(service_account_email)),
       options_(std::move(options)) {
   if (!rest_client_) {
+    options_.set<rest_internal::CurlFollowLocationOption>(true);
     rest_client_ = rest_internal::GetDefaultRestClient(
         "http://" + google::cloud::internal::GceMetadataHostname(), options_);
   }

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -127,14 +127,13 @@ ComputeEngineCredentials::DoMetadataServerGetRequest(std::string const& path,
   request.SetPath(path);
   request.AddHeader("metadata-flavor", "Google");
   if (recursive) request.AddQueryParameter("recursive", "true");
-  return rest_client_->Post(request,
-                            std::vector<std::pair<std::string, std::string>>{});
+  return rest_client_->Get(request);
 }
 
 Status ComputeEngineCredentials::RetrieveServiceAccountInfo() const {
   auto response = DoMetadataServerGetRequest(
-      "/computeMetadata/v1/instance/service-accounts/" +
-          service_account_email_ + "/",
+      "computeMetadata/v1/instance/service-accounts/" + service_account_email_ +
+          "/",
       true);
   if (!response) {
     return std::move(response).status();
@@ -160,8 +159,8 @@ ComputeEngineCredentials::Refresh() const {
   }
 
   auto response = DoMetadataServerGetRequest(
-      "/computeMetadata/v1/instance/service-accounts/" +
-          service_account_email_ + "/token",
+      "computeMetadata/v1/instance/service-accounts/" + service_account_email_ +
+          "/token",
       false);
   if (!response) {
     return std::move(response).status();

--- a/google/cloud/internal/oauth2_google_credentials_test.cc
+++ b/google/cloud/internal/oauth2_google_credentials_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/oauth2_google_credentials.h"
+#include "google/cloud/internal/compute_engine_util.h"
 #include "google/cloud/internal/filesystem.h"
 #include "google/cloud/internal/oauth2_anonymous_credentials.h"
 #include "google/cloud/internal/oauth2_authorized_user_credentials.h"
@@ -281,6 +282,8 @@ TEST_F(GoogleCredentialsTest, MissingCredentialsViaGcloudFilePath) {
   // eventually finding no valid credentials and hitting a runtime error.
   ScopedEnvironment gcloud_path_override_env_var(GoogleGcloudAdcFileEnvVar(),
                                                  filename);
+  ScopedEnvironment gcloud_metadata_host_override_env_var(
+      internal::GceMetadataHostnameEnvVar(), "nowhere.com");
 
   auto creds = GoogleDefaultCredentials();
   EXPECT_THAT(creds, StatusIs(Not(StatusCode::kOk),


### PR DESCRIPTION
Querying the gce metadata needs to be a GET instead of a POST and must be able to follow redirects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8421)
<!-- Reviewable:end -->
