### PR TITLE
fix(bigtable): ReadRows retries from the `last_scanned_row_key`

### DIFF
--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -374,6 +374,9 @@ class AsyncRowReader : public std::enable_shared_from_this<
         return parser_status;
       }
     }
+    if (!response.last_scanned_row_key().empty()) {
+      last_read_row_key_ = std::move(*response.mutable_last_scanned_row_key());
+    }
     return Status();
   }
 

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -140,6 +140,9 @@ bool RowReader::NextChunk() {
       response_ = {};
       return false;
     }
+    if (!response_.last_scanned_row_key().empty()) {
+      last_read_row_key_ = std::move(*response_.mutable_last_scanned_row_key());
+    }
   }
   return true;
 }


### PR DESCRIPTION
Fixes #8321 

Thank you to @liujiongxin for the report and the fix!

The bigtable tests are old and use things like `FakeCompletionQueueImpl` instead of the newer `MockCompletionQueueImpl`. I am not going to modernize the tests right now.

Both tests borrow heavily from the basic retry tests (immediately above them) in the test fixtures. They just add one more `Read()` that returns an empty chunk with the `last_scanned_row_key` set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8423)
<!-- Reviewable:end -->
