### PR TITLE
refactor(bigtable): simplify AdminClient

### DIFF
--- a/google/cloud/bigtable/admin_client.cc
+++ b/google/cloud/bigtable/admin_client.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/admin_client.h"
-#include "google/cloud/bigtable/internal/admin_client_params.h"
 #include "google/cloud/bigtable/internal/defaults.h"
 
 namespace google {
@@ -21,46 +20,12 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace {
-
-class DefaultAdminClient : public google::cloud::bigtable::AdminClient {
- public:
-  DefaultAdminClient(std::string project,
-                     bigtable_internal::AdminClientParams params)
-      : project_(std::move(project)),
-        cq_(params.options.get<GrpcCompletionQueueOption>()),
-        background_threads_(std::move(params.background_threads)),
-        connection_(bigtable_admin::MakeBigtableTableAdminConnection(
-            std::move(params.options))) {}
-
-  std::string const& project() const override { return project_; }
-
- private:
-  std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection()
-      override {
-    return connection_;
-  }
-
-  CompletionQueue cq() override { return cq_; }
-
-  std::shared_ptr<BackgroundThreads> background_threads() override {
-    return background_threads_;
-  }
-
-  std::string project_;
-  CompletionQueue cq_;
-  std::shared_ptr<BackgroundThreads> background_threads_;
-  std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection_;
-};
-
-}  // namespace
-
 std::shared_ptr<AdminClient> MakeAdminClient(std::string project,
                                              Options options) {
   auto params = bigtable_internal::AdminClientParams(
       internal::DefaultTableAdminOptions(std::move(options)));
-  return std::make_shared<DefaultAdminClient>(std::move(project),
-                                              std::move(params));
+  return std::shared_ptr<AdminClient>(
+      new AdminClient(std::move(project), std::move(params)));
 }
 
 std::shared_ptr<AdminClient> CreateDefaultAdminClient(std::string project,

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -150,9 +150,9 @@ class TableAdmin {
    */
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id)
-      : connection_(client->connection()),
-        cq_(client->cq()),
-        background_threads_(client->background_threads()),
+      : connection_(client->connection_),
+        cq_(client->cq_),
+        background_threads_(client->background_threads_),
         project_id_(client->project()),
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),
@@ -195,9 +195,9 @@ class TableAdmin {
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   TableAdmin(std::shared_ptr<AdminClient> client, std::string instance_id,
              Policies&&... policies)
-      : connection_(client->connection()),
-        cq_(client->cq()),
-        background_threads_(client->background_threads()),
+      : connection_(client->connection_),
+        cq_(client->cq_),
+        background_threads_(client->background_threads_),
         project_id_(client->project()),
         instance_id_(std::move(instance_id)),
         instance_name_(InstanceName()),


### PR DESCRIPTION
Part of the work for #8419 

This makes the intent of the API much clearer. The class is no longer meant to be extended. But any code using the factory functions will continue to work.

I removed pure virtual functions but I am not calling this a breaking change, because it has not been released yet. The `InstanceAdminClient` version of this is a different story.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8424)
<!-- Reviewable:end -->
