### PR TITLE
doc(storage): improve `{Bucket,Object}Metadata` docs

### DIFF
--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -530,26 +530,26 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   // Please keep these in alphabetical order, that make it easier to verify we
   // have actually implemented all of them.
-  //@{
   /**
    * @name Get and set Bucket Access Control Lists.
    *
    * @see https://cloud.google.com/storage/docs/access-control/lists
    */
+  ///@{
   std::vector<BucketAccessControl> const& acl() const { return acl_; }
   std::vector<BucketAccessControl>& mutable_acl() { return acl_; }
   BucketMetadata& set_acl(std::vector<BucketAccessControl> acl) {
     acl_ = std::move(acl);
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
   /**
    * @name Get and set billing configuration for the Bucket.
    *
    * @see https://cloud.google.com/storage/docs/requester-pays
    */
+  ///@{
   bool has_billing() const { return billing_.has_value(); }
   BucketBilling const& billing() const { return *billing_; }
   absl::optional<BucketBilling> const& billing_as_optional() const {
@@ -563,9 +563,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     billing_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
   /**
    * @name Get and set the default event based hold for the Bucket.
    *
@@ -583,14 +582,14 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    * @see https://cloud.google.com/storage/docs/holding-objects for examples
    *    of using default event-based hold policy.
    */
+  ///@{
   bool default_event_based_hold() const { return default_event_based_hold_; }
   BucketMetadata& set_default_event_based_hold(bool v) {
     default_event_based_hold_ = v;
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
   /**
    * @name Get and set CORS configuration for the Bucket.
    *
@@ -603,15 +602,15 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    * @see https://cloud.google.com/storage/docs/configuring-cors for information
    *     on how to set and troubleshoot CORS settings.
    */
+  ///@{
   std::vector<CorsEntry> const& cors() const { return cors_; }
   std::vector<CorsEntry>& mutable_cors() { return cors_; }
   BucketMetadata& set_cors(std::vector<CorsEntry> cors) {
     cors_ = std::move(cors);
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
   /**
    * @name Get and set the Default Object Access Control Lists.
    *
@@ -622,6 +621,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    * https://cloud.google.com/storage/docs/access-control/create-manage-lists#defaultobjects
    *     for information on how to set the default ACLs.
    */
+  ///@{
   std::vector<ObjectAccessControl> const& default_acl() const {
     return default_acl_;
   }
@@ -632,9 +632,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     default_acl_ = std::move(acl);
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
   /**
    * @name Get and set the Default Object Access Control Lists.
    *
@@ -645,6 +644,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    * https://cloud.google.com/storage/docs/encryption/customer-managed-keys
    *     for information on Customer-Managed Encryption Keys.
    */
+  ///@{
   bool has_encryption() const { return encryption_.has_value(); }
   BucketEncryption const& encryption() const { return *encryption_; }
   absl::optional<BucketEncryption> const& encryption_as_optional() const {
@@ -658,11 +658,10 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     encryption_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
   using CommonMetadata::etag;
 
-  //@{
   /**
    * @name Get and set the IAM configuration.
    *
@@ -675,6 +674,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    * [ubla-should-link]:
    * https://cloud.google.com/storage/docs/uniform-bucket-level-access#should-you-use
    */
+  ///@{
   bool has_iam_configuration() const { return iam_configuration_.has_value(); }
   BucketIamConfiguration const& iam_configuration() const {
     return *iam_configuration_;
@@ -691,19 +691,28 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     iam_configuration_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
   using CommonMetadata::id;
   using CommonMetadata::kind;
 
-  //@{
   /// @name Accessors and modifiers to the `labels`.
+  ///@{
+
+  /// Returns `true` if the key is present in the Bucket's metadata labels.
   bool has_label(std::string const& key) const {
     return labels_.end() != labels_.find(key);
   }
+
+  /**
+   * Returns the value of @p key in the Bucket's metadata labels.
+   *
+   * It is undefined behavior to call `label(key)` if `has_label(key) == false`.
+   */
   std::string const& label(std::string const& key) const {
     return labels_.at(key);
   }
+
   /// Delete a label. This is a no-op if the key does not exist.
   BucketMetadata& delete_label(std::string const& key) {
     auto i = labels_.find(key);
@@ -725,17 +734,20 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return *this;
   }
 
+  /// Returns all the Bucket's labels.
   std::map<std::string, std::string> const& labels() const { return labels_; }
-  std::map<std::string, std::string>& mutable_labels() { return labels_; }
-  //@}
 
-  //@{
+  /// Returns all the Bucket's labels.
+  std::map<std::string, std::string>& mutable_labels() { return labels_; }
+  ///@}
+
   /**
    * @name Accessors and modifiers for object lifecycle rules.
    *
    * @see https://cloud.google.com/storage/docs/managing-lifecycles for general
    *     information on object lifecycle rules.
    */
+  ///@{
   bool has_lifecycle() const { return lifecycle_.has_value(); }
   BucketLifecycle const& lifecycle() const { return *lifecycle_; }
   absl::optional<BucketLifecycle> const& lifecycle_as_optional() const {
@@ -749,7 +761,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     lifecycle_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
   std::string const& location() const { return location_; }
   BucketMetadata& set_location(std::string v) {
@@ -759,8 +771,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   std::string const& location_type() const { return location_type_; }
 
-  //@{
   /// @name Accessors and modifiers for logging configuration.
+  ///@{
   bool has_logging() const { return logging_.has_value(); }
   BucketLogging const& logging() const { return *logging_; }
   absl::optional<BucketLogging> const& logging_as_optional() const {
@@ -774,15 +786,27 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     logging_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
+  /// The bucket metageneration.
   using CommonMetadata::metageneration;
+
+  /// The bucket name.
   using CommonMetadata::name;
+
+  /**
+   * Changes the name.
+   *
+   * @note Bucket names can only be set during bucket creation. This modifier
+   *   is used to set the name when using a `BucketMetadata` object that changes
+   *   some other attribute.
+   */
   BucketMetadata& set_name(std::string v) {
     CommonMetadata::set_name(std::move(v));
     return *this;
   }
 
+  /// Returns true if the bucket `owner` attribute is present.
   using CommonMetadata::has_owner;
   using CommonMetadata::owner;
 
@@ -790,8 +814,8 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   using CommonMetadata::self_link;
 
-  //@{
   /// @name Accessors and modifiers for retention policy configuration.
+  ///@{
   bool has_retention_policy() const { return retention_policy_.has_value(); }
   BucketRetentionPolicy const& retention_policy() const {
     return *retention_policy_;
@@ -821,30 +845,34 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     retention_policy_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
-  /**
-   * @name Accessors and modifiers for the Recovery Point Objective.
-   */
+  /// @name Accessors and modifiers for the Recovery Point Objective.
+  ///@{
   std::string const& rpo() const { return rpo_; }
   BucketMetadata& set_rpo(std::string v) {
     rpo_ = std::move(v);
     return *this;
   }
-  //@}
+  ///@}
 
+  /// @name Access and modify the default storage class attribute.
+  ///@{
   using CommonMetadata::storage_class;
   BucketMetadata& set_storage_class(std::string v) {
     CommonMetadata::set_storage_class(std::move(v));
     return *this;
   }
+  ///@}
 
+  /// Returns the bucket creation timestamp.
   using CommonMetadata::time_created;
+
+  /// Returns the timestamp for the last bucket metadata update.
   using CommonMetadata::updated;
 
-  //@{
   /// @name Accessors and modifiers for versioning configuration.
+  ///@{
   absl::optional<BucketVersioning> const& versioning() const {
     return versioning_;
   }
@@ -865,10 +893,10 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     versioning_ = std::move(v);
     return *this;
   }
-  //@}
+  ///@}
 
-  //@{
   /// @name Accessors and modifiers for website configuration.
+  ///@{
   bool has_website() const { return website_.has_value(); }
   BucketWebsite const& website() const { return *website_; }
   absl::optional<BucketWebsite> const& website_as_optional() const {
@@ -882,7 +910,7 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     website_.reset();
     return *this;
   }
-  //@}
+  ///@}
 
   friend bool operator==(BucketMetadata const& lhs, BucketMetadata const& rhs);
   friend bool operator!=(BucketMetadata const& lhs, BucketMetadata const& rhs) {

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -88,6 +88,13 @@ inline bool operator>=(CustomerEncryption const& lhs,
 
 /**
  * Represents the metadata for a Google Cloud Storage Object.
+ *
+ * Note that all modifiers just change the local representation of the Object's
+ * metadata.  Applications should use `Client::PatchObject()`, or a similar
+ * operation, to actually modify the metadata stored by GCS.
+ *
+ * @see https://cloud.google.com/storage/docs/json_api/v1/objects for a more
+ *     detailed description of each attribute and their effects.
  */
 class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
  public:
@@ -95,78 +102,149 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
 
   // Please keep these in alphabetical order, that make it easier to verify we
   // have actually implemented all of them.
+
+  /// The access control list for this object.
   std::vector<ObjectAccessControl> const& acl() const { return acl_; }
+
+  /// The access control list for this object.
   std::vector<ObjectAccessControl>& mutable_acl() { return acl_; }
+
+  /// Change the access control list.
   ObjectMetadata& set_acl(std::vector<ObjectAccessControl> acl) {
     acl_ = std::move(acl);
     return *this;
   }
 
+  /// The name of the bucket containing this object.
   std::string const& bucket() const { return bucket_; }
 
+  /// The cacheControl attribute.
   std::string const& cache_control() const { return cache_control_; }
+
+  /// Set the cacheControl attributes.
   ObjectMetadata& set_cache_control(std::string cache_control) {
     cache_control_ = std::move(cache_control);
     return *this;
   }
 
+  /// The number of components, for objects built using `ComposeObject()`.
   std::int32_t component_count() const { return component_count_; }
 
+  /// The `contentDisposition` attribute.
   std::string content_disposition() const { return content_disposition_; }
+
+  /// Change the `contentDisposition` attribute.
   ObjectMetadata& set_content_disposition(std::string value) {
     content_disposition_ = std::move(value);
     return *this;
   }
 
+  /// The `contentEncoding` attribute.
   std::string content_encoding() const { return content_encoding_; }
+
+  /// Change the `contentEncoding` attribute.
   ObjectMetadata& set_content_encoding(std::string value) {
     content_encoding_ = std::move(value);
     return *this;
   }
 
+  /// The `contentLanguage` attribute.
   std::string content_language() const { return content_language_; }
+
+  /// Change the `contentLanguage` attribute.
   ObjectMetadata& set_content_language(std::string value) {
     content_language_ = std::move(value);
     return *this;
   }
 
+  /// The `contentType` attribute.
   std::string content_type() const { return content_type_; }
+
+  /// Change the `contentLanguage` attribute.
   ObjectMetadata& set_content_type(std::string value) {
     content_type_ = std::move(value);
     return *this;
   }
 
+  /// The `CRC32C` checksum for the object contents.
   std::string const& crc32c() const { return crc32c_; }
 
+  /// Returns `true` if the object uses CSEK (Customer-Supplied Encryption
+  /// Keys).
   bool has_customer_encryption() const {
     return customer_encryption_.has_value();
   }
+
+  /**
+   * Returns the CSEK metadata (algorithm and key SHA256).
+   *
+   * It is undefined behavior to call this member function if
+   * `has_customer_encryption() == false`.
+   */
   CustomerEncryption const& customer_encryption() const {
     return customer_encryption_.value();
   }
 
+  /// The `Etag` attribute.
   using CommonMetadata::etag;
 
+  /// The `eventBasedHold` attribute.
   bool event_based_hold() const { return event_based_hold_; }
+
+  /// Changes the `eventBasedHold` attribute.
   ObjectMetadata& set_event_based_hold(bool v) {
     event_based_hold_ = v;
     return *this;
   }
 
+  /**
+   * The object generation.
+   *
+   * In buckets with object versioning enabled, each object may have multiple
+   * generations. Each generation data (the object contents) is immutable, but
+   * the metadata associated with each generation can be changed.
+   */
   std::int64_t generation() const { return generation_; }
 
+  /// The `id` attribute (the object name)
   using CommonMetadata::id;
+
+  /// The `kind` attribute, that is, `storage#object`.
   using CommonMetadata::kind;
 
+  /**
+   * The name of the KMS (Key Management Service) key used in this object.
+   *
+   * This is empty for objects not using CMEK (Customer Managed Encryption
+   * Keys).
+   */
   std::string const& kms_key_name() const { return kms_key_name_; }
+
+  /// The MD5 hash of the object contents. Can be empty.
   std::string const& md5_hash() const { return md5_hash_; }
+
+  /// The HTTPS link to access the object contents.
   std::string const& media_link() const { return media_link_; }
 
-  //@{
-  /// @name Accessors and modifiers to the `metadata` labels.
+  /**
+   * @name Accessors and modifiers for metadata metadata.
+   *
+   * The object metadata contains a user-defined set of `key`, `value` pairs,
+   * which are also called "metadata". Applications can use these fields to
+   * add custom annotations to each object.
+   */
+  ///@{
+  /// Returns `true` if the key is present in the object metadata entries.
   bool has_metadata(std::string const& key) const {
     return metadata_.end() != metadata_.find(key);
   }
+
+  /**
+   * Returns the value of @p key in the Object's metadata entries.
+   *
+   * It is undefined behavior to call `metadata(key)` if `has_metadata(key) ==
+   * false`.
+   */
   std::string const& metadata(std::string const& key) const {
     return metadata_.at(key);
   }
@@ -192,56 +270,99 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
     return *this;
   }
 
+  /// Returns all the Object's metadata entries,
   std::map<std::string, std::string> const& metadata() const {
     return metadata_;
   }
-  std::map<std::string, std::string>& mutable_metadata() { return metadata_; }
-  //@}
 
+  /// Returns all the Object's metadata entries.
+  std::map<std::string, std::string>& mutable_metadata() { return metadata_; }
+  ///@}
+
+  /// Returns `true` if the object has a `owner` attributes.
   using CommonMetadata::has_owner;
+
+  /**
+   * The generation of the object metadata.
+   *
+   * Note that changes to the object metadata (e.g. changing the `cacheControl`
+   * attribute) increases the metageneration, but does not change the object
+   * generation.
+   */
   using CommonMetadata::metageneration;
+
+  /// The object name, including bucket and generation.
   using CommonMetadata::name;
+
+  /**
+   * The object's owner attributes.
+   *
+   * It is undefined behavior to call this member function if
+   * `has_owner() == false`.
+   */
   using CommonMetadata::owner;
 
+  /// The retention expiration time, or the system clock's epoch, if not set.
   std::chrono::system_clock::time_point retention_expiration_time() const {
     return retention_expiration_time_;
   }
 
+  /// An HTTPS link to the object metadata.
   using CommonMetadata::self_link;
 
+  /// The size of the object's data.
   std::uint64_t size() const { return size_; }
 
+  /// The `storageClass` attribute.
   using CommonMetadata::storage_class;
+
+  /// Changes the `storageClass` attribute.
   ObjectMetadata& set_storage_class(std::string v) {
     CommonMetadata::set_storage_class(std::move(v));
     return *this;
   }
 
+  /// The `temporaryHold` attribute.
   bool temporary_hold() const { return temporary_hold_; }
+
+  /// Changes the `temporaryHold` attribute.
   ObjectMetadata& set_temporary_hold(bool v) {
     temporary_hold_ = v;
     return *this;
   }
 
+  /// The object creation timestamp.
   using CommonMetadata::time_created;
 
+  /// The object's deletion timestamp.
   std::chrono::system_clock::time_point time_deleted() const {
     return time_deleted_;
   }
+
+  /// The timestamp for the last storage class change.
   std::chrono::system_clock::time_point time_storage_class_updated() const {
     return time_storage_class_updated_;
   }
 
+  /// The timestamp for the last object *metadata* update.
   using CommonMetadata::updated;
 
+  /// Returns `true` if the object has a `customTime` attribute.
   bool has_custom_time() const { return custom_time_.has_value(); }
+
+  /// Returns the object's `customTime` or the system clock's epoch.
   std::chrono::system_clock::time_point custom_time() const {
     return custom_time_.value_or(std::chrono::system_clock::time_point{});
   }
+
+  /// Changes the `customTime` attribute.
   ObjectMetadata& set_custom_time(std::chrono::system_clock::time_point v) {
     custom_time_ = v;
     return *this;
   }
+
+  /// Reset (clears) the `customTime` attribute. `has_custom_time()` returns
+  /// `false` after calling this function.
   ObjectMetadata& reset_custom_time() {
     custom_time_.reset();
     return *this;

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -118,10 +118,10 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   /// The name of the bucket containing this object.
   std::string const& bucket() const { return bucket_; }
 
-  /// The cacheControl attribute.
+  /// The `cacheControl` attribute.
   std::string const& cache_control() const { return cache_control_; }
 
-  /// Set the cacheControl attributes.
+  /// Set the `cacheControl` attribute.
   ObjectMetadata& set_cache_control(std::string cache_control) {
     cache_control_ = std::move(cache_control);
     return *this;
@@ -227,7 +227,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::string const& media_link() const { return media_link_; }
 
   /**
-   * @name Accessors and modifiers for metadata metadata.
+   * @name Accessors and modifiers for metadata entries.
    *
    * The object metadata contains a user-defined set of `key`, `value` pairs,
    * which are also called "metadata". Applications can use these fields to
@@ -270,7 +270,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
     return *this;
   }
 
-  /// Returns all the Object's metadata entries,
+  /// Returns all the Object's metadata entries.
   std::map<std::string, std::string> const& metadata() const {
     return metadata_;
   }
@@ -279,13 +279,13 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   std::map<std::string, std::string>& mutable_metadata() { return metadata_; }
   ///@}
 
-  /// Returns `true` if the object has a `owner` attributes.
+  /// Returns `true` if the object has an `owner` attribute.
   using CommonMetadata::has_owner;
 
   /**
    * The generation of the object metadata.
    *
-   * Note that changes to the object metadata (e.g. changing the `cacheControl`
+   * @note Changes to the object metadata (e.g. changing the `cacheControl`
    * attribute) increases the metageneration, but does not change the object
    * generation.
    */
@@ -295,7 +295,7 @@ class ObjectMetadata : private internal::CommonMetadata<ObjectMetadata> {
   using CommonMetadata::name;
 
   /**
-   * The object's owner attributes.
+   * The object's `owner` attribute.
    *
    * It is undefined behavior to call this member function if
    * `has_owner() == false`.


### PR DESCRIPTION
The documentation was not rendering correctly. It was reusing the
description from one function to many unrelated functions. In addition,
the groups were also rendering incorrectly.

After re-reading the Doxygen documentation it seems that

```cc
/// @name Group description
///@{
... grouped member functions
///@}
```

Is the "Right Thing":tm:

Fixes #8429.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8434)
<!-- Reviewable:end -->
