### PR TITLE
doc: expanding metadata fields in storage_get_metadata sample

### DIFF
--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -259,7 +259,17 @@ void GetObjectMetadata(google::cloud::storage::Client client,
 
     std::cout << "The metadata for object " << object_metadata->name()
               << " in bucket " << object_metadata->bucket() << " is "
-              << *object_metadata << "\n";
+              << " CacheControl : " << object_metadata->cache_control() << "\n"
+              << " ComponentCount : " << object_metadata->component_count() << "\n"
+              << " ContentDisposition : " << object_metadata->content_disposition() << "\n"
+              << " ContentEncoding : " << object_metadata->content_encoding() << "\n"
+              << " ContentLanguage : " << object_metadata->content_language() << "\n"
+              << " ContentType : " << object_metadata->content_type() << "\n"
+              << " Crc32c : " << object_metadata->crc32c() << "\n"
+              << " Generation : " << object_metadata->generation() << "\n"
+              << " KmsKeyName : " << object_metadata->kms_key_name() << "\n"
+              << " Md5Hash : " << object_metadata->md5_hash() << "\n"
+              << " MediaLink : " << object_metadata->media_link() << "\n";
   }
   //! [get object metadata] [END storage_get_metadata]
   (std::move(client), argv.at(0), argv.at(1));

--- a/google/cloud/storage/examples/storage_object_samples.cc
+++ b/google/cloud/storage/examples/storage_object_samples.cc
@@ -257,6 +257,8 @@ void GetObjectMetadata(google::cloud::storage::Client client,
       throw std::runtime_error(object_metadata.status().message());
     }
 
+    //! Printing out metadata fields, for full list see:
+    //! https://googleapis.dev/cpp/google-cloud-storage/latest/classgoogle_1_1cloud_1_1storage_1_1v1_1_1ObjectMetadata.html
     std::cout << "The metadata for object " << object_metadata->name()
               << " in bucket " << object_metadata->bucket() << " is "
               << " CacheControl : " << object_metadata->cache_control() << "\n"


### PR DESCRIPTION
Internal issue 153524869. This expands metadata fields to be more aligned with our other samples and displays the media link field that was requested in the internal issue. 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8435)
<!-- Reviewable:end -->
