### PR TITLE
fix(spanner): instantiate OptionsSpan objects in legacy admin calls

### DIFF
--- a/google/cloud/spanner/database_admin_connection.h
+++ b/google/cloud/spanner/database_admin_connection.h
@@ -27,6 +27,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/pagination_range.h"
+#include "google/cloud/options.h"
 #include "absl/types/optional.h"
 #include <google/spanner/admin/database/v1/spanner_database_admin.pb.h>
 #include <chrono>
@@ -239,6 +240,8 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("DatabaseAdminConnection")
     std::string filter;
   };
   //@}
+
+  virtual Options options() { return Options{}; }
 
   /// Define the interface for a google.spanner.v1.DatabaseAdmin.CreateDatabase
   /// RPC.

--- a/google/cloud/spanner/instance_admin_client.cc
+++ b/google/cloud/spanner/instance_admin_client.cc
@@ -15,6 +15,7 @@
 // TODO(#7356): Remove this file after the deprecation period expires
 #include "google/cloud/internal/disable_deprecation_warnings.inc"
 #include "google/cloud/spanner/instance_admin_client.h"
+#include "google/cloud/options.h"
 
 namespace google {
 namespace cloud {
@@ -23,6 +24,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<google::spanner::admin::instance::v1::Instance>
 InstanceAdminClient::GetInstance(Instance const& in) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->GetInstance({in.FullName()});
 }
 
@@ -30,6 +32,7 @@ future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::CreateInstance(
     google::spanner::admin::instance::v1::CreateInstanceRequest const&
         request) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->CreateInstance({request});
 }
 
@@ -37,35 +40,42 @@ future<StatusOr<google::spanner::admin::instance::v1::Instance>>
 InstanceAdminClient::UpdateInstance(
     google::spanner::admin::instance::v1::UpdateInstanceRequest const&
         request) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->UpdateInstance({request});
 }
 
 Status InstanceAdminClient::DeleteInstance(Instance const& in) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->DeleteInstance({in.FullName()});
 }
 
 StatusOr<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminClient::GetInstanceConfig(std::string const& name) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->GetInstanceConfig({name});
 }
 
 ListInstanceConfigsRange InstanceAdminClient::ListInstanceConfigs(
     std::string project_id) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->ListInstanceConfigs({std::move(project_id)});
 }
 
 ListInstancesRange InstanceAdminClient::ListInstances(std::string project_id,
                                                       std::string filter) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->ListInstances({std::move(project_id), std::move(filter)});
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::GetIamPolicy(
     Instance const& in) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->GetIamPolicy({in.FullName()});
 }
 
 StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     Instance const& in, google::iam::v1::Policy policy) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->SetIamPolicy({in.FullName(), std::move(policy)});
 }
 
@@ -91,11 +101,12 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     Instance const& in, IamUpdater const& updater,
     std::unique_ptr<TransactionRerunPolicy> rerun_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy) {
+  internal::OptionsSpan span(conn_->options());
   using RerunnablePolicy = spanner_internal::SafeTransactionRerun;
 
   Status last_status;
   do {
-    auto current_policy = GetIamPolicy(in);
+    auto current_policy = conn_->GetIamPolicy({in.FullName()});
     if (!current_policy) {
       last_status = std::move(current_policy).status();
     } else {
@@ -105,7 +116,7 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
         return current_policy;
       }
       desired->set_etag(std::move(etag));
-      auto result = SetIamPolicy(in, *std::move(desired));
+      auto result = conn_->SetIamPolicy({in.FullName(), *std::move(desired)});
       if (RerunnablePolicy::IsOk(result.status())) {
         return result;
       }
@@ -120,6 +131,7 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
 StatusOr<google::iam::v1::TestIamPermissionsResponse>
 InstanceAdminClient::TestIamPermissions(Instance const& in,
                                         std::vector<std::string> permissions) {
+  internal::OptionsSpan span(conn_->options());
   return conn_->TestIamPermissions({in.FullName(), std::move(permissions)});
 }
 

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -37,17 +37,19 @@ namespace {
 class InstanceAdminConnectionImpl : public InstanceAdminConnection {
  public:
   InstanceAdminConnectionImpl(
-      std::shared_ptr<spanner_internal::InstanceAdminStub> stub,
-      Options const& opts)
+      std::shared_ptr<spanner_internal::InstanceAdminStub> stub, Options opts)
       : stub_(std::move(stub)),
-        retry_policy_prototype_(opts.get<SpannerRetryPolicyOption>()->clone()),
+        opts_(std::move(opts)),
+        retry_policy_prototype_(opts_.get<SpannerRetryPolicyOption>()->clone()),
         backoff_policy_prototype_(
-            opts.get<SpannerBackoffPolicyOption>()->clone()),
+            opts_.get<SpannerBackoffPolicyOption>()->clone()),
         polling_policy_prototype_(
-            opts.get<SpannerPollingPolicyOption>()->clone()),
-        background_threads_(internal::MakeBackgroundThreadsFactory(opts)()) {}
+            opts_.get<SpannerPollingPolicyOption>()->clone()),
+        background_threads_(internal::MakeBackgroundThreadsFactory(opts_)()) {}
 
   ~InstanceAdminConnectionImpl() override = default;
+
+  Options options() override { return opts_; }
 
   StatusOr<gcsa::Instance> GetInstance(GetInstanceParams gip) override {
     gcsa::GetInstanceRequest request;
@@ -258,6 +260,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
  private:
   std::shared_ptr<spanner_internal::InstanceAdminStub> stub_;
+  Options opts_;
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   std::unique_ptr<PollingPolicy const> polling_policy_prototype_;

--- a/google/cloud/spanner/instance_admin_connection.h
+++ b/google/cloud/spanner/instance_admin_connection.h
@@ -22,6 +22,7 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/backoff_policy.h"
 #include "google/cloud/internal/pagination_range.h"
+#include "google/cloud/options.h"
 #include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
 #include <map>
 #include <string>
@@ -155,6 +156,8 @@ class GOOGLE_CLOUD_CPP_SPANNER_ADMIN_API_DEPRECATED("InstanceAdminConnection")
     std::vector<std::string> permissions;
   };
   //@}
+
+  virtual Options options() { return Options{}; }
 
   /// Return the metadata for the given instance.
   virtual StatusOr<google::spanner::admin::instance::v1::Instance> GetInstance(


### PR DESCRIPTION
This doesn't change the legacy Spanner database/instance admin APIs at
all, but it does ensure that the connection options have been installed
in an `OptionsSpan` over calls into the library.

Fixes #8438 and #8439.