### PR TITLE
fix(storage): json["projectTeam"] might be present but null

### DIFF
--- a/google/cloud/storage/internal/access_control_common_parser.cc
+++ b/google/cloud/storage/internal/access_control_common_parser.cc
@@ -36,10 +36,12 @@ Status AccessControlCommonParser::FromJson(AccessControlCommon& result,
   result.self_link_ = json.value("selfLink", "");
   if (json.count("projectTeam") != 0) {
     auto tmp = json["projectTeam"];
-    ProjectTeam p;
-    p.project_number = tmp.value("projectNumber", "");
-    p.team = tmp.value("team", "");
-    result.project_team_ = std::move(p);
+    if (!tmp.is_null()) {
+      ProjectTeam p;
+      p.project_number = tmp.value("projectNumber", "");
+      p.team = tmp.value("team", "");
+      result.project_team_ = std::move(p);
+    }
   }
   return Status();
 }

--- a/google/cloud/storage/internal/access_control_common_parser.cc
+++ b/google/cloud/storage/internal/access_control_common_parser.cc
@@ -36,12 +36,12 @@ Status AccessControlCommonParser::FromJson(AccessControlCommon& result,
   result.self_link_ = json.value("selfLink", "");
   if (json.count("projectTeam") != 0) {
     auto tmp = json["projectTeam"];
-    if (!tmp.is_null()) {
-      ProjectTeam p;
-      p.project_number = tmp.value("projectNumber", "");
-      p.team = tmp.value("team", "");
-      result.project_team_ = std::move(p);
-    }
+    if (tmp.is_null())
+      return Status{};
+    ProjectTeam p;
+    p.project_number = tmp.value("projectNumber", "");
+    p.team = tmp.value("team", "");
+    result.project_team_ = std::move(p);
   }
   return Status();
 }

--- a/google/cloud/storage/internal/access_control_common_parser.cc
+++ b/google/cloud/storage/internal/access_control_common_parser.cc
@@ -36,8 +36,7 @@ Status AccessControlCommonParser::FromJson(AccessControlCommon& result,
   result.self_link_ = json.value("selfLink", "");
   if (json.count("projectTeam") != 0) {
     auto tmp = json["projectTeam"];
-    if (tmp.is_null())
-      return Status{};
+    if (tmp.is_null()) return Status{};
     ProjectTeam p;
     p.project_number = tmp.value("projectNumber", "");
     p.team = tmp.value("team", "");

--- a/google/cloud/storage/internal/access_control_common_parser_test.cc
+++ b/google/cloud/storage/internal/access_control_common_parser_test.cc
@@ -37,16 +37,16 @@ TEST(AccessControlCommonParserTest, FromJson) {
   EXPECT_THAT(result.bucket(), Eq(bucket));
   EXPECT_THAT(result.role(), Eq(role));
   EXPECT_THAT(result.email(), Eq(email));
-  EXPECT_THAT(result.project_team(), Eq(ProjectTeam()));
+  EXPECT_FALSE(result.has_project_team());
 }
 
-TEST(AccessControlCommonParserTest, nullProjectTeamIsValid) {
+TEST(AccessControlCommonParserTest, NullProjectTeamIsValid) {
   nlohmann::json metadata{{"projectTeam", nullptr}};
   internal::AccessControlCommon result{};
   auto status = internal::AccessControlCommonParser::FromJson(result, metadata);
   ASSERT_STATUS_OK(status);
 
-  EXPECT_THAT(result.project_team(), Eq(ProjectTeam()));
+  EXPECT_FALSE(result.has_project_team());
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/access_control_common_parser_test.cc
+++ b/google/cloud/storage/internal/access_control_common_parser_test.cc
@@ -37,6 +37,16 @@ TEST(AccessControlCommonParserTest, FromJson) {
   EXPECT_THAT(result.bucket(), Eq(bucket));
   EXPECT_THAT(result.role(), Eq(role));
   EXPECT_THAT(result.email(), Eq(email));
+  EXPECT_THAT(result.project_team(), Eq(ProjectTeam()));
+}
+
+TEST(AccessControlCommonParserTest, nullProjectTeamIsValid) {
+  nlohmann::json metadata{{"projectTeam", nullptr}};
+  internal::AccessControlCommon result{};
+  auto status = internal::AccessControlCommonParser::FromJson(result, metadata);
+  ASSERT_STATUS_OK(status);
+
+  EXPECT_THAT(result.project_team(), Eq(ProjectTeam()));
 }
 
 }  // namespace


### PR DESCRIPTION
We are working on google-cloud integration for our project [Apache Nifi Minifi CPP](https://github.com/apache/nifi-minifi-cpp)
And I found that the `projectTeam` is an optional field in the `ObjectMetadata` json, however it will crash if it is present but null.
This makes impossible to make integration tests using the [fake-gcs-server](https://github.com/fsouza/fake-gcs-server), because the response to a ResumableUploadRequest is something like this due to the datastructure in [google-cloud-go](https://github.com/googleapis/google-cloud-go/blob/main/storage/acl.go#L60)
```
{
   "bucket":"my-bucket",
   "name":"my-key",
   "contentType":"",
   "contentEncoding":"",
   "acl":[
      {
         "entity":"projectOwner",
         "entityId":"",
         "role":"OWNER",
         "domain":"",
         "email":"",
         "projectTeam":null
      }
   ],
   "created":"0001-01-01T00:00:00Z",
   "updated":"0001-01-01T00:00:00Z",
   "deleted":"0001-01-01T00:00:00Z"
}
```
which will crash with the following error 
```
terminate called after throwing an instance of 'nlohmann::detail::type_error'
  what():  [json.exception.type_error.306] cannot use value() with null
Signal: SIGABRT (Aborted)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8446)
<!-- Reviewable:end -->
