### PR TITLE
refactor(bigtable)!: mark InstanceAdminClient as final

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,7 +108,7 @@ The library has been expanded to include the following services:
 
 ### [Bigtable](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigtable/README.md)
 
-**BREAKING CHANGE:** The `bigtable::TableAdminClient` interface has changed
+**BREAKING CHANGE:** The `bigtable::AdminClient` interface has changed
 significantly. Any code that extends this class or calls its experimental public
 APIs (`reset()`, `Channel()`) will be broken. For the most part, this should
 only affect customers who mock this class in their tests. Code that calls
@@ -139,6 +139,10 @@ information on these new classes, see our [Architecture Design] document.
 
 Again, we apologize for making this breaking change, but we believe it is in the
 best long-term interest of our customers.
+
+**BREAKING CHANGE:** The `bigtable::InstanceAdminClient` class has been marked
+as `final`. It should not be extended for mocking. Customers should instead use
+`bigtable_admin_mocks::MockBigtableInstanceAdminConnection` for mocking.
 
 ### New Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,8 +141,8 @@ Again, we apologize for making this breaking change, but we believe it is in the
 best long-term interest of our customers.
 
 **BREAKING CHANGE:** The `bigtable::InstanceAdminClient` class has been marked
-as `final`. It should not be extended for mocking. Customers should instead use
-`bigtable_admin_mocks::MockBigtableInstanceAdminConnection` for mocking.
+as `final`. After the changes in [v1.36.0](#v1360---2022-02), there is no need
+or reason to be extending this class.
 
 ### New Libraries
 

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -153,7 +153,7 @@ class InstanceAdmin {
    */
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit InstanceAdmin(std::shared_ptr<InstanceAdminClient> client)
-      : InstanceAdmin(client->connection(), client->project()) {}
+      : InstanceAdmin(client->connection_, client->project()) {}
 
   /**
    * Create a new InstanceAdmin using explicit policies to handle RPC errors.
@@ -182,7 +182,7 @@ class InstanceAdmin {
   // NOLINTNEXTLINE(performance-unnecessary-value-param)
   explicit InstanceAdmin(std::shared_ptr<InstanceAdminClient> client,
                          Policies&&... policies)
-      : connection_(client->connection()),
+      : connection_(client->connection_),
         project_id_(client->project()),
         project_name_(Project(project_id_).FullName()),
         retry_prototype_(

--- a/google/cloud/bigtable/instance_admin_client.cc
+++ b/google/cloud/bigtable/instance_admin_client.cc
@@ -19,34 +19,12 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace {
-
-class DefaultInstanceAdminClient : public InstanceAdminClient {
- public:
-  DefaultInstanceAdminClient(std::string project, Options options)
-      : project_(std::move(project)),
-        connection_(bigtable_admin::MakeBigtableInstanceAdminConnection(
-            std::move(options))) {}
-
-  std::string const& project() const override { return project_; }
-
- private:
-  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection()
-      override {
-    return connection_;
-  }
-
-  std::string project_;
-  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection_;
-};
-
-}  // anonymous namespace
 
 std::shared_ptr<InstanceAdminClient> MakeInstanceAdminClient(
     std::string project, Options options) {
   options = internal::DefaultInstanceAdminOptions(std::move(options));
-  return std::make_shared<DefaultInstanceAdminClient>(std::move(project),
-                                                      std::move(options));
+  return std::shared_ptr<InstanceAdminClient>(
+      new InstanceAdminClient(std::move(project), std::move(options)));
 }
 
 std::shared_ptr<InstanceAdminClient> CreateDefaultInstanceAdminClient(

--- a/google/cloud/bigtable/instance_admin_client.h
+++ b/google/cloud/bigtable/instance_admin_client.h
@@ -37,17 +37,25 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *     configure `bigtable_admin::BigtableInstanceAdminClient`, instead of using
  *     this class to configure `bigtable::InstanceAdmin`.
  */
-class InstanceAdminClient {
+class InstanceAdminClient final {
  public:
   virtual ~InstanceAdminClient() = default;
 
   /// The project id that this AdminClient works on.
-  virtual std::string const& project() const = 0;
+  virtual std::string const& project() { return project_; }
 
  private:
   friend class InstanceAdmin;
-  virtual std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection>
-  connection() = 0;
+  friend std::shared_ptr<InstanceAdminClient> MakeInstanceAdminClient(
+      std::string, Options);
+
+  InstanceAdminClient(std::string project, Options options)
+      : project_(std::move(project)),
+        connection_(bigtable_admin::MakeBigtableInstanceAdminConnection(
+            std::move(options))) {}
+
+  std::string project_;
+  std::shared_ptr<bigtable_admin::BigtableInstanceAdminConnection> connection_;
 };
 
 /// Create a new instance admin client configured via @p options.


### PR DESCRIPTION
Fixes #8419

The `InstanceAdmin` equivalent of #8424. I also added a note in the changelog, because this is technically a break since the last release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8449)
<!-- Reviewable:end -->
