### PR TITLE
feat: better support for PSC and VPC-SC

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -121,6 +121,9 @@ void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata(
         "x-goog-user-project", options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -230,6 +230,9 @@ void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata(
         "x-goog-user-project", options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -348,6 +348,9 @@ void $metadata_class_name$::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata(
         "x-goog-user-project", options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 )""");
 

--- a/google/cloud/accessapproval/internal/access_approval_metadata_decorator.cc
+++ b/google/cloud/accessapproval/internal/access_approval_metadata_decorator.cc
@@ -109,6 +109,9 @@ void AccessApprovalMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.cc
@@ -292,6 +292,9 @@ void AccessContextManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/apigateway/internal/api_gateway_metadata_decorator.cc
+++ b/google/cloud/apigateway/internal/api_gateway_metadata_decorator.cc
@@ -192,6 +192,9 @@ void ApiGatewayServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/apigeeconnect/internal/connection_metadata_decorator.cc
+++ b/google/cloud/apigeeconnect/internal/connection_metadata_decorator.cc
@@ -55,6 +55,9 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/applications_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/applications_metadata_decorator.cc
@@ -99,6 +99,9 @@ void ApplicationsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/authorized_certificates_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_metadata_decorator.cc
@@ -86,6 +86,9 @@ void AuthorizedCertificatesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/authorized_domains_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_domains_metadata_decorator.cc
@@ -55,6 +55,9 @@ void AuthorizedDomainsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/domain_mappings_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/domain_mappings_metadata_decorator.cc
@@ -107,6 +107,9 @@ void DomainMappingsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/firewall_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/firewall_metadata_decorator.cc
@@ -92,6 +92,9 @@ void FirewallMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/instances_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/instances_metadata_decorator.cc
@@ -96,6 +96,9 @@ void InstancesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/services_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/services_metadata_decorator.cc
@@ -96,6 +96,9 @@ void ServicesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/versions_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/versions_metadata_decorator.cc
@@ -105,6 +105,9 @@ void VersionsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.cc
@@ -74,6 +74,9 @@ void ArtifactRegistryMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/asset/internal/asset_metadata_decorator.cc
+++ b/google/cloud/asset/internal/asset_metadata_decorator.cc
@@ -170,6 +170,9 @@ void AssetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.cc
@@ -105,6 +105,9 @@ void AssuredWorkloadsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/automl/internal/auto_ml_metadata_decorator.cc
+++ b/google/cloud/automl/internal/auto_ml_metadata_decorator.cc
@@ -212,6 +212,9 @@ void AutoMlMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/automl/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/automl/internal/prediction_metadata_decorator.cc
@@ -81,6 +81,9 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -74,6 +74,9 @@ void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/connection_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/connection_metadata_decorator.cc
@@ -113,6 +113,9 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/data_transfer_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/data_transfer_metadata_decorator.cc
@@ -182,6 +182,9 @@ void DataTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/model_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/model_metadata_decorator.cc
@@ -76,6 +76,9 @@ void ModelServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/reservation_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/reservation_metadata_decorator.cc
@@ -228,6 +228,9 @@ void ReservationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
@@ -225,6 +225,9 @@ void BigtableInstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
@@ -207,6 +207,9 @@ void BigtableTableAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/budget_metadata_decorator.cc
+++ b/google/cloud/billing/internal/budget_metadata_decorator.cc
@@ -86,6 +86,9 @@ void BudgetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/cloud_billing_metadata_decorator.cc
+++ b/google/cloud/billing/internal/cloud_billing_metadata_decorator.cc
@@ -126,6 +126,9 @@ void CloudBillingMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/cloud_catalog_metadata_decorator.cc
+++ b/google/cloud/billing/internal/cloud_catalog_metadata_decorator.cc
@@ -63,6 +63,9 @@ void CloudCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.cc
@@ -108,6 +108,9 @@ void BinauthzManagementServiceV1Metadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.cc
@@ -56,6 +56,9 @@ void SystemPolicyV1Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.cc
@@ -57,6 +57,9 @@ void ValidationHelperV1Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/channel/internal/cloud_channel_metadata_decorator.cc
+++ b/google/cloud/channel/internal/cloud_channel_metadata_decorator.cc
@@ -359,6 +359,9 @@ void CloudChannelServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.cc
@@ -216,6 +216,9 @@ void CloudBuildMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -80,10 +80,25 @@ struct UserProjectOption {
 };
 
 /**
+ * Configure the "authority" attribute.
+ *
+ * For gRPC requests this is the `authority()` field in the
+ * `grpc::ClientContext`. This configures the :authority pseudo-header in the
+ * HTTP/2 request.
+ *     https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
+ *
+ * For REST-based services using HTTP/1.1 or HTTP/1.0 this is the `Host` header.
+ */
+struct AuthorityOption {
+  using Type = std::string;
+};
+
+/**
  * A list of all the common options.
  */
-using CommonOptionList = OptionList<EndpointOption, UserAgentProductsOption,
-                                    TracingComponentsOption, UserProjectOption>;
+using CommonOptionList =
+    OptionList<EndpointOption, UserAgentProductsOption, TracingComponentsOption,
+               UserProjectOption, AuthorityOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud

--- a/google/cloud/composer/internal/environments_metadata_decorator.cc
+++ b/google/cloud/composer/internal/environments_metadata_decorator.cc
@@ -113,6 +113,9 @@ void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/composer/internal/image_versions_metadata_decorator.cc
+++ b/google/cloud/composer/internal/image_versions_metadata_decorator.cc
@@ -57,6 +57,9 @@ void ImageVersionsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.cc
@@ -371,6 +371,9 @@ void ContactCenterInsightsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/container/internal/cluster_manager_metadata_decorator.cc
+++ b/google/cloud/container/internal/cluster_manager_metadata_decorator.cc
@@ -296,6 +296,9 @@ void ClusterManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.cc
@@ -79,6 +79,9 @@ void ContainerAnalysisMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/containeranalysis/internal/grafeas_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_metadata_decorator.cc
@@ -146,6 +146,9 @@ void GrafeasMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/data_catalog_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_metadata_decorator.cc
@@ -265,6 +265,9 @@ void DataCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.cc
@@ -147,6 +147,9 @@ void PolicyTagManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.cc
@@ -72,6 +72,9 @@ void PolicyTagManagerSerializationMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datamigration/internal/data_migration_metadata_decorator.cc
+++ b/google/cloud/datamigration/internal/data_migration_metadata_decorator.cc
@@ -216,6 +216,9 @@ void DataMigrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/autoscaling_policy_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/autoscaling_policy_metadata_decorator.cc
@@ -91,6 +91,9 @@ void AutoscalingPolicyServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/batch_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/batch_controller_metadata_decorator.cc
@@ -95,6 +95,9 @@ void BatchControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/cluster_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/cluster_controller_metadata_decorator.cc
@@ -134,6 +134,9 @@ void ClusterControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/job_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/job_controller_metadata_decorator.cc
@@ -116,6 +116,9 @@ void JobControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/workflow_template_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/workflow_template_metadata_decorator.cc
@@ -126,6 +126,9 @@ void WorkflowTemplateServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/debugger/internal/controller2_metadata_decorator.cc
+++ b/google/cloud/debugger/internal/controller2_metadata_decorator.cc
@@ -73,6 +73,9 @@ void Controller2Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/debugger/internal/debugger2_metadata_decorator.cc
+++ b/google/cloud/debugger/internal/debugger2_metadata_decorator.cc
@@ -87,6 +87,9 @@ void Debugger2Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dlp/internal/dlp_metadata_decorator.cc
+++ b/google/cloud/dlp/internal/dlp_metadata_decorator.cc
@@ -309,6 +309,9 @@ void DlpServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/documentai/internal/document_processor_metadata_decorator.cc
+++ b/google/cloud/documentai/internal/document_processor_metadata_decorator.cc
@@ -91,6 +91,9 @@ void DocumentProcessorServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/eventarc/internal/eventarc_metadata_decorator.cc
+++ b/google/cloud/eventarc/internal/eventarc_metadata_decorator.cc
@@ -105,6 +105,9 @@ void EventarcMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/eventarc/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/eventarc/internal/publisher_metadata_decorator.cc
@@ -56,6 +56,9 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.cc
@@ -159,6 +159,9 @@ void CloudFilestoreManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/functions/internal/cloud_functions_metadata_decorator.cc
+++ b/google/cloud/functions/internal/cloud_functions_metadata_decorator.cc
@@ -153,6 +153,9 @@ void CloudFunctionsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.cc
@@ -137,6 +137,9 @@ void GameServerClustersServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_configs_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_metadata_decorator.cc
@@ -99,6 +99,9 @@ void GameServerConfigsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.cc
@@ -153,6 +153,9 @@ void GameServerDeploymentsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/realms_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/realms_metadata_decorator.cc
@@ -114,6 +114,9 @@ void RealmsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gkehub/internal/gke_hub_metadata_decorator.cc
+++ b/google/cloud/gkehub/internal/gke_hub_metadata_decorator.cc
@@ -155,6 +155,9 @@ void GkeHubMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/grpc_options.h
+++ b/google/cloud/grpc_options.h
@@ -126,6 +126,7 @@ struct GrpcCompletionQueueOption {
 
 using BackgroundThreadsFactory =
     std::function<std::unique_ptr<BackgroundThreads>()>;
+
 /**
  * Changes the `BackgroundThreadsFactory`.
  *

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
@@ -79,6 +79,9 @@ void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_metadata_decorator.cc
@@ -241,6 +241,9 @@ void IAMMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.cc
@@ -88,6 +88,9 @@ void IdentityAwareProxyAdminServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
@@ -115,6 +115,9 @@ void IdentityAwareProxyOAuthServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/ids/internal/ids_metadata_decorator.cc
+++ b/google/cloud/ids/internal/ids_metadata_decorator.cc
@@ -95,6 +95,9 @@ void IDSMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -37,8 +37,11 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
     if (e && !e->empty()) {
       opts.set<EndpointOption>(*std::move(e));
     } else {
-      opts.set<EndpointOption>(std::move(default_endpoint));
+      opts.set<EndpointOption>(default_endpoint);
     }
+  }
+  if (!opts.has<AuthorityOption>()) {
+    opts.set<AuthorityOption>(std::move(default_endpoint));
   }
   auto e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
   if (e && !e->empty()) opts.set<UserProjectOption>(*std::move(e));

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -37,6 +37,7 @@ TEST(PopulateCommonOptions, Simple) {
   auto actual =
       PopulateCommonOptions(Options{}, {}, {}, "default.googleapis.com");
   EXPECT_TRUE(actual.has<EndpointOption>());
+  EXPECT_TRUE(actual.has<AuthorityOption>());
   EXPECT_TRUE(actual.has<UserAgentProductsOption>());
   EXPECT_THAT(actual.get<UserAgentProductsOption>(),
               Contains(UserAgentPrefix()));
@@ -82,6 +83,7 @@ TEST(PopulateCommonOptions, Endpoint) {
     auto actual =
         PopulateCommonOptions(test.initial, "DEFAULT", "EMULATOR", "default");
     EXPECT_EQ(actual.get<EndpointOption>(), test.expected);
+    EXPECT_EQ(actual.get<AuthorityOption>(), "default");
   }
 }
 
@@ -110,6 +112,17 @@ TEST(PopulateCommonOptions, UserProject) {
   ScopedEnvironment unset("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
   auto actual = PopulateCommonOptions(Options{}, {}, {}, "default");
   EXPECT_FALSE(actual.has<UserProjectOption>());
+}
+
+TEST(PopulateCommonOptions, OverrideAuthorityOption) {
+  // Unset all the relevant environment variables
+  ScopedEnvironment user("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
+  ScopedEnvironment tracing("GOOGLE_CLOUD_CPP_ENABLE_TRACING", absl::nullopt);
+  auto actual = PopulateCommonOptions(
+      Options{}.set<AuthorityOption>("custom-authority.googleapis.com"), {}, {},
+      "default.googleapis.com");
+  EXPECT_EQ(actual.get<EndpointOption>(), "default.googleapis.com");
+  EXPECT_EQ(actual.get<AuthorityOption>(), "custom-authority.googleapis.com");
 }
 
 TEST(PopulateCommonOptions, DefaultTracingComponentsNoEnvironment) {

--- a/google/cloud/iot/internal/device_manager_metadata_decorator.cc
+++ b/google/cloud/iot/internal/device_manager_metadata_decorator.cc
@@ -193,6 +193,9 @@ void DeviceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/kms/internal/key_management_metadata_decorator.cc
+++ b/google/cloud/kms/internal/key_management_metadata_decorator.cc
@@ -257,6 +257,9 @@ void KeyManagementServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/language/internal/language_metadata_decorator.cc
+++ b/google/cloud/language/internal/language_metadata_decorator.cc
@@ -95,6 +95,9 @@ void LanguageServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -97,6 +97,9 @@ void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/managedidentities/internal/managed_identities_metadata_decorator.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_metadata_decorator.cc
@@ -155,6 +155,9 @@ void ManagedIdentitiesServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/memcache/internal/cloud_memcache_metadata_decorator.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_metadata_decorator.cc
@@ -125,6 +125,9 @@ void CloudMemcacheMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/alert_policy_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/alert_policy_metadata_decorator.cc
@@ -86,6 +86,9 @@ void AlertPolicyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/dashboards_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/dashboards_metadata_decorator.cc
@@ -86,6 +86,9 @@ void DashboardsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/group_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/group_metadata_decorator.cc
@@ -91,6 +91,9 @@ void GroupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/metric_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metric_metadata_decorator.cc
@@ -118,6 +118,9 @@ void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.cc
@@ -103,6 +103,9 @@ void MetricsScopesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/notification_channel_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/notification_channel_metadata_decorator.cc
@@ -132,6 +132,9 @@ void NotificationChannelServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/query_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/query_metadata_decorator.cc
@@ -55,6 +55,9 @@ void QueryServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/service_monitoring_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_metadata_decorator.cc
@@ -127,6 +127,9 @@ void ServiceMonitoringServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/uptime_check_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/uptime_check_metadata_decorator.cc
@@ -95,6 +95,9 @@ void UptimeCheckServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/networkmanagement/internal/reachability_metadata_decorator.cc
+++ b/google/cloud/networkmanagement/internal/reachability_metadata_decorator.cc
@@ -122,6 +122,9 @@ void ReachabilityServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/notebooks/internal/managed_notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_metadata_decorator.cc
@@ -143,6 +143,9 @@ void ManagedNotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/notebooks/internal/notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/internal/notebook_metadata_decorator.cc
@@ -347,6 +347,9 @@ void NotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/orgpolicy/internal/org_policy_metadata_decorator.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_metadata_decorator.cc
@@ -98,6 +98,9 @@ void OrgPolicyMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.cc
+++ b/google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.cc
@@ -103,6 +103,9 @@ void AgentEndpointServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/internal/os_config_metadata_decorator.cc
+++ b/google/cloud/osconfig/internal/os_config_metadata_decorator.cc
@@ -119,6 +119,9 @@ void OsConfigServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/oslogin/internal/os_login_metadata_decorator.cc
+++ b/google/cloud/oslogin/internal/os_login_metadata_decorator.cc
@@ -93,6 +93,9 @@ void OsLoginServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.cc
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.cc
@@ -55,6 +55,9 @@ void IamCheckerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/privateca/internal/certificate_authority_metadata_decorator.cc
+++ b/google/cloud/privateca/internal/certificate_authority_metadata_decorator.cc
@@ -356,6 +356,9 @@ void CertificateAuthorityServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/profiler/internal/profiler_metadata_decorator.cc
+++ b/google/cloud/profiler/internal/profiler_metadata_decorator.cc
@@ -72,6 +72,9 @@ void ProfilerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -60,7 +60,9 @@ int main(int argc, char* argv[]) try {
   if (!endpoint) throw std::runtime_error(endpoint.status().message());
   auto client =
       pubsublite::AdminServiceClient(pubsublite::MakeAdminServiceConnection(
-          gc::Options{}.set<gc::EndpointOption>(*endpoint)));
+          gc::Options{}
+              .set<gc::EndpointOption>(*endpoint)
+              .set<gc::AuthorityOption>(*endpoint)));
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + zone_id;
   for (auto const& topic : client.ListTopics(parent)) {

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
@@ -215,6 +215,9 @@ void AdminServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
@@ -73,6 +73,9 @@ void CursorServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
@@ -58,6 +58,9 @@ void PartitionAssignmentServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
@@ -57,6 +57,9 @@ void PublisherServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
@@ -57,6 +57,9 @@ void SubscriberServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
@@ -71,6 +71,9 @@ void TopicStatsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/quickstart/quickstart.cc
+++ b/google/cloud/pubsublite/quickstart/quickstart.cc
@@ -31,7 +31,9 @@ int main(int argc, char* argv[]) try {
   if (!endpoint) throw std::runtime_error(endpoint.status().message());
   auto client =
       pubsublite::AdminServiceClient(pubsublite::MakeAdminServiceConnection(
-          gc::Options{}.set<gc::EndpointOption>(*endpoint)));
+          gc::Options{}
+              .set<gc::EndpointOption>(*endpoint)
+              .set<gc::AuthorityOption>(*endpoint)));
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + zone_id;
   for (auto const& topic : client.ListTopics(parent)) {

--- a/google/cloud/recommender/internal/recommender_metadata_decorator.cc
+++ b/google/cloud/recommender/internal/recommender_metadata_decorator.cc
@@ -113,6 +113,9 @@ void RecommenderMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/redis/internal/cloud_redis_metadata_decorator.cc
+++ b/google/cloud/redis/internal/cloud_redis_metadata_decorator.cc
@@ -141,6 +141,9 @@ void CloudRedisMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/folders_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/folders_metadata_decorator.cc
@@ -153,6 +153,9 @@ void FoldersMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/organizations_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/organizations_metadata_decorator.cc
@@ -86,6 +86,9 @@ void OrganizationsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/projects_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/projects_metadata_decorator.cc
@@ -154,6 +154,9 @@ void ProjectsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.cc
@@ -72,6 +72,9 @@ void ResourceSettingsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/catalog_metadata_decorator.cc
+++ b/google/cloud/retail/internal/catalog_metadata_decorator.cc
@@ -78,6 +78,9 @@ void CatalogServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/completion_metadata_decorator.cc
+++ b/google/cloud/retail/internal/completion_metadata_decorator.cc
@@ -81,6 +81,9 @@ void CompletionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/retail/internal/prediction_metadata_decorator.cc
@@ -55,6 +55,9 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/product_metadata_decorator.cc
+++ b/google/cloud/retail/internal/product_metadata_decorator.cc
@@ -138,6 +138,9 @@ void ProductServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/search_metadata_decorator.cc
+++ b/google/cloud/retail/internal/search_metadata_decorator.cc
@@ -55,6 +55,9 @@ void SearchServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/user_event_metadata_decorator.cc
+++ b/google/cloud/retail/internal/user_event_metadata_decorator.cc
@@ -106,6 +106,9 @@ void UserEventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.cc
@@ -104,6 +104,9 @@ void CloudSchedulerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/secretmanager/internal/secret_manager_metadata_decorator.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_metadata_decorator.cc
@@ -169,6 +169,9 @@ void SecretManagerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/securitycenter/internal/security_center_metadata_decorator.cc
+++ b/google/cloud/securitycenter/internal/security_center_metadata_decorator.cc
@@ -324,6 +324,9 @@ void SecurityCenterMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.cc
@@ -55,6 +55,9 @@ void QuotaControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicecontrol/internal/service_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/internal/service_controller_metadata_decorator.cc
@@ -63,6 +63,9 @@ void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicedirectory/internal/lookup_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/internal/lookup_metadata_decorator.cc
@@ -55,6 +55,9 @@ void LookupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicedirectory/internal/registration_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/internal/registration_metadata_decorator.cc
@@ -189,6 +189,9 @@ void RegistrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicemanagement/internal/service_manager_metadata_decorator.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_metadata_decorator.cc
@@ -197,6 +197,9 @@ void ServiceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/serviceusage/internal/service_usage_metadata_decorator.cc
+++ b/google/cloud/serviceusage/internal/service_usage_metadata_decorator.cc
@@ -115,6 +115,9 @@ void ServiceUsageMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/shell/internal/cloud_shell_metadata_decorator.cc
+++ b/google/cloud/shell/internal/cloud_shell_metadata_decorator.cc
@@ -108,6 +108,9 @@ void CloudShellServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
@@ -206,6 +206,9 @@ void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
@@ -148,6 +148,9 @@ void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -168,6 +168,9 @@ void MetadataSpannerStub::SetMetadata(grpc::ClientContext& context,
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/internal/speech_metadata_decorator.cc
+++ b/google/cloud/speech/internal/speech_metadata_decorator.cc
@@ -90,6 +90,9 @@ void SpeechMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -194,6 +194,9 @@ void StorageMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.cc
@@ -129,6 +129,9 @@ void StorageTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/company_metadata_decorator.cc
+++ b/google/cloud/talent/internal/company_metadata_decorator.cc
@@ -85,6 +85,9 @@ void CompanyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/completion_metadata_decorator.cc
+++ b/google/cloud/talent/internal/completion_metadata_decorator.cc
@@ -54,6 +54,9 @@ void CompletionMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/event_metadata_decorator.cc
+++ b/google/cloud/talent/internal/event_metadata_decorator.cc
@@ -55,6 +55,9 @@ void EventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/job_metadata_decorator.cc
+++ b/google/cloud/talent/internal/job_metadata_decorator.cc
@@ -142,6 +142,9 @@ void JobServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/tenant_metadata_decorator.cc
+++ b/google/cloud/talent/internal/tenant_metadata_decorator.cc
@@ -83,6 +83,9 @@ void TenantServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tasks/internal/cloud_tasks_metadata_decorator.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_metadata_decorator.cc
@@ -161,6 +161,9 @@ void CloudTasksMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.cc
+++ b/google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.cc
@@ -63,6 +63,9 @@ void TextToSpeechMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tpu/internal/tpu_metadata_decorator.cc
+++ b/google/cloud/tpu/internal/tpu_metadata_decorator.cc
@@ -148,6 +148,9 @@ void TpuMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/trace/internal/trace_metadata_decorator.cc
+++ b/google/cloud/trace/internal/trace_metadata_decorator.cc
@@ -62,6 +62,9 @@ void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/translate/internal/translation_metadata_decorator.cc
+++ b/google/cloud/translate/internal/translation_metadata_decorator.cc
@@ -150,6 +150,9 @@ void TranslationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.cc
@@ -74,6 +74,9 @@ void VideoIntelligenceServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/internal/image_annotator_metadata_decorator.cc
+++ b/google/cloud/vision/internal/image_annotator_metadata_decorator.cc
@@ -98,6 +98,9 @@ void ImageAnnotatorMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/internal/product_search_metadata_decorator.cc
+++ b/google/cloud/vision/internal/product_search_metadata_decorator.cc
@@ -213,6 +213,9 @@ void ProductSearchMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vmmigration/internal/vm_migration_metadata_decorator.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_metadata_decorator.cc
@@ -443,6 +443,9 @@ void VmMigrationMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.cc
@@ -98,6 +98,9 @@ void VpcAccessServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/webrisk/internal/web_risk_metadata_decorator.cc
+++ b/google/cloud/webrisk/internal/web_risk_metadata_decorator.cc
@@ -79,6 +79,9 @@ void WebRiskServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.cc
@@ -157,6 +157,9 @@ void WebSecurityScannerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/workflows/internal/executions_metadata_decorator.cc
+++ b/google/cloud/workflows/internal/executions_metadata_decorator.cc
@@ -82,6 +82,9 @@ void ExecutionsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/workflows/internal/workflows_metadata_decorator.cc
+++ b/google/cloud/workflows/internal/workflows_metadata_decorator.cc
@@ -105,6 +105,9 @@ void WorkflowsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
When using [PSC] (Private Service Connect) or [VPC-SC] (Virtual Private
Cloud - Service Controls) we need to specify the `authority` in each
gRPC request. This is the HTTP/2 analog of a `Host` header, and allows
applications to access a service while using a custom endpoint. For
example, the target endpoint could be `pubsub-custom.p.googleapis.com`,
but the authority field remains `pubsub.googleapis.com`.

[PSC]: https://cloud.google.com/vpc/docs/private-service-connect
[VPC-SC]: https://cloud.google.com/vpc-service-controls

Part of the work for #3317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8453)
<!-- Reviewable:end -->
