### PR TITLE
refactor(bigtable): only default UserProjectOption for Data API

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -89,11 +89,6 @@ Options DefaultOptions(Options opts) {
     opts.set<InstanceAdminEndpointOption>(*std::move(instance_admin_emulator));
   }
 
-  auto user_project = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
-  if (user_project && !user_project->empty()) {
-    opts.set<UserProjectOption>(*std::move(user_project));
-  }
-
   if (!opts.has<DataEndpointOption>()) {
     opts.set<DataEndpointOption>("bigtable.googleapis.com");
   }
@@ -164,6 +159,11 @@ Options DefaultOptions(Options opts) {
 }
 
 Options DefaultDataOptions(Options opts) {
+  using ::google::cloud::internal::GetEnv;
+  auto user_project = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
+  if (user_project && !user_project->empty()) {
+    opts.set<UserProjectOption>(*std::move(user_project));
+  }
   opts = DefaultOptions(std::move(opts));
   return opts.set<EndpointOption>(opts.get<DataEndpointOption>());
 }

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -155,30 +155,6 @@ TEST(OptionsTest, DefaultTableAdminOptions) {
   EXPECT_EQ("tableadmin.googleapis.com", options.get<EndpointOption>());
 }
 
-TEST(OptionsTest, InstanceAdminUserProjectOption) {
-  auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
-  auto options = DefaultInstanceAdminOptions(
-      Options{}.set<UserProjectOption>("test-project"));
-  EXPECT_EQ(options.get<UserProjectOption>(), "test-project");
-
-  env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", "env-project");
-  options = DefaultInstanceAdminOptions(
-      Options{}.set<UserProjectOption>("test-project"));
-  EXPECT_EQ(options.get<UserProjectOption>(), "env-project");
-}
-
-TEST(OptionsTest, TableAdminUserProjectOption) {
-  auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
-  auto options = DefaultTableAdminOptions(
-      Options{}.set<UserProjectOption>("test-project"));
-  EXPECT_EQ(options.get<UserProjectOption>(), "test-project");
-
-  env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", "env-project");
-  options = DefaultTableAdminOptions(
-      Options{}.set<UserProjectOption>("test-project"));
-  EXPECT_EQ(options.get<UserProjectOption>(), "env-project");
-}
-
 TEST(OptionsTest, DataUserProjectOption) {
   auto env = ScopedEnvironment("GOOGLE_CLOUD_CPP_USER_PROJECT", absl::nullopt);
   auto options =


### PR DESCRIPTION
An unnecessary change. I just like it slightly better if we only default `UserProjectOption` for the Data API, and let the generated `Connection`s do the defaulting for the Admin APIs. I plan to do the same for the incoming `AuthorityOption`.

My thinking in general is that `bigtable::internal::DefaultOptions()` should only mimic the default configuration from the old `bigtable::ClientOptions`. Also I think that isolating these temporary defaults in `DefaultDataOptions` will make things easier to clean up when the Data API is modernized (some time this century).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8455)
<!-- Reviewable:end -->
