### PR TITLE
feat(pubsub): support x-goog-user-project

### DIFF
--- a/google/cloud/pubsub/internal/default_batch_sink.h
+++ b/google/cloud/pubsub/internal/default_batch_sink.h
@@ -32,10 +32,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class DefaultBatchSink : public BatchSink {
  public:
   static std::shared_ptr<DefaultBatchSink> Create(
-      std::shared_ptr<PublisherStub> stub, CompletionQueue cq,
-      Options const& opts) {
+      std::shared_ptr<PublisherStub> stub, CompletionQueue cq, Options opts) {
     return std::shared_ptr<DefaultBatchSink>(
-        new DefaultBatchSink(std::move(stub), std::move(cq), opts));
+        new DefaultBatchSink(std::move(stub), std::move(cq), std::move(opts)));
   }
 
   ~DefaultBatchSink() override = default;
@@ -47,12 +46,11 @@ class DefaultBatchSink : public BatchSink {
 
  private:
   DefaultBatchSink(std::shared_ptr<PublisherStub> stub, CompletionQueue cq,
-                   Options const& opts);
+                   Options opts);
 
   std::shared_ptr<PublisherStub> stub_;
   CompletionQueue cq_;
-  std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
-  std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy_;
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_metadata.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata.cc
@@ -95,6 +95,11 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
                                     std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);
   context.AddMetadata("x-goog-api-client", x_goog_api_client_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_metadata_test.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata_test.cc
@@ -55,7 +55,7 @@ class PublisherMetadataTest : public ::testing::Test {
   static Options TestOptions(std::string const& user_project) {
     return user_project.empty()
                ? Options{}
-               : Options{}.set<UserProjectOption>("test-project");
+               : Options{}.set<UserProjectOption>(user_project);
   }
 
  private:

--- a/google/cloud/pubsub/internal/schema_metadata.cc
+++ b/google/cloud/pubsub/internal/schema_metadata.cc
@@ -72,6 +72,11 @@ void SchemaMetadata::SetMetadata(grpc::ClientContext& context,
                                  std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);
   context.AddMetadata("x-goog-api-client", x_goog_api_client_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/schema_metadata_test.cc
+++ b/google/cloud/pubsub/internal/schema_metadata_test.cc
@@ -56,7 +56,7 @@ class SchemaMetadataTest : public ::testing::Test {
   static Options TestOptions(std::string const& user_project) {
     return user_project.empty()
                ? Options{}
-               : Options{}.set<UserProjectOption>("test-project");
+               : Options{}.set<UserProjectOption>(user_project);
   }
 
  private:

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.h
@@ -68,19 +68,19 @@ class StreamingSubscriptionBatchSource
       CompletionQueue cq,
       std::shared_ptr<SessionShutdownManager> shutdown_manager,
       std::shared_ptr<SubscriberStub> stub, std::string subscription_full_name,
-      std::string client_id, Options const& opts,
+      std::string client_id, Options opts,
       AckBatchingConfig ack_batching_config = {})
       : cq_(std::move(cq)),
         shutdown_manager_(std::move(shutdown_manager)),
         stub_(std::move(stub)),
         subscription_full_name_(std::move(subscription_full_name)),
         client_id_(std::move(client_id)),
+        options_(std::move(opts)),
         max_outstanding_messages_(
-            opts.get<pubsub::MaxOutstandingMessagesOption>()),
-        max_outstanding_bytes_(opts.get<pubsub::MaxOutstandingBytesOption>()),
-        max_deadline_time_(opts.get<pubsub::MaxDeadlineTimeOption>()),
-        retry_policy_(opts.get<pubsub::RetryPolicyOption>()->clone()),
-        backoff_policy_(opts.get<pubsub::BackoffPolicyOption>()->clone()),
+            options_.get<pubsub::MaxOutstandingMessagesOption>()),
+        max_outstanding_bytes_(
+            options_.get<pubsub::MaxOutstandingBytesOption>()),
+        max_deadline_time_(options_.get<pubsub::MaxDeadlineTimeOption>()),
         ack_batching_config_(std::move(ack_batching_config)) {}
 
   ~StreamingSubscriptionBatchSource() override = default;
@@ -153,11 +153,10 @@ class StreamingSubscriptionBatchSource
   std::shared_ptr<SubscriberStub> const stub_;
   std::string const subscription_full_name_;
   std::string const client_id_;
+  Options options_;
   std::int64_t const max_outstanding_messages_;
   std::int64_t const max_outstanding_bytes_;
   std::chrono::seconds const max_deadline_time_;
-  std::unique_ptr<pubsub::RetryPolicy const> retry_policy_;
-  std::unique_ptr<pubsub::BackoffPolicy const> backoff_policy_;
   AckBatchingConfig const ack_batching_config_;
 
   std::mutex mu_;

--- a/google/cloud/pubsub/internal/subscriber_metadata.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata.cc
@@ -142,6 +142,11 @@ void SubscriberMetadata::SetMetadata(grpc::ClientContext& context,
                                      std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);
   context.AddMetadata("x-goog-api-client", x_goog_api_client_);
+  auto const& options = internal::CurrentOptions();
+  if (options.has<UserProjectOption>()) {
+    context.AddMetadata("x-goog-user-project",
+                        options.get<UserProjectOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_metadata_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_test.cc
@@ -55,7 +55,7 @@ class SubscriberMetadataTest : public ::testing::Test {
   static Options TestOptions(std::string const& user_project) {
     return user_project.empty()
                ? Options{}
-               : Options{}.set<UserProjectOption>("test-project");
+               : Options{}.set<UserProjectOption>(user_project);
   }
 
  private:

--- a/google/cloud/pubsub/internal/subscriber_metadata_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_test.cc
@@ -29,6 +29,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::ValidateMetadataFixture;
+using ::testing::_;
+using ::testing::Contains;
+using ::testing::Not;
+using ::testing::Pair;
 
 class SubscriberMetadataTest : public ::testing::Test {
  protected:
@@ -36,6 +40,22 @@ class SubscriberMetadataTest : public ::testing::Test {
                           std::string const& method) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, google::cloud::internal::ApiClientHeader());
+  }
+
+  void ValidateNoUserProject(grpc::ClientContext& context) {
+    auto md = validate_metadata_fixture_.GetMetadata(context);
+    EXPECT_THAT(md, Not(Contains(Pair("x-goog-user-project", _))));
+  }
+
+  void ValidateTestUserProject(grpc::ClientContext& context) {
+    auto md = validate_metadata_fixture_.GetMetadata(context);
+    EXPECT_THAT(md, Contains(Pair("x-goog-user-project", "test-project")));
+  }
+
+  static Options TestOptions(std::string const& user_project) {
+    return user_project.empty()
+               ? Options{}
+               : Options{}.set<UserProjectOption>("test-project");
   }
 
  private:
@@ -50,14 +70,28 @@ TEST_F(SubscriberMetadataTest, CreateSubscription) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.CreateSubscription"));
         return make_status_or(google::pubsub::v1::Subscription{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::Subscription const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::Subscription{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::Subscription const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::Subscription{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::Subscription subscription;
-  subscription.set_name(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto status = stub.CreateSubscription(context, subscription);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::Subscription subscription;
+    subscription.set_name(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto status = stub.CreateSubscription(context, subscription);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, GetSubscription) {
@@ -68,14 +102,28 @@ TEST_F(SubscriberMetadataTest, GetSubscription) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.GetSubscription"));
         return make_status_or(google::pubsub::v1::Subscription{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::GetSubscriptionRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::Subscription{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::GetSubscriptionRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::Subscription{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::GetSubscriptionRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto status = stub.GetSubscription(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::GetSubscriptionRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto status = stub.GetSubscription(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, UpdateSubscription) {
@@ -86,14 +134,28 @@ TEST_F(SubscriberMetadataTest, UpdateSubscription) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.UpdateSubscription"));
         return make_status_or(google::pubsub::v1::Subscription{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::UpdateSubscriptionRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::Subscription{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::UpdateSubscriptionRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::Subscription{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::UpdateSubscriptionRequest request;
-  request.mutable_subscription()->set_name(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto status = stub.UpdateSubscription(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::UpdateSubscriptionRequest request;
+    request.mutable_subscription()->set_name(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto status = stub.UpdateSubscription(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, ListSubscriptions) {
@@ -104,13 +166,27 @@ TEST_F(SubscriberMetadataTest, ListSubscriptions) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.ListSubscriptions"));
         return make_status_or(google::pubsub::v1::ListSubscriptionsResponse{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ListSubscriptionsRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::ListSubscriptionsResponse{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ListSubscriptionsRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::ListSubscriptionsResponse{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::ListSubscriptionsRequest request;
-  request.set_project("projects/test-project");
-  auto status = stub.ListSubscriptions(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::ListSubscriptionsRequest request;
+    request.set_project("projects/test-project");
+    auto status = stub.ListSubscriptions(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, DeleteSubscription) {
@@ -121,14 +197,28 @@ TEST_F(SubscriberMetadataTest, DeleteSubscription) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.DeleteSubscription"));
         return Status{};
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::DeleteSubscriptionRequest const&) {
+        ValidateNoUserProject(context);
+        return Status{};
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::DeleteSubscriptionRequest const&) {
+        ValidateTestUserProject(context);
+        return Status{};
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::DeleteSubscriptionRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto status = stub.DeleteSubscription(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::DeleteSubscriptionRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto status = stub.DeleteSubscription(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, ModifyPushConfig) {
@@ -139,14 +229,28 @@ TEST_F(SubscriberMetadataTest, ModifyPushConfig) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.ModifyPushConfig"));
         return Status{};
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ModifyPushConfigRequest const&) {
+        ValidateNoUserProject(context);
+        return Status{};
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ModifyPushConfigRequest const&) {
+        ValidateTestUserProject(context);
+        return Status{};
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::ModifyPushConfigRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto status = stub.ModifyPushConfig(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::ModifyPushConfigRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto status = stub.ModifyPushConfig(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, AsyncStreamingPull) {
@@ -158,15 +262,31 @@ TEST_F(SubscriberMetadataTest, AsyncStreamingPull) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.pubsub.v1.Subscriber.StreamingPull"));
         return absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+      })
+      .WillOnce([this](google::cloud::CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
+                       google::pubsub::v1::StreamingPullRequest const&) {
+        ValidateNoUserProject(*context);
+        return absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+      })
+      .WillOnce([this](google::cloud::CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
+                       google::pubsub::v1::StreamingPullRequest const&) {
+        ValidateTestUserProject(*context);
+        return absl::make_unique<pubsub_testing::MockAsyncPullStream>();
       });
+
   SubscriberMetadata stub(mock);
-  google::cloud::CompletionQueue cq;
-  google::pubsub::v1::StreamingPullRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto stream = stub.AsyncStreamingPull(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
-  EXPECT_TRUE(stream);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    google::cloud::CompletionQueue cq;
+    google::pubsub::v1::StreamingPullRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto stream = stub.AsyncStreamingPull(
+        cq, absl::make_unique<grpc::ClientContext>(), request);
+    EXPECT_TRUE(stream);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, AsyncAcknowledge) {
@@ -178,15 +298,31 @@ TEST_F(SubscriberMetadataTest, AsyncAcknowledge) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.pubsub.v1.Subscriber.Acknowledge"));
         return make_ready_future(Status{});
+      })
+      .WillOnce([this](google::cloud::CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
+                       google::pubsub::v1::AcknowledgeRequest const&) {
+        ValidateNoUserProject(*context);
+        return make_ready_future(Status{});
+      })
+      .WillOnce([this](google::cloud::CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
+                       google::pubsub::v1::AcknowledgeRequest const&) {
+        ValidateTestUserProject(*context);
+        return make_ready_future(Status{});
       });
+
   SubscriberMetadata stub(mock);
-  google::cloud::CompletionQueue cq;
-  google::pubsub::v1::AcknowledgeRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto response = stub.AsyncAcknowledge(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
-  EXPECT_STATUS_OK(response.get());
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    google::cloud::CompletionQueue cq;
+    google::pubsub::v1::AcknowledgeRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto response = stub.AsyncAcknowledge(
+        cq, absl::make_unique<grpc::ClientContext>(), request);
+    EXPECT_STATUS_OK(response.get());
+  }
 }
 
 TEST_F(SubscriberMetadataTest, AsyncModifyAckDeadline) {
@@ -198,15 +334,31 @@ TEST_F(SubscriberMetadataTest, AsyncModifyAckDeadline) {
         EXPECT_STATUS_OK(IsContextMDValid(
             *context, "google.pubsub.v1.Subscriber.ModifyAckDeadline"));
         return make_ready_future(Status{});
+      })
+      .WillOnce([this](google::cloud::CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
+                       google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        ValidateNoUserProject(*context);
+        return make_ready_future(Status{});
+      })
+      .WillOnce([this](google::cloud::CompletionQueue&,
+                       std::unique_ptr<grpc::ClientContext> context,
+                       google::pubsub::v1::ModifyAckDeadlineRequest const&) {
+        ValidateTestUserProject(*context);
+        return make_ready_future(Status{});
       });
+
   SubscriberMetadata stub(mock);
-  google::cloud::CompletionQueue cq;
-  google::pubsub::v1::ModifyAckDeadlineRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto response = stub.AsyncModifyAckDeadline(
-      cq, absl::make_unique<grpc::ClientContext>(), request);
-  EXPECT_STATUS_OK(response.get());
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    google::cloud::CompletionQueue cq;
+    google::pubsub::v1::ModifyAckDeadlineRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto response = stub.AsyncModifyAckDeadline(
+        cq, absl::make_unique<grpc::ClientContext>(), request);
+    EXPECT_STATUS_OK(response.get());
+  }
 }
 
 TEST_F(SubscriberMetadataTest, CreateSnapshot) {
@@ -217,14 +369,28 @@ TEST_F(SubscriberMetadataTest, CreateSnapshot) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.CreateSnapshot"));
         return make_status_or(google::pubsub::v1::Snapshot{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::CreateSnapshotRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::Snapshot{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::CreateSnapshotRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::Snapshot{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::CreateSnapshotRequest request;
-  request.set_name(
-      pubsub::Snapshot("test-project", "test-snapshot").FullName());
-  auto status = stub.CreateSnapshot(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::CreateSnapshotRequest request;
+    request.set_name(
+        pubsub::Snapshot("test-project", "test-snapshot").FullName());
+    auto status = stub.CreateSnapshot(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, GetSnapshot) {
@@ -235,14 +401,28 @@ TEST_F(SubscriberMetadataTest, GetSnapshot) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.GetSnapshot"));
         return make_status_or(google::pubsub::v1::Snapshot{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::GetSnapshotRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::Snapshot{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::GetSnapshotRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::Snapshot{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::GetSnapshotRequest request;
-  request.set_snapshot(
-      pubsub::Snapshot("test-project", "test-snapshot").FullName());
-  auto status = stub.GetSnapshot(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::GetSnapshotRequest request;
+    request.set_snapshot(
+        pubsub::Snapshot("test-project", "test-snapshot").FullName());
+    auto status = stub.GetSnapshot(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, ListSnapshots) {
@@ -253,13 +433,27 @@ TEST_F(SubscriberMetadataTest, ListSnapshots) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.ListSnapshots"));
         return make_status_or(google::pubsub::v1::ListSnapshotsResponse{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ListSnapshotsRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::ListSnapshotsResponse{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ListSnapshotsRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::ListSnapshotsResponse{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::ListSnapshotsRequest request;
-  request.set_project("projects/test-project");
-  auto status = stub.ListSnapshots(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::ListSnapshotsRequest request;
+    request.set_project("projects/test-project");
+    auto status = stub.ListSnapshots(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, UpdateSnapshot) {
@@ -270,14 +464,28 @@ TEST_F(SubscriberMetadataTest, UpdateSnapshot) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.UpdateSnapshot"));
         return make_status_or(google::pubsub::v1::Snapshot{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::UpdateSnapshotRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::Snapshot{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::UpdateSnapshotRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::Snapshot{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::UpdateSnapshotRequest request;
-  request.mutable_snapshot()->set_name(
-      pubsub::Snapshot("test-project", "test-snapshot").FullName());
-  auto status = stub.UpdateSnapshot(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::UpdateSnapshotRequest request;
+    request.mutable_snapshot()->set_name(
+        pubsub::Snapshot("test-project", "test-snapshot").FullName());
+    auto status = stub.UpdateSnapshot(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, DeleteSnapshot) {
@@ -288,14 +496,28 @@ TEST_F(SubscriberMetadataTest, DeleteSnapshot) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.pubsub.v1.Subscriber.DeleteSnapshot"));
         return Status{};
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::DeleteSnapshotRequest const&) {
+        ValidateNoUserProject(context);
+        return Status{};
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::DeleteSnapshotRequest const&) {
+        ValidateTestUserProject(context);
+        return Status{};
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::DeleteSnapshotRequest request;
-  request.set_snapshot(
-      pubsub::Snapshot("test-project", "test-snapshot").FullName());
-  auto status = stub.DeleteSnapshot(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::DeleteSnapshotRequest request;
+    request.set_snapshot(
+        pubsub::Snapshot("test-project", "test-snapshot").FullName());
+    auto status = stub.DeleteSnapshot(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 TEST_F(SubscriberMetadataTest, Seek) {
@@ -306,14 +528,28 @@ TEST_F(SubscriberMetadataTest, Seek) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context, "google.pubsub.v1.Subscriber.Seek"));
         return make_status_or(google::pubsub::v1::SeekResponse{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::SeekRequest const&) {
+        ValidateNoUserProject(context);
+        return make_status_or(google::pubsub::v1::SeekResponse{});
+      })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::SeekRequest const&) {
+        ValidateTestUserProject(context);
+        return make_status_or(google::pubsub::v1::SeekResponse{});
       });
+
   SubscriberMetadata stub(mock);
-  grpc::ClientContext context;
-  google::pubsub::v1::SeekRequest request;
-  request.set_subscription(
-      pubsub::Subscription("test-project", "test-subscription").FullName());
-  auto status = stub.Seek(context, request);
-  EXPECT_STATUS_OK(status);
+  for (auto const* user_project : {"", "", "test-project"}) {
+    internal::OptionsSpan span(TestOptions(user_project));
+    grpc::ClientContext context;
+    google::pubsub::v1::SeekRequest request;
+    request.set_subscription(
+        pubsub::Subscription("test-project", "test-subscription").FullName());
+    auto status = stub.Seek(context, request);
+    EXPECT_STATUS_OK(status);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
Change the metadata decorators to inject `x-goog-user-project` from the
current option span.

For the admin APIs, use the per-call options to configure a span in the
`*Client` class.  For `pubsub::Publisher` and `pubsub::Subscriber` it is
less clear which call "triggers" an RPC, and far less clear how to merge
options from multiple RPCs.  I have decided to use the per-connection
options in this case. We can always add more fine-grained options later,
but this takes care of the common case.

Part of the work for #8284 and will help with #3317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8456)
<!-- Reviewable:end -->
