### PR TITLE
feat(bigtable): better support for PSC and VPC-SC

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -164,6 +164,9 @@ Options DefaultDataOptions(Options opts) {
   if (user_project && !user_project->empty()) {
     opts.set<UserProjectOption>(*std::move(user_project));
   }
+  if (!opts.has<AuthorityOption>()) {
+    opts.set<AuthorityOption>("bigtable.googleapis.com");
+  }
   opts = DefaultOptions(std::move(opts));
   return opts.set<EndpointOption>(opts.get<DataEndpointOption>());
 }

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -167,6 +167,15 @@ TEST(OptionsTest, DataUserProjectOption) {
   EXPECT_EQ(options.get<UserProjectOption>(), "env-project");
 }
 
+TEST(OptionsTest, DataAuthorityOption) {
+  auto options = DefaultDataOptions(Options{});
+  EXPECT_EQ(options.get<AuthorityOption>(), "bigtable.googleapis.com");
+
+  options = DefaultDataOptions(
+      Options{}.set<AuthorityOption>("custom-endpoint.googleapis.com"));
+  EXPECT_EQ(options.get<AuthorityOption>(), "custom-endpoint.googleapis.com");
+}
+
 TEST(EndpointEnvTest, EmulatorEnvOnly) {
   ScopedEnvironment emulator("BIGTABLE_EMULATOR_HOST", "emulator-host:8000");
 


### PR DESCRIPTION
The bigtable part of #3317 

Also, there was an oopsies for the `user_project_`. One reason we did not catch it is because there are no tests for `DataClient::ApplyOptions()`. I just fixed the bug, without adding any tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8458)
<!-- Reviewable:end -->
