### PR TITLE
feat(pubsub): support `AuthorityOption`

### DIFF
--- a/google/cloud/pubsub/internal/publisher_metadata.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata.cc
@@ -100,6 +100,9 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_metadata.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata.cc
@@ -147,6 +147,9 @@ void SubscriberMetadata::SetMetadata(grpc::ClientContext& context,
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
+  if (options.has<AuthorityOption>()) {
+    context.set_authority(options.get<AuthorityOption>());
+  }
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
By default use `pubsub.googleapis.com` as the `authority` in all
requests, regardless of the `EndpointOption` value.  This improves the
support for PSC and VPC-SC.

Part of the work for #3317

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8460)
<!-- Reviewable:end -->
