### PR TITLE
feat(storage): support AuthorityOption

### DIFF
--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -32,7 +32,21 @@ struct UserIpOption {
   using Type = std::string;
 };
 
-/// Configure the REST endpoint for the GCS client library.
+/**
+ * Configure the REST endpoint for the GCS client library.
+ *
+ * This endpoint must include the URL scheme (`http` or `https`) and `authority`
+ * (host and port) used to access the GCS service, for example:
+ *    https://storage.googleapis.com
+ * When using emulators or testbench it can be of the form:
+ *    http://localhost:8080/my-gcs-emulator-path
+ *
+ * @note The `Host` header is based on the `authority` component of the URL.
+ *   Applications can override this default value using
+ *   `google::cloud::AuthorityOption`
+ *
+ * @see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#URLs_and_URNs
+ */
 struct RestEndpointOption {
   using Type = std::string;
 };

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -113,7 +113,7 @@ std::string HostHeader(Options const& options, char const* service) {
   // In those cases the application would target a URL like
   // `https://restricted.googleapis.com`, or `https://private.googleapis.com`,
   // or their own proxy, and need to provide the target's service host.
-  auto auth = options.get<AuthorityOption>();
+  auto const& auth = options.get<AuthorityOption>();
   if (!auth.empty()) return absl::StrCat("Host: ", auth);
   auto const& endpoint = options.get<RestEndpointOption>();
   if (absl::StrContains(endpoint, "googleapis.com")) {

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -113,9 +113,8 @@ std::string HostHeader(Options const& options, char const* service) {
   // In those cases the application would target a URL like
   // `https://restricted.googleapis.com`, or `https://private.googleapis.com`,
   // or their own proxy, and need to provide the target's service host.
-  if (!options.get<AuthorityOption>().empty()) {
-    return absl::StrCat("Host: ", options.get<AuthorityOption>());
-  }
+  auto auth = options.get<AuthorityOption>();
+  if (!auth.empty()) return absl::StrCat("Host: ", auth);
   auto const& endpoint = options.get<RestEndpointOption>();
   if (absl::StrContains(endpoint, "googleapis.com")) {
     return absl::StrCat("Host: ", service, ".googleapis.com");

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -110,9 +110,12 @@ std::string HostHeader(Options const& options, char const* service) {
   // header based on the URL. In most cases this is the correct value. The main
   // exception are applications using `VPC-SC`:
   //     https://cloud.google.com/vpc/docs/configure-private-google-access
-  // In those cases the application would target an URL like
+  // In those cases the application would target a URL like
   // `https://restricted.googleapis.com`, or `https://private.googleapis.com`,
   // or their own proxy, and need to provide the target's service host.
+  if (!options.get<AuthorityOption>().empty()) {
+    return absl::StrCat("Host: ", options.get<AuthorityOption>());
+  }
   auto const& endpoint = options.get<RestEndpointOption>();
   if (absl::StrContains(endpoint, "googleapis.com")) {
     return absl::StrCat("Host: ", service, ".googleapis.com");

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -101,38 +101,42 @@ class CurlClientTest : public ::testing::Test,
 TEST(CurlClientStandaloneFunctions, HostHeader) {
   struct Test {
     std::string endpoint;
+    std::string authority;
     std::string service;
     std::string expected;
   } cases[] = {
-      {"https://storage.googleapis.com", "storage",
+      {"https://storage.googleapis.com", "", "storage",
        "Host: storage.googleapis.com"},
-      {"https://storage.googleapis.com:443", "storage",
+      {"https://storage.googleapis.com", "auth", "storage", "Host: auth"},
+      {"https://storage.googleapis.com:443", "", "storage",
        "Host: storage.googleapis.com"},
-      {"https://restricted.googleapis.com", "storage",
+      {"https://restricted.googleapis.com", "", "storage",
        "Host: storage.googleapis.com"},
-      {"https://private.googleapis.com", "storage",
+      {"https://private.googleapis.com", "", "storage",
        "Host: storage.googleapis.com"},
-      {"https://restricted.googleapis.com", "iamcredentials",
+      {"https://restricted.googleapis.com", "", "iamcredentials",
        "Host: iamcredentials.googleapis.com"},
-      {"https://private.googleapis.com", "iamcredentials",
+      {"https://private.googleapis.com", "", "iamcredentials",
        "Host: iamcredentials.googleapis.com"},
-      {"http://localhost:8080", "", ""},
-      {"http://[::1]", "", ""},
-      {"http://[::1]/", "", ""},
-      {"http://[::1]/foo/bar", "", ""},
-      {"http://[::1]:8080/", "", ""},
-      {"http://[::1]:8080/foo/bar", "", ""},
-      {"http://localhost:8080", "", ""},
-      {"https://storage-download.127.0.0.1.nip.io/xmlapi/", "", ""},
-      {"https://gcs.127.0.0.1.nip.io/storage/v1/", "", ""},
-      {"https://gcs.127.0.0.1.nip.io:4443/upload/storage/v1/", "", ""},
-      {"https://gcs.127.0.0.1.nip.io:4443/upload/storage/v1/", "", ""},
+      {"http://localhost:8080", "", "", ""},
+      {"http://localhost:8080", "auth", "", "Host: auth"},
+      {"http://[::1]", "", "", ""},
+      {"http://[::1]/", "", "", ""},
+      {"http://[::1]/foo/bar", "", "", ""},
+      {"http://[::1]:8080/", "", "", ""},
+      {"http://[::1]:8080/foo/bar", "", "", ""},
+      {"http://localhost:8080", "", "", ""},
+      {"https://storage-download.127.0.0.1.nip.io/xmlapi/", "", "", ""},
+      {"https://gcs.127.0.0.1.nip.io/storage/v1/", "", "", ""},
+      {"https://gcs.127.0.0.1.nip.io:4443/upload/storage/v1/", "", "", ""},
+      {"https://gcs.127.0.0.1.nip.io:4443/upload/storage/v1/", "", "", ""},
   };
 
   for (auto const& test : cases) {
     SCOPED_TRACE("Testing for " + test.endpoint + ", " + test.service);
-    auto const actual = HostHeader(
-        Options{}.set<RestEndpointOption>(test.endpoint), test.service.c_str());
+    auto options = Options{}.set<RestEndpointOption>(test.endpoint);
+    if (!test.authority.empty()) options.set<AuthorityOption>(test.authority);
+    auto const actual = HostHeader(options, test.service.c_str());
     EXPECT_EQ(test.expected, actual);
   }
 }

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -42,6 +42,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 using ::google::cloud::internal::MakeBackgroundThreadsFactory;
+using ::google::cloud::internal::OptionsSpan;
 
 int DefaultGrpcNumChannels() {
   auto constexpr kMinimumChannels = 4;
@@ -58,6 +59,9 @@ Options DefaultOptionsGrpc(Options options) {
   }
   if (!options.has<EndpointOption>()) {
     options.set<EndpointOption>("storage.googleapis.com");
+  }
+  if (!options.has<AuthorityOption>()) {
+    options.set<AuthorityOption>("storage.googleapis.com");
   }
   using google::cloud::internal::GetEnv;
   auto env = GetEnv("CLOUD_STORAGE_GRPC_ENDPOINT");
@@ -110,6 +114,7 @@ std::unique_ptr<GrpcClient::WriteObjectStream> GrpcClient::CreateUploadWriter(
 
 StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
     QueryResumableUploadRequest const& request) {
+  OptionsSpan span(options_);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request, "resource");
   auto const timeout = options_.get<TransferStallTimeoutOption>();
@@ -153,6 +158,7 @@ ClientOptions const& GrpcClient::client_options() const {
 
 StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
     ListBucketsRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -163,6 +169,7 @@ StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
 
 StatusOr<BucketMetadata> GrpcClient::CreateBucket(
     CreateBucketRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -173,6 +180,7 @@ StatusOr<BucketMetadata> GrpcClient::CreateBucket(
 
 StatusOr<BucketMetadata> GrpcClient::GetBucketMetadata(
     GetBucketMetadataRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -183,6 +191,7 @@ StatusOr<BucketMetadata> GrpcClient::GetBucketMetadata(
 
 StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
     DeleteBucketRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -193,6 +202,7 @@ StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
 
 StatusOr<BucketMetadata> GrpcClient::UpdateBucket(
     UpdateBucketRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -203,6 +213,7 @@ StatusOr<BucketMetadata> GrpcClient::UpdateBucket(
 
 StatusOr<BucketMetadata> GrpcClient::PatchBucket(
     PatchBucketRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
@@ -217,6 +228,7 @@ StatusOr<BucketMetadata> GrpcClient::PatchBucket(
 
 StatusOr<IamPolicy> GrpcClient::GetBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -234,6 +246,7 @@ StatusOr<IamPolicy> GrpcClient::GetBucketIamPolicy(
 
 StatusOr<NativeIamPolicy> GrpcClient::GetNativeBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -247,6 +260,7 @@ StatusOr<NativeIamPolicy> GrpcClient::GetNativeBucketIamPolicy(
 
 StatusOr<IamPolicy> GrpcClient::SetBucketIamPolicy(
     SetBucketIamPolicyRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -264,6 +278,7 @@ StatusOr<IamPolicy> GrpcClient::SetBucketIamPolicy(
 
 StatusOr<NativeIamPolicy> GrpcClient::SetNativeBucketIamPolicy(
     SetNativeBucketIamPolicyRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -274,6 +289,7 @@ StatusOr<NativeIamPolicy> GrpcClient::SetNativeBucketIamPolicy(
 
 StatusOr<TestBucketIamPermissionsResponse> GrpcClient::TestBucketIamPermissions(
     TestBucketIamPermissionsRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -284,6 +300,7 @@ StatusOr<TestBucketIamPermissionsResponse> GrpcClient::TestBucketIamPermissions(
 
 StatusOr<BucketMetadata> GrpcClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -294,6 +311,7 @@ StatusOr<BucketMetadata> GrpcClient::LockBucketRetentionPolicy(
 
 StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
     InsertObjectMediaRequest const& request) {
+  OptionsSpan span(options_);
   auto r = GrpcObjectRequestParser::ToProto(request);
   if (!r) return std::move(r).status();
   auto proto_request = *r;
@@ -345,6 +363,7 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
 
 StatusOr<ObjectMetadata> GrpcClient::CopyObject(
     CopyObjectRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request, "resource");
@@ -360,6 +379,7 @@ StatusOr<ObjectMetadata> GrpcClient::CopyObject(
 
 StatusOr<ObjectMetadata> GrpcClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -370,6 +390,7 @@ StatusOr<ObjectMetadata> GrpcClient::GetObjectMetadata(
 
 StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
     ReadObjectRangeRequest const& request) {
+  OptionsSpan span(options_);
   // With the REST API this condition was detected by the server as an error,
   // generally we prefer the server to detect errors because its answers are
   // authoritative. In this case, the server cannot: with gRPC '0' is the same
@@ -396,6 +417,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
 
 StatusOr<ListObjectsResponse> GrpcClient::ListObjects(
     ListObjectsRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -406,6 +428,7 @@ StatusOr<ListObjectsResponse> GrpcClient::ListObjects(
 
 StatusOr<EmptyResponse> GrpcClient::DeleteObject(
     DeleteObjectRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -416,6 +439,7 @@ StatusOr<EmptyResponse> GrpcClient::DeleteObject(
 
 StatusOr<ObjectMetadata> GrpcClient::UpdateObject(
     UpdateObjectRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
@@ -427,6 +451,7 @@ StatusOr<ObjectMetadata> GrpcClient::UpdateObject(
 
 StatusOr<ObjectMetadata> GrpcClient::PatchObject(
     PatchObjectRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
@@ -438,6 +463,7 @@ StatusOr<ObjectMetadata> GrpcClient::PatchObject(
 
 StatusOr<ObjectMetadata> GrpcClient::ComposeObject(
     ComposeObjectRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
@@ -449,6 +475,7 @@ StatusOr<ObjectMetadata> GrpcClient::ComposeObject(
 
 StatusOr<RewriteObjectResponse> GrpcClient::RewriteObject(
     RewriteObjectRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
@@ -460,6 +487,7 @@ StatusOr<RewriteObjectResponse> GrpcClient::RewriteObject(
 
 StatusOr<std::unique_ptr<ResumableUploadSession>>
 GrpcClient::CreateResumableSession(ResumableUploadRequest const& request) {
+  OptionsSpan span(options_);
   auto session_id = request.GetOption<UseResumableUploadSession>().value_or("");
   if (!session_id.empty()) {
     return FullyRestoreResumableSession(request, session_id);
@@ -579,6 +607,7 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchDefaultObjectAcl(
 
 StatusOr<ServiceAccount> GrpcClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
+  OptionsSpan span(options_);
   auto proto = GrpcServiceAccountParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/testing/mock_storage_stub.h"
 #include "google/cloud/credentials.h"
+#include "google/cloud/options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <gmock/gmock.h>
@@ -27,11 +28,14 @@ namespace internal {
 namespace {
 
 namespace v2 = ::google::storage::v2;
+using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Pair;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
+
+auto constexpr kAuthority = "storage.googleapis.com";
 
 class GrpcClientTest : public ::testing::Test {
  protected:
@@ -60,6 +64,7 @@ TEST_F(GrpcClientTest, QueryResumableUpload) {
   EXPECT_CALL(*mock, QueryWriteStatus)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::QueryWriteStatusRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -83,6 +88,7 @@ TEST_F(GrpcClientTest, CreateBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::CreateBucketRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -105,6 +111,7 @@ TEST_F(GrpcClientTest, GetBucket) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        google::storage::v2::GetBucketRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -126,6 +133,7 @@ TEST_F(GrpcClientTest, DeleteBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::DeleteBucketRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -146,6 +154,7 @@ TEST_F(GrpcClientTest, ListBuckets) {
   EXPECT_CALL(*mock, ListBuckets)
       .WillOnce([this](grpc::ClientContext& context,
                        google::storage::v2::ListBucketsRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -167,6 +176,7 @@ TEST_F(GrpcClientTest, LockBucketRetentionPolicy) {
       .WillOnce(
           [this](grpc::ClientContext& context,
                  google::storage::v2::LockBucketRetentionPolicyRequest const&) {
+            EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
             auto metadata = GetMetadata(context);
             EXPECT_THAT(metadata,
                         UnorderedElementsAre(
@@ -188,6 +198,7 @@ TEST_F(GrpcClientTest, UpdateBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::UpdateBucketRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -209,6 +220,7 @@ TEST_F(GrpcClientTest, PatchBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::UpdateBucketRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -230,6 +242,7 @@ TEST_F(GrpcClientTest, GetBucketIamPolicy) {
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::GetIamPolicyRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -250,6 +263,7 @@ TEST_F(GrpcClientTest, GetNativeBucketIamPolicy) {
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::GetIamPolicyRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -270,6 +284,7 @@ TEST_F(GrpcClientTest, SetBucketIamPolicy) {
   EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::SetIamPolicyRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -292,6 +307,7 @@ TEST_F(GrpcClientTest, SetNativeBucketIamPolicy) {
   EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::SetIamPolicyRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -314,6 +330,7 @@ TEST_F(GrpcClientTest, TestBucketIamPermissions) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::iam::v1::TestIamPermissionsRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -364,6 +381,7 @@ TEST_F(GrpcClientTest, CopyObject) {
   EXPECT_CALL(*mock, RewriteObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::RewriteObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -392,6 +410,7 @@ TEST_F(GrpcClientTest, CopyObjectTooLarge) {
   EXPECT_CALL(*mock, RewriteObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::RewriteObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -423,6 +442,7 @@ TEST_F(GrpcClientTest, GetObjectMetadata) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -466,6 +486,7 @@ TEST_F(GrpcClientTest, ListObjects) {
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::ListObjectsRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -487,6 +508,7 @@ TEST_F(GrpcClientTest, DeleteObject) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::DeleteObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -509,6 +531,7 @@ TEST_F(GrpcClientTest, UpdateObject) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::UpdateObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -535,6 +558,7 @@ TEST_F(GrpcClientTest, PatchObject) {
   EXPECT_CALL(*mock, UpdateObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::UpdateObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -559,6 +583,7 @@ TEST_F(GrpcClientTest, ComposeObject) {
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::ComposeObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -581,6 +606,7 @@ TEST_F(GrpcClientTest, RewriteObject) {
   EXPECT_CALL(*mock, RewriteObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::RewriteObjectRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -609,6 +635,7 @@ TEST_F(GrpcClientTest, CreateResumableSession) {
   EXPECT_CALL(*mock, StartResumableWrite)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::StartResumableWriteRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -634,6 +661,7 @@ TEST_F(GrpcClientTest, GetServiceAccount) {
   EXPECT_CALL(*mock, GetServiceAccount)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetServiceAccountRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -351,6 +351,7 @@ TEST_F(GrpcClientTest, InsertObjectMedia) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, WriteObject)
       .WillOnce([this](std::unique_ptr<grpc::ClientContext> context) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(


### PR DESCRIPTION
If present, use the `AuthorityOption` to configure the `Host: ` header
or the `.set_authority()` attribute in `grpc::ClientContext`. By
default, configure `AuthorityOption` to be `storage.googleapis.com`,
applications can override this when initializing the `storage::Client`.

There is already an issue open to add per-call `Options` that would
provide more fine-grained control of this field.

Fixes #3317.  I am adding a node to #8164 because we will need to undo some of this work to support per-call options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8462)
<!-- Reviewable:end -->
