### PR TITLE
feat(spanner): use prevailing Options in ConnectionImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
   generated automatically from the service definitions. The new APIs can be
   found in the [`google/cloud/spanner/admin`](https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/spanner/admin)
   tree and within the `google::cloud::spanner_admin` namespace. Starting with
-  the v1.32.0 release, and depending on your compiler settings, using these
+  the v1.32.0 release, and depending on your compiler settings, using the old
   classes/functions may elicit a deprecation warning. See
   [#7356](https://github.com/googleapis/google-cloud-cpp/issues/7356) for more
   details.
@@ -143,6 +143,15 @@ best long-term interest of our customers.
 **BREAKING CHANGE:** The `bigtable::InstanceAdminClient` class has been marked
 as `final`. After the changes in [v1.36.0](#v1360---2022-02), there is no need
 or reason to be extending this class.
+
+### [Spanner](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/spanner/README.md)
+
+All the `spanner::Client` operations now take optional `google::cloud::Options`
+arguments, replacing the existing `ClientOptions`, `CommitOptions`,
+`PartitionOptions`, `QueryOptions`, and `ReadOptions` arguments, or adding
+options to operations that previously had none. Users should migrate to these
+new overloads (although no deprecation schedule for the old interfaces has been
+announced).
 
 ### New Libraries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,8 +150,8 @@ All the `spanner::Client` operations now take optional `google::cloud::Options`
 arguments, replacing the existing `ClientOptions`, `CommitOptions`,
 `PartitionOptions`, `QueryOptions`, and `ReadOptions` arguments, or adding
 options to operations that previously had none. Users should migrate to these
-new overloads (although no deprecation schedule for the old interfaces has been
-announced).
+new overloads. (Note that the old `spanner::*Options` types have not been
+deprecated as they are still used in the `spanner::Connection` interface.)
 
 ### New Libraries
 

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -325,26 +325,40 @@ class StreamingPartitionedDmlResult {
 
 std::shared_ptr<spanner::RetryPolicy> const&
 ConnectionImpl::RetryPolicyPrototype() const {
-  // TODO(#4528) TODO(#7690): Base this on internal::CurrentOptions().
+  // TODO(#4528): Support per-operation defaults for retry policies.
+  auto const& options = internal::CurrentOptions();
+  if (options.has<spanner::SpannerRetryPolicyOption>()) {
+    return options.get<spanner::SpannerRetryPolicyOption>();
+  }
   return opts_.get<spanner::SpannerRetryPolicyOption>();
 }
 
 std::shared_ptr<spanner::BackoffPolicy> const&
 ConnectionImpl::BackoffPolicyPrototype() const {
-  // TODO(#4528) TODO(#7690): Base this on internal::CurrentOptions().
+  // TODO(#4528): Support per-operation defaults for backoff policies.
+  auto const& options = internal::CurrentOptions();
+  if (options.has<spanner::SpannerBackoffPolicyOption>()) {
+    return options.get<spanner::SpannerBackoffPolicyOption>();
+  }
   return opts_.get<spanner::SpannerBackoffPolicyOption>();
 }
 
 bool ConnectionImpl::RpcStreamTracingEnabled() const {
-  // TODO(#7690): Base this on internal::CurrentOptions() if we want to
-  // allow per-operation options to influence "rpc-streams" tracing.
-  return internal::Contains(opts_.get<TracingComponentsOption>(),
-                            "rpc-streams");
+  std::string const rpc_streams = "rpc-streams";
+  auto const& options = internal::CurrentOptions();
+  auto const& tracing_components = options.get<TracingComponentsOption>();
+  if (!internal::Contains(tracing_components, rpc_streams)) {
+    auto const& tracing_components = opts_.get<TracingComponentsOption>();
+    if (!internal::Contains(tracing_components, rpc_streams)) return false;
+  }
+  return true;
 }
 
 TracingOptions const& ConnectionImpl::RpcTracingOptions() const {
-  // TODO(#7690): Base this on internal::CurrentOptions() if we want to
-  // allow per-operation options to influence "rpc-streams" tracing.
+  auto const& options = internal::CurrentOptions();
+  if (options.has<GrpcTracingOptionsOption>()) {
+    return options.get<GrpcTracingOptionsOption>();
+  }
   return opts_.get<GrpcTracingOptionsOption>();
 }
 


### PR DESCRIPTION
Allow the prevailing `Options` to override the connection options
for the retry/backoff policies and RPC tracing parameters, so that
any per-operation options are heeded.

This is the final step in fixing #7690, so announce that users
should now prefer to use `Options` on all Spanner client calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8466)
<!-- Reviewable:end -->
