### PR TITLE
ci: cleanup check-api GOOGLE_CLOUD_CPP_ENABLE value

### DIFF
--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -28,7 +28,7 @@ mapfile -t feature_list < <(bazelisk --batch query \
   'kind(cc_library, //:all) except filter("experimental|mocks", kind(cc_library, //:all))' |
   sed -e 's;//:;;')
 enabled="$(printf ";%s" "${feature_list[@]}")"
-echo "${enabled:1}"
+enabled="${enabled:1}"
 
 INSTALL_PREFIX=/var/tmp/google-cloud-cpp
 # abi-dumper wants us to use -Og, but that causes bogus warnings about


### PR DESCRIPTION
I meant to remove the `;` at the beginning of the enabled services list.
It is harmless, but untidy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8469)
<!-- Reviewable:end -->
