### PR TITLE
feat(generator): all bidir streams are experimental

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -136,10 +136,10 @@ GoldenKitchenSinkClient::DoNothing(google::protobuf::Empty const& request, Optio
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::test::admin::database::v1::AppendRowsRequest,
     google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkClient::AsyncAppendRows(Options opts) {
+GoldenKitchenSinkClient::AsyncAppendRows(ExperimentalTag tag, Options opts) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(opts), options_));
-  return connection_->AsyncAppendRows();
+  return connection_->AsyncAppendRows(std::move(tag));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -20,6 +20,7 @@
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTEGRATION_TESTS_GOLDEN_GOLDEN_KITCHEN_SINK_CLIENT_H
 
 #include "generator/integration_tests/golden/golden_kitchen_sink_connection.h"
+#include "google/cloud/experimental_tag.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
@@ -363,7 +364,7 @@ class GoldenKitchenSinkClient {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows(Options opts = {});
+  AsyncAppendRows(ExperimentalTag, Options opts = {});
 
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -83,7 +83,7 @@ GoldenKitchenSinkConnection::DoNothing(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::test::admin::database::v1::AppendRowsRequest,
     google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkConnection::AsyncAppendRows() {
+GoldenKitchenSinkConnection::AsyncAppendRows(ExperimentalTag) {
   return absl::make_unique<
       ::google::cloud::internal::AsyncStreamingReadWriteRpcError<
           google::test::admin::database::v1::AppendRowsRequest,

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -23,6 +23,7 @@
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_retry_traits.h"
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/experimental_tag.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
@@ -75,7 +76,7 @@ class GoldenKitchenSinkConnection {
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows();
+  AsyncAppendRows(ExperimentalTag);
 };
 
 std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h
@@ -78,7 +78,7 @@ class GoldenKitchenSinkConnectionImpl
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
-  AsyncAppendRows() override;
+  AsyncAppendRows(ExperimentalTag) override;
 
  private:
   std::unique_ptr<golden::GoldenKitchenSinkRetryPolicy> retry_policy() {

--- a/generator/integration_tests/golden/internal/streaming.cc
+++ b/generator/integration_tests/golden/internal/streaming.cc
@@ -24,7 +24,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::test::admin::database::v1::AppendRowsRequest,
     google::test::admin::database::v1::AppendRowsResponse>>
-GoldenKitchenSinkConnectionImpl::AsyncAppendRows() {
+GoldenKitchenSinkConnectionImpl::AsyncAppendRows(ExperimentalTag) {
   return stub_->AsyncAppendRows(
       background_->cq(), absl::make_unique<grpc::ClientContext>());
 }

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -62,7 +62,7 @@ class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnecti
   MOCK_METHOD((std::unique_ptr<
       ::google::cloud::AsyncStreamingReadWriteRpc<
           google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>>),
-      AsyncAppendRows, (), (override));
+      AsyncAppendRows, (ExperimentalTag), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_client_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_client_test.cc
@@ -318,7 +318,7 @@ TEST(GoldenKitchenSinkClientTest, AsyncAppendRows) {
         .set<UserAgentProductsOption>({"override-me"});
   });
 
-  EXPECT_CALL(*mock, AsyncAppendRows).WillOnce([] {
+  EXPECT_CALL(*mock, AsyncAppendRows).WillOnce([](ExperimentalTag) {
     auto const& current = internal::CurrentOptions();
     EXPECT_TRUE(current.has<EndpointOption>());
     EXPECT_TRUE(current.has<GrpcTracingOptionsOption>());
@@ -358,6 +358,7 @@ TEST(GoldenKitchenSinkClientTest, AsyncAppendRows) {
                            .set<EndpointOption>("test-endpoint")
                            .set<UserAgentProductsOption>({"override-me-too"}));
   auto stream = client.AsyncAppendRows(
+      ExperimentalTag{},
       Options{}.set<UserAgentProductsOption>({"test-only/1.0"}));
   ASSERT_TRUE(stream->Start().get());
   AppendRowsRequest request;

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_connection_test.cc
@@ -309,7 +309,7 @@ TEST(GoldenKitchenSinkConnectionTest, AppendRowsError) {
         Status{StatusCode::kUnavailable, "try-again"});
   });
   auto conn = CreateTestingConnection(std::move(mock));
-  auto stream = conn->AsyncAppendRows();
+  auto stream = conn->AsyncAppendRows(ExperimentalTag{});
   ASSERT_FALSE(stream->Start().get());
   auto status = stream->Finish().get();
   EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable, "try-again"));

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -71,10 +71,12 @@ Status ClientGenerator::GenerateHeader() {
 
   // includes
   HeaderPrint("\n");
-  HeaderLocalIncludes({vars("connection_header_path"), "google/cloud/future.h",
-                       "google/cloud/options.h",
-                       "google/cloud/polling_policy.h",
-                       "google/cloud/status_or.h", "google/cloud/version.h"});
+  HeaderLocalIncludes(
+      {vars("connection_header_path"),
+       HasBidirStreamingMethod() ? "google/cloud/experimental_tag.h" : "",
+       "google/cloud/future.h", "google/cloud/options.h",
+       "google/cloud/polling_policy.h", "google/cloud/status_or.h",
+       "google/cloud/version.h"});
   if (get_iam_policy_extension_ && set_iam_policy_extension_) {
     HeaderLocalIncludes({"google/cloud/iam_updater.h"});
   }
@@ -121,7 +123,7 @@ Status ClientGenerator::GenerateHeader() {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       $request_type$,
       $response_type$>>
-  Async$method_name$(Options opts = {});
+  Async$method_name$(ExperimentalTag, Options opts = {});
 )""");
       continue;
     }
@@ -358,10 +360,10 @@ Status ClientGenerator::GenerateCc() {
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     $request_type$,
     $response_type$>>
-$client_class_name$::Async$method_name$(Options opts) {
+$client_class_name$::Async$method_name$(ExperimentalTag tag, Options opts) {
   internal::OptionsSpan span(
       internal::MergeOptions(std::move(opts), options_));
-  return connection_->Async$method_name$();
+  return connection_->Async$method_name$(std::move(tag));
 }
 )""");
       continue;

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -60,6 +60,7 @@ Status ConnectionGenerator::GenerateHeader() {
        HasBidirStreamingMethod()
            ? "google/cloud/internal/async_read_write_stream_impl.h"
            : "",
+       HasBidirStreamingMethod() ? "google/cloud/experimental_tag.h" : "",
        "google/cloud/version.h"});
   HeaderSystemIncludes(
       {HasLongrunningMethod() ? "google/longrunning/operations.grpc.pb.h" : "",
@@ -83,7 +84,7 @@ Status ConnectionGenerator::GenerateHeader() {
   );
 
   // TODO(#8234): This is a special case for backwards compatibility of the
-  // streaming updated function.
+  //     streaming update function.
   if (vars().at("service_name") == "BigQueryRead") {
     // streaming updater functions
     for (auto const& method : methods()) {
@@ -124,7 +125,7 @@ Status ConnectionGenerator::GenerateHeader() {
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       $request_type$,
       $response_type$>>
-  Async$method_name$();
+  Async$method_name$(ExperimentalTag);
 )""");
       continue;
     }
@@ -257,7 +258,7 @@ $connection_class_name$::~$connection_class_name$() = default;
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     $request_type$,
     $response_type$>>
-$connection_class_name$::Async$method_name$() {
+$connection_class_name$::Async$method_name$(ExperimentalTag) {
   return absl::make_unique<
       ::google::cloud::internal::AsyncStreamingReadWriteRpcError<
           $request_type$,

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -229,7 +229,7 @@ std::string ConnectionImplGenerator::MethodDeclaration(
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       $request_type$,
       $response_type$>>
-  Async$method_name$() override;
+  Async$method_name$(ExperimentalTag) override;
 )""";
   }
 

--- a/generator/internal/mock_connection_generator.cc
+++ b/generator/internal/mock_connection_generator.cc
@@ -68,7 +68,7 @@ class $mock_connection_class_name$ : public $product_namespace$::$connection_cla
   MOCK_METHOD((std::unique_ptr<
       ::google::cloud::AsyncStreamingReadWriteRpc<
           $request_type$, $response_type$>>),
-      Async$method_name$, (), (override));
+      Async$method_name$, (ExperimentalTag), (override));
 )""");
       continue;
     }

--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -51,6 +51,7 @@ add_library(
     common_options.h
     credentials.cc
     credentials.h
+    experimental_tag.h
     future.h
     future_generic.h
     future_void.h

--- a/google/cloud/experimental_tag.h
+++ b/google/cloud/experimental_tag.h
@@ -21,6 +21,12 @@ namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+/**
+ * An argument type to indicate experimental functions.
+ *
+ * Functions that receive this type as an argument are experimental, they are
+ * subject to change (including removal) without notice.
+ */
 struct ExperimentalTag {};
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/experimental_tag.h
+++ b/google/cloud/experimental_tag.h
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      https://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,23 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/speech/internal/speech_connection_impl.h"
-#include <memory>
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EXPERIMENTAL_TAG_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EXPERIMENTAL_TAG_H
+
+#include "google/cloud/version.h"
 
 namespace google {
 namespace cloud {
-namespace speech_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
-    google::cloud::speech::v1::StreamingRecognizeRequest,
-    google::cloud::speech::v1::StreamingRecognizeResponse>>
-SpeechConnectionImpl::AsyncStreamingRecognize(ExperimentalTag) {
-  return stub_->AsyncStreamingRecognize(
-      background_->cq(), absl::make_unique<grpc::ClientContext>());
-}
+struct ExperimentalTag {};
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace speech_internal
 }  // namespace cloud
 }  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_EXPERIMENTAL_TAG_H

--- a/google/cloud/experimental_tag.h
+++ b/google/cloud/experimental_tag.h
@@ -24,7 +24,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * An argument type to indicate experimental functions.
  *
- * Functions that receive this type as an argument are experimental, they are
+ * Functions that receive this type as an argument are experimental. They are
  * subject to change (including removal) without notice.
  */
 struct ExperimentalTag {};

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_common_hdrs = [
     "backoff_policy.h",
     "common_options.h",
     "credentials.h",
+    "experimental_tag.h",
     "future.h",
     "future_generic.h",
     "future_void.h",

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -7,7 +7,7 @@ This directory contains an idiomatic C++ client library for interacting with
 a service for real-time log management and analysis at scale.
 
 <!-- TODO(#7796) - delay GA until we implement TailLogEntries()'s retry loop -->
-
+<!-- GA delayed until (at least) 2022-03-31 -->
 This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow

--- a/google/cloud/logging/internal/logging_service_v2_connection_impl.h
+++ b/google/cloud/logging/internal/logging_service_v2_connection_impl.h
@@ -70,7 +70,7 @@ class LoggingServiceV2ConnectionImpl
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::logging::v2::TailLogEntriesRequest,
       google::logging::v2::TailLogEntriesResponse>>
-  AsyncTailLogEntries() override;
+      AsyncTailLogEntries(ExperimentalTag) override;
 
  private:
   std::unique_ptr<logging::LoggingServiceV2RetryPolicy> retry_policy() {

--- a/google/cloud/logging/internal/streaming.cc
+++ b/google/cloud/logging/internal/streaming.cc
@@ -23,7 +23,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::logging::v2::TailLogEntriesRequest,
     google::logging::v2::TailLogEntriesResponse>>
-LoggingServiceV2ConnectionImpl::AsyncTailLogEntries() {
+LoggingServiceV2ConnectionImpl::AsyncTailLogEntries(ExperimentalTag) {
   // TODO(#7796) - add resume loop
   return stub_->AsyncTailLogEntries(background_->cq(),
                                     absl::make_unique<grpc::ClientContext>());

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -113,9 +113,9 @@ StreamRange<std::string> LoggingServiceV2Client::ListLogs(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::logging::v2::TailLogEntriesRequest,
     google::logging::v2::TailLogEntriesResponse>>
-LoggingServiceV2Client::AsyncTailLogEntries(Options opts) {
+LoggingServiceV2Client::AsyncTailLogEntries(ExperimentalTag tag, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
-  return connection_->AsyncTailLogEntries();
+  return connection_->AsyncTailLogEntries(std::move(tag));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/logging_service_v2_client.h
+++ b/google/cloud/logging/logging_service_v2_client.h
@@ -20,6 +20,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_LOGGING_LOGGING_SERVICE_V2_CLIENT_H
 
 #include "google/cloud/logging/logging_service_v2_connection.h"
+#include "google/cloud/experimental_tag.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
@@ -354,7 +355,7 @@ class LoggingServiceV2Client {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::logging::v2::TailLogEntriesRequest,
       google::logging::v2::TailLogEntriesResponse>>
-  AsyncTailLogEntries(Options opts = {});
+  AsyncTailLogEntries(ExperimentalTag, Options opts = {});
 
  private:
   std::shared_ptr<LoggingServiceV2Connection> connection_;

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -71,7 +71,7 @@ StreamRange<std::string> LoggingServiceV2Connection::ListLogs(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::logging::v2::TailLogEntriesRequest,
     google::logging::v2::TailLogEntriesResponse>>
-LoggingServiceV2Connection::AsyncTailLogEntries() {
+LoggingServiceV2Connection::AsyncTailLogEntries(ExperimentalTag) {
   return absl::make_unique<
       ::google::cloud::internal::AsyncStreamingReadWriteRpcError<
           google::logging::v2::TailLogEntriesRequest,

--- a/google/cloud/logging/logging_service_v2_connection.h
+++ b/google/cloud/logging/logging_service_v2_connection.h
@@ -23,6 +23,7 @@
 #include "google/cloud/logging/internal/logging_service_v2_stub.h"
 #include "google/cloud/logging/logging_service_v2_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/experimental_tag.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
@@ -72,7 +73,7 @@ class LoggingServiceV2Connection {
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::logging::v2::TailLogEntriesRequest,
       google::logging::v2::TailLogEntriesResponse>>
-  AsyncTailLogEntries();
+      AsyncTailLogEntries(ExperimentalTag);
 };
 
 std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(

--- a/google/cloud/logging/mocks/mock_logging_service_v2_connection.h
+++ b/google/cloud/logging/mocks/mock_logging_service_v2_connection.h
@@ -56,7 +56,7 @@ class MockLoggingServiceV2Connection
   MOCK_METHOD((std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
                    google::logging::v2::TailLogEntriesRequest,
                    google::logging::v2::TailLogEntriesResponse>>),
-              AsyncTailLogEntries, (), (override));
+              AsyncTailLogEntries, (ExperimentalTag), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -7,6 +7,7 @@ This directory contains an idiomatic C++ client library for the
 to text by applying powerful neural network models.
 
 <!-- TODO(#7991): verify the StreamingRecognize API is usable before GA -->
+<!-- GA delayed until (at least) 2022-03-31 -->
 This library is **experimental**. Its APIs are subject to change without notice.
 
 Please note that the Google Cloud C++ client libraries do **not** follow

--- a/google/cloud/speech/internal/speech_connection_impl.h
+++ b/google/cloud/speech/internal/speech_connection_impl.h
@@ -61,7 +61,7 @@ class SpeechConnectionImpl : public speech::SpeechConnection {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::speech::v1::StreamingRecognizeRequest,
       google::cloud::speech::v1::StreamingRecognizeResponse>>
-  AsyncStreamingRecognize() override;
+      AsyncStreamingRecognize(ExperimentalTag) override;
 
  private:
   std::unique_ptr<speech::SpeechRetryPolicy> retry_policy() {

--- a/google/cloud/speech/mocks/mock_speech_connection.h
+++ b/google/cloud/speech/mocks/mock_speech_connection.h
@@ -44,7 +44,7 @@ class MockSpeechConnection : public speech::SpeechConnection {
   MOCK_METHOD((std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
                    google::cloud::speech::v1::StreamingRecognizeRequest,
                    google::cloud::speech::v1::StreamingRecognizeResponse>>),
-              AsyncStreamingRecognize, (), (override));
+              AsyncStreamingRecognize, (ExperimentalTag), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/speech_client.cc
+++ b/google/cloud/speech/speech_client.cc
@@ -71,9 +71,9 @@ SpeechClient::LongRunningRecognize(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::speech::v1::StreamingRecognizeRequest,
     google::cloud::speech::v1::StreamingRecognizeResponse>>
-SpeechClient::AsyncStreamingRecognize(Options opts) {
+SpeechClient::AsyncStreamingRecognize(ExperimentalTag tag, Options opts) {
   internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
-  return connection_->AsyncStreamingRecognize();
+  return connection_->AsyncStreamingRecognize(std::move(tag));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/speech_client.h
+++ b/google/cloud/speech/speech_client.h
@@ -20,6 +20,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPEECH_SPEECH_CLIENT_H
 
 #include "google/cloud/speech/speech_connection.h"
+#include "google/cloud/experimental_tag.h"
 #include "google/cloud/future.h"
 #include "google/cloud/options.h"
 #include "google/cloud/polling_policy.h"
@@ -182,7 +183,7 @@ class SpeechClient {
   std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::speech::v1::StreamingRecognizeRequest,
       google::cloud::speech::v1::StreamingRecognizeResponse>>
-  AsyncStreamingRecognize(Options opts = {});
+  AsyncStreamingRecognize(ExperimentalTag, Options opts = {});
 
  private:
   std::shared_ptr<SpeechConnection> connection_;

--- a/google/cloud/speech/speech_connection.cc
+++ b/google/cloud/speech/speech_connection.cc
@@ -50,7 +50,7 @@ SpeechConnection::LongRunningRecognize(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
     google::cloud::speech::v1::StreamingRecognizeRequest,
     google::cloud::speech::v1::StreamingRecognizeResponse>>
-SpeechConnection::AsyncStreamingRecognize() {
+SpeechConnection::AsyncStreamingRecognize(ExperimentalTag) {
   return absl::make_unique<
       ::google::cloud::internal::AsyncStreamingReadWriteRpcError<
           google::cloud::speech::v1::StreamingRecognizeRequest,

--- a/google/cloud/speech/speech_connection.h
+++ b/google/cloud/speech/speech_connection.h
@@ -23,6 +23,7 @@
 #include "google/cloud/speech/internal/speech_stub.h"
 #include "google/cloud/speech/speech_connection_idempotency_policy.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/experimental_tag.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
 #include "google/cloud/options.h"
@@ -65,7 +66,7 @@ class SpeechConnection {
   virtual std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
       google::cloud::speech::v1::StreamingRecognizeRequest,
       google::cloud::speech::v1::StreamingRecognizeResponse>>
-  AsyncStreamingRecognize();
+      AsyncStreamingRecognize(ExperimentalTag);
 };
 
 std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options = {});


### PR DESCRIPTION
Change the bidirectional streaming RPCs to take a `ExperimentalTag`
parameter. We are not certain if these APIs are ergonomic enough, and
may want to change them for something easier to use.  Until we make
these decisions, it seems sad to keep all the other RPCs from reaching
"GA" status. In the case of BigQuery, the overall library is GA, we
don't want to revert the GA status based on a single RPC.

This is not a breaking change, as none of the libraries affected by the
change are GA.  It does reset the clock for these libraries until T+28d.

Related to #8459

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8471)
<!-- Reviewable:end -->
