### PR TITLE
fix: use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,9 +300,9 @@ function (google_cloud_cpp_enable_features)
                 add_subdirectory(google/cloud/storage)
             endif ()
         else ()
-            if (NOT IS_DIRECTORY "${CMAKE_SOURCE_DIR}/google/cloud/${feature}"
+            if (NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}"
                 OR NOT EXISTS
-                   "${CMAKE_SOURCE_DIR}/google/cloud/${feature}/CMakeLists.txt")
+                   "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/CMakeLists.txt")
                 message(
                     WARNING
                         "${feature} is not a valid feature in google-cloud-cpp, ignored"
@@ -312,7 +312,7 @@ function (google_cloud_cpp_enable_features)
             add_subdirectory(google/cloud/${feature})
             if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
                 AND IS_DIRECTORY
-                    "${CMAKE_SOURCE_DIR}/google/cloud/${feature}/samples")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/samples")
                 add_subdirectory(google/cloud/${feature}/samples)
             endif ()
             # Older libraries used examples/ to host their examples. The
@@ -320,7 +320,7 @@ function (google_cloud_cpp_enable_features)
             # references these files explicitly.
             if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
                 AND IS_DIRECTORY
-                    "${CMAKE_SOURCE_DIR}/google/cloud/${feature}/examples")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/examples")
                 add_subdirectory(google/cloud/${feature}/examples)
             endif ()
         endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,9 +300,12 @@ function (google_cloud_cpp_enable_features)
                 add_subdirectory(google/cloud/storage)
             endif ()
         else ()
-            if (NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}"
-                OR NOT EXISTS
-                   "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/CMakeLists.txt")
+            if (NOT IS_DIRECTORY
+                "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}"
+                OR NOT
+                   EXISTS
+                   "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/CMakeLists.txt"
+            )
                 message(
                     WARNING
                         "${feature} is not a valid feature in google-cloud-cpp, ignored"
@@ -312,7 +315,8 @@ function (google_cloud_cpp_enable_features)
             add_subdirectory(google/cloud/${feature})
             if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
                 AND IS_DIRECTORY
-                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/samples")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/samples"
+            )
                 add_subdirectory(google/cloud/${feature}/samples)
             endif ()
             # Older libraries used examples/ to host their examples. The
@@ -320,7 +324,8 @@ function (google_cloud_cpp_enable_features)
             # references these files explicitly.
             if (GOOGLE_CLOUD_CPP_ENABLE_EXAMPLES
                 AND IS_DIRECTORY
-                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/examples")
+                    "${CMAKE_CURRENT_SOURCE_DIR}/google/cloud/${feature}/examples"
+            )
                 add_subdirectory(google/cloud/${feature}/examples)
             endif ()
         endif ()


### PR DESCRIPTION
Recent commits broke the possibility to use the project with CMake as an ExternalProject(FetchContent in my case).
In https://github.com/googleapis/google-cloud-cpp/commit/f4c898f47838dffade2f0cdf4a182e0347a34612 and https://github.com/googleapis/google-cloud-cpp/commit/14a0ad2bf1574a87277778b2b146a80672872ccb in the root CMakeLists.txt the folder structure is checked relative to CMAKE_SOURCE_DIR which works if the project is standalone, however if used as an external project CMAKE_SOURCE_DIR refers to the topmost project's source dir.

I suggest we change these to CMAKE_CURRENT_SOURCE_DIR since `add_subdirectory` already works relative to that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8477)
<!-- Reviewable:end -->
