### PR TITLE
cleanup: use GA Bazel rules for quickstarts

### DIFF
--- a/google/cloud/accessapproval/quickstart/BUILD.bazel
+++ b/google/cloud/accessapproval/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-accessapproval",
+        "@com_github_googleapis_google_cloud_cpp//:accessapproval",
     ],
 )

--- a/google/cloud/accesscontextmanager/quickstart/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-accesscontextmanager",
+        "@com_github_googleapis_google_cloud_cpp//:accesscontextmanager",
     ],
 )

--- a/google/cloud/apigateway/quickstart/BUILD.bazel
+++ b/google/cloud/apigateway/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-apigateway",
+        "@com_github_googleapis_google_cloud_cpp//:apigateway",
     ],
 )

--- a/google/cloud/appengine/quickstart/BUILD.bazel
+++ b/google/cloud/appengine/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-appengine",
+        "@com_github_googleapis_google_cloud_cpp//:appengine",
     ],
 )

--- a/google/cloud/artifactregistry/quickstart/BUILD.bazel
+++ b/google/cloud/artifactregistry/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-artifactregistry",
+        "@com_github_googleapis_google_cloud_cpp//:artifactregistry",
     ],
 )

--- a/google/cloud/asset/quickstart/BUILD.bazel
+++ b/google/cloud/asset/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-asset",
+        "@com_github_googleapis_google_cloud_cpp//:asset",
     ],
 )

--- a/google/cloud/assuredworkloads/quickstart/BUILD.bazel
+++ b/google/cloud/assuredworkloads/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-assuredworkloads",
+        "@com_github_googleapis_google_cloud_cpp//:assuredworkloads",
     ],
 )

--- a/google/cloud/automl/quickstart/BUILD.bazel
+++ b/google/cloud/automl/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-automl",
+        "@com_github_googleapis_google_cloud_cpp//:automl",
     ],
 )

--- a/google/cloud/billing/quickstart/BUILD.bazel
+++ b/google/cloud/billing/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-billing",
+        "@com_github_googleapis_google_cloud_cpp//:billing",
     ],
 )

--- a/google/cloud/binaryauthorization/quickstart/BUILD.bazel
+++ b/google/cloud/binaryauthorization/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-binaryauthorization",
+        "@com_github_googleapis_google_cloud_cpp//:binaryauthorization",
     ],
 )

--- a/google/cloud/channel/quickstart/BUILD.bazel
+++ b/google/cloud/channel/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-channel",
+        "@com_github_googleapis_google_cloud_cpp//:channel",
     ],
 )

--- a/google/cloud/cloudbuild/quickstart/BUILD.bazel
+++ b/google/cloud/cloudbuild/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-cloudbuild",
+        "@com_github_googleapis_google_cloud_cpp//:cloudbuild",
     ],
 )

--- a/google/cloud/composer/quickstart/BUILD.bazel
+++ b/google/cloud/composer/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-composer",
+        "@com_github_googleapis_google_cloud_cpp//:composer",
     ],
 )

--- a/google/cloud/container/quickstart/BUILD.bazel
+++ b/google/cloud/container/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-container",
+        "@com_github_googleapis_google_cloud_cpp//:container",
     ],
 )

--- a/google/cloud/containeranalysis/quickstart/BUILD.bazel
+++ b/google/cloud/containeranalysis/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-containeranalysis",
+        "@com_github_googleapis_google_cloud_cpp//:containeranalysis",
     ],
 )

--- a/google/cloud/datamigration/quickstart/BUILD.bazel
+++ b/google/cloud/datamigration/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-datamigration",
+        "@com_github_googleapis_google_cloud_cpp//:datamigration",
     ],
 )

--- a/google/cloud/debugger/quickstart/BUILD.bazel
+++ b/google/cloud/debugger/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-debugger",
+        "@com_github_googleapis_google_cloud_cpp//:debugger",
     ],
 )

--- a/google/cloud/dlp/quickstart/BUILD.bazel
+++ b/google/cloud/dlp/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-dlp",
+        "@com_github_googleapis_google_cloud_cpp//:dlp",
     ],
 )

--- a/google/cloud/eventarc/quickstart/BUILD.bazel
+++ b/google/cloud/eventarc/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-eventarc",
+        "@com_github_googleapis_google_cloud_cpp//:eventarc",
     ],
 )

--- a/google/cloud/filestore/quickstart/BUILD.bazel
+++ b/google/cloud/filestore/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-filestore",
+        "@com_github_googleapis_google_cloud_cpp//:filestore",
     ],
 )

--- a/google/cloud/functions/quickstart/BUILD.bazel
+++ b/google/cloud/functions/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-functions",
+        "@com_github_googleapis_google_cloud_cpp//:functions",
     ],
 )

--- a/google/cloud/gameservices/quickstart/BUILD.bazel
+++ b/google/cloud/gameservices/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-gameservices",
+        "@com_github_googleapis_google_cloud_cpp//:gameservices",
     ],
 )

--- a/google/cloud/gkehub/quickstart/BUILD.bazel
+++ b/google/cloud/gkehub/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-gkehub",
+        "@com_github_googleapis_google_cloud_cpp//:gkehub",
     ],
 )

--- a/google/cloud/iap/quickstart/BUILD.bazel
+++ b/google/cloud/iap/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-iap",
+        "@com_github_googleapis_google_cloud_cpp//:iap",
     ],
 )

--- a/google/cloud/ids/quickstart/BUILD.bazel
+++ b/google/cloud/ids/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-ids",
+        "@com_github_googleapis_google_cloud_cpp//:ids",
     ],
 )

--- a/google/cloud/iot/quickstart/BUILD.bazel
+++ b/google/cloud/iot/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-iot",
+        "@com_github_googleapis_google_cloud_cpp//:iot",
     ],
 )

--- a/google/cloud/kms/quickstart/BUILD.bazel
+++ b/google/cloud/kms/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-kms",
+        "@com_github_googleapis_google_cloud_cpp//:kms",
     ],
 )

--- a/google/cloud/memcache/quickstart/BUILD.bazel
+++ b/google/cloud/memcache/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-memcache",
+        "@com_github_googleapis_google_cloud_cpp//:memcache",
     ],
 )

--- a/google/cloud/monitoring/quickstart/BUILD.bazel
+++ b/google/cloud/monitoring/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-monitoring",
+        "@com_github_googleapis_google_cloud_cpp//:monitoring",
     ],
 )

--- a/google/cloud/networkmanagement/quickstart/BUILD.bazel
+++ b/google/cloud/networkmanagement/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-networkmanagement",
+        "@com_github_googleapis_google_cloud_cpp//:networkmanagement",
     ],
 )

--- a/google/cloud/notebooks/quickstart/BUILD.bazel
+++ b/google/cloud/notebooks/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-notebooks",
+        "@com_github_googleapis_google_cloud_cpp//:notebooks",
     ],
 )

--- a/google/cloud/orgpolicy/quickstart/BUILD.bazel
+++ b/google/cloud/orgpolicy/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-orgpolicy",
+        "@com_github_googleapis_google_cloud_cpp//:orgpolicy",
     ],
 )

--- a/google/cloud/oslogin/quickstart/BUILD.bazel
+++ b/google/cloud/oslogin/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-oslogin",
+        "@com_github_googleapis_google_cloud_cpp//:oslogin",
     ],
 )

--- a/google/cloud/policytroubleshooter/quickstart/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-policytroubleshooter",
+        "@com_github_googleapis_google_cloud_cpp//:policytroubleshooter",
     ],
 )

--- a/google/cloud/privateca/quickstart/BUILD.bazel
+++ b/google/cloud/privateca/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-privateca",
+        "@com_github_googleapis_google_cloud_cpp//:privateca",
     ],
 )

--- a/google/cloud/pubsublite/quickstart/BUILD.bazel
+++ b/google/cloud/pubsublite/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-pubsublite",
+        "@com_github_googleapis_google_cloud_cpp//:pubsublite",
     ],
 )

--- a/google/cloud/recommender/quickstart/BUILD.bazel
+++ b/google/cloud/recommender/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-recommender",
+        "@com_github_googleapis_google_cloud_cpp//:recommender",
     ],
 )

--- a/google/cloud/redis/quickstart/BUILD.bazel
+++ b/google/cloud/redis/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-redis",
+        "@com_github_googleapis_google_cloud_cpp//:redis",
     ],
 )

--- a/google/cloud/resourcemanager/quickstart/BUILD.bazel
+++ b/google/cloud/resourcemanager/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-resourcemanager",
+        "@com_github_googleapis_google_cloud_cpp//:resourcemanager",
     ],
 )

--- a/google/cloud/retail/quickstart/BUILD.bazel
+++ b/google/cloud/retail/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-retail",
+        "@com_github_googleapis_google_cloud_cpp//:retail",
     ],
 )

--- a/google/cloud/scheduler/quickstart/BUILD.bazel
+++ b/google/cloud/scheduler/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-scheduler",
+        "@com_github_googleapis_google_cloud_cpp//:scheduler",
     ],
 )

--- a/google/cloud/securitycenter/quickstart/BUILD.bazel
+++ b/google/cloud/securitycenter/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-securitycenter",
+        "@com_github_googleapis_google_cloud_cpp//:securitycenter",
     ],
 )

--- a/google/cloud/servicecontrol/quickstart/BUILD.bazel
+++ b/google/cloud/servicecontrol/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-servicecontrol",
+        "@com_github_googleapis_google_cloud_cpp//:servicecontrol",
     ],
 )

--- a/google/cloud/servicedirectory/quickstart/BUILD.bazel
+++ b/google/cloud/servicedirectory/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-servicedirectory",
+        "@com_github_googleapis_google_cloud_cpp//:servicedirectory",
     ],
 )

--- a/google/cloud/servicemanagement/quickstart/BUILD.bazel
+++ b/google/cloud/servicemanagement/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-servicemanagement",
+        "@com_github_googleapis_google_cloud_cpp//:servicemanagement",
     ],
 )

--- a/google/cloud/serviceusage/quickstart/BUILD.bazel
+++ b/google/cloud/serviceusage/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-serviceusage",
+        "@com_github_googleapis_google_cloud_cpp//:serviceusage",
     ],
 )

--- a/google/cloud/shell/quickstart/BUILD.bazel
+++ b/google/cloud/shell/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-shell",
+        "@com_github_googleapis_google_cloud_cpp//:shell",
     ],
 )

--- a/google/cloud/storage/quickstart/BUILD.bazel
+++ b/google/cloud/storage/quickstart/BUILD.bazel
@@ -32,6 +32,6 @@ cc_binary(
         "quickstart_grpc.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:storage-grpc",
+        "@com_github_googleapis_google_cloud_cpp//:experimental-storage-grpc",
     ],
 )

--- a/google/cloud/storage/quickstart/BUILD.bazel
+++ b/google/cloud/storage/quickstart/BUILD.bazel
@@ -32,6 +32,6 @@ cc_binary(
         "quickstart_grpc.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-storage-grpc",
+        "@com_github_googleapis_google_cloud_cpp//:storage-grpc",
     ],
 )

--- a/google/cloud/storagetransfer/quickstart/BUILD.bazel
+++ b/google/cloud/storagetransfer/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-storagetransfer",
+        "@com_github_googleapis_google_cloud_cpp//:storagetransfer",
     ],
 )

--- a/google/cloud/talent/quickstart/BUILD.bazel
+++ b/google/cloud/talent/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-talent",
+        "@com_github_googleapis_google_cloud_cpp//:talent",
     ],
 )

--- a/google/cloud/texttospeech/quickstart/BUILD.bazel
+++ b/google/cloud/texttospeech/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-texttospeech",
+        "@com_github_googleapis_google_cloud_cpp//:texttospeech",
     ],
 )

--- a/google/cloud/tpu/quickstart/BUILD.bazel
+++ b/google/cloud/tpu/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-tpu",
+        "@com_github_googleapis_google_cloud_cpp//:tpu",
     ],
 )

--- a/google/cloud/trace/quickstart/BUILD.bazel
+++ b/google/cloud/trace/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-trace",
+        "@com_github_googleapis_google_cloud_cpp//:trace",
     ],
 )

--- a/google/cloud/translate/quickstart/BUILD.bazel
+++ b/google/cloud/translate/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-translate",
+        "@com_github_googleapis_google_cloud_cpp//:translate",
     ],
 )

--- a/google/cloud/videointelligence/quickstart/BUILD.bazel
+++ b/google/cloud/videointelligence/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-videointelligence",
+        "@com_github_googleapis_google_cloud_cpp//:videointelligence",
     ],
 )

--- a/google/cloud/vision/quickstart/BUILD.bazel
+++ b/google/cloud/vision/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-vision",
+        "@com_github_googleapis_google_cloud_cpp//:vision",
     ],
 )

--- a/google/cloud/vmmigration/quickstart/BUILD.bazel
+++ b/google/cloud/vmmigration/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-vmmigration",
+        "@com_github_googleapis_google_cloud_cpp//:vmmigration",
     ],
 )

--- a/google/cloud/vpcaccess/quickstart/BUILD.bazel
+++ b/google/cloud/vpcaccess/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-vpcaccess",
+        "@com_github_googleapis_google_cloud_cpp//:vpcaccess",
     ],
 )

--- a/google/cloud/webrisk/quickstart/BUILD.bazel
+++ b/google/cloud/webrisk/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-webrisk",
+        "@com_github_googleapis_google_cloud_cpp//:webrisk",
     ],
 )

--- a/google/cloud/websecurityscanner/quickstart/BUILD.bazel
+++ b/google/cloud/websecurityscanner/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-websecurityscanner",
+        "@com_github_googleapis_google_cloud_cpp//:websecurityscanner",
     ],
 )

--- a/google/cloud/workflows/quickstart/BUILD.bazel
+++ b/google/cloud/workflows/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-workflows",
+        "@com_github_googleapis_google_cloud_cpp//:workflows",
     ],
 )


### PR DESCRIPTION
Only for GA libraries, prefer the GA name for the quickstarts. We can
then remove the `:experimental-${library}` aliases at our convenience.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8482)
<!-- Reviewable:end -->
