### PR TITLE
cleanup(GCS+gRPC)!: simplify plugin configuration

### DIFF
--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -15,27 +15,19 @@
 #include "google/cloud/storage/grpc_plugin.h"
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/hybrid_client.h"
-#include "google/cloud/internal/getenv.h"
 
 namespace google {
 namespace cloud {
 namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace {
-absl::optional<std::string> GrpcConfig() {
-  return google::cloud::internal::GetEnv(
-      "GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG");
-}
-}  // namespace
-
 google::cloud::storage::Client DefaultGrpcClient(Options opts) {
   opts = google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
-  auto config = GrpcConfig();
-  if (config.value_or("none") == "none") {
+  auto config = opts.get<GrpcPluginOption>();
+  if (config == "none" || config.empty()) {
     return google::cloud::storage::Client(std::move(opts));
   }
-  if (config.value_or("") == "metadata") {
+  if (config == "metadata") {
     return storage::internal::ClientImplDetails::CreateClient(
         storage::internal::GrpcClient::Create(opts));
   }


### PR DESCRIPTION
With the new backend for Google Direct Access (aka Direct Path) it is
easier to configure gRPC.  I also made it possible to configure the
plugin using `google::cloud::Options`.  Some of these changes are not
backwards compatible, but this is an experimental component.

Motivated by #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8488)
<!-- Reviewable:end -->
