### PR TITLE
feat(GCS+gRPC): benchmark with Direct Path

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -110,6 +110,47 @@ StatusOr<ApiName> ParseApiName(std::string const& val) {
   return Status{StatusCode::kInvalidArgument, "unknown ApiName " + val};
 }
 
+StatusOr<ExperimentLibrary> ParseExperimentLibrary(std::string const& val) {
+  for (auto v : {ExperimentLibrary::kRaw, ExperimentLibrary::kCppClient}) {
+    if (val == ToString(v)) return v;
+  }
+  return Status{StatusCode::kInvalidArgument,
+                "unknown ExperimentLibrary " + val};
+}
+
+StatusOr<ExperimentTransport> ParseExperimentTransport(std::string const& val) {
+  for (auto v : {ExperimentTransport::kDirectPath, ExperimentTransport::kGrpc,
+                 ExperimentTransport::kJson, ExperimentTransport::kXml}) {
+    if (val == ToString(v)) return v;
+  }
+  return Status{StatusCode::kInvalidArgument,
+                "unknown ExperimentTransport " + val};
+}
+
+std::string ToString(ExperimentLibrary v) {
+  switch (v) {
+    case ExperimentLibrary::kCppClient:
+      return "CppClient";
+    case ExperimentLibrary::kRaw:
+      return "Raw";
+  }
+  return "";
+}
+
+std::string ToString(ExperimentTransport v) {
+  switch (v) {
+    case ExperimentTransport::kDirectPath:
+      return "DirectPath";
+    case ExperimentTransport::kGrpc:
+      return "Grpc";
+    case ExperimentTransport::kJson:
+      return "Json";
+    case ExperimentTransport::kXml:
+      return "Xml";
+  }
+  return "";
+}
+
 std::string RandomBucketPrefix() { return "cloud-cpp-testing-bm"; }
 
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -68,6 +68,36 @@ char const* ToString(ApiName api);
 
 StatusOr<ApiName> ParseApiName(std::string const& val);
 
+// We want to compare the following alternatives.
+//
+// - Raw (no C++ client library) JSON Download
+// - Raw XML Download
+// - Raw gRPC Download
+// - Raw gRPC+DirectPath Download
+// - JSON Download
+// - XML Download
+// - gRPC Download
+// - gRPC+DirectPath Download
+// - JSON Upload
+// - gRPC Upload
+// - gRPC+DirectPath Upload
+//
+// We will model this with 3 dimensions for each experiment:
+// - Direction: Upload vs. Download
+// - Library: Raw vs. Client library
+// - Transport: XML vs. JSON vs. gRPC vs. gRPC+DirectPath
+//
+// Some combinations are simply not implemented and ignored when building the
+// set of experiments.
+enum class ExperimentLibrary { kRaw, kCppClient };
+enum class ExperimentTransport { kDirectPath, kGrpc, kJson, kXml };
+
+StatusOr<ExperimentLibrary> ParseExperimentLibrary(std::string const& val);
+StatusOr<ExperimentTransport> ParseExperimentTransport(std::string const& val);
+
+std::string ToString(ExperimentLibrary v);
+std::string ToString(ExperimentTransport v);
+
 std::string RandomBucketPrefix();
 
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -246,6 +246,8 @@ gcs_bm::ClientProvider MakeProvider(ThroughputOptions const& options) {
     if (t == ExperimentTransport::kGrpc) {
       return DefaultGrpcClient(opts.set<gcs_ex::GrpcPluginOption>("none"));
     }
+#else
+    (void)t;  // disable unused parameter warning
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     return gcs::Client(opts);
   };

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -387,7 +387,7 @@ google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {
           "--duration=1s",
           "--minimum-sample-count=4",
           "--maximum-sample-count=10",
-          "--enabled-apis=JSON,XML",
+          "--enabled-transports=Json,Xml",
           "--enabled-crc32c=enabled",
           "--enabled-md5=disabled",
       },

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -15,8 +15,10 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_EXPERIMENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_EXPERIMENT_H
 
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/benchmarks/throughput_options.h"
 #include "google/cloud/storage/benchmarks/throughput_result.h"
+#include <functional>
 #include <memory>
 #include <string>
 #include <vector>
@@ -51,14 +53,14 @@ class ThroughputExperiment {
                                ThroughputExperimentConfig const& config) = 0;
 };
 
+using ClientProvider =
+    std::function<google::cloud::storage::Client(ExperimentTransport)>;
+
 /**
  * Create the list of upload experiments based on the @p options.
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
-    ThroughputOptions const& options,
-    google::cloud::storage::Client rest_client,
-    google::cloud::storage::Client grpc_client,
-    google::cloud::Options const& client_options);
+    ThroughputOptions const& options, ClientProvider provider);
 
 /**
  * Create the list of download experiments based on the @p options.
@@ -67,10 +69,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
  * they depend on the upload experiment to create the objects to be downloaded.
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
-    ThroughputOptions const& options,
-    google::cloud::storage::Client rest_client,
-    google::cloud::storage::Client grpc_client,
-    google::cloud::Options const& client_options, int thread_id);
+    ThroughputOptions const& options, ClientProvider provider, int thread_id);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -41,12 +41,13 @@ struct ThroughputOptions {
   std::size_t read_quantum = 1 * kMiB;
   std::int32_t minimum_sample_count = 0;
   std::int32_t maximum_sample_count = std::numeric_limits<std::int32_t>::max();
-  std::vector<ApiName> enabled_apis = {
-      ApiName::kApiJson,
-      ApiName::kApiXml,
-#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
-      ApiName::kApiGrpc,
-#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+  std::vector<ExperimentLibrary> libs = {
+      ExperimentLibrary::kCppClient,
+  };
+  std::vector<ExperimentTransport> transports = {
+      ExperimentTransport::kGrpc,
+      ExperimentTransport::kJson,
+      ExperimentTransport::kXml,
   };
   std::vector<bool> enabled_crc32c = {false, true};
   std::vector<bool> enabled_md5 = {false, true};

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -43,7 +43,8 @@ TEST(ThroughputOptions, Basic) {
       "--duration=1s",
       "--minimum-sample-count=1",
       "--maximum-sample-count=2",
-      "--enabled-apis=JSON,GRPC,XML",
+      "--enabled-libs=Raw,CppClient",
+      "--enabled-transports=DirectPath,Grpc,Json,Xml",
       "--enabled-crc32c=enabled",
       "--enabled-md5=disabled",
       "--client-per-thread=false",
@@ -63,9 +64,13 @@ TEST(ThroughputOptions, Basic) {
   EXPECT_EQ(1, options->duration.count());
   EXPECT_EQ(1, options->minimum_sample_count);
   EXPECT_EQ(2, options->maximum_sample_count);
-  EXPECT_THAT(options->enabled_apis,
-              UnorderedElementsAre(ApiName::kApiGrpc, ApiName::kApiXml,
-                                   ApiName::kApiJson));
+  EXPECT_THAT(options->libs,
+              UnorderedElementsAre(ExperimentLibrary::kRaw,
+                                   ExperimentLibrary::kCppClient));
+  EXPECT_THAT(options->transports,
+              UnorderedElementsAre(
+                  ExperimentTransport::kDirectPath, ExperimentTransport::kGrpc,
+                  ExperimentTransport::kJson, ExperimentTransport::kXml));
   EXPECT_THAT(options->enabled_crc32c, ElementsAre(true));
   EXPECT_THAT(options->enabled_md5, ElementsAre(false));
 }
@@ -109,16 +114,28 @@ TEST(ThroughputOptions, MD5) {
   EXPECT_THAT(options->enabled_md5, UnorderedElementsAre(false, true));
 }
 
-TEST(ThroughputOptions, Apis) {
+TEST(ThroughputOptions, Libraries) {
   EXPECT_FALSE(
-      ParseThroughputOptions({"self-test", "--region=r", "--enabled-apis="}));
+      ParseThroughputOptions({"self-test", "--region=r", "--enabled-libs="}));
   EXPECT_FALSE(ParseThroughputOptions(
-      {"self-test", "--region=r", "--enabled-apis=JSON,XML,INVALID"}));
+      {"self-test", "--region=r", "--enabled-libs=CppClient,Raw,INVALID"}));
   auto options = ParseThroughputOptions(
-      {"self-test", "--region=r", "--enabled-apis=JSON,XML,GRPC"});
-  EXPECT_THAT(options->enabled_apis,
-              UnorderedElementsAre(ApiName::kApiJson, ApiName::kApiXml,
-                                   ApiName::kApiGrpc));
+      {"self-test", "--region=r", "--enabled-libs=CppClient,Raw"});
+  EXPECT_THAT(options->libs, UnorderedElementsAre(ExperimentLibrary::kCppClient,
+                                                  ExperimentLibrary::kRaw));
+}
+
+TEST(ThroughputOptions, Transports) {
+  EXPECT_FALSE(ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-transports="}));
+  EXPECT_FALSE(ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-transports=Grpc,INVALID"}));
+  auto options = ParseThroughputOptions(
+      {"self-test", "--region=r", "--enabled-transports=Grpc,Json,DirectPath"});
+  EXPECT_THAT(options->transports,
+              UnorderedElementsAre(ExperimentTransport::kGrpc,
+                                   ExperimentTransport::kDirectPath,
+                                   ExperimentTransport::kJson));
 }
 
 TEST(ThroughputOptions, Validate) {

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/benchmarks/throughput_result.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_replace_quiet.h"
+#include <algorithm>
 #include <sstream>
 #include <string>
 
@@ -36,27 +37,35 @@ std::string QuoteCsv(T const& element) {
   return absl::StrCat(R"(")", absl::StrReplaceAll(result, {{R"(")", R"("")"}}),
                       R"(")");
 }
+
+std::string CleanupCsv(std::string v) {
+  std::replace(v.begin(), v.end(), ',', ';');
+  return v;
+}
+
 }  // namespace
 
 void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
-  os << ToString(r.op)                 // force clang to keep one field per-line
+  os << ToString(r.library)            // clang-format hack
+     << ',' << ToString(r.transport)   //
+     << ',' << ToString(r.op)          //
      << ',' << r.object_size           //
      << ',' << r.transfer_size         //
      << ',' << r.app_buffer_size       //
      << ',' << r.lib_buffer_size       //
      << ',' << r.crc_enabled           //
      << ',' << r.md5_enabled           //
-     << ',' << ToString(r.api)         //
      << ',' << r.elapsed_time.count()  //
      << ',' << r.cpu_time.count()      //
+     << ',' << CleanupCsv(r.peer)      //
      << ',' << QuoteCsv(r.status)      //
      << '\n';
 }
 
 void PrintThroughputResultHeader(std::ostream& os) {
-  os << "Op,ObjectSize,TransferSize,AppBufferSize,LibBufferSize"
-     << ",Crc32cEnabled,MD5Enabled,ApiName"
-     << ",ElapsedTimeUs,CpuTimeUs,Status\n";
+  os << "Library,Transport,Op,ObjectSize,TransferSize,AppBufferSize"
+     << ",LibBufferSize,Crc32cEnabled,MD5Enabled"
+     << ",ElapsedTimeUs,CpuTimeUs,Peer,Status\n";
 }
 
 char const* ToString(OpType op) {

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -57,6 +57,10 @@ enum OpType {
  * etc.) as well as its results: status, CPU time, and elapsed time.
  */
 struct ThroughputResult {
+  /// The library used in this experiment
+  ExperimentLibrary library;
+  /// The transport used in this experiment
+  ExperimentTransport transport;
   /// The type of operation in this experiment.
   OpType op;
   /// The total size of the object involved in this experiment. Currently also
@@ -73,8 +77,6 @@ struct ThroughputResult {
   bool crc_enabled;
   /// True if the MD5 hashes are enabled in this experiment.
   bool md5_enabled;
-  /// The API, protocol, or library used in this experiment.
-  ApiName api;
   /// The total time used to complete the experiment.
   std::chrono::microseconds elapsed_time;
   /// The amount of CPU time (as reported by getrusage(2)) consumed in the
@@ -83,6 +85,8 @@ struct ThroughputResult {
   /// The result of the operation. The analysis may need to discard failed
   /// uploads or downloads.
   google::cloud::Status status;
+  /// The peer used during the transfer
+  std::string peer;
 };
 
 /// Print @p r as a CSV line.


### PR DESCRIPTION
Change the existing throughput_vs_cpu benchmark to compare gRPC and
gRPC+DirectPath side-by-side.  Add peer information when available.

This will need some more work, but it is a good change as-is.  Motivated by #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8489)
<!-- Reviewable:end -->
