### PR TITLE
cleanup(pubsublite): remove param from Write

### DIFF
--- a/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h
+++ b/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h
@@ -163,7 +163,7 @@ class ResumableAsyncStreamingReadWriteRpc {
    * happened. If the `Start` future is not satisfied, the user may call `Write`
    * again to write the value to a new underlying stream.
    */
-  virtual future<bool> Write(RequestType const&, grpc::WriteOptions) = 0;
+  virtual future<bool> Write(RequestType const&) = 0;
 
   /**
    * Finishes the streaming RPC.
@@ -253,7 +253,7 @@ class ResumableAsyncStreamingReadWriteRpcImpl
         });
   }
 
-  future<bool> Write(RequestType const& r, grpc::WriteOptions o) override {
+  future<bool> Write(RequestType const& r) override {
     future<bool> write_future;
 
     {
@@ -267,7 +267,7 @@ class ResumableAsyncStreamingReadWriteRpcImpl
           return write_reinit_done_->get_future().then(
               [](future<void>) { return false; });
         case State::kInitialized:
-          write_future = stream_->Write(r, o);
+          write_future = stream_->Write(r, grpc::WriteOptions());
           assert(!in_progress_write_.has_value());
           in_progress_write_.emplace();
       }

--- a/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc_test.cc
+++ b/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc_test.cc
@@ -618,9 +618,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest, BasicReadWriteGood) {
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(make_ready_future(true))));
-  ASSERT_TRUE(
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message())
-          .get());
+  ASSERT_TRUE(stream_->Write(kBasicRequest).get());
 
   EXPECT_CALL(first_stream_ref_, Read)
       .WillOnce(Return(
@@ -664,9 +662,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
   auto shutdown = stream_->Shutdown();
   shutdown.get();
 
-  ASSERT_FALSE(
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message())
-          .get());
+  ASSERT_FALSE(stream_->Write(kBasicRequest).get());
   ASSERT_FALSE(stream_->Read().get().has_value());
   EXPECT_THAT(start.get(), IsOk());
 }
@@ -681,8 +677,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(write_promise.get_future())));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   EXPECT_CALL(first_stream_ref_, Read)
       .WillOnce(Return(ByMove(read_promise.get_future())));
@@ -721,8 +716,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(write_promise.get_future())));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   EXPECT_CALL(first_stream_ref_, Finish)
       .WillOnce(Return(ByMove(finish_promise.get_future())));
@@ -758,8 +752,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(write_promise.get_future())));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   EXPECT_CALL(first_stream_ref_, Finish)
       .WillOnce(Return(ByMove(make_ready_future(kFailStatus))));
@@ -791,8 +784,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(write_promise.get_future())));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   EXPECT_CALL(first_stream_ref_, Cancel);
   EXPECT_CALL(first_stream_ref_, Finish)
@@ -825,9 +817,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(make_ready_future(true))));
-  ASSERT_TRUE(
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message())
-          .get());
+  ASSERT_TRUE(stream_->Write(kBasicRequest).get());
 
   promise<absl::optional<FakeResponse>> read_promise;
   EXPECT_CALL(first_stream_ref_, Read)
@@ -904,8 +894,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(make_ready_future(false))));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   // write shouldn't finish until retry
   // loop done
@@ -944,8 +933,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(second_stream_ref, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(make_ready_future(true))));
-  write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  write = stream_->Write(kBasicRequest);
   ASSERT_TRUE(write.get());
 
   // start shouldn't finish until permanent
@@ -973,8 +961,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(write_promise.get_future())));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   EXPECT_CALL(first_stream_ref_, Read)
       .WillOnce(
@@ -1099,8 +1086,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 
   EXPECT_CALL(first_stream_ref_, Write(kBasicRequest, _))
       .WillOnce(Return(ByMove(write_promise.get_future())));
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
 
   EXPECT_CALL(first_stream_ref_, Finish)
       .WillOnce(Return(ByMove(make_ready_future(kFailStatus))));
@@ -1192,8 +1178,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
   // finish until retry loop finishes
   EXPECT_EQ(read.wait_for(ms(kFutureWaitMs)), std::future_status::timeout);
 
-  auto write =
-      stream_->Write(kBasicRequest, grpc::WriteOptions().set_last_message());
+  auto write = stream_->Write(kBasicRequest);
   EXPECT_EQ(write.wait_for(ms(kFutureWaitMs)), std::future_status::timeout);
   start_promise.set_value(true);
 


### PR DESCRIPTION
param should always be default constructed object anyway

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8506)
<!-- Reviewable:end -->
