### PR TITLE
test(storage): correct download size in benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -156,7 +156,8 @@ class DownloadObject : public ThroughputExperiment {
         gcs::DisableCrc32cChecksum(!config.enable_crc32c),
         gcs::DisableMD5Hash(!config.enable_md5), api_selector);
     std::int64_t transfer_size = 0;
-    while (reader.read(buffer.data(), buffer.size())) {
+    while (!reader.eof() && !reader.bad()) {
+      reader.read(buffer.data(), buffer.size());
       transfer_size += reader.gcount();
     }
     auto const usage = timer.Sample();


### PR DESCRIPTION
The download benchmarks were skipping the last successful `read()`.

Motivated by #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8512)
<!-- Reviewable:end -->
