### PR TITLE
test(storage): simplify benchmark output

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -13,8 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/throughput_result.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
-#include "google/cloud/internal/absl_str_replace_quiet.h"
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -24,48 +22,38 @@ namespace cloud {
 namespace storage_benchmarks {
 
 namespace {
-template <typename T>
-std::string QuoteCsv(T const& element) {
-  std::ostringstream os;
-  os << element;
-  std::string result = os.str();
-  if (result.find_first_of("\",\r\n") == std::string::npos) {
-    return result;
-  }
-
-  // Enclose the string in double quotes, and escape other double quotes.
-  return absl::StrCat(R"(")", absl::StrReplaceAll(result, {{R"(")", R"("")"}}),
-                      R"(")");
-}
 
 std::string CleanupCsv(std::string v) {
   std::replace(v.begin(), v.end(), ',', ';');
+  std::replace(v.begin(), v.end(), '\n', ';');
+  std::replace(v.begin(), v.end(), '\r', ';');
   return v;
 }
 
 }  // namespace
 
 void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
-  os << ToString(r.library)            // clang-format hack
-     << ',' << ToString(r.transport)   //
-     << ',' << ToString(r.op)          //
-     << ',' << r.object_size           //
-     << ',' << r.transfer_size         //
-     << ',' << r.app_buffer_size       //
-     << ',' << r.lib_buffer_size       //
-     << ',' << r.crc_enabled           //
-     << ',' << r.md5_enabled           //
-     << ',' << r.elapsed_time.count()  //
-     << ',' << r.cpu_time.count()      //
-     << ',' << CleanupCsv(r.peer)      //
-     << ',' << QuoteCsv(r.status)      //
+  os << ToString(r.library)                    // clang-format hack
+     << ',' << ToString(r.transport)           //
+     << ',' << ToString(r.op)                  //
+     << ',' << r.object_size                   //
+     << ',' << r.transfer_size                 //
+     << ',' << r.app_buffer_size               //
+     << ',' << r.lib_buffer_size               //
+     << ',' << r.crc_enabled                   //
+     << ',' << r.md5_enabled                   //
+     << ',' << r.elapsed_time.count()          //
+     << ',' << r.cpu_time.count()              //
+     << ',' << CleanupCsv(r.peer)              //
+     << ',' << r.status.code()                 //
+     << ',' << CleanupCsv(r.status.message())  //
      << '\n';
 }
 
 void PrintThroughputResultHeader(std::ostream& os) {
   os << "Library,Transport,Op,ObjectSize,TransferSize,AppBufferSize"
      << ",LibBufferSize,Crc32cEnabled,MD5Enabled"
-     << ",ElapsedTimeUs,CpuTimeUs,Peer,Status\n";
+     << ",ElapsedTimeUs,CpuTimeUs,Peer,StatusCode,Status\n";
 }
 
 char const* ToString(OpType op) {

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -49,11 +49,6 @@ MATCHER_P(
     ++pos;
   }
   std::string status = arg.substr(pos);
-  if (!status.empty() && status.back() == '\n') status.pop_back();
-  if (status.size() < 2 || status.front() != '"' || status.back() != '"') {
-    *result_listener << "Missing opening or closing quote: " << status;
-    return false;
-  }
   if (status.find(substr) == std::string::npos) {
     *result_listener << "Didn't find " << substr << " in " << status;
     return false;
@@ -118,30 +113,30 @@ TEST(ThroughputResult, QuoteCsv) {
   result.status = Status{StatusCode::kInternal, R"(message "with quotes")"};
   auto line = ToString(result);
   ASSERT_STATUS_OK(line);
-  EXPECT_THAT(*line, HasQuotedStatus(R"(message ""with quotes"")"));
+  EXPECT_THAT(*line, HasQuotedStatus(R"(message "with quotes")"));
 
   result.status = Status{StatusCode::kInternal, R"(message, with comma)"};
   line = ToString(result);
   ASSERT_STATUS_OK(line);
-  EXPECT_THAT(*line, HasQuotedStatus(R"(message, with comma)"));
+  EXPECT_THAT(*line, HasQuotedStatus(R"(message; with comma)"));
 
   result.status = Status{StatusCode::kInternal, "message\nwith newline"};
   line = ToString(result);
   ASSERT_STATUS_OK(line);
-  EXPECT_THAT(*line, HasQuotedStatus("message\nwith newline"));
+  EXPECT_THAT(*line, HasQuotedStatus("message;with newline"));
 
   result.status = Status{StatusCode::kInternal, "message\r\nwith CRLF"};
   line = ToString(result);
   ASSERT_STATUS_OK(line);
-  EXPECT_THAT(*line, HasQuotedStatus("message\r\nwith CRLF"));
+  EXPECT_THAT(*line, HasQuotedStatus("message;;with CRLF"));
 
   result.status =
       Status{StatusCode::kInternal, R"("message, "with quotes", commas,)"
                                     "\r\nand CRLF"};
   line = ToString(result);
   ASSERT_STATUS_OK(line);
-  EXPECT_THAT(*line, HasQuotedStatus(R"(message, ""with quotes"", commas,)"
-                                     "\r\nand CRLF"));
+  EXPECT_THAT(*line, HasQuotedStatus(R"(message; "with quotes"; commas;)"
+                                     ";;and CRLF"));
 }
 
 }  // namespace


### PR DESCRIPTION
Replace any commas, newlines, and carriage returns in message strings
with semicolons. This seems to work better with the Python parser for
CSV files than quoting the value.

Motivated by  #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8513)
<!-- Reviewable:end -->
