### PR TITLE
test(storage): command-line options for benchmark endpoints

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -154,7 +154,7 @@ int main(int argc, char* argv[]) {
             << options->maximum_object_size << "]\n# Write Size Range: ["
             << options->minimum_write_size << "," << options->maximum_write_size
             << "]\n# Write Quantum: " << options->write_quantum
-            << "\n# Min Read Size Range: [" << options->minimum_read_size << ","
+            << "\n# Read Size Range: [" << options->minimum_read_size << ","
             << options->maximum_read_size
             << "]\n# Read Quantum: " << options->read_quantum
             << "\n# Object Size Range (MiB): ["
@@ -165,7 +165,7 @@ int main(int argc, char* argv[]) {
             << options->maximum_write_size / gcs_bm::kKiB
             << "]\n# Write Quantum (KiB): "
             << options->write_quantum / gcs_bm::kKiB
-            << "\n# Min Read Size Range (KiB): ["
+            << "\n# Read Size Range (KiB): ["
             << options->minimum_read_size / gcs_bm::kKiB << ","
             << options->maximum_read_size / gcs_bm::kKiB
             << "]\n# Read Quantum (KiB): "

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -139,6 +139,15 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options, &parse_checksums](std::string const& val) {
          options.enabled_md5 = parse_checksums(val);
        }},
+      {"--rest-endpoint", "sets the endpoint for REST-based benchmarks",
+       [&options](std::string const& val) { options.rest_endpoint = val; }},
+      {"--grpc-endpoint", "sets the endpoint for gRPC-based benchmarks",
+       [&options](std::string const& val) { options.grpc_endpoint = val; }},
+      {"--direct-path-endpoint",
+       "sets the endpoint for gRPC+DirectPath-based benchmarks",
+       [&options](std::string const& val) {
+         options.direct_path_endpoint = val;
+       }},
   };
   auto usage = BuildUsage(desc, argv[0]);
 

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -51,6 +51,9 @@ struct ThroughputOptions {
   };
   std::vector<bool> enabled_crc32c = {false, true};
   std::vector<bool> enabled_md5 = {false, true};
+  std::string rest_endpoint = "https://storage.googleapis.com";
+  std::string grpc_endpoint = "storage.googleapis.com";
+  std::string direct_path_endpoint = "google-c2p:///storage.googleapis.com";
 };
 
 google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -48,6 +48,9 @@ TEST(ThroughputOptions, Basic) {
       "--enabled-crc32c=enabled",
       "--enabled-md5=disabled",
       "--client-per-thread=false",
+      "--rest-endpoint=test-only-rest",
+      "--grpc-endpoint=test-only-grpc",
+      "--direct-path-endpoint=test-only-direct-path",
   });
   ASSERT_STATUS_OK(options);
   EXPECT_EQ("test-project", options->project_id);
@@ -73,6 +76,9 @@ TEST(ThroughputOptions, Basic) {
                   ExperimentTransport::kJson, ExperimentTransport::kXml));
   EXPECT_THAT(options->enabled_crc32c, ElementsAre(true));
   EXPECT_THAT(options->enabled_md5, ElementsAre(false));
+  EXPECT_EQ("test-only-rest", options->rest_endpoint);
+  EXPECT_EQ("test-only-grpc", options->grpc_endpoint);
+  EXPECT_EQ("test-only-direct-path", options->direct_path_endpoint);
 }
 
 TEST(ThroughputOptions, Description) {


### PR DESCRIPTION
Add command-line options to control the endpoints in the throughput
benchmarks. This is useful as the direct path endpoint name changes
depending on the gRPC version, and it helps troubleshooting too.

Also fixed a number of nits in the output.

Part of the work for #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8514)
<!-- Reviewable:end -->
