### PR TITLE
cleanup(storage): no public constructor for RetryClient

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -49,7 +49,7 @@ std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
   if (enable_logging) {
     client = std::make_shared<internal::LoggingClient>(std::move(client));
   }
-  return std::make_shared<internal::RetryClient>(std::move(client), opts);
+  return internal::RetryClient::Create(std::move(client), opts);
 }
 
 std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -93,6 +93,13 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
 }
 }  // namespace
 
+std::shared_ptr<RetryClient> RetryClient::Create(
+    std::shared_ptr<RawClient> client, Options const& options) {
+  // Cannot use `std::make_shared<>` because the constructor is private.
+  return std::shared_ptr<RetryClient>(
+      new RetryClient(std::move(client), options));
+}
+
 RetryClient::RetryClient(std::shared_ptr<RawClient> client,
                          Options const& options)
     : client_(std::move(client)),

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -33,8 +33,8 @@ namespace internal {
 class RetryClient : public RawClient,
                     public std::enable_shared_from_this<RetryClient> {
  public:
-  explicit RetryClient(std::shared_ptr<RawClient> client,
-                       Options const& options);
+  static std::shared_ptr<RetryClient> Create(std::shared_ptr<RawClient> client,
+                                             Options const& options);
 
   ~RetryClient() override = default;
 
@@ -154,6 +154,9 @@ class RetryClient : public RawClient,
   std::shared_ptr<RawClient> client() const { return client_; }
 
  private:
+  explicit RetryClient(std::shared_ptr<RawClient> client,
+                       Options const& options);
+
   std::shared_ptr<RawClient> client_;
   std::shared_ptr<RetryPolicy const> retry_policy_prototype_;
   std::shared_ptr<BackoffPolicy const> backoff_policy_prototype_;

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -79,7 +79,7 @@ Options BasicTestPolicies() {
 /// @test No failures scenario.
 TEST(RetryObjectReadSourceTest, NoFailures) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -97,7 +97,7 @@ TEST(RetryObjectReadSourceTest, NoFailures) {
 /// @test Permanent failure when creating the raw source
 TEST(RetryObjectReadSourceTest, PermanentFailureOnSessionCreation) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -111,7 +111,7 @@ TEST(RetryObjectReadSourceTest, PermanentFailureOnSessionCreation) {
 /// @test Transient failures exhaust retry policy when creating the raw source
 TEST(RetryObjectReadSourceTest, TransientFailuresExhaustOnSessionCreation) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -127,7 +127,7 @@ TEST(RetryObjectReadSourceTest, TransientFailuresExhaustOnSessionCreation) {
 /// @test Recovery from a transient failures when creating the raw source
 TEST(RetryObjectReadSourceTest, SessionCreationRecoversFromTransientFailures) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -148,7 +148,7 @@ TEST(RetryObjectReadSourceTest, SessionCreationRecoversFromTransientFailures) {
 TEST(RetryObjectReadSourceTest, PermanentReadFailure) {
   auto raw_client = std::make_shared<testing::MockClient>();
   auto* raw_source = new MockObjectReadSource;
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -176,10 +176,10 @@ TEST(RetryObjectReadSourceTest, BackoffPolicyResetOnSuccess) {
     ++num_backoff_policy_called;
     return std::chrono::milliseconds(0);
   });
-  auto client = std::make_shared<RetryClient>(
-      std::shared_ptr<internal::RawClient>(raw_client),
-      BasicTestPolicies().set<BackoffPolicyOption>(
-          backoff_policy_mock.clone()));
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(raw_client),
+                          BasicTestPolicies().set<BackoffPolicyOption>(
+                              backoff_policy_mock.clone()));
 
   EXPECT_EQ(0, num_backoff_policy_called);
 
@@ -235,7 +235,7 @@ TEST(RetryObjectReadSourceTest, BackoffPolicyResetOnSuccess) {
 /// @test Check that retry policy is shared between reads and resetting session
 TEST(RetryObjectReadSourceTest, RetryPolicyExhaustedOnResetSession) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -264,7 +264,7 @@ TEST(RetryObjectReadSourceTest, RetryPolicyExhaustedOnResetSession) {
 /// @test `ReadLast` behaviour after a transient failure
 TEST(RetryObjectReadSourceTest, TransientFailureWithReadLastOption) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)
@@ -296,7 +296,7 @@ TEST(RetryObjectReadSourceTest, TransientFailureWithReadLastOption) {
 /// @test The generation is captured such that we resume from the same version
 TEST(RetryObjectReadSourceTest, TransientFailureWithGeneration) {
   auto raw_client = std::make_shared<testing::MockClient>();
-  auto client = std::make_shared<RetryClient>(
+  auto client = RetryClient::Create(
       std::shared_ptr<internal::RawClient>(raw_client), BasicTestPolicies());
 
   EXPECT_CALL(*raw_client, ReadObject)


### PR DESCRIPTION
Instances of this class must always be created in the heap and managed
via `std::shared_ptr<>`.  Use a factory function to create them.

Fixes #3026

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8518)
<!-- Reviewable:end -->
