### PR TITLE
test(GCS+gRPC): timestamp benchmark results

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -68,6 +68,7 @@ class UploadObject : public ThroughputExperiment {
     // ObjectInsert()
     if (static_cast<std::size_t>(config.object_size) < random_data_.size() &&
         prefer_insert_) {
+      auto const start = std::chrono::system_clock::now();
       auto timer = Timer::PerThread();
       std::string data =
           random_data_.substr(0, static_cast<std::size_t>(config.object_size));
@@ -79,6 +80,7 @@ class UploadObject : public ThroughputExperiment {
       return ThroughputResult{ExperimentLibrary::kCppClient,
                               transport_,
                               kOpInsert,
+                              start,
                               config.object_size,
                               config.object_size,
                               config.app_buffer_size,
@@ -90,6 +92,7 @@ class UploadObject : public ThroughputExperiment {
                               object_metadata.status(),
                               "[insert-no-peer]"};
     }
+    auto const start = std::chrono::system_clock::now();
     auto timer = Timer::PerThread();
     auto writer = client_.WriteObject(
         bucket_name, object_name,
@@ -109,6 +112,7 @@ class UploadObject : public ThroughputExperiment {
     return ThroughputResult{ExperimentLibrary::kCppClient,
                             transport_,
                             kOpWrite,
+                            start,
                             config.object_size,
                             config.object_size,
                             config.app_buffer_size,
@@ -150,6 +154,7 @@ class DownloadObject : public ThroughputExperiment {
 
     std::vector<char> buffer(config.app_buffer_size);
 
+    auto const start = std::chrono::system_clock::now();
     auto timer = Timer::PerThread();
     auto reader = client_.ReadObject(
         bucket_name, object_name,
@@ -164,6 +169,7 @@ class DownloadObject : public ThroughputExperiment {
     return ThroughputResult{ExperimentLibrary::kCppClient,
                             transport_,
                             config.op,
+                            start,
                             config.object_size,
                             transfer_size,
                             config.app_buffer_size,
@@ -208,6 +214,7 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
     auto header = creds_->AuthorizationHeader();
     if (!header) return {};
 
+    auto const start = std::chrono::system_clock::now();
     auto timer = Timer::PerThread();
     struct curl_slist* slist1 = nullptr;
     slist1 = curl_slist_append(slist1, header->c_str());
@@ -255,6 +262,7 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
     return ThroughputResult{ExperimentLibrary::kRaw,
                             ExperimentTransport::kXml,
                             config.op,
+                            start,
                             config.object_size,
                             config.object_size,
                             config.app_buffer_size,
@@ -298,6 +306,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
   ThroughputResult Run(std::string const& bucket_name,
                        std::string const& object_name,
                        ThroughputExperimentConfig const& config) override {
+    auto const start = std::chrono::system_clock::now();
     auto timer = Timer::PerThread();
     google::storage::v2::ReadObjectRequest request;
     request.set_bucket(bucket_name);
@@ -318,6 +327,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
     return ThroughputResult{ExperimentLibrary::kRaw,
                             transport_,
                             config.op,
+                            start,
                             config.object_size,
                             bytes_received,
                             config.app_buffer_size,

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/throughput_result.h"
+#include "absl/time/time.h"
 #include <algorithm>
 #include <sstream>
 #include <string>
@@ -33,9 +34,14 @@ std::string CleanupCsv(std::string v) {
 }  // namespace
 
 void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
+  auto constexpr kFormat = "%E4Y-%m-%dT%H:%M:%E*SZ";
+  auto const start =
+      absl::FormatTime(kFormat, absl::FromChrono(r.start), absl::UTCTimeZone());
+
   os << ToString(r.library)                    // clang-format hack
      << ',' << ToString(r.transport)           //
      << ',' << ToString(r.op)                  //
+     << ',' << start                           //
      << ',' << r.object_size                   //
      << ',' << r.transfer_size                 //
      << ',' << r.app_buffer_size               //
@@ -51,7 +57,7 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
 }
 
 void PrintThroughputResultHeader(std::ostream& os) {
-  os << "Library,Transport,Op,ObjectSize,TransferSize,AppBufferSize"
+  os << "Library,Transport,Op,Start,ObjectSize,TransferSize,AppBufferSize"
      << ",LibBufferSize,Crc32cEnabled,MD5Enabled"
      << ",ElapsedTimeUs,CpuTimeUs,Peer,StatusCode,Status\n";
 }

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -63,6 +63,8 @@ struct ThroughputResult {
   ExperimentTransport transport;
   /// The type of operation in this experiment.
   OpType op;
+  /// The start time for this result.
+  std::chrono::system_clock::time_point start;
   /// The total size of the object involved in this experiment. Currently also
   /// represents the number of bytes transferred.
   std::int64_t object_size;

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -73,6 +73,7 @@ TEST(ThroughputResult, HeaderMatches) {
 
   auto const line = ToString(ThroughputResult{
       ExperimentLibrary::kCppClient, ExperimentTransport::kGrpc, kOpInsert,
+      std::chrono::system_clock::now(),
       /*object_size=*/5 * kMiB, /*transfer_size=*/3 * kMiB,
       /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
       /*crc_enabled=*/true, /*md5_enabled=*/false,


### PR DESCRIPTION
Add a timestamp to each benchmark result. I will use this to plot the
performance over time.

Part of the work for #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8519)
<!-- Reviewable:end -->
