### PR TITLE
test(storage): stream benchmark results

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include <functional>
 #include <future>
 #include <set>
 #include <sstream>
@@ -103,11 +104,11 @@ A helper script in this directory can generate pretty graphs from the output of
 this program.
 )""";
 
-using TestResults = std::vector<ThroughputResult>;
+using ResultHandler = std::function<void(gcs_bm::ThroughputResult)>;
 
-TestResults RunThread(ThroughputOptions const& ThroughputOptions,
-                      std::string const& bucket_name, int thread_id);
-void PrintResults(TestResults const& results);
+void RunThread(ThroughputOptions const& ThroughputOptions,
+               std::string const& bucket_name, int thread_id,
+               ResultHandler const& handler);
 
 google::cloud::StatusOr<ThroughputOptions> ParseArgs(int argc, char* argv[]);
 
@@ -200,15 +201,19 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+  std::mutex mu;
+  auto handler = [&mu](gcs_bm::ThroughputResult const& result) {
+    std::lock_guard<std::mutex> lk(mu);
+    gcs_bm::PrintAsCsv(std::cout, result);
+  };
+
   gcs_bm::PrintThroughputResultHeader(std::cout);
-  std::vector<std::future<TestResults>> tasks;
+  std::vector<std::future<void>> tasks;
   for (int i = 0; i != options->thread_count; ++i) {
-    tasks.emplace_back(
-        std::async(std::launch::async, RunThread, *options, bucket_name, i));
+    tasks.emplace_back(std::async(std::launch::async, RunThread, *options,
+                                  bucket_name, i, handler));
   }
-  for (auto& f : tasks) {
-    PrintResults(f.get());
-  }
+  for (auto& f : tasks) f.get();
 
   gcs_bm::DeleteAllObjects(client, bucket_name, options->thread_count);
   auto status = client.DeleteBucket(bucket_name);
@@ -222,13 +227,6 @@ int main(int argc, char* argv[]) {
 }
 
 namespace {
-
-void PrintResults(TestResults const& results) {
-  for (auto const& r : results) {
-    gcs_bm::PrintAsCsv(std::cout, r);
-  }
-  std::cout << std::flush;
-}
 
 gcs_bm::ClientProvider MakeProvider(ThroughputOptions const& options) {
   return [=](ExperimentTransport t) {
@@ -254,8 +252,8 @@ gcs_bm::ClientProvider MakeProvider(ThroughputOptions const& options) {
   };
 }
 
-TestResults RunThread(ThroughputOptions const& options,
-                      std::string const& bucket_name, int thread_id) {
+void RunThread(ThroughputOptions const& options, std::string const& bucket_name,
+               int thread_id, ResultHandler const& handler) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
 
   google::cloud::StatusOr<gcs::ClientOptions> client_options =
@@ -263,7 +261,7 @@ TestResults RunThread(ThroughputOptions const& options,
   if (!client_options) {
     std::cout << "# Could not create ClientOptions, status="
               << client_options.status() << "\n";
-    return {};
+    return;
   }
   auto const upload_buffer_size = client_options->upload_buffer_size();
   auto const download_buffer_size = client_options->download_buffer_size();
@@ -275,7 +273,7 @@ TestResults RunThread(ThroughputOptions const& options,
     // This is possible if only gRPC is requested but the benchmark was compiled
     // without gRPC support.
     std::cout << "# None of the APIs configured are available\n";
-    return {};
+    return;
   }
   auto downloaders =
       gcs_bm::CreateDownloadExperiments(options, provider, thread_id);
@@ -283,7 +281,7 @@ TestResults RunThread(ThroughputOptions const& options,
     // This is possible if only gRPC is requested but the benchmark was compiled
     // without gRPC support.
     std::cout << "# None of the APIs configured are available\n";
-    return {};
+    return;
   }
 
   std::uniform_int_distribution<std::size_t> uploader_generator(
@@ -308,8 +306,6 @@ TestResults RunThread(ThroughputOptions const& options,
 
   auto deadline = std::chrono::steady_clock::now() + options.duration;
 
-  TestResults results;
-
   std::int32_t iteration_count = 0;
   for (auto start = std::chrono::steady_clock::now();
        iteration_count < options.maximum_sample_count &&
@@ -329,7 +325,7 @@ TestResults RunThread(ThroughputOptions const& options,
                           gcs_bm::kOpWrite, object_size, write_size,
                           upload_buffer_size, enable_crc, enable_md5});
     auto status = upload_result.status;
-    results.emplace_back(std::move(upload_result));
+    handler(std::move(upload_result));
 
     if (!status.ok()) {
       if (options.thread_count == 1) {
@@ -340,21 +336,15 @@ TestResults RunThread(ThroughputOptions const& options,
 
     auto& downloader = downloaders[downloader_generator(generator)];
     for (auto op : {gcs_bm::kOpRead0, gcs_bm::kOpRead1, gcs_bm::kOpRead2}) {
-      results.emplace_back(downloader->Run(
+      handler(downloader->Run(
           bucket_name, object_name,
           gcs_bm::ThroughputExperimentConfig{op, object_size, read_size,
                                              download_buffer_size, enable_crc,
                                              enable_md5}));
     }
-    if (options.thread_count == 1) {
-      // Immediately print the results, this makes it easier to debug problems.
-      PrintResults(results);
-      results.clear();
-    }
     auto client = provider(ExperimentTransport::kJson);
     (void)client.DeleteObject(bucket_name, object_name);
   }
-  return results;
 }
 
 google::cloud::StatusOr<ThroughputOptions> SelfTest(char const* argv0) {

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -201,6 +201,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
+  // Serialize output to `std::cout`.
   std::mutex mu;
   auto handler = [&mu](gcs_bm::ThroughputResult const& result) {
     std::lock_guard<std::mutex> lk(mu);

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -16,9 +16,7 @@
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/grpc_error_delegate.h"
-#include "absl/algorithm/container.h"
 #include "absl/memory/memory.h"
-#include "absl/strings/str_split.h"
 #include <google/storage/v2/storage.grpc.pb.h>
 #include <curl/curl.h>
 #include <vector>


### PR DESCRIPTION
I am starting to run benchmarks that take hours to complete.  Sometimes
it is desirable to capture partial results from these benchmarks to
debug the analysis scripts, or even run preliminary analysis. With this
change the throughput-vs-cpu benchmark streams its results as it runs,
instead of printing the results at the end of the test.

Motivated by #3398

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8520)
<!-- Reviewable:end -->
