### PR TITLE
fix(spanner): correct handling of PartialResultSet.resume_token

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -50,11 +50,11 @@ class DefaultPartialResultSetReader : public PartialResultSetReader {
 
   void TryCancel() override { context_->TryCancel(); }
 
-  absl::optional<google::spanner::v1::PartialResultSet> Read() override {
+  absl::optional<PartialResultSet> Read() override {
     google::spanner::v1::PartialResultSet result;
     bool success = reader_->Read(&result);
     if (!success) return {};
-    return result;
+    return PartialResultSet{std::move(result), false};
   }
 
   Status Finish() override {

--- a/google/cloud/spanner/internal/logging_result_set_reader.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader.cc
@@ -28,15 +28,15 @@ void LoggingResultSetReader::TryCancel() {
   GCP_LOG(DEBUG) << __func__ << "() >> (void)";
 }
 
-absl::optional<google::spanner::v1::PartialResultSet>
-LoggingResultSetReader::Read() {
+absl::optional<PartialResultSet> LoggingResultSetReader::Read() {
   GCP_LOG(DEBUG) << __func__ << "() << (void)";
   auto result = impl_->Read();
   if (!result) {
     GCP_LOG(DEBUG) << __func__ << "() >> (optional-with-no-value)";
   } else {
     GCP_LOG(DEBUG) << __func__ << "() >> "
-                   << DebugString(*result, tracing_options_);
+                   << (result->resumption ? "resumption " : "")
+                   << DebugString(result->result, tracing_options_);
   }
   return result;
 }

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -34,7 +34,7 @@ class LoggingResultSetReader : public PartialResultSetReader {
   ~LoggingResultSetReader() override = default;
 
   void TryCancel() override;
-  absl::optional<google::spanner::v1::PartialResultSet> Read() override;
+  absl::optional<PartialResultSet> Read() override;
   Status Finish() override;
 
  private:

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -51,14 +51,13 @@ TEST_F(LoggingResultSetReaderTest, Read) {
       .WillOnce([] {
         spanner_proto::PartialResultSet result;
         result.set_resume_token("test-token");
-        return result;
+        return PartialResultSet{std::move(result), false};
       })
-      .WillOnce(
-          [] { return absl::optional<spanner_proto::PartialResultSet>{}; });
+      .WillOnce([] { return absl::optional<PartialResultSet>{}; });
   LoggingResultSetReader reader(std::move(mock), TracingOptions{});
   auto result = reader.Read();
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ("test-token", result->resume_token());
+  EXPECT_EQ("test-token", result->result.resume_token());
 
   auto log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("Read")));

--- a/google/cloud/spanner/internal/partial_result_set_reader.h
+++ b/google/cloud/spanner/internal/partial_result_set_reader.h
@@ -28,6 +28,17 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
+ * The result of a successful `PartialResultSetReader::Read()`, which may
+ * be the next partial result of a stream, or a resumption of an interrupted
+ * stream from the last "resume token". In the latter case, the caller should
+ * discard any pending row-assembly state as that data will be replayed.
+ */
+struct PartialResultSet {
+  google::spanner::v1::PartialResultSet result;
+  bool resumption;
+};
+
+/**
  * Wrap `grpc::ClientReaderInterface<google::spanner::v1::PartialResultSet>`.
  *
  * This defines an interface to handle a streaming RPC returning a sequence of
@@ -40,7 +51,7 @@ class PartialResultSetReader {
  public:
   virtual ~PartialResultSetReader() = default;
   virtual void TryCancel() = 0;
-  virtual absl::optional<google::spanner::v1::PartialResultSet> Read() = 0;
+  virtual absl::optional<PartialResultSet> Read() = 0;
   virtual Status Finish() = 0;
 };
 

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -53,7 +53,7 @@ class PartialResultSetResume : public PartialResultSetReader {
   ~PartialResultSetResume() override = default;
 
   void TryCancel() override;
-  absl::optional<google::spanner::v1::PartialResultSet> Read() override;
+  absl::optional<PartialResultSet> Read() override;
   Status Finish() override;
 
  private:

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -105,12 +105,12 @@ Status PartialResultSetSource::ReadFromStream() {
     return reader_->Finish();
   }
 
-  if (result_set->has_metadata()) {
+  if (result_set->result.has_metadata()) {
     // If we got metadata more than once, log it, but use the first one.
     if (metadata_) {
       GCP_LOG(WARNING) << "Unexpectedly received two sets of metadata";
     } else {
-      metadata_ = std::move(*result_set->mutable_metadata());
+      metadata_ = std::move(*result_set->result.mutable_metadata());
       // Copies the column names into a shared_ptr that will be shared with
       // every Row object returned from NextRow().
       columns_ = std::make_shared<std::vector<std::string>>();
@@ -120,15 +120,23 @@ Status PartialResultSetSource::ReadFromStream() {
     }
   }
 
-  if (result_set->has_stats()) {
+  if (result_set->result.has_stats()) {
     // If we got stats more than once, log it, but use the last one.
     if (stats_) {
       GCP_LOG(WARNING) << "Unexpectedly received two sets of stats";
     }
-    stats_ = std::move(*result_set->mutable_stats());
+    stats_ = std::move(*result_set->result.mutable_stats());
   }
 
-  auto& new_values = *result_set->mutable_values();
+  // If reader_->Read() resulted in a new PartialResultSetReader (i.e., it
+  // used the last resume_token to resume an interrupted stream), then we
+  // must clear the buffered partial-row data as it will be replayed.
+  if (result_set->resumption) {
+    buffer_.clear();
+    chunk_ = {};
+  }
+
+  auto& new_values = *result_set->result.mutable_values();
 
   // Merge values if necessary, as described in:
   // https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.PartialResultSet
@@ -163,7 +171,7 @@ Status PartialResultSetSource::ReadFromStream() {
     chunk_ = {};
   }
 
-  if (result_set->chunked_value()) {
+  if (result_set->result.chunked_value()) {
     if (new_values.empty()) {
       return Status(StatusCode::kInternal,
                     "PartialResultSet had chunked_value "

--- a/google/cloud/spanner/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/spanner/testing/mock_partial_result_set_reader.h
@@ -28,7 +28,7 @@ class MockPartialResultSetReader
     : public spanner_internal::PartialResultSetReader {
  public:
   MOCK_METHOD(void, TryCancel, (), (override));
-  MOCK_METHOD(absl::optional<google::spanner::v1::PartialResultSet>, Read, (),
+  MOCK_METHOD(absl::optional<spanner_internal::PartialResultSet>, Read, (),
               (override));
   MOCK_METHOD(Status, Finish, (), (override));
 };


### PR DESCRIPTION
Problems:
- A `google::spanner::v1::PartialResultSet` may not contain
  a `resume_token` when it also does not complete a new row,
  so `last_resume_token_` should not be updated in that case.
- When `PartialResultSetResume::Read()` uses its factory and
  `last_resume_token_` to create a new `PartialResultSetReader`,
  it should inform the `PartialResultSetSource` so that any
  partly-constructed row can be discarded before processing
  the resumed stream (which will resend that row).

That is, a "resume token" is really a row iterator, and a level
above row fragmentation and value chunking. So fix all of that.

Then expand the `ConnectionImplTest.ReadSuccess` test case to
exercise the new code paths.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8521)
<!-- Reviewable:end -->
