### PR TITLE
docs: Document service endpoint environment variables

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -183,6 +183,9 @@ were written by a robot:
 The Cloud documentation links (`cloud.google.com/*/docs/*`) in these files are
 not always valid. Find the correct urls and update the links.
 
+Also, be sure to document each service's endpoint environment variable in
+`doc/main.dox`
+
 ## Update the root files
 
 Manually edit the following files:

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -632,6 +632,9 @@ which should give you a taste of the $title$ C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ EDIT HERE _ENDPOINT=...` changes the default endpoint
+  ( EDIT HERE .googleapis.com) used by ` EDIT HERE Connection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Access Approval API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ACCESS_APPROVAL_ENDPOINT=...` changes the default endpoint
+  (accessapproval.googleapis.com) used by `AccessApprovalConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Access Context Manager API C++ client libra
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ACCESS_CONTEXT_MANAGER_ENDPOINT=...` changes the default endpoint
+  (accesscontextmanager.googleapis.com) used by `AccessContextManagerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the API Gateway API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_API_GATEWAY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (apigateway.googleapis.com) used by `ApiGatewayServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -42,6 +42,9 @@ which should give you a taste of the Apigee Connect API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_APIGEE_CONNECTION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (apigeeconnect.googleapis.com) used by `ConnectionServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -38,6 +38,30 @@ which should give you a taste of the App Engine Admin API C++ client library API
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_APPLICATIONS_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `ApplicationsConnection`.
+
+- `GOOGLE_CLOUD_CPP_AUTHORIZED_CERTIFICATES_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `AuthorizedCertificatesConnection`.
+
+- `GOOGLE_CLOUD_CPP_AUTHORIZED_DOMAINS_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `AuthorizedDomainsConnection`.
+
+- `GOOGLE_CLOUD_CPP_DOMAIN_MAPPINGS_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `DomainMappingsConnection`.
+
+- `GOOGLE_CLOUD_CPP_FIREWALL_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `FirewallConnection`.
+
+- `GOOGLE_CLOUD_CPP_INSTANCES_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `InstancesConnection`.
+
+- `GOOGLE_CLOUD_CPP_SERVICES_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `ServicesConnection`.
+
+- `GOOGLE_CLOUD_CPP_VERSIONS_ENDPOINT=...` changes the default endpoint
+  (appengine.googleapis.com) used by `VersionsConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Artifact Registry API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ARTIFACT_REGISTRY_ENDPOINT=...` changes the default endpoint
+  (artifactregistry.googleapis.com) used by `ArtifactRegistryConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud Asset API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ASSET_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudasset.googleapis.com) used by `AssetServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Assured Workloads API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ASSURED_WORKLOADS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (assuredworkloads.googleapis.com) used by `AssuredWorkloadsServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -39,6 +39,12 @@ which should give you a taste of the Cloud AutoML API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_AUTO_ML_ENDPOINT=...` changes the default endpoint
+  (automl.googleapis.com) used by `AutoMlConnection`.
+
+- `GOOGLE_CLOUD_CPP_AUTOML_PREDICTION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (automl.googleapis.com) used by `PredictionServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/bigquery/doc/bigquery-main.dox
+++ b/google/cloud/bigquery/doc/bigquery-main.dox
@@ -57,6 +57,24 @@ The following are general notes about using the library.
 There are several environment variables that can be set to configure certain
 behaviors in the library.
 
+- `GOOGLE_CLOUD_CPP_BIGQUERY_READ_ENDPOINT=...` changes the default endpoint
+  (bigquerystorage.googleapis.com) used by `BigQueryReadConnection`.
+
+- `GOOGLE_CLOUD_CPP_BIGQUERY_WRITE_ENDPOINT=...` changes the default endpoint
+  (bigquerystorage.googleapis.com) used by `BigQueryWriteConnection`.
+
+- `GOOGLE_CLOUD_CPP_BIGQUERY_CONNECTION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (bigqueryconnection.googleapis.com) used by `ConnectionServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_DATA_TRANSFER_SERVICE_ENDPOINT=...` changes the default endpoint
+  (bigquerydatatransfer.googleapis.com) used by `DataTransferServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_MODEL_SERVICE_ENDPOINT=...` changes the default endpoint
+  (bigquery.googleapis.com) used by `ModelServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_RESERVATION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (bigqueryreservation.googleapis.com) used by `ReservationServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured you own logging backend,

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -40,6 +40,15 @@ which should give you a taste of the Cloud Billing Budget API C++ client library
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_BUDGET_SERVICE_ENDPOINT=...` changes the default endpoint
+  (billingbudgets.googleapis.com) used by `BudgetServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_CLOUD_BILLING_ENDPOINT=...` changes the default endpoint
+  (cloudbilling.googleapis.com) used by `CloudBillingConnection`.
+
+- `GOOGLE_CLOUD_CPP_CLOUD_CATALOG_ENDPOINT=...` changes the default endpoint
+  (cloudbilling.googleapis.com) used by `CloudCatalogConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -39,6 +39,15 @@ which should give you a taste of the Binary Authorization API C++ client library
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_BINAUTHZ_MANAGEMENT_SERVICE_V1_ENDPOINT=...` changes the default endpoint
+  (binaryauthorization.googleapis.com) used by `BinauthzManagementServiceV1Connection`.
+
+- `GOOGLE_CLOUD_CPP_SYSTEM_POLICY_V1_ENDPOINT=...` changes the default endpoint
+  (binaryauthorization.googleapis.com) used by `SystemPolicyV1Connection`.
+
+- `GOOGLE_CLOUD_CPP_VALIDATION_HELPER_V1_ENDPOINT=...` changes the default endpoint
+  (binaryauthorization.googleapis.com) used by `ValidationHelperV1Connection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Cloud Channel API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_CHANNEL_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudchannel.googleapis.com) used by `CloudChannelServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Cloud Build API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_BUILD_ENDPOINT=...` changes the default endpoint
+  (cloudbuild.googleapis.com) used by `CloudBuildConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -38,6 +38,12 @@ which should give you a taste of the Cloud Composer C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ENVIRONMENTS_ENDPOINT=...` changes the default endpoint
+  (composer.googleapis.com) used by `EnvironmentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_IMAGE_VERSIONS_ENDPOINT=...` changes the default endpoint
+  (composer.googleapis.com) used by `ImageVersionsConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Contact Center AI Insights API C++ client l
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CONTACT_CENTER_INSIGHTS_ENDPOINT=...` changes the default endpoint
+  (contactcenterinsights.googleapis.com) used by `ContactCenterInsightsConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Kubernetes Engine API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLUSTER_MANAGER_ENDPOINT=...` changes the default endpoint
+  (container.googleapis.com) used by `ClusterManagerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -40,6 +40,12 @@ which should give you a taste of the Container Analysis API C++ client library A
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CONTAINER_ANALYSIS_ENDPOINT=...` changes the default endpoint
+  (containeranalysis.googleapis.com) used by `ContainerAnalysisConnection`.
+
+- `GOOGLE_CLOUD_CPP_GRAFEAS_ENDPOINT=...` changes the default endpoint
+  (containeranalysis.googleapis.com) used by `GrafeasConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -38,6 +38,15 @@ which should give you a taste of the Google Cloud Data Catalog API C++ client li
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_DATA_CATALOG_ENDPOINT=...` changes the default endpoint
+  (datacatalog.googleapis.com) used by `DataCatalogConnection`.
+
+- `GOOGLE_CLOUD_CPP_POLICY_TAG_MANAGER_ENDPOINT=...` changes the default endpoint
+  (datacatalog.googleapis.com) used by `PolicyTagManagerConnection`.
+
+- `GOOGLE_CLOUD_CPP_POLICY_TAG_MANAGER_SERIALIZATION_ENDPOINT=...` changes the default endpoint
+  (datacatalog.googleapis.com) used by `PolicyTagManagerSerializationConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Database Migration API C++ client library A
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_DATA_MIGRATION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (datamigration.googleapis.com) used by `DataMigrationServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -41,6 +41,21 @@ which should give you a taste of the Cloud Dataproc API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_AUTOSCALING_POLICY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (dataproc.googleapis.com) used by `AutoscalingPolicyServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_ENDPOINT=...` changes the default endpoint
+  (dataproc.googleapis.com) used by `BatchControllerConnection`.
+
+- `GOOGLE_CLOUD_CPP_CLUSTER_CONTROLLER_ENDPOINT=...` changes the default endpoint
+  (dataproc.googleapis.com) used by `ClusterControllerConnection`.
+
+- `GOOGLE_CLOUD_CPP_JOB_CONTROLLER_ENDPOINT=...` changes the default endpoint
+  (dataproc.googleapis.com) used by `JobControllerConnection`.
+
+- `GOOGLE_CLOUD_CPP_WORKFLOW_TEMPLATE_SERVICE_ENDPOINT=...` changes the default endpoint
+  (dataproc.googleapis.com) used by `WorkflowTemplateServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -39,6 +39,12 @@ which should give you a taste of the Stackdriver Debugger API C++ client library
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CONTROLLER2_ENDPOINT=...` changes the default endpoint
+  (clouddebugger.googleapis.com) used by `Controller2Connection`.
+
+- `GOOGLE_CLOUD_CPP_DEBUGGER2_ENDPOINT=...` changes the default endpoint
+  (clouddebugger.googleapis.com) used by `Debugger2Connection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Cloud Data Loss Prevention (DLP) API C++ cl
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_DLP_SERVICE_ENDPOINT=...` changes the default endpoint
+  (dlp.googleapis.com) used by `DlpServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud Document AI API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_DOCUMENT_PROCESSOR_SERVICE_ENDPOINT=...` changes the default endpoint
+  (documentai.googleapis.com) used by `DocumentProcessorServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -38,6 +38,12 @@ which should give you a taste of the Eventarc API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_EVENTARC_ENDPOINT=...` changes the default endpoint
+  (eventarc.googleapis.com) used by `EventarcConnection`.
+
+- `GOOGLE_CLOUD_CPP_PUBLISHER_ENDPOINT=...` changes the default endpoint
+  (eventarcpublishing.googleapis.com) used by `PublisherConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Cloud Filestore API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_FILESTORE_MANAGER_ENDPOINT=...` changes the default endpoint
+  (file.googleapis.com) used by `CloudFilestoreManagerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Cloud Functions API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_FUNCTIONS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudfunctions.googleapis.com) used by `CloudFunctionsServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -39,6 +39,18 @@ which should give you a taste of the Game Services API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_GAME_SERVER_CLUSTERS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (gameservices.googleapis.com) used by `GameServerClustersServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_GAME_SERVER_CONFIGS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (gameservices.googleapis.com) used by `GameServerConfigsServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_GAME_SERVER_DEPLOYMENTS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (gameservices.googleapis.com) used by `GameServerDeploymentsServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_REALMS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (gameservices.googleapis.com) used by `RealmsServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the GKE Hub C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_GKE_HUB_ENDPOINT=...` changes the default endpoint
+  (gkehub.googleapis.com) used by `GkeHubConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/iam/doc/iam-main.dox
+++ b/google/cloud/iam/doc/iam-main.dox
@@ -57,6 +57,12 @@ The following are general notes about using the library.
 There are several environment variables that can be set to configure certain
 behaviors in the library.
 
+- `GOOGLE_CLOUD_CPP_IAM_ENDPOINT=...` changes the default endpoint
+  (iam.googleapis.com) used by `IAMConnection`.
+
+- `GOOGLE_CLOUD_CPP_IAM_CREDENTIALS_ENDPOINT=...` changes the default endpoint
+  (iamcredentials.googleapis.com) used by `IAMCredentialsConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured you own logging backend,

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -38,6 +38,12 @@ which should give you a taste of the Cloud Identity-Aware Proxy API C++ client l
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_IDENTITY_AWARE_PROXY_ADMIN_SERVICE_ENDPOINT=...` changes the default endpoint
+  (iap.googleapis.com) used by `IdentityAwareProxyAdminServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_IDENTITY_AWARE_PROXY_O_AUTH_SERVICE_ENDPOINT=...` changes the default endpoint
+  (iap.googleapis.com) used by `IdentityAwareProxyOAuthServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -43,6 +43,9 @@ which should give you a taste of the Cloud IDS API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_IDS_ENDPOINT=...` changes the default endpoint
+  (ids.googleapis.com) used by `IDSConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud IoT API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_DEVICE_MANAGER_ENDPOINT=...` changes the default endpoint
+  (cloudiot.googleapis.com) used by `DeviceManagerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the KMS C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_KEY_MANAGEMENT_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudkms.googleapis.com) used by `KeyManagementServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Cloud Natural Language API C++ client libra
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_LANGUAGE_SERVICE_ENDPOINT=...` changes the default endpoint
+  (language.googleapis.com) used by `LanguageServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Cloud Logging API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_LOGGING_SERVICE_V2_ENDPOINT=...` changes the default endpoint
+  (logging.googleapis.com) used by `LoggingServiceV2Connection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Managed Service for Microsoft Active Direct
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_MANAGED_IDENTITIES_SERVICE_ENDPOINT=...` changes the default endpoint
+  (managedidentities.googleapis.com) used by `ManagedIdentitiesServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud Memorystore for Memcached API C++ cli
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_MEMCACHE_ENDPOINT=...` changes the default endpoint
+  (memcache.googleapis.com) used by `CloudMemcacheConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -41,6 +41,33 @@ which should give you a taste of the Cloud Monitoring API C++ client library API
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ALERT_POLICY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `AlertPolicyServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_DASHBOARDS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `DashboardsServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_GROUP_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `GroupServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `MetricServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_METRICS_SCOPES_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `MetricsScopesConnection`.
+
+- `GOOGLE_CLOUD_CPP_NOTIFICATION_CHANNEL_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `NotificationChannelServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_QUERY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `QueryServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_SERVICE_MONITORING_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `ServiceMonitoringServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_UPTIME_CHECK_SERVICE_ENDPOINT=...` changes the default endpoint
+  (monitoring.googleapis.com) used by `UptimeCheckServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Network Management API C++ client library A
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_REACHABILITY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (networkmanagement.googleapis.com) used by `ReachabilityServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -39,6 +39,12 @@ which should give you a taste of the Notebooks API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_MANAGED_NOTEBOOK_SERVICE_ENDPOINT=...` changes the default endpoint
+  (notebooks.googleapis.com) used by `ManagedNotebookServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_NOTEBOOK_SERVICE_ENDPOINT=...` changes the default endpoint
+  (notebooks.googleapis.com) used by `NotebookServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Organization Policy API C++ client library 
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ORG_POLICY_ENDPOINT=...` changes the default endpoint
+  (orgpolicy.googleapis.com) used by `OrgPolicyConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -39,6 +39,12 @@ which should give you a taste of the OS Config API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_AGENT_ENDPOINT_SERVICE_ENDPOINT=...` changes the default endpoint
+  (osconfig.googleapis.com) used by `AgentEndpointServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_OS_CONFIG_SERVICE_ENDPOINT=...` changes the default endpoint
+  (osconfig.googleapis.com) used by `OsConfigServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud OS Login API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_OS_LOGIN_SERVICE_ENDPOINT=...` changes the default endpoint
+  (oslogin.googleapis.com) used by `OsLoginServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Policy Troubleshooter API C++ client librar
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_IAM_CHECKER_ENDPOINT=...` changes the default endpoint
+  (policytroubleshooter.googleapis.com) used by `IamCheckerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Certificate Authority API C++ client librar
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CERTIFICATE_AUTHORITY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (privateca.googleapis.com) used by `CertificateAuthorityServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -46,6 +46,9 @@ which should give you a taste of the Cloud Profiler API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_PROFILER_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudprofiler.googleapis.com) used by `ProfilerServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -41,6 +41,12 @@ which should give you a taste of the Pub/Sub Lite API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_ADMIN_SERVICE_ENDPOINT=...` changes the default endpoint
+  (pubsublite.googleapis.com) used by `AdminServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_TOPIC_STATS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (pubsublite.googleapis.com) used by `TopicStatsServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Recommender C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_RECOMMENDER_ENDPOINT=...` changes the default endpoint
+  (recommender.googleapis.com) used by `RecommenderConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Google Cloud Memorystore for Redis API C++ 
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_REDIS_ENDPOINT=...` changes the default endpoint
+  (redis.googleapis.com) used by `CloudRedisConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -39,6 +39,15 @@ which should give you a taste of the Cloud Resource Manager API C++ client libra
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_FOLDERS_ENDPOINT=...` changes the default endpoint
+  (cloudresourcemanager.googleapis.com) used by `FoldersConnection`.
+
+- `GOOGLE_CLOUD_CPP_ORGANIZATIONS_ENDPOINT=...` changes the default endpoint
+  (cloudresourcemanager.googleapis.com) used by `OrganizationsConnection`.
+
+- `GOOGLE_CLOUD_CPP_PROJECTS_ENDPOINT=...` changes the default endpoint
+  (cloudresourcemanager.googleapis.com) used by `ProjectsConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Resource Settings API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_RESOURCE_SETTINGS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (resourcesettings.googleapis.com) used by `ResourceSettingsServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -40,6 +40,24 @@ which should give you a taste of the Retail API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CATALOG_SERVICE_ENDPOINT=...` changes the default endpoint
+  (retail.googleapis.com) used by `CatalogServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_COMPLETION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (retail.googleapis.com) used by `CompletionServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_RETAIL_PREDICTION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (retail.googleapis.com) used by `PredictionServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_PRODUCT_SERVICE_ENDPOINT=...` changes the default endpoint
+  (retail.googleapis.com) used by `ProductServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_SEARCH_SERVICE_ENDPOINT=...` changes the default endpoint
+  (retail.googleapis.com) used by `SearchServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_USER_EVENT_SERVICE_ENDPOINT=...` changes the default endpoint
+  (retail.googleapis.com) used by `UserEventServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Cloud Scheduler API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_SCHEDULER_ENDPOINT=...` changes the default endpoint
+  (cloudscheduler.googleapis.com) used by `CloudSchedulerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Secret Manager API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_SECRET_MANAGER_SERVICE_ENDPOINT=...` changes the default endpoint
+  (secretmanager.googleapis.com) used by `SecretManagerServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Security Command Center API C++ client libr
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_SECURITY_CENTER_ENDPOINT=...` changes the default endpoint
+  (securitycenter.googleapis.com) used by `SecurityCenterConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -39,6 +39,12 @@ which should give you a taste of the Service Control API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_QUOTA_CONTROLLER_ENDPOINT=...` changes the default endpoint
+  (servicecontrol.googleapis.com) used by `QuotaControllerConnection`.
+
+- `GOOGLE_CLOUD_CPP_SERVICE_CONTROLLER_ENDPOINT=...` changes the default endpoint
+  (servicecontrol.googleapis.com) used by `ServiceControllerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -39,6 +39,12 @@ which should give you a taste of the Service Directory API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_LOOKUP_SERVICE_ENDPOINT=...` changes the default endpoint
+  (servicedirectory.googleapis.com) used by `LookupServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_REGISTRATION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (servicedirectory.googleapis.com) used by `RegistrationServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -37,6 +37,9 @@ which should give you a taste of the Service Management API C++ client library A
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_SERVICE_MANAGER_ENDPOINT=...` changes the default endpoint
+  (servicemanagement.googleapis.com) used by `ServiceManagerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Service Usage API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_SERVICE_USAGE_ENDPOINT=...` changes the default endpoint
+  (serviceusage.googleapis.com) used by `ServiceUsageConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud Shell API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_SHELL_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudshell.googleapis.com) used by `CloudShellServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Cloud Speech-to-Text API C++ client library
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` changes the default endpoint
+  (speech.googleapis.com) used by `SpeechConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Storage Transfer API C++ client library API
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_STORAGE_TRANSFER_SERVICE_ENDPOINT=...` changes the default endpoint
+  (storagetransfer.googleapis.com) used by `StorageTransferServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -39,6 +39,21 @@ which should give you a taste of the Cloud Talent Solution C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_COMPANY_SERVICE_ENDPOINT=...` changes the default endpoint
+  (jobs.googleapis.com) used by `CompanyServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_COMPLETION_ENDPOINT=...` changes the default endpoint
+  (jobs.googleapis.com) used by `CompletionConnection`.
+
+- `GOOGLE_CLOUD_CPP_EVENT_SERVICE_ENDPOINT=...` changes the default endpoint
+  (jobs.googleapis.com) used by `EventServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_JOB_SERVICE_ENDPOINT=...` changes the default endpoint
+  (jobs.googleapis.com) used by `JobServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_TENANT_SERVICE_ENDPOINT=...` changes the default endpoint
+  (jobs.googleapis.com) used by `TenantServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Cloud Tasks API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_CLOUD_TASKS_ENDPOINT=...` changes the default endpoint
+  (cloudtasks.googleapis.com) used by `CloudTasksConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -39,6 +39,9 @@ which should give you a taste of the Cloud Text-to-Speech API C++ client library
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_TEXT_TO_SPEECH_ENDPOINT=...` changes the default endpoint
+  (texttospeech.googleapis.com) used by `TextToSpeechConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Cloud TPU API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_TPU_ENDPOINT=...` changes the default endpoint
+  (tpu.googleapis.com) used by `TpuConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Stackdriver Trace API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_TRACE_SERVICE_ENDPOINT=...` changes the default endpoint
+  (cloudtrace.googleapis.com) used by `TraceServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Cloud Translation API C++ client library AP
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_TRANSLATION_SERVICE_ENDPOINT=...` changes the default endpoint
+  (translate.googleapis.com) used by `TranslationServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Cloud Video Intelligence API C++ client lib
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_VIDEO_INTELLIGENCE_SERVICE_ENDPOINT=...` changes the default endpoint
+  (videointelligence.googleapis.com) used by `VideoIntelligenceServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -40,6 +40,12 @@ which should give you a taste of the Cloud Vision API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_IMAGE_ANNOTATOR_ENDPOINT=...` changes the default endpoint
+  (vision.googleapis.com) used by `ImageAnnotatorConnection`.
+
+- `GOOGLE_CLOUD_CPP_PRODUCT_SEARCH_ENDPOINT=...` changes the default endpoint
+  (vision.googleapis.com) used by `ProductSearchConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the VM Migration API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_VM_MIGRATION_ENDPOINT=...` changes the default endpoint
+  (vmmigration.googleapis.com) used by `VmMigrationConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -38,6 +38,9 @@ which should give you a taste of the Serverless VPC Access API C++ client librar
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_VPC_ACCESS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (vpcaccess.googleapis.com) used by `VpcAccessServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -40,6 +40,9 @@ which should give you a taste of the Web Risk API C++ client library API.
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_WEB_RISK_SERVICE_ENDPOINT=...` changes the default endpoint
+  (webrisk.googleapis.com) used by `WebRiskServiceConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -41,6 +41,9 @@ which should give you a taste of the Web Security Scanner API C++ client library
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_WEB_SECURITY_SCANNER_ENDPOINT=...` changes the default endpoint
+  (websecurityscanner.googleapis.com) used by `WebSecurityScannerConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -40,6 +40,12 @@ which should give you a taste of the Workflow Executions API C++ client library 
 
 ## Environment Variables
 
+- `GOOGLE_CLOUD_CPP_EXECUTIONS_ENDPOINT=...` changes the default endpoint
+  (workflowexecutions.googleapis.com) used by `ExecutionsConnection`.
+
+- `GOOGLE_CLOUD_CPP_WORKFLOWS_ENDPOINT=...` changes the default endpoint
+  (workflows.googleapis.com) used by `WorkflowsConnection`.
+
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC
   request and response.  Unless you have configured your own logging backend,


### PR DESCRIPTION
Fixes #8320

All of the changes in the first commit were the result of running a script, which Googlers can find [here](https://paste.googleplex.com/5867102910021632). Reviewers should not hesitate to point out nits, because it will be easy to regenerate these changes.

I also decided to update the scaffolding so we (hopefully) don't forget to document these variables in future libraries.

Note that Bigtable, Pub/Sub, Spanner, and Storage already document their endpoint variables.