### PR TITLE
cleanup: scaffold

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -140,9 +140,6 @@ std::map<std::string, std::string> ScaffoldVars(
                        [](std::string const& x) { return x.empty(); });
   vars["proto_deps"] = absl::StrJoin(deps.begin(), end, "\n    ");
 
-  vars["cpp_files"] = "# EDIT HERE: add list of C++ files\n";
-  vars["mock_files"] = "# EDIT HERE: add list of mock headers\n";
-
   return vars;
 }
 

--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -47,9 +47,7 @@ which should give you a taste of the Access Approval API C++ client library API.
   the program's console.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc-streams` turns on tracing for streaming
-  gRPC calls, such as `Client::Read()`, `Client::ExecuteQuery()`, and
-  `Client::ProfileQuery()`. This can produce a lot of output, so use with
-  caution!
+  gRPC calls. This can produce a lot of output, so use with caution!
 
 - `GOOGLE_CLOUD_CPP_TRACING_OPTIONS=...` modifies the behavior of gRPC tracing,
   including whether messages will be output on multiple lines, or whether


### PR DESCRIPTION
the scaffold variables were unused. and `accessapproval` had some spanner specific documentation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8524)
<!-- Reviewable:end -->
