### PR TITLE
fix: treat `kDeadlineExceeded` as permanent error

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -104,7 +104,7 @@ service {
   initial_copyright_year: "2021"
   omitted_services: ["BigQueryWrite"]
   backwards_compatibility_namespace_alias: true
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
@@ -150,7 +150,7 @@ service {
   product_path: "google/cloud/bigtable/admin"
   initial_copyright_year: "2021"
   emulator_endpoint_env_var: "BIGTABLE_INSTANCE_ADMIN_EMULATOR_HOST"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable", "kAborted"]
+  retryable_status_codes: ["kUnavailable", "kAborted"]
 }
 
 service {
@@ -160,7 +160,7 @@ service {
   omitted_rpcs: ["CreateTableFromSnapshot", "SnapshotTable", "GetSnapshot", "ListSnapshots", "DeleteSnapshot"]
   emulator_endpoint_env_var: "BIGTABLE_EMULATOR_HOST"
   gen_async_rpcs: ["CheckConsistency"]
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable", "kAborted"]
+  retryable_status_codes: ["kUnavailable", "kAborted"]
 }
 
 # Billing
@@ -433,7 +433,7 @@ service {
   product_path: "google/cloud/iam"
   initial_copyright_year: "2020"
   backwards_compatibility_namespace_alias: true
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
@@ -442,7 +442,7 @@ service {
   initial_copyright_year: "2021"
   omitted_rpcs: ["SignBlob", "SignJwt", "UpdateServiceAccount"]
   backwards_compatibility_namespace_alias: true
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Identity-Aware Proxy (IAP)
@@ -852,7 +852,7 @@ service {
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT"
   emulator_endpoint_env_var: "SPANNER_EMULATOR_HOST"
   backwards_compatibility_namespace_alias: true
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
@@ -862,7 +862,7 @@ service {
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT"
   emulator_endpoint_env_var: "SPANNER_EMULATOR_HOST"
   backwards_compatibility_namespace_alias: true
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Speech

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -19,7 +19,7 @@ service {
   service_proto_path: "google/cloud/accessapproval/v1/accessapproval.proto"
   product_path: "google/cloud/accessapproval"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Access Context Manager
@@ -77,7 +77,7 @@ service {
   service_proto_path: "google/cloud/assuredworkloads/v1/assuredworkloads.proto"
   product_path: "google/cloud/assuredworkloads"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Auto ML
@@ -86,7 +86,7 @@ service {
   additional_proto_files: ["google/cloud/automl/v1/operations.proto"]
   product_path: "google/cloud/automl"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
@@ -168,21 +168,21 @@ service {
   service_proto_path: "google/cloud/billing/v1/cloud_billing.proto"
   product_path: "google/cloud/billing"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/billing/v1/cloud_catalog.proto"
   product_path: "google/cloud/billing"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/billing/budgets/v1/budget_service.proto"
   product_path: "google/cloud/billing"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Binary Authorization
@@ -190,7 +190,7 @@ service {
   service_proto_path: "google/cloud/binaryauthorization/v1/service.proto"
   product_path: "google/cloud/binaryauthorization"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Certificate Authority
@@ -198,7 +198,7 @@ service {
   service_proto_path: "google/cloud/security/privateca/v1/service.proto"
   product_path: "google/cloud/privateca"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable", "kUnknown"]
+  retryable_status_codes: ["kUnavailable", "kUnknown"]
 }
 
 # Cloud Build
@@ -206,7 +206,7 @@ service {
   service_proto_path: "google/devtools/cloudbuild/v1/cloudbuild.proto"
   product_path: "google/cloud/cloudbuild"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Cloud Channel
@@ -223,14 +223,14 @@ service {
   service_proto_path: "google/devtools/clouddebugger/v2/controller.proto"
   product_path: "google/cloud/debugger"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/devtools/clouddebugger/v2/debugger.proto"
   product_path: "google/cloud/debugger"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Composer
@@ -262,7 +262,7 @@ service {
   service_proto_path: "google/container/v1/cluster_service.proto"
   product_path: "google/cloud/container"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Container Analysis
@@ -347,7 +347,7 @@ service {
   service_proto_path: "google/privacy/dlp/v2/dlp.proto"
   product_path: "google/cloud/dlp"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Document AI
@@ -387,21 +387,13 @@ service {
   additional_proto_files: ["google/cloud/functions/v1/operations.proto"]
   product_path: "google/cloud/functions"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Game Services
 service {
   service_proto_path: "google/cloud/gaming/v1/game_server_clusters_service.proto"
   product_path: "google/cloud/gameservices"
-  initial_copyright_year: "2022"
-  retryable_status_codes: ["kUnavailable"]
-}
-
-# GKE Hub
-service {
-  service_proto_path: "google/cloud/gkehub/v1/service.proto"
-  product_path: "google/cloud/gkehub"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
 }
@@ -423,6 +415,14 @@ service {
 service {
   service_proto_path: "google/cloud/gaming/v1/realms_service.proto"
   product_path: "google/cloud/gameservices"
+  initial_copyright_year: "2022"
+  retryable_status_codes: ["kUnavailable"]
+}
+
+# GKE Hub
+service {
+  service_proto_path: "google/cloud/gkehub/v1/service.proto"
+  product_path: "google/cloud/gkehub"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
 }
@@ -458,7 +458,7 @@ service {
   service_proto_path: "google/cloud/policytroubleshooter/v1/checker.proto"
   product_path: "google/cloud/policytroubleshooter"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # IDS (Cloud Intrusion Detection System)
@@ -474,7 +474,7 @@ service {
   service_proto_path: "google/cloud/iot/v1/device_manager.proto"
   product_path: "google/cloud/iot"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # KMS
@@ -482,7 +482,7 @@ service {
   service_proto_path: "google/cloud/kms/v1/service.proto"
   product_path: "google/cloud/kms"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Language
@@ -498,7 +498,7 @@ service {
   service_proto_path: "google/logging/v2/logging.proto"
   product_path: "google/cloud/logging"
   initial_copyright_year: "2021"
-  retryable_status_codes: ["kInternal", "kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kInternal", "kUnavailable"]
 }
 
 # Managed Microsoft Active Directory (Managed Microsoft AD or Managed Identities)
@@ -603,7 +603,7 @@ service {
   service_proto_path: "google/cloud/orgpolicy/v2/orgpolicy.proto"
   product_path: "google/cloud/orgpolicy"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # OS Config
@@ -626,7 +626,7 @@ service {
   service_proto_path: "google/cloud/oslogin/v1/oslogin.proto"
   product_path: "google/cloud/oslogin"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Cloud Profiler
@@ -642,7 +642,7 @@ service {
   service_proto_path: "google/cloud/pubsublite/v1/admin.proto"
   product_path: "google/cloud/pubsublite"
   initial_copyright_year: "2021"
-  retryable_status_codes: ["kInternal", "kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kInternal", "kUnavailable"]
 }
 
 service {
@@ -673,7 +673,7 @@ service {
   service_proto_path: "google/cloud/pubsublite/v1/topic_stats.proto"
   product_path: "google/cloud/pubsublite"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kInternal", "kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kInternal", "kUnavailable"]
 }
 
 # Recommender
@@ -681,7 +681,7 @@ service {
   service_proto_path: "google/cloud/recommender/v1/recommender_service.proto"
   product_path: "google/cloud/recommender"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Redis
@@ -727,14 +727,14 @@ service {
   service_proto_path: "google/cloud/retail/v2/catalog_service.proto"
   product_path: "google/cloud/retail"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/retail/v2/completion_service.proto"
   product_path: "google/cloud/retail"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
@@ -742,28 +742,28 @@ service {
   product_path: "google/cloud/retail"
   initial_copyright_year: "2022"
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_RETAIL_PREDICTION_SERVICE_ENDPOINT"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/retail/v2/product_service.proto"
   product_path: "google/cloud/retail"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/retail/v2/search_service.proto"
   product_path: "google/cloud/retail"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/retail/v2/user_event_service.proto"
   product_path: "google/cloud/retail"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Scheduler
@@ -771,7 +771,7 @@ service {
   service_proto_path: "google/cloud/scheduler/v1/cloudscheduler.proto"
   product_path: "google/cloud/scheduler"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Secret Manager
@@ -779,7 +779,7 @@ service {
   service_proto_path: "google/cloud/secretmanager/v1/service.proto"
   product_path: "google/cloud/secretmanager"
   initial_copyright_year: "2021"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Security Center
@@ -787,7 +787,7 @@ service {
   service_proto_path: "google/cloud/securitycenter/v1/securitycenter_service.proto"
   product_path: "google/cloud/securitycenter"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Service Control
@@ -907,14 +907,14 @@ service {
   service_proto_path: "google/cloud/talent/v4/company_service.proto"
   product_path: "google/cloud/talent"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/talent/v4/completion_service.proto"
   product_path: "google/cloud/talent"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
@@ -928,14 +928,14 @@ service {
   service_proto_path: "google/cloud/talent/v4/job_service.proto"
   product_path: "google/cloud/talent"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/talent/v4/tenant_service.proto"
   product_path: "google/cloud/talent"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Tasks
@@ -943,7 +943,7 @@ service {
   service_proto_path: "google/cloud/tasks/v2/cloudtasks.proto"
   product_path: "google/cloud/tasks"
   initial_copyright_year: "2021"
-  retryable_status_codes: ["kInternal", "kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kInternal", "kUnavailable"]
 }
 
 # Text-to-Speech
@@ -951,7 +951,7 @@ service {
   service_proto_path: "google/cloud/texttospeech/v1/cloud_tts.proto"
   product_path: "google/cloud/texttospeech"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # TPU
@@ -975,7 +975,7 @@ service {
   service_proto_path: "google/cloud/translate/v3/translation_service.proto"
   product_path: "google/cloud/translate"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Video Intelligence
@@ -983,7 +983,7 @@ service {
   service_proto_path: "google/cloud/videointelligence/v1/video_intelligence.proto"
   product_path: "google/cloud/videointelligence"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Vision
@@ -991,14 +991,14 @@ service {
   service_proto_path: "google/cloud/vision/v1/image_annotator.proto"
   product_path: "google/cloud/vision"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/vision/v1/product_search_service.proto"
   product_path: "google/cloud/vision"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # VM Migration
@@ -1022,7 +1022,7 @@ service {
   service_proto_path: "google/cloud/webrisk/v1/webrisk.proto"
   product_path: "google/cloud/webrisk"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Web Security Scanner
@@ -1030,7 +1030,7 @@ service {
   service_proto_path: "google/cloud/websecurityscanner/v1/web_security_scanner.proto"
   product_path: "google/cloud/websecurityscanner"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 # Workflows
@@ -1038,12 +1038,12 @@ service {
   service_proto_path: "google/cloud/workflows/v1/workflows.proto"
   product_path: "google/cloud/workflows"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }
 
 service {
   service_proto_path: "google/cloud/workflows/executions/v1/executions.proto"
   product_path: "google/cloud/workflows"
   initial_copyright_year: "2022"
-  retryable_status_codes: ["kDeadlineExceeded", "kUnavailable"]
+  retryable_status_codes: ["kUnavailable"]
 }

--- a/google/cloud/accessapproval/internal/access_approval_retry_traits.h
+++ b/google/cloud/accessapproval/internal/access_approval_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct AccessApprovalRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/assuredworkloads/internal/assured_workloads_retry_traits.h
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct AssuredWorkloadsServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/automl/internal/auto_ml_retry_traits.h
+++ b/google/cloud/automl/internal/auto_ml_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct AutoMlRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/bigquery/internal/bigquery_read_retry_traits.h
+++ b/google/cloud/bigquery/internal/bigquery_read_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct BigQueryReadRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_retry_traits.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_retry_traits.h
@@ -32,7 +32,6 @@ struct BigtableInstanceAdminRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kAborted &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_retry_traits.h
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_retry_traits.h
@@ -32,7 +32,6 @@ struct BigtableTableAdminRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kAborted &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/bigtable/rpc_retry_policy.h
+++ b/google/cloud/bigtable/rpc_retry_policy.h
@@ -43,7 +43,6 @@ struct SafeGrpcRetry {
   static inline bool IsTransientFailure(Status const& status) {
     auto const code = status.code();
     return code == StatusCode::kAborted || code == StatusCode::kUnavailable ||
-           code == StatusCode::kDeadlineExceeded ||
            google::cloud::internal::IsTransientInternalError(status);
   }
   static inline bool IsPermanentFailure(Status const& status) {

--- a/google/cloud/billing/internal/budget_retry_traits.h
+++ b/google/cloud/billing/internal/budget_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct BudgetServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/billing/internal/cloud_billing_retry_traits.h
+++ b/google/cloud/billing/internal/cloud_billing_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CloudBillingRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/billing/internal/cloud_catalog_retry_traits.h
+++ b/google/cloud/billing/internal/cloud_catalog_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CloudCatalogRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_retry_traits.h
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct BinauthzManagementServiceV1RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_retry_traits.h
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct SystemPolicyV1RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_retry_traits.h
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ValidationHelperV1RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/cloudbuild/internal/cloud_build_retry_traits.h
+++ b/google/cloud/cloudbuild/internal/cloud_build_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CloudBuildRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/container/internal/cluster_manager_retry_traits.h
+++ b/google/cloud/container/internal/cluster_manager_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ClusterManagerRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/debugger/internal/controller2_retry_traits.h
+++ b/google/cloud/debugger/internal/controller2_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct Controller2RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/debugger/internal/debugger2_retry_traits.h
+++ b/google/cloud/debugger/internal/debugger2_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct Debugger2RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/dlp/internal/dlp_retry_traits.h
+++ b/google/cloud/dlp/internal/dlp_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct DlpServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/functions/internal/cloud_functions_retry_traits.h
+++ b/google/cloud/functions/internal/cloud_functions_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CloudFunctionsServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/iam/internal/iam_credentials_retry_traits.h
+++ b/google/cloud/iam/internal/iam_credentials_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct IAMCredentialsRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/iam/internal/iam_retry_traits.h
+++ b/google/cloud/iam/internal/iam_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct IAMRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/iot/internal/device_manager_retry_traits.h
+++ b/google/cloud/iot/internal/device_manager_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct DeviceManagerRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/kms/internal/key_management_retry_traits.h
+++ b/google/cloud/kms/internal/key_management_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct KeyManagementServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/logging/internal/logging_service_v2_retry_traits.h
+++ b/google/cloud/logging/internal/logging_service_v2_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct LoggingServiceV2RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/orgpolicy/internal/org_policy_retry_traits.h
+++ b/google/cloud/orgpolicy/internal/org_policy_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct OrgPolicyRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/oslogin/internal/os_login_retry_traits.h
+++ b/google/cloud/oslogin/internal/os_login_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct OsLoginServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/policytroubleshooter/internal/iam_checker_retry_traits.h
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct IamCheckerRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/privateca/internal/certificate_authority_retry_traits.h
+++ b/google/cloud/privateca/internal/certificate_authority_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CertificateAuthorityServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kUnknown;
   }

--- a/google/cloud/pubsub/retry_policy.h
+++ b/google/cloud/pubsub/retry_policy.h
@@ -28,7 +28,6 @@ struct RetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
            status.code() != StatusCode::kAborted &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable &&
            status.code() != StatusCode::kResourceExhausted;

--- a/google/cloud/pubsublite/internal/admin_retry_traits.h
+++ b/google/cloud/pubsublite/internal/admin_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct AdminServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/pubsublite/internal/topic_stats_retry_traits.h
+++ b/google/cloud/pubsublite/internal/topic_stats_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct TopicStatsServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/recommender/internal/recommender_retry_traits.h
+++ b/google/cloud/recommender/internal/recommender_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct RecommenderRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/retail/internal/catalog_retry_traits.h
+++ b/google/cloud/retail/internal/catalog_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CatalogServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/retail/internal/completion_retry_traits.h
+++ b/google/cloud/retail/internal/completion_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CompletionServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/retail/internal/prediction_retry_traits.h
+++ b/google/cloud/retail/internal/prediction_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct PredictionServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/retail/internal/product_retry_traits.h
+++ b/google/cloud/retail/internal/product_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ProductServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/retail/internal/search_retry_traits.h
+++ b/google/cloud/retail/internal/search_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct SearchServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/retail/internal/user_event_retry_traits.h
+++ b/google/cloud/retail/internal/user_event_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct UserEventServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/scheduler/internal/cloud_scheduler_retry_traits.h
+++ b/google/cloud/scheduler/internal/cloud_scheduler_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CloudSchedulerRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/secretmanager/internal/secret_manager_retry_traits.h
+++ b/google/cloud/secretmanager/internal/secret_manager_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct SecretManagerServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/securitycenter/internal/security_center_retry_traits.h
+++ b/google/cloud/securitycenter/internal/security_center_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct SecurityCenterRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/spanner/admin/internal/database_admin_retry_traits.h
+++ b/google/cloud/spanner/admin/internal/database_admin_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct DatabaseAdminRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/spanner/admin/internal/instance_admin_retry_traits.h
+++ b/google/cloud/spanner/admin/internal/instance_admin_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct InstanceAdminRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/storage/retry_policy.h
+++ b/google/cloud/storage/retry_policy.h
@@ -28,7 +28,8 @@ namespace internal {
 /// Defines what error codes are permanent errors.
 struct StatusTraits {
   static bool IsPermanentFailure(Status const& status) {
-    return status.code() != StatusCode::kInternal &&
+    return status.code() != StatusCode::kDeadlineExceeded &&
+           status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kResourceExhausted &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/storage/retry_policy.h
+++ b/google/cloud/storage/retry_policy.h
@@ -28,8 +28,7 @@ namespace internal {
 /// Defines what error codes are permanent errors.
 struct StatusTraits {
   static bool IsPermanentFailure(Status const& status) {
-    return status.code() != StatusCode::kDeadlineExceeded &&
-           status.code() != StatusCode::kInternal &&
+    return status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kResourceExhausted &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/talent/internal/company_retry_traits.h
+++ b/google/cloud/talent/internal/company_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CompanyServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/talent/internal/completion_retry_traits.h
+++ b/google/cloud/talent/internal/completion_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CompletionRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/talent/internal/job_retry_traits.h
+++ b/google/cloud/talent/internal/job_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct JobServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/talent/internal/tenant_retry_traits.h
+++ b/google/cloud/talent/internal/tenant_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct TenantServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/tasks/internal/cloud_tasks_retry_traits.h
+++ b/google/cloud/tasks/internal/cloud_tasks_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct CloudTasksRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kInternal &&
            status.code() != StatusCode::kUnavailable;
   }

--- a/google/cloud/texttospeech/internal/text_to_speech_retry_traits.h
+++ b/google/cloud/texttospeech/internal/text_to_speech_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct TextToSpeechRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/translate/internal/translation_retry_traits.h
+++ b/google/cloud/translate/internal/translation_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct TranslationServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/videointelligence/internal/video_intelligence_retry_traits.h
+++ b/google/cloud/videointelligence/internal/video_intelligence_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct VideoIntelligenceServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/vision/internal/image_annotator_retry_traits.h
+++ b/google/cloud/vision/internal/image_annotator_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ImageAnnotatorRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/vision/internal/product_search_retry_traits.h
+++ b/google/cloud/vision/internal/product_search_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ProductSearchRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/webrisk/internal/web_risk_retry_traits.h
+++ b/google/cloud/webrisk/internal/web_risk_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct WebRiskServiceRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_retry_traits.h
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct WebSecurityScannerRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/workflows/internal/executions_retry_traits.h
+++ b/google/cloud/workflows/internal/executions_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct ExecutionsRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };

--- a/google/cloud/workflows/internal/workflows_retry_traits.h
+++ b/google/cloud/workflows/internal/workflows_retry_traits.h
@@ -31,7 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct WorkflowsRetryTraits {
   static inline bool IsPermanentFailure(google::cloud::Status const& status) {
     return status.code() != StatusCode::kOk &&
-           status.code() != StatusCode::kDeadlineExceeded &&
            status.code() != StatusCode::kUnavailable;
   }
 };


### PR DESCRIPTION
I did not change all of them. I left BigQuery, Bigtable Admin, IAM, and Spanner Admin retry traits as they were. The thinking was that these libraries were more mature. (I changed Logging because it is not GA).

We might want to talk about this...

(Oh and the diff looks weird for GKE Hub / Gaming because I rearranged the order)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8525)
<!-- Reviewable:end -->
