### PR TITLE
feat(common): `g::c::future` support for coroutines

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -89,6 +89,7 @@ add_library(
     internal/format_time_point.cc
     internal/format_time_point.h
     internal/future_base.h
+    internal/future_coroutines.h
     internal/future_fwd.h
     internal/future_impl.cc
     internal/future_impl.h
@@ -204,6 +205,7 @@ if (BUILD_TESTING)
     set(google_cloud_cpp_common_unit_tests
         # cmake-format: sort
         common_options_test.cc
+        future_coroutines_test.cc
         future_generic_test.cc
         future_generic_then_test.cc
         future_void_test.cc

--- a/google/cloud/future.h
+++ b/google/cloud/future.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_H
 
+#include "google/cloud/internal/future_coroutines.h"
 #include "google/cloud/internal/future_then_impl.h"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_FUTURE_H

--- a/google/cloud/future_coroutines_test.cc
+++ b/google/cloud/future_coroutines_test.cc
@@ -1,0 +1,152 @@
+//
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/future.h"
+#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine
+#include <gmock/gmock.h>
+#include <algorithm>
+#include <ranges>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace google::cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::HasSubstr;
+
+future<std::string> AsyncAppend(future<std::string> a, future<int> b) {
+  co_return co_await std::move(a) + std::to_string(co_await std::move(b));
+}
+
+TEST(FutureCoroutines, BaseGeneric) {
+  promise<std::string> pa;
+  promise<int> pb;
+  auto pending = AsyncAppend(pa.get_future(), pb.get_future());
+  pa.set_value("4");
+  pb.set_value(2);
+  EXPECT_EQ(pending.get(), "42");
+}
+
+future<void> WaitAll(std::vector<future<void>> futures) {
+  for (auto& f : futures) co_await std::move(f);
+}
+
+TEST(FutureCoroutines, BaseVoid) {
+  std::vector<promise<void>> promises(3);
+  std::vector<future<void>> futures(promises.size());
+  std::transform(promises.begin(), promises.end(), futures.begin(),
+                 [](auto& p) { return p.get_future(); });
+  auto done = WaitAll(std::move(futures));
+  for (auto& p : promises | std::views::reverse) p.set_value();
+
+  done.get();
+}
+
+template <typename U>
+future<std::string> WithCoReturn(future<void> wait, future<U> r) {
+  co_await std::move(wait);
+  co_return co_await std::move(r);
+}
+
+TEST(FutureCoroutines, CoReturnGeneric) {
+  promise<std::string> pa;
+  promise<void> wait;
+  auto x = WithCoReturn(wait.get_future(), pa.get_future());
+  EXPECT_FALSE(x.is_ready());
+  wait.set_value();
+  EXPECT_FALSE(x.is_ready());
+  pa.set_value("42");
+  EXPECT_TRUE(x.is_ready());
+  EXPECT_EQ(x.get(), "42");
+}
+
+TEST(FutureCoroutines, CoReturnChange) {
+  auto constexpr kValue = "42";
+  promise<char const*> pa;
+  promise<void> wait;
+  auto x = WithCoReturn(wait.get_future(), pa.get_future());
+  EXPECT_FALSE(x.is_ready());
+  wait.set_value();
+  EXPECT_FALSE(x.is_ready());
+  pa.set_value(kValue);
+  EXPECT_TRUE(x.is_ready());
+  x.get();
+}
+
+future<std::vector<std::thread::id>> GetThreads(
+    std::vector<future<void>> futures) {
+  std::vector<std::thread::id> threads(futures.size());
+  for (auto& f : futures) {
+    co_await std::move(f);
+    threads.push_back(std::this_thread::get_id());
+  }
+  co_return threads;
+}
+
+TEST(FutureCoroutines, Threads) {
+  std::vector<promise<void>> promises(32);
+  std::vector<future<void>> futures(promises.size());
+  std::transform(promises.begin(), promises.end(), futures.begin(),
+                 [](auto& p) { return p.get_future(); });
+  auto done = GetThreads(std::move(futures));
+
+  std::vector<std::jthread> threads(promises.size());
+  std::transform(
+      promises.begin(), promises.end(), threads.begin(), [](promise<void>& p) {
+        return std::jthread{[](auto p) { p.set_value(); }, std::move(p)};
+      });
+  auto all = done.get();
+  std::vector<std::thread::id> ids;
+  std::unique_copy(all.begin(), all.end(), std::back_inserter(ids));
+  EXPECT_GE(ids.size(), 2);
+}
+
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+future<void> TestThrowVoid(future<void> t) { co_return co_await std::move(t); }
+
+future<int> TestThrowInt(future<int> t) { co_return co_await std::move(t); }
+
+TEST(FutureCoroutines, ThrowVoid) {
+  promise<void> p;
+  auto f = TestThrowVoid(p.get_future());
+  p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_THROW(
+      try { f.get(); } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("test message"));
+        throw;
+      },
+      std::runtime_error);
+}
+
+TEST(FutureCoroutines, ThrowInt) {
+  promise<int> p;
+  auto f = TestThrowInt(p.get_future());
+  p.set_exception(std::make_exception_ptr(std::runtime_error("test message")));
+  EXPECT_THROW(
+      try { f.get(); } catch (std::runtime_error const& ex) {
+        EXPECT_THAT(ex.what(), HasSubstr("test message"));
+        throw;
+      },
+      std::runtime_error);
+}
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud
+
+#endif  // GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L

--- a/google/cloud/future_generic.h
+++ b/google/cloud/future_generic.h
@@ -136,6 +136,8 @@ class future final : private internal::future_base<T> {
   template <typename U>
   friend class future;
   friend class future<void>;
+
+  friend struct internal::CoroutineSupport;
 };
 
 /**
@@ -222,6 +224,15 @@ inline future<typename internal::make_ready_return<T>::type> make_ready_future(
   return p.get_future();
 }
 
+namespace internal {
+
+template <typename T>
+std::shared_ptr<future_shared_state_base> CoroutineSupport::get_shared_state(
+    future<T>& f) {
+  return static_cast<future_base<T>&>(f).shared_state();
+}
+
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/future_void.h
+++ b/google/cloud/future_void.h
@@ -129,6 +129,8 @@ class future<void> final : private internal::future_base<void> {
 
   template <typename U>
   friend class future;
+
+  friend struct internal::CoroutineSupport;
 };
 
 /**
@@ -208,6 +210,15 @@ inline future<void> make_ready_future() {
   return p.get_future();
 }
 
+namespace internal {
+
+inline std::shared_ptr<future_shared_state_base>
+CoroutineSupport::get_shared_state(
+    future<void>& f) {
+  return static_cast<future_base<void>&>(f).shared_state();
+}
+
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -48,6 +48,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/filesystem.h",
     "internal/format_time_point.h",
     "internal/future_base.h",
+    "internal/future_coroutines.h",
     "internal/future_fwd.h",
     "internal/future_impl.h",
     "internal/future_then_impl.h",

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_common_unit_tests = [
     "common_options_test.cc",
+    "future_coroutines_test.cc",
     "future_generic_test.cc",
     "future_generic_then_test.cc",
     "future_void_test.cc",

--- a/google/cloud/internal/future_base.h
+++ b/google/cloud/internal/future_base.h
@@ -137,6 +137,10 @@ class future_base {  // NOLINT(readability-identifier-naming)
    */
   bool cancel() { return shared_state_->cancel(); }
 
+  std::shared_ptr<future_shared_state_base> shared_state() const {
+    return std::dynamic_pointer_cast<future_shared_state_base>(shared_state_);
+  }
+
  protected:
   /// Shorthand to refer to the shared state type.
   using shared_state_type = internal::future_shared_state<T>;

--- a/google/cloud/internal/future_coroutines.h
+++ b/google/cloud/internal/future_coroutines.h
@@ -1,0 +1,131 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_COROUTINES_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_COROUTINES_H
+
+#include "google/cloud/internal/port_platform.h"
+#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine
+#include "google/cloud/future_generic.h"
+#include "google/cloud/future_void.h"
+#include "google/cloud/version.h"
+#include <coroutine>
+#include <memory>
+
+/// Specialize `std::coroutine_traits` for `google::cloud_future<T>`.
+template <typename T, typename... Args>
+requires(!std::is_void_v<T> && !std::is_reference_v<T>) /**/
+    struct std::coroutine_traits<google::cloud::future<T>, Args...> {
+  struct promise_type {
+    google::cloud::promise<T> impl;
+
+    [[nodiscard]] google::cloud::future<T> get_return_object() noexcept {
+      return impl.get_future();
+    }
+
+    [[nodiscard]] std::suspend_never initial_suspend() const noexcept {
+      return {};
+    }
+    [[nodiscard]] std::suspend_never final_suspend() const noexcept {
+      return {};
+    }
+
+    void return_value(T const& value) noexcept(
+        std::is_nothrow_copy_constructible_v<T>) {
+      this->set_value(value);
+    }
+    void return_value(T&& value) noexcept(
+        std::is_nothrow_move_constructible_v<T>) {
+      impl.set_value(std::move(value));
+    }
+    void unhandled_exception() noexcept {
+      impl.set_exception(std::current_exception());
+    }
+  };
+};
+
+/// Specialize `std::coroutine_traits` for `google::cloud_future<void>`.
+template <typename... Args>
+struct std::coroutine_traits<google::cloud::future<void>, Args...> {
+  struct promise_type {
+    google::cloud::promise<void> impl;
+
+    [[nodiscard]] google::cloud::future<void> get_return_object() noexcept {
+      return impl.get_future();
+    }
+
+    [[nodiscard]] std::suspend_never initial_suspend() const noexcept {
+      return {};
+    }
+    [[nodiscard]] std::suspend_never final_suspend() const noexcept {
+      return {};
+    }
+
+    void return_void() noexcept { impl.set_value(); }
+    void unhandled_exception() noexcept {
+      impl.set_exception(std::current_exception());
+    }
+  };
+};
+
+namespace google::cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// Overload `co_await` for `google::cloud::future<T>`
+template <typename T>
+auto operator co_await(future<T> f) noexcept
+    requires(!std::is_reference_v<T>) /**/ {
+  struct awaiter {
+    future<T> impl;
+
+    /// Return `true` if the future is already satisfied.
+    [[nodiscard]] bool await_ready() const noexcept {
+      using namespace std::chrono_literals;
+      return impl.is_ready();
+    }
+
+    /// Suspend execution until the future becomes satisfied.
+    void await_suspend(std::coroutine_handle<> h) {
+      struct continuation : public internal::continuation_base {
+        std::coroutine_handle<> handle;
+
+        explicit continuation(std::coroutine_handle<>&& h)
+            : handle(std::move(h)) {}
+
+        // When the future becomes satisfied we resume the coroutine. At that
+        // point the coroutine will call `await_resume()` to get the value.
+        void execute() override { handle.resume(); }
+      };
+
+      // We cannot use `impl.then()` because that returns a new future, and
+      // coroutines expect the future to remain unchanged.  We reach into the
+      // future's internals to set up a callback without invalidating the
+      // future.
+      auto shared_state = internal::CoroutineSupport::get_shared_state(impl);
+      shared_state->set_continuation(
+          std::make_unique<continuation>(std::move(h)));
+    }
+
+    // Get the value (or exception) from the future.
+    T await_resume() { return impl.get(); }
+  };
+
+  return awaiter{std::move(f)};
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace google::cloud
+
+#endif  // GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_COROUTINES_H


### PR DESCRIPTION
Integrate `google::cloud::future<T>` with C++20 coroutines.  This
feature is optional, and only enabled if the compiler supports C++20.
Because some C++20 compilers disable coroutines by default, this feature
is disabled if `__cpp_impl_coroutine` is not defined, or it is 0.
