### PR TITLE
feat!: let CMAKE_CXX_STANDARD remain unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,12 +68,15 @@ https://github.com/googleapis/google-cloud-cpp/issues/8234.
 
 ## v1.39.0 - TBD
 
-In this release our CMake build no longer sets `CMAKE_CXX_STANDARD` to `11`
-when it was unspecified by the caller on Linux and Windows. Instead, we leave
-it unset, relying on the compiler's default C++ language standard. On macOS, we
-continue to default `CMAKE_CXX_STANDARD=11`, since the compiler's default of
-C++98 is too old. For more details, see:
-https://github.com/googleapis/google-cloud-cpp/issues/6767.
+**BREAKING CHANGES**
+
+* In this release our CMake build no longer sets `CMAKE_CXX_STANDARD` to `11`
+  when it was unspecified by the caller on Linux and Windows. Instead, we leave
+  it unset, relying on the compiler's default C++ language standard. On macOS,
+  we continue to default `CMAKE_CXX_STANDARD=11`, since the compiler's default
+  of C++98 is too old. To get the previous behavior, use
+  `cmake -DCMAKE_CXX_STANDARD=11 ...`. For more details, see:
+  https://github.com/googleapis/google-cloud-cpp/issues/6767.
 
 ### [KMS](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/README.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ https://github.com/googleapis/google-cloud-cpp/issues/8234.
 
 ## v1.39.0 - TBD
 
+In this release our CMake build no longer sets `CMAKE_CXX_STANDARD` to `11`
+when it was unspecified by the caller on Linux and Windows. Instead, we leave
+it unset, relying on the compiler's default C++ language standard. On macOS, we
+continue to default `CMAKE_CXX_STANDARD=11`, since the compiler's default of
+C++98 is too old. For more details, see:
+https://github.com/googleapis/google-cloud-cpp/issues/6767.
+
 ### [KMS](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/README.md)
 
 The library has been expanded to include the following services:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,13 +70,14 @@ https://github.com/googleapis/google-cloud-cpp/issues/8234.
 
 **BREAKING CHANGES**
 
-* In this release our CMake build no longer sets `CMAKE_CXX_STANDARD` to `11`
-  when it was unspecified by the caller on Linux and Windows. Instead, we leave
-  it unset, relying on the compiler's default C++ language standard. On macOS,
-  we continue to default `CMAKE_CXX_STANDARD=11`, since the compiler's default
-  of C++98 is too old. To get the previous behavior, use
-  `cmake -DCMAKE_CXX_STANDARD=11 ...`. For more details, see:
-  https://github.com/googleapis/google-cloud-cpp/issues/6767.
+* Starting with this release Linux and Windows builds based on CMake
+  no longer set `CMAKE_CXX_STANDARD` to `11`.  We rely on the compiler's
+  default C++ language standard. Note that all the compilers we support default
+  to C++14.
+  * On macOS the default is C++98, as `google-cloud-cpp` requires C++ >= 11, we continue
+    to set `CMAKE_CXX_STANDARD` on that platform.
+  * This only changes the default C++ version, we continue to test and support C++11.
+  * For more details, see [#6767](https://github.com/googleapis/google-cloud-cpp/issues/6767).
 
 ### [KMS](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/README.md)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,15 @@ cmake_minimum_required(VERSION 3.5)
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
 
+# Enable support for SelectMSVCRuntime
+if (NOT (CMAKE_VERSION VERSION_LESS 3.15))
+    cmake_policy(SET CMP0091 NEW)
+endif ()
+project(
+    google-cloud-cpp
+    VERSION 1.39.0
+    LANGUAGES CXX C)
+
 if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
     # AppleClang defaults to C++98, so we bump it to C++11.
     message(
@@ -33,15 +42,6 @@ if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
     )
     set(CMAKE_CXX_STANDARD 11)
 endif ()
-
-# Enable support for SelectMSVCRuntime
-if (NOT (CMAKE_VERSION VERSION_LESS 3.15))
-    cmake_policy(SET CMP0091 NEW)
-endif ()
-project(
-    google-cloud-cpp
-    VERSION 1.39.0
-    LANGUAGES CXX C)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,21 @@ cmake_minimum_required(VERSION 3.5)
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
 
+if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
+    # AppleClang defaults to C++98, so we bump it to C++11.
+    message(
+        WARNING
+            "CMAKE_CXX_STANDARD was undefined, defaulting to C++11."
+            "To select the desired standard use something like the following:"
+            "\n"
+            "    cmake -DCMAKE_CXX_STANDARD=17 ..."
+            "\n"
+            "For more details, see "
+            "https://cmake.org/cmake/help/latest/variable/CMAKE_CXX_STANDARD.html"
+    )
+    set(CMAKE_CXX_STANDARD 11)
+endif ()
+
 # Enable support for SelectMSVCRuntime
 if (NOT (CMAKE_VERSION VERSION_LESS 3.15))
     cmake_policy(SET CMP0091 NEW)
@@ -27,18 +42,6 @@ project(
     google-cloud-cpp
     VERSION 1.39.0
     LANGUAGES CXX C)
-
-# Allow applications to override the CMAKE_CXX_STANDARD, but if not set use 11.
-if (NOT CMAKE_CXX_STANDARD)
-    set(CMAKE_CXX_STANDARD 11)
-endif ()
-if (CMAKE_CXX_STANDARD VERSION_LESS 11)
-    message(
-        FATAL_ERROR
-            "CMAKE_CXX_STANDARD must be >= 11, was ${CMAKE_CXX_STANDARD}")
-endif ()
-
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)

--- a/ci/cloudbuild/builds/clang-tidy.sh
+++ b/ci/cloudbuild/builds/clang-tidy.sh
@@ -26,8 +26,11 @@ export CTCACHE_DIR=~/.cache/ctcache
 mapfile -t cmake_args < <(cmake::common_args)
 
 # See https://github.com/matus-chochlik/ctcache for docs about the clang-tidy-cache
+# Note: we use C++11 for this build because we don't want tidy suggestions that
+# require a newer C++ standard.
 cmake "${cmake_args[@]}" \
   -DCMAKE_CXX_CLANG_TIDY=/usr/local/bin/clang-tidy-wrapper \
+  -DCMAKE_CXX_STANDARD=11 \
   -DGOOGLE_CLOUD_CPP_ENABLE_GENERATOR=ON \
   -DGOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC=ON
 cmake --build cmake-out

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -52,8 +52,6 @@ function cmake::common_args() {
   local args
   args=(
     -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)"
-    # By default, we build with the oldest C++ standard that we support.
-    -DCMAKE_CXX_STANDARD=11
   )
   args+=(-GNinja -S . -B cmake-out)
   printf "%s\n" "${args[@]}"

--- a/ci/cloudbuild/builds/lib/cmake.sh
+++ b/ci/cloudbuild/builds/lib/cmake.sh
@@ -52,6 +52,8 @@ function cmake::common_args() {
   local args
   args=(
     -DGOOGLE_CLOUD_CPP_ENABLE="$(features::always_build_cmake)"
+    # By default, we build with the oldest C++ standard that we support.
+    -DCMAKE_CXX_STANDARD=11
   )
   args+=(-GNinja -S . -B cmake-out)
   printf "%s\n" "${args[@]}"


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-cpp/issues/6767

Rather than us explicitly setting (defaulting) `CMAKE_CXX_STANDARD=11`, we leave it unset and rely on the compiler's default C++ language standard. This will let customers more easily build w/ the "correct" standard for their platform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8537)
<!-- Reviewable:end -->
