### PR TITLE
fix: compiler warning from generator

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -254,7 +254,7 @@ void SetResourceRoutingMethodVars(
     method_vars["method_request_param_key"] = param;
     std::vector<std::string> chunks;
     auto const* input_type = method.input_type();
-    for (auto const sv : absl::StrSplit(param, '.')) {
+    for (auto const& sv : absl::StrSplit(param, '.')) {
       auto const chunk = std::string(sv);
       auto const* chunk_descriptor = input_type->FindFieldByName(chunk);
       chunks.push_back(FieldName(chunk_descriptor));


### PR DESCRIPTION
Fixes: #8244

I was not able to reproduce the warning on my M1 Mac, but I'm pretty sure this
change would be the fix for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8541)
<!-- Reviewable:end -->
