### PR TITLE
ci: skip quickstarts on macos when no credentials

### DIFF
--- a/ci/kokoro/macos/builds/cmake-vcpkg.sh
+++ b/ci/kokoro/macos/builds/cmake-vcpkg.sh
@@ -88,10 +88,14 @@ ctest_args=(
 
 # Cannot use `env -C` as the version of env on macOS does not support that flag
 io::log_h2 "Running minimal quickstart programs"
-(
-  cd "${BINARY_DIR}"
-  ctest "${ctest_args[@]}" -R "(storage_quickstart|pubsub_quickstart)"
-)
+if [ -r "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+  (
+    cd "${BINARY_DIR}"
+    ctest "${ctest_args[@]}" -R "(storage_quickstart|pubsub_quickstart)"
+  )
+else
+  io::log_yellow "No ${GOOGLE_APPLICATION_CREDENTIALS}. Skipping quickstarts."
+fi
 
 io::log_h2 "ccache stats"
 ccache --show-stats


### PR DESCRIPTION
This makes it easier to build the code and run the tests on macos.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8542)
<!-- Reviewable:end -->
