### PR TITLE
ci: wait longer for the pubsub emulator to start listening

### DIFF
--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -33,7 +33,7 @@ function pubsub_emulator::internal::read_emulator_port() {
 
   local emulator_port="0"
   local -r expected=": Server started, listening on "
-  for _ in $(seq 1 12); do
+  for _ in $(seq 1 60); do
     if grep -q "${expected}" "${logfile}"; then
       # The port number is whatever is after 'listening on'.
       emulator_port=$(grep "${expected}" "${logfile}" | awk -F' ' '{print $NF}')
@@ -73,7 +73,7 @@ function pubsub_emulator::start() {
 
   local -r emulator_port="$(pubsub_emulator::internal::read_emulator_port emulator.log)"
   if [[ "${emulator_port}" = "0" ]]; then
-    echo "Cannot determine Cloud Pub/Sub emulator port." >&2
+    io::log_red "Cannot determine Cloud Pub/Sub emulator port." >&2
     cat emulator.log >&2
     pubsub_emulator::kill
     return 1

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -63,7 +63,7 @@ function spanner_emulator::start() {
   # to kill the emulator at the end using that command.
   readonly SPANNER_EMULATOR_CMD="${CLOUD_SDK_LOCATION}/bin/cloud_spanner_emulator/emulator_main"
   if [[ ! -x "${SPANNER_EMULATOR_CMD}" ]]; then
-    echo 1>&2 "The spanner emulator does not seem to be installed, aborting"
+    echo 1>&2 "The Cloud Spanner emulator does not seem to be installed, aborting"
     return 1
   fi
 
@@ -75,7 +75,8 @@ function spanner_emulator::start() {
 
   emulator_port="$(spanner_emulator::internal::read_emulator_port emulator.log)"
   if [[ "${emulator_port}" = "0" ]]; then
-    echo "Cannot determine Cloud Spanner emulator port." >&2
+    io::log_red "Cannot determine Cloud Spanner emulator port." >&2
+    cat emulator.log >&2
     spanner_emulator::kill
     return 1
   fi


### PR DESCRIPTION
Loop 60 times (up from 12) while waiting to see the "listening on"
message from the pubsub emulator log.

For both pubsub and spanner emit the "Cannot determine port" error
message with a timestamp, so that it is easy to see just how long
we waited.

Finally, for spanner, dump the emulator log when we fail to find a
port, so that we might have some idea of what went wrong.

Fixes #8539.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8545)
<!-- Reviewable:end -->
