### PR TITLE
ci: add patch to the checkers docker image

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -27,6 +27,7 @@ RUN dnf makecache && \
         diffutils \
         findutils \
         git \
+        patch \
         python-pip \
         ShellCheck
 


### PR DESCRIPTION
It appears that even the checkers build needs the patch command
when the com_google_googleapis `patch_tool = "patch"` is set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8549)
<!-- Reviewable:end -->
