### PR TITLE
cleanup: mark google/cloud/ bazel targets as deprecated

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigquery/integration_tests/BUILD.bazel
+++ b/google/cloud/bigquery/integration_tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigquery/integration_tests/BUILD.bazel
+++ b/google/cloud/bigquery/integration_tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigquery/samples/BUILD.bazel
+++ b/google/cloud/bigquery/samples/BUILD.bazel
@@ -19,7 +19,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigquery/samples/BUILD.bazel
+++ b/google/cloud/bigquery/samples/BUILD.bazel
@@ -14,7 +14,17 @@
 
 """Examples for the Cloud BigQuery C++ client library."""
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
-# required to use the top-level BUILD file rather than reaching down into this
-# one.
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/tests/BUILD.bazel
+++ b/google/cloud/bigtable/tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/bigtable/tests/BUILD.bazel
+++ b/google/cloud/bigtable/tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/examples/BUILD.bazel
+++ b/google/cloud/examples/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/examples/BUILD.bazel
+++ b/google/cloud/examples/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/grpc_utils/BUILD.bazel
+++ b/google/cloud/grpc_utils/BUILD.bazel
@@ -28,7 +28,7 @@ cc_library(
     ],
     deprecation = (
         "please use //google/cloud:google_cloud_cpp_grpc_utils instead." +
-        " This target will be removed on or about 2023-03-16. More details at" +
+        " This target will be removed on or about 2023-01-01. More details at" +
         " https://github.com/googleapis/google-cloud-cpp/issues/3932"
     ),
     tags = ["manual"],

--- a/google/cloud/grpc_utils/BUILD.bazel
+++ b/google/cloud/grpc_utils/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -38,7 +28,7 @@ cc_library(
     ],
     deprecation = (
         "please use //google/cloud:google_cloud_cpp_grpc_utils instead." +
-        " This target will be removed on or about 2023-01-01. More details at" +
+        " This target will be removed on or about 2023-03-16. More details at" +
         " https://github.com/googleapis/google-cloud-cpp/issues/3932"
     ),
     tags = ["manual"],

--- a/google/cloud/grpc_utils/BUILD.bazel
+++ b/google/cloud/grpc_utils/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/iam/samples/BUILD.bazel
+++ b/google/cloud/iam/samples/BUILD.bazel
@@ -19,7 +19,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/iam/samples/BUILD.bazel
+++ b/google/cloud/iam/samples/BUILD.bazel
@@ -14,7 +14,17 @@
 
 """Examples for the Cloud IAM C++ client library."""
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/logging/integration_tests/BUILD.bazel
+++ b/google/cloud/logging/integration_tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/logging/integration_tests/BUILD.bazel
+++ b/google/cloud/logging/integration_tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsub/integration_tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/pubsub/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsub/integration_tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -14,7 +14,17 @@
 
 """Examples for the Cloud Pub/Sub C++ client library."""
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -19,7 +19,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
-# required to use the top-level BUILD file rather than reaching down into this
-# one.
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/spanner/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/admin/integration_tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/spanner/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/admin/integration_tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/integration_tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/spanner/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/integration_tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/samples/BUILD.bazel
+++ b/google/cloud/spanner/samples/BUILD.bazel
@@ -19,7 +19,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/spanner/samples/BUILD.bazel
+++ b/google/cloud/spanner/samples/BUILD.bazel
@@ -14,7 +14,17 @@
 
 """Examples for the Cloud Spanner C++ client library."""
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
-# required to use the top-level BUILD file rather than reaching down into this
-# one.
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -17,7 +17,7 @@
 package(
     default_deprecation = """
     These targets are not for public use and will be removed sometime around
-    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
     file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
     more details.
     """,

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -12,7 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+# TODO(#3701) Change the default_visibility to "//visibility:private", and
+# widen visibility as needed with per-target visibility.
+package(
+    default_deprecation = """
+    These targets are not for public use and will be removed sometime around
+    July 1, 2022. Only use Bazel targets defined in the top-level //BUILD.bazel
+    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
+    more details.
+    """,
+    default_visibility = ["//visibility:public"],
+)
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
Part of: #3701

We want users to only use targets in the top-level //BUILD.bazel file.
Very likely nobody is using these targets even right now. But a 90+ day
deprecation would be nice. We could extend this to a year if people feel
that's necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8550)
<!-- Reviewable:end -->
