### PR TITLE
doc: name quickstart placeholders in their README

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -763,7 +763,7 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    bazel run :quickstart -- [...]
@@ -800,7 +800,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [...]

--- a/google/cloud/accessapproval/quickstart/README.md
+++ b/google/cloud/accessapproval/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/accesscontextmanager/quickstart/README.md
+++ b/google/cloud/accesscontextmanager/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [POLICY_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [POLICY_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/apigateway/quickstart/README.md
+++ b/google/cloud/apigateway/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/apigeeconnect/quickstart/README.md
+++ b/google/cloud/apigeeconnect/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [ENDPOINT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [ENDPOINT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/appengine/quickstart/README.md
+++ b/google/cloud/appengine/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [APP_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [APP_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/artifactregistry/quickstart/README.md
+++ b/google/cloud/artifactregistry/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/asset/quickstart/README.md
+++ b/google/cloud/asset/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/assuredworkloads/quickstart/README.md
+++ b/google/cloud/assuredworkloads/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [ORGANIZATION_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [ORGANIZATION_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/automl/quickstart/README.md
+++ b/google/cloud/automl/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/bigquery/quickstart/README.md
+++ b/google/cloud/bigquery/quickstart/README.md
@@ -70,7 +70,7 @@ https://cloud.google.com/docs/authentication/production
    Note that, as it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    bazel run :quickstart -- [GCP PROJECT ID] [TABLE]
@@ -107,7 +107,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [GCP PROJECT ID] [TABLE]

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -71,7 +71,7 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    bazel run :quickstart -- [GCP PROJECT] [CLOUD BIGTABLE INSTANCE] [CLOUD BIGTABLE TABLE]
@@ -108,7 +108,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [GCP PROJECT] [CLOUD BIGTABLE INSTANCE] [CLOUD BIGTABLE TABLE]

--- a/google/cloud/billing/quickstart/README.md
+++ b/google/cloud/billing/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/binaryauthorization/quickstart/README.md
+++ b/google/cloud/binaryauthorization/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/channel/quickstart/README.md
+++ b/google/cloud/channel/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [ACCOUNT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [ACCOUNT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/cloudbuild/quickstart/README.md
+++ b/google/cloud/cloudbuild/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/composer/quickstart/README.md
+++ b/google/cloud/composer/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/contactcenterinsights/quickstart/README.md
+++ b/google/cloud/contactcenterinsights/quickstart/README.md
@@ -77,10 +77,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -114,10 +114,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/container/quickstart/README.md
+++ b/google/cloud/container/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/containeranalysis/quickstart/README.md
+++ b/google/cloud/containeranalysis/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/datacatalog/quickstart/README.md
+++ b/google/cloud/datacatalog/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/datamigration/quickstart/README.md
+++ b/google/cloud/datamigration/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/dataproc/quickstart/README.md
+++ b/google/cloud/dataproc/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [REGION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [REGION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/debugger/quickstart/README.md
+++ b/google/cloud/debugger/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/dlp/quickstart/README.md
+++ b/google/cloud/dlp/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/documentai/quickstart/README.md
+++ b/google/cloud/documentai/quickstart/README.md
@@ -71,10 +71,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID] [PROCESSOR_ID]
    ```
 
 ## Using with CMake
@@ -108,10 +108,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID] [PROCESSOR_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/eventarc/quickstart/README.md
+++ b/google/cloud/eventarc/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/filestore/quickstart/README.md
+++ b/google/cloud/filestore/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/functions/quickstart/README.md
+++ b/google/cloud/functions/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/gameservices/quickstart/README.md
+++ b/google/cloud/gameservices/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID] [REALM_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID] [REALM_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/gkehub/quickstart/README.md
+++ b/google/cloud/gkehub/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/iam/quickstart/README.md
+++ b/google/cloud/iam/quickstart/README.md
@@ -69,7 +69,7 @@ https://cloud.google.com/docs/authentication/production
    Note that, as it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    bazel run :quickstart -- [GCP PROJECT ID]
@@ -106,7 +106,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [GCP PROJECT ID]

--- a/google/cloud/iap/quickstart/README.md
+++ b/google/cloud/iap/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/ids/quickstart/README.md
+++ b/google/cloud/ids/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/iot/quickstart/README.md
+++ b/google/cloud/iot/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/kms/quickstart/README.md
+++ b/google/cloud/kms/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/language/quickstart/README.md
+++ b/google/cloud/language/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/managedidentities/quickstart/README.md
+++ b/google/cloud/managedidentities/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/memcache/quickstart/README.md
+++ b/google/cloud/memcache/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/monitoring/quickstart/README.md
+++ b/google/cloud/monitoring/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/networkmanagement/quickstart/README.md
+++ b/google/cloud/networkmanagement/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/notebooks/quickstart/README.md
+++ b/google/cloud/notebooks/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/orgpolicy/quickstart/README.md
+++ b/google/cloud/orgpolicy/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/osconfig/quickstart/README.md
+++ b/google/cloud/osconfig/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/oslogin/quickstart/README.md
+++ b/google/cloud/oslogin/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [USER_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [USER_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/policytroubleshooter/quickstart/README.md
+++ b/google/cloud/policytroubleshooter/quickstart/README.md
@@ -70,10 +70,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PRINCIPAL] [RESOURCE_NAME] [PERMISSION]
    ```
 
 ## Using with CMake
@@ -107,10 +107,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PRINCIPAL] [RESOURCE_NAME] [PERMISSION]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/privateca/quickstart/README.md
+++ b/google/cloud/privateca/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/profiler/quickstart/README.md
+++ b/google/cloud/profiler/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -70,10 +70,10 @@ https://cloud.google.com/docs/authentication/production
    Note that, as it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [GCP PROJECT ID] [TOPIC ID]
+   bazel run :quickstart -- [GCP PROJECT ID] [PUB/SUB TOPIC ID]
    ```
 
 ## Using with CMake
@@ -107,7 +107,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [GCP PROJECT ID] [PUB/SUB TOPIC ID]

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [ZONE_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [ZONE_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/recommender/quickstart/README.md
+++ b/google/cloud/recommender/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/redis/quickstart/README.md
+++ b/google/cloud/redis/quickstart/README.md
@@ -70,10 +70,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -107,10 +107,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/resourcemanager/quickstart/README.md
+++ b/google/cloud/resourcemanager/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [FOLDER_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [FOLDER_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/resourcesettings/quickstart/README.md
+++ b/google/cloud/resourcesettings/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/retail/quickstart/README.md
+++ b/google/cloud/retail/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/scheduler/quickstart/README.md
+++ b/google/cloud/scheduler/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/securitycenter/quickstart/README.md
+++ b/google/cloud/securitycenter/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/servicecontrol/quickstart/README.md
+++ b/google/cloud/servicecontrol/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/servicedirectory/quickstart/README.md
+++ b/google/cloud/servicedirectory/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/servicemanagement/quickstart/README.md
+++ b/google/cloud/servicemanagement/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/serviceusage/quickstart/README.md
+++ b/google/cloud/serviceusage/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/shell/quickstart/README.md
+++ b/google/cloud/shell/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [USER_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [USER_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -71,7 +71,7 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    bazel run :quickstart -- [GCP PROJECT] [CLOUD SPANNER INSTANCE] [CLOUD SPANNER DATABASE]
@@ -108,7 +108,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [GCP PROJECT] [CLOUD SPANNER INSTANCE] [CLOUD SPANNER DATABASE]

--- a/google/cloud/speech/quickstart/README.md
+++ b/google/cloud/speech/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -109,7 +109,7 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
    .build/quickstart [BUCKET NAME]

--- a/google/cloud/storagetransfer/quickstart/README.md
+++ b/google/cloud/storagetransfer/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/talent/quickstart/README.md
+++ b/google/cloud/talent/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/tasks/README.md
+++ b/google/cloud/tasks/README.md
@@ -42,7 +42,7 @@ this library.
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location\n";
+    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
     return 1;
   }
 

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/tasks/quickstart/quickstart.cc
+++ b/google/cloud/tasks/quickstart/quickstart.cc
@@ -18,7 +18,7 @@
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
-    std::cerr << "Usage: " << argv[0] << " project-id location\n";
+    std::cerr << "Usage: " << argv[0] << " project-id location-id\n";
     return 1;
   }
 

--- a/google/cloud/texttospeech/quickstart/README.md
+++ b/google/cloud/texttospeech/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/tpu/quickstart/README.md
+++ b/google/cloud/tpu/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/trace/quickstart/README.md
+++ b/google/cloud/trace/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/translate/quickstart/README.md
+++ b/google/cloud/translate/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/videointelligence/quickstart/README.md
+++ b/google/cloud/videointelligence/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/vision/quickstart/README.md
+++ b/google/cloud/vision/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/vmmigration/quickstart/README.md
+++ b/google/cloud/vmmigration/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/vpcaccess/quickstart/README.md
+++ b/google/cloud/vpcaccess/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/webrisk/quickstart/README.md
+++ b/google/cloud/webrisk/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/websecurityscanner/quickstart/README.md
+++ b/google/cloud/websecurityscanner/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID]
    ```
 
 ## Platform Specific Notes

--- a/google/cloud/workflows/quickstart/README.md
+++ b/google/cloud/workflows/quickstart/README.md
@@ -69,10 +69,10 @@ https://cloud.google.com/docs/authentication/production
    project. As it is often the case with C++ libraries, compiling these
    dependencies may take several minutes.
 
-3. Run the example, change the place holder(s) to appropriate values:
+3. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   bazel run :quickstart -- [...]
+   bazel run :quickstart -- [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Using with CMake
@@ -106,10 +106,10 @@ https://cloud.google.com/docs/authentication/production
    cmake --build .build
    ```
 
-4. Run the example, change the place holder to appropriate values:
+4. Run the example, change the placeholder(s) to appropriate values:
 
    ```bash
-   .build/quickstart [...]
+   .build/quickstart [PROJECT_ID] [LOCATION_ID]
    ```
 
 ## Platform Specific Notes


### PR DESCRIPTION
Improve the README file for each quickstart by naming the quickstart
program arguments, if any. Also fixed (?) the spelling of "place holder"
to "placeholder".