### PR TITLE
feat: expose build targets for common libraries

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -245,3 +245,17 @@ cc_library(
         "//google/cloud/storage:google_cloud_cpp_storage_grpc",
     ],
 )
+
+cc_library(
+    name = "common",
+    deps = [
+        "//google/cloud:google_cloud_cpp_common",
+    ],
+)
+
+cc_library(
+    name = "grpc_utils",
+    deps = [
+        "//google/cloud:google_cloud_cpp_grpc_utils",
+    ],
+)

--- a/ci/cloudbuild/builds/check-api.sh
+++ b/ci/cloudbuild/builds/check-api.sh
@@ -59,10 +59,6 @@ function dump_abi() {
 }
 export -f dump_abi # enables this function to be called from a subshell
 
-feature_list+=(
-  "common"
-  "grpc_utils"
-)
 mapfile -t libraries < <(printf "google_cloud_cpp_%s\n" "${feature_list[@]}")
 
 # Run the dump_abi function for each library in parallel since its slow.

--- a/ci/generate-markdown/generate-readme.sh
+++ b/ci/generate-markdown/generate-readme.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 (
   mapfile -t libraries < <(bazelisk --batch query \
     --noshow_progress --noshow_loading_progress \
-    'kind(cc_library, //:all) except filter("experimental|mocks", kind(cc_library, //:all))' |
+    'kind(cc_library, //:all) except filter("experimental|mocks|common|grpc_utils", kind(cc_library, //:all))' |
     sed -e 's;//:;;' |
     LC_ALL=C sort)
   sed '/<!-- inject-GA-libraries-start -->/q' "README.md.tmp"


### PR DESCRIPTION
Since #3701 says we want users to only use top-level build targets like
`//:foo`, we need to expose the targets from our
`google/cloud/BUILD.bazel` file.

I'm happy to bikeshe the target names here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8552)
<!-- Reviewable:end -->
