### PR TITLE
ci: discard some uninteresting emulator-test output

### DIFF
--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -34,7 +34,7 @@ function pubsub_emulator::internal::read_emulator_port() {
   local emulator_port="0"
   local -r expected=": Server started, listening on "
   for _ in $(seq 1 60); do
-    if grep -q "${expected}" "${logfile}"; then
+    if grep -q -s "${expected}" "${logfile}"; then
       # The port number is whatever is after 'listening on'.
       emulator_port=$(grep "${expected}" "${logfile}" | awk -F' ' '{print $NF}')
       break

--- a/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/pubsub/ci/run_integration_tests_emulator_bazel.sh
@@ -43,7 +43,7 @@ production_only_targets=()
 # otherwise.
 pushd "${HOME}" >/dev/null
 pubsub_emulator::start
-popd
+popd >/dev/null
 trap pubsub_emulator::kill EXIT
 
 excluded_targets=()

--- a/google/cloud/spanner/ci/lib/spanner_emulator.sh
+++ b/google/cloud/spanner/ci/lib/spanner_emulator.sh
@@ -34,7 +34,7 @@ function spanner_emulator::internal::read_emulator_port() {
   local emulator_port="0"
   local -r expected=" : Server address: "
   for _ in $(seq 1 8); do
-    if grep -q "${expected}" "${logfile}"; then
+    if grep -q -s "${expected}" "${logfile}"; then
       # The port number is whatever is after the last ':'.
       emulator_port=$(grep "${expected}" "${logfile}" | awk -F: '{print $NF}')
       break

--- a/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
+++ b/google/cloud/spanner/ci/run_integration_tests_emulator_bazel.sh
@@ -36,7 +36,7 @@ bazel_test_args=("$@")
 # otherwise. Use a fixed port so Bazel can cache the test results.
 pushd "${HOME}" >/dev/null
 spanner_emulator::start 8787
-popd
+popd >/dev/null
 trap spanner_emulator::kill EXIT
 
 "${BAZEL_BIN}" "${BAZEL_VERB}" "${bazel_test_args[@]}" \


### PR DESCRIPTION
- Add a `-s` (`--no-messages`) flag to the quiet grep for the
  "listening on" in emulator logfile, which will suppress any
  `grep: emulator.log: No such file or directory` message
  should we be looking before the logfile actually exists.

- Discard the `popd` output (`/workspace`) after starting the
  emulator.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8554)
<!-- Reviewable:end -->
