### PR TITLE
Revert "cleanup: mark google/cloud/ bazel targets as deprecated"

### DIFF
--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigquery/integration_tests/BUILD.bazel
+++ b/google/cloud/bigquery/integration_tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigquery/samples/BUILD.bazel
+++ b/google/cloud/bigquery/samples/BUILD.bazel
@@ -14,17 +14,7 @@
 
 """Examples for the Cloud BigQuery C++ client library."""
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
+# required to use the top-level BUILD file rather than reaching down into this
+# one.
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/bigtable/tests/BUILD.bazel
+++ b/google/cloud/bigtable/tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/examples/BUILD.bazel
+++ b/google/cloud/examples/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/iam/samples/BUILD.bazel
+++ b/google/cloud/iam/samples/BUILD.bazel
@@ -14,17 +14,7 @@
 
 """Examples for the Cloud IAM C++ client library."""
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/logging/integration_tests/BUILD.bazel
+++ b/google/cloud/logging/integration_tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsub/integration_tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -14,17 +14,7 @@
 
 """Examples for the Cloud Pub/Sub C++ client library."""
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
+# required to use the top-level BUILD file rather than reaching down into this
+# one.
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/admin/integration_tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/integration_tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/spanner/samples/BUILD.bazel
+++ b/google/cloud/spanner/samples/BUILD.bazel
@@ -14,17 +14,7 @@
 
 """Examples for the Cloud Spanner C++ client library."""
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+# TODO(#3701) Change this visibility to "//:__subpackages__" so that users are
+# required to use the top-level BUILD file rather than reaching down into this
+# one.
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -12,17 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# TODO(#3701) Change the default_visibility to "//visibility:private", and
-# widen visibility as needed with per-target visibility.
-package(
-    default_deprecation = """
-    These targets are not for public use and will be removed sometime around
-    2023-03-16. Only use Bazel targets defined in the top-level //BUILD.bazel
-    file. See https://github.com/googleapis/google-cloud-cpp/issues/3701 for
-    more details.
-    """,
-    default_visibility = ["//visibility:public"],
-)
+package(default_visibility = ["//visibility:public"])
 
 licenses(["notice"])  # Apache 2.0
 


### PR DESCRIPTION
Reverts googleapis/google-cloud-cpp#8550

Reverting because this causes too many deprecation warnings in our own builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8561)
<!-- Reviewable:end -->
