### PR TITLE
cleanup: only set authority if `AuthorityOption` is non-empty

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -121,9 +121,8 @@ void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata(
         "x-goog-user-project", options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -230,9 +230,8 @@ void GoldenThingAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata(
         "x-goog-user-project", options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -348,9 +348,8 @@ void $metadata_class_name$::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata(
         "x-goog-user-project", options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 )""");
 

--- a/google/cloud/accessapproval/internal/access_approval_metadata_decorator.cc
+++ b/google/cloud/accessapproval/internal/access_approval_metadata_decorator.cc
@@ -109,9 +109,8 @@ void AccessApprovalMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_metadata_decorator.cc
@@ -292,9 +292,8 @@ void AccessContextManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/apigateway/internal/api_gateway_metadata_decorator.cc
+++ b/google/cloud/apigateway/internal/api_gateway_metadata_decorator.cc
@@ -192,9 +192,8 @@ void ApiGatewayServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/apigeeconnect/internal/connection_metadata_decorator.cc
+++ b/google/cloud/apigeeconnect/internal/connection_metadata_decorator.cc
@@ -55,9 +55,8 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/applications_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/applications_metadata_decorator.cc
@@ -99,9 +99,8 @@ void ApplicationsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/authorized_certificates_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_metadata_decorator.cc
@@ -86,9 +86,8 @@ void AuthorizedCertificatesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/authorized_domains_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/authorized_domains_metadata_decorator.cc
@@ -55,9 +55,8 @@ void AuthorizedDomainsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/domain_mappings_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/domain_mappings_metadata_decorator.cc
@@ -107,9 +107,8 @@ void DomainMappingsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/firewall_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/firewall_metadata_decorator.cc
@@ -92,9 +92,8 @@ void FirewallMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/instances_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/instances_metadata_decorator.cc
@@ -96,9 +96,8 @@ void InstancesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/services_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/services_metadata_decorator.cc
@@ -96,9 +96,8 @@ void ServicesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/appengine/internal/versions_metadata_decorator.cc
+++ b/google/cloud/appengine/internal/versions_metadata_decorator.cc
@@ -105,9 +105,8 @@ void VersionsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_metadata_decorator.cc
@@ -74,9 +74,8 @@ void ArtifactRegistryMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/asset/internal/asset_metadata_decorator.cc
+++ b/google/cloud/asset/internal/asset_metadata_decorator.cc
@@ -170,9 +170,8 @@ void AssetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_metadata_decorator.cc
@@ -105,9 +105,8 @@ void AssuredWorkloadsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/automl/internal/auto_ml_metadata_decorator.cc
+++ b/google/cloud/automl/internal/auto_ml_metadata_decorator.cc
@@ -212,9 +212,8 @@ void AutoMlMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/automl/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/automl/internal/prediction_metadata_decorator.cc
@@ -81,9 +81,8 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_metadata_decorator.cc
@@ -74,9 +74,8 @@ void BigQueryReadMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/bigquery_write_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/bigquery_write_metadata_decorator.cc
@@ -101,9 +101,8 @@ void BigQueryWriteMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/connection_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/connection_metadata_decorator.cc
@@ -113,9 +113,8 @@ void ConnectionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/data_transfer_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/data_transfer_metadata_decorator.cc
@@ -182,9 +182,8 @@ void DataTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/model_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/model_metadata_decorator.cc
@@ -76,9 +76,8 @@ void ModelServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigquery/internal/reservation_metadata_decorator.cc
+++ b/google/cloud/bigquery/internal/reservation_metadata_decorator.cc
@@ -228,9 +228,8 @@ void ReservationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_metadata_decorator.cc
@@ -225,9 +225,8 @@ void BigtableInstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_metadata_decorator.cc
@@ -207,9 +207,8 @@ void BigtableTableAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -48,9 +48,7 @@ class DefaultDataClient : public DataClient {
                     Options options = {})
       : project_(std::move(project)),
         instance_(std::move(instance)),
-        authority_(options.has<AuthorityOption>()
-                       ? absl::make_optional(options.get<AuthorityOption>())
-                       : absl::nullopt),
+        authority_(options.get<AuthorityOption>()),
         user_project_(
             options.has<UserProjectOption>()
                 ? absl::make_optional(options.get<UserProjectOption>())
@@ -192,9 +190,7 @@ class DefaultDataClient : public DataClient {
   }
 
   void ApplyOptions(grpc::ClientContext* context) {
-    if (authority_) {
-      context->set_authority(*authority_);
-    }
+    if (!authority_.empty()) context->set_authority(authority_);
     if (user_project_) {
       context->AddMetadata("x-goog-user-project", *user_project_);
     }
@@ -202,7 +198,7 @@ class DefaultDataClient : public DataClient {
 
   std::string project_;
   std::string instance_;
-  absl::optional<std::string> authority_;
+  std::string authority_;
   absl::optional<std::string> user_project_;
   internal::CommonClient<btproto::Bigtable> impl_;
 };

--- a/google/cloud/billing/internal/budget_metadata_decorator.cc
+++ b/google/cloud/billing/internal/budget_metadata_decorator.cc
@@ -86,9 +86,8 @@ void BudgetServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/cloud_billing_metadata_decorator.cc
+++ b/google/cloud/billing/internal/cloud_billing_metadata_decorator.cc
@@ -126,9 +126,8 @@ void CloudBillingMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/billing/internal/cloud_catalog_metadata_decorator.cc
+++ b/google/cloud/billing/internal/cloud_catalog_metadata_decorator.cc
@@ -63,9 +63,8 @@ void CloudCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_metadata_decorator.cc
@@ -108,9 +108,8 @@ void BinauthzManagementServiceV1Metadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_metadata_decorator.cc
@@ -56,9 +56,8 @@ void SystemPolicyV1Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.cc
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_metadata_decorator.cc
@@ -57,9 +57,8 @@ void ValidationHelperV1Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/channel/internal/cloud_channel_metadata_decorator.cc
+++ b/google/cloud/channel/internal/cloud_channel_metadata_decorator.cc
@@ -359,9 +359,8 @@ void CloudChannelServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_metadata_decorator.cc
@@ -216,9 +216,8 @@ void CloudBuildMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -88,6 +88,10 @@ struct UserProjectOption {
  *     https://datatracker.ietf.org/doc/html/rfc7540#section-8.1.2.3
  *
  * For REST-based services using HTTP/1.1 or HTTP/1.0 this is the `Host` header.
+ *
+ * For this option to have no effect on the headers, it must be explicitly set
+ * to the empty string. This use case is not typical for applications outside of
+ * Google.
  */
 struct AuthorityOption {
   using Type = std::string;

--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -89,9 +89,8 @@ struct UserProjectOption {
  *
  * For REST-based services using HTTP/1.1 or HTTP/1.0 this is the `Host` header.
  *
- * For this option to have no effect on the headers, it must be explicitly set
- * to the empty string. This use case is not typical for applications outside of
- * Google.
+ * Setting this option to the empty string has no effect, i.e., no headers are
+ * set. This can be useful if you are not using Google's production environment.
  */
 struct AuthorityOption {
   using Type = std::string;

--- a/google/cloud/composer/internal/environments_metadata_decorator.cc
+++ b/google/cloud/composer/internal/environments_metadata_decorator.cc
@@ -113,9 +113,8 @@ void EnvironmentsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/composer/internal/image_versions_metadata_decorator.cc
+++ b/google/cloud/composer/internal/image_versions_metadata_decorator.cc
@@ -57,9 +57,8 @@ void ImageVersionsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_metadata_decorator.cc
@@ -371,9 +371,8 @@ void ContactCenterInsightsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/container/internal/cluster_manager_metadata_decorator.cc
+++ b/google/cloud/container/internal/cluster_manager_metadata_decorator.cc
@@ -296,9 +296,8 @@ void ClusterManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/internal/container_analysis_metadata_decorator.cc
@@ -79,9 +79,8 @@ void ContainerAnalysisMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/containeranalysis/internal/grafeas_metadata_decorator.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_metadata_decorator.cc
@@ -146,9 +146,8 @@ void GrafeasMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/data_catalog_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_metadata_decorator.cc
@@ -297,9 +297,8 @@ void DataCatalogMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_metadata_decorator.cc
@@ -147,9 +147,8 @@ void PolicyTagManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_serialization_metadata_decorator.cc
@@ -72,9 +72,8 @@ void PolicyTagManagerSerializationMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/datamigration/internal/data_migration_metadata_decorator.cc
+++ b/google/cloud/datamigration/internal/data_migration_metadata_decorator.cc
@@ -216,9 +216,8 @@ void DataMigrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/autoscaling_policy_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/autoscaling_policy_metadata_decorator.cc
@@ -91,9 +91,8 @@ void AutoscalingPolicyServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/batch_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/batch_controller_metadata_decorator.cc
@@ -95,9 +95,8 @@ void BatchControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/cluster_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/cluster_controller_metadata_decorator.cc
@@ -134,9 +134,8 @@ void ClusterControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/job_controller_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/job_controller_metadata_decorator.cc
@@ -116,9 +116,8 @@ void JobControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/internal/workflow_template_metadata_decorator.cc
+++ b/google/cloud/dataproc/internal/workflow_template_metadata_decorator.cc
@@ -126,9 +126,8 @@ void WorkflowTemplateServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/debugger/internal/controller2_metadata_decorator.cc
+++ b/google/cloud/debugger/internal/controller2_metadata_decorator.cc
@@ -73,9 +73,8 @@ void Controller2Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/debugger/internal/debugger2_metadata_decorator.cc
+++ b/google/cloud/debugger/internal/debugger2_metadata_decorator.cc
@@ -87,9 +87,8 @@ void Debugger2Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dlp/internal/dlp_metadata_decorator.cc
+++ b/google/cloud/dlp/internal/dlp_metadata_decorator.cc
@@ -309,9 +309,8 @@ void DlpServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/documentai/internal/document_processor_metadata_decorator.cc
+++ b/google/cloud/documentai/internal/document_processor_metadata_decorator.cc
@@ -91,9 +91,8 @@ void DocumentProcessorServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/eventarc/internal/eventarc_metadata_decorator.cc
+++ b/google/cloud/eventarc/internal/eventarc_metadata_decorator.cc
@@ -183,9 +183,8 @@ void EventarcMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/eventarc/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/eventarc/internal/publisher_metadata_decorator.cc
@@ -56,9 +56,8 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_metadata_decorator.cc
@@ -159,9 +159,8 @@ void CloudFilestoreManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/functions/internal/cloud_functions_metadata_decorator.cc
+++ b/google/cloud/functions/internal/cloud_functions_metadata_decorator.cc
@@ -153,9 +153,8 @@ void CloudFunctionsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_metadata_decorator.cc
@@ -137,9 +137,8 @@ void GameServerClustersServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_configs_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_metadata_decorator.cc
@@ -99,9 +99,8 @@ void GameServerConfigsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_metadata_decorator.cc
@@ -153,9 +153,8 @@ void GameServerDeploymentsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gameservices/internal/realms_metadata_decorator.cc
+++ b/google/cloud/gameservices/internal/realms_metadata_decorator.cc
@@ -114,9 +114,8 @@ void RealmsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/gkehub/internal/gke_hub_metadata_decorator.cc
+++ b/google/cloud/gkehub/internal/gke_hub_metadata_decorator.cc
@@ -155,9 +155,8 @@ void GkeHubMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_credentials_metadata_decorator.cc
@@ -79,9 +79,8 @@ void IAMCredentialsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iam/internal/iam_metadata_decorator.cc
+++ b/google/cloud/iam/internal/iam_metadata_decorator.cc
@@ -241,9 +241,8 @@ void IAMMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_metadata_decorator.cc
@@ -88,9 +88,8 @@ void IdentityAwareProxyAdminServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_metadata_decorator.cc
@@ -115,9 +115,8 @@ void IdentityAwareProxyOAuthServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/ids/internal/ids_metadata_decorator.cc
+++ b/google/cloud/ids/internal/ids_metadata_decorator.cc
@@ -95,9 +95,8 @@ void IDSMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/iot/internal/device_manager_metadata_decorator.cc
+++ b/google/cloud/iot/internal/device_manager_metadata_decorator.cc
@@ -193,9 +193,8 @@ void DeviceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/kms/internal/ekm_metadata_decorator.cc
+++ b/google/cloud/kms/internal/ekm_metadata_decorator.cc
@@ -79,9 +79,8 @@ void EkmServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/kms/internal/key_management_metadata_decorator.cc
+++ b/google/cloud/kms/internal/key_management_metadata_decorator.cc
@@ -257,9 +257,8 @@ void KeyManagementServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/language/internal/language_metadata_decorator.cc
+++ b/google/cloud/language/internal/language_metadata_decorator.cc
@@ -95,9 +95,8 @@ void LanguageServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
+++ b/google/cloud/logging/internal/logging_service_v2_metadata_decorator.cc
@@ -97,9 +97,8 @@ void LoggingServiceV2Metadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/managedidentities/internal/managed_identities_metadata_decorator.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_metadata_decorator.cc
@@ -155,9 +155,8 @@ void ManagedIdentitiesServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/memcache/internal/cloud_memcache_metadata_decorator.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_metadata_decorator.cc
@@ -125,9 +125,8 @@ void CloudMemcacheMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/alert_policy_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/alert_policy_metadata_decorator.cc
@@ -86,9 +86,8 @@ void AlertPolicyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/dashboards_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/dashboards_metadata_decorator.cc
@@ -86,9 +86,8 @@ void DashboardsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/group_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/group_metadata_decorator.cc
@@ -91,9 +91,8 @@ void GroupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/metric_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metric_metadata_decorator.cc
@@ -118,9 +118,8 @@ void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metrics_scopes_metadata_decorator.cc
@@ -103,9 +103,8 @@ void MetricsScopesMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/notification_channel_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/notification_channel_metadata_decorator.cc
@@ -132,9 +132,8 @@ void NotificationChannelServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/query_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/query_metadata_decorator.cc
@@ -55,9 +55,8 @@ void QueryServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/service_monitoring_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_metadata_decorator.cc
@@ -127,9 +127,8 @@ void ServiceMonitoringServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/monitoring/internal/uptime_check_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/uptime_check_metadata_decorator.cc
@@ -95,9 +95,8 @@ void UptimeCheckServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/networkmanagement/internal/reachability_metadata_decorator.cc
+++ b/google/cloud/networkmanagement/internal/reachability_metadata_decorator.cc
@@ -122,9 +122,8 @@ void ReachabilityServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/notebooks/internal/managed_notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_metadata_decorator.cc
@@ -143,9 +143,8 @@ void ManagedNotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/notebooks/internal/notebook_metadata_decorator.cc
+++ b/google/cloud/notebooks/internal/notebook_metadata_decorator.cc
@@ -347,9 +347,8 @@ void NotebookServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/orgpolicy/internal/org_policy_metadata_decorator.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_metadata_decorator.cc
@@ -98,9 +98,8 @@ void OrgPolicyMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.cc
+++ b/google/cloud/osconfig/internal/agent_endpoint_metadata_decorator.cc
@@ -103,9 +103,8 @@ void AgentEndpointServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/osconfig/internal/os_config_metadata_decorator.cc
+++ b/google/cloud/osconfig/internal/os_config_metadata_decorator.cc
@@ -144,9 +144,8 @@ void OsConfigServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/oslogin/internal/os_login_metadata_decorator.cc
+++ b/google/cloud/oslogin/internal/os_login_metadata_decorator.cc
@@ -93,9 +93,8 @@ void OsLoginServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.cc
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_metadata_decorator.cc
@@ -55,9 +55,8 @@ void IamCheckerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/privateca/internal/certificate_authority_metadata_decorator.cc
+++ b/google/cloud/privateca/internal/certificate_authority_metadata_decorator.cc
@@ -356,9 +356,8 @@ void CertificateAuthorityServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/profiler/internal/profiler_metadata_decorator.cc
+++ b/google/cloud/profiler/internal/profiler_metadata_decorator.cc
@@ -72,9 +72,8 @@ void ProfilerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/publisher_metadata.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata.cc
@@ -100,9 +100,8 @@ void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsub/internal/subscriber_metadata.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata.cc
@@ -147,9 +147,8 @@ void SubscriberMetadata::SetMetadata(grpc::ClientContext& context,
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/admin_metadata_decorator.cc
@@ -215,9 +215,8 @@ void AdminServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/cursor_metadata_decorator.cc
@@ -73,9 +73,8 @@ void CursorServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/partition_assignment_metadata_decorator.cc
@@ -58,9 +58,8 @@ void PartitionAssignmentServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/publisher_metadata_decorator.cc
@@ -57,9 +57,8 @@ void PublisherServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/subscriber_metadata_decorator.cc
@@ -57,9 +57,8 @@ void SubscriberServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_metadata_decorator.cc
@@ -71,9 +71,8 @@ void TopicStatsServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/recommender/internal/recommender_metadata_decorator.cc
+++ b/google/cloud/recommender/internal/recommender_metadata_decorator.cc
@@ -113,9 +113,8 @@ void RecommenderMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/redis/internal/cloud_redis_metadata_decorator.cc
+++ b/google/cloud/redis/internal/cloud_redis_metadata_decorator.cc
@@ -141,9 +141,8 @@ void CloudRedisMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/folders_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/folders_metadata_decorator.cc
@@ -153,9 +153,8 @@ void FoldersMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/organizations_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/organizations_metadata_decorator.cc
@@ -86,9 +86,8 @@ void OrganizationsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcemanager/internal/projects_metadata_decorator.cc
+++ b/google/cloud/resourcemanager/internal/projects_metadata_decorator.cc
@@ -154,9 +154,8 @@ void ProjectsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_metadata_decorator.cc
@@ -72,9 +72,8 @@ void ResourceSettingsServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/catalog_metadata_decorator.cc
+++ b/google/cloud/retail/internal/catalog_metadata_decorator.cc
@@ -78,9 +78,8 @@ void CatalogServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/completion_metadata_decorator.cc
+++ b/google/cloud/retail/internal/completion_metadata_decorator.cc
@@ -81,9 +81,8 @@ void CompletionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/prediction_metadata_decorator.cc
+++ b/google/cloud/retail/internal/prediction_metadata_decorator.cc
@@ -55,9 +55,8 @@ void PredictionServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/product_metadata_decorator.cc
+++ b/google/cloud/retail/internal/product_metadata_decorator.cc
@@ -138,9 +138,8 @@ void ProductServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/search_metadata_decorator.cc
+++ b/google/cloud/retail/internal/search_metadata_decorator.cc
@@ -55,9 +55,8 @@ void SearchServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/retail/internal/user_event_metadata_decorator.cc
+++ b/google/cloud/retail/internal/user_event_metadata_decorator.cc
@@ -106,9 +106,8 @@ void UserEventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_metadata_decorator.cc
@@ -104,9 +104,8 @@ void CloudSchedulerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/secretmanager/internal/secret_manager_metadata_decorator.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_metadata_decorator.cc
@@ -169,9 +169,8 @@ void SecretManagerServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/securitycenter/internal/security_center_metadata_decorator.cc
+++ b/google/cloud/securitycenter/internal/security_center_metadata_decorator.cc
@@ -369,9 +369,8 @@ void SecurityCenterMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/internal/quota_controller_metadata_decorator.cc
@@ -55,9 +55,8 @@ void QuotaControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicecontrol/internal/service_controller_metadata_decorator.cc
+++ b/google/cloud/servicecontrol/internal/service_controller_metadata_decorator.cc
@@ -63,9 +63,8 @@ void ServiceControllerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicedirectory/internal/lookup_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/internal/lookup_metadata_decorator.cc
@@ -55,9 +55,8 @@ void LookupServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicedirectory/internal/registration_metadata_decorator.cc
+++ b/google/cloud/servicedirectory/internal/registration_metadata_decorator.cc
@@ -189,9 +189,8 @@ void RegistrationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/servicemanagement/internal/service_manager_metadata_decorator.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_metadata_decorator.cc
@@ -179,9 +179,8 @@ void ServiceManagerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/serviceusage/internal/service_usage_metadata_decorator.cc
+++ b/google/cloud/serviceusage/internal/service_usage_metadata_decorator.cc
@@ -115,9 +115,8 @@ void ServiceUsageMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/shell/internal/cloud_shell_metadata_decorator.cc
+++ b/google/cloud/shell/internal/cloud_shell_metadata_decorator.cc
@@ -108,9 +108,8 @@ void CloudShellServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_metadata_decorator.cc
@@ -206,9 +206,8 @@ void DatabaseAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_metadata_decorator.cc
@@ -148,9 +148,8 @@ void InstanceAdminMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -168,9 +168,8 @@ void MetadataSpannerStub::SetMetadata(grpc::ClientContext& context,
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/speech/internal/speech_metadata_decorator.cc
+++ b/google/cloud/speech/internal/speech_metadata_decorator.cc
@@ -90,9 +90,8 @@ void SpeechMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -194,9 +194,8 @@ void StorageMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_metadata_decorator.cc
@@ -129,9 +129,8 @@ void StorageTransferServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/company_metadata_decorator.cc
+++ b/google/cloud/talent/internal/company_metadata_decorator.cc
@@ -85,9 +85,8 @@ void CompanyServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/completion_metadata_decorator.cc
+++ b/google/cloud/talent/internal/completion_metadata_decorator.cc
@@ -54,9 +54,8 @@ void CompletionMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/event_metadata_decorator.cc
+++ b/google/cloud/talent/internal/event_metadata_decorator.cc
@@ -55,9 +55,8 @@ void EventServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/job_metadata_decorator.cc
+++ b/google/cloud/talent/internal/job_metadata_decorator.cc
@@ -142,9 +142,8 @@ void JobServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/talent/internal/tenant_metadata_decorator.cc
+++ b/google/cloud/talent/internal/tenant_metadata_decorator.cc
@@ -83,9 +83,8 @@ void TenantServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tasks/internal/cloud_tasks_metadata_decorator.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_metadata_decorator.cc
@@ -161,9 +161,8 @@ void CloudTasksMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.cc
+++ b/google/cloud/texttospeech/internal/text_to_speech_metadata_decorator.cc
@@ -63,9 +63,8 @@ void TextToSpeechMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/tpu/internal/tpu_metadata_decorator.cc
+++ b/google/cloud/tpu/internal/tpu_metadata_decorator.cc
@@ -148,9 +148,8 @@ void TpuMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/trace/internal/trace_metadata_decorator.cc
+++ b/google/cloud/trace/internal/trace_metadata_decorator.cc
@@ -62,9 +62,8 @@ void TraceServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/translate/internal/translation_metadata_decorator.cc
+++ b/google/cloud/translate/internal/translation_metadata_decorator.cc
@@ -150,9 +150,8 @@ void TranslationServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_metadata_decorator.cc
@@ -74,9 +74,8 @@ void VideoIntelligenceServiceMetadata::SetMetadata(
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/internal/image_annotator_metadata_decorator.cc
+++ b/google/cloud/vision/internal/image_annotator_metadata_decorator.cc
@@ -98,9 +98,8 @@ void ImageAnnotatorMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vision/internal/product_search_metadata_decorator.cc
+++ b/google/cloud/vision/internal/product_search_metadata_decorator.cc
@@ -213,9 +213,8 @@ void ProductSearchMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vmmigration/internal/vm_migration_metadata_decorator.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_metadata_decorator.cc
@@ -443,9 +443,8 @@ void VmMigrationMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_metadata_decorator.cc
@@ -98,9 +98,8 @@ void VpcAccessServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/webrisk/internal/web_risk_metadata_decorator.cc
+++ b/google/cloud/webrisk/internal/web_risk_metadata_decorator.cc
@@ -79,9 +79,8 @@ void WebRiskServiceMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_metadata_decorator.cc
@@ -157,9 +157,8 @@ void WebSecurityScannerMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/workflows/internal/executions_metadata_decorator.cc
+++ b/google/cloud/workflows/internal/executions_metadata_decorator.cc
@@ -82,9 +82,8 @@ void ExecutionsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/workflows/internal/workflows_metadata_decorator.cc
+++ b/google/cloud/workflows/internal/workflows_metadata_decorator.cc
@@ -105,9 +105,8 @@ void WorkflowsMetadata::SetMetadata(grpc::ClientContext& context) {
     context.AddMetadata("x-goog-user-project",
                         options.get<UserProjectOption>());
   }
-  if (options.has<AuthorityOption>()) {
-    context.set_authority(options.get<AuthorityOption>());
-  }
+  auto const& authority = options.get<AuthorityOption>();
+  if (!authority.empty()) context.set_authority(authority);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This doesn't change any behavior, as gRPC also [checks if this value is empty](https://github.com/grpc/grpc/blob/37ab6091030350b442f0267f1f22e7a490f1f536/src/cpp/client/channel_cc.cc#L124). I just feel a tiny bit better about doing this check on our end.

Add documentation (for internal Google users) on how to "unset" the option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8564)
<!-- Reviewable:end -->
