### PR TITLE
feat(common): make coroutine support optional

### DIFF
--- a/google/cloud/future_coroutines_test.cc
+++ b/google/cloud/future_coroutines_test.cc
@@ -14,7 +14,7 @@
 // limitations under the License.
 
 #include "google/cloud/future.h"
-#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine
+#if GOOGLE_CLOUD_CPP_HAVE_COROUTINES
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <ranges>
@@ -149,4 +149,4 @@ TEST(FutureCoroutines, ThrowInt) {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud
 
-#endif  // GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L
+#endif  // GOOGLE_CLOUD_CPP_CPP_HAVE_COROUTINES

--- a/google/cloud/internal/future_coroutines.h
+++ b/google/cloud/internal/future_coroutines.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_COROUTINES_H
 
 #include "google/cloud/internal/port_platform.h"
-#if GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine
+#if GOOGLE_CLOUD_CPP_HAVE_COROUTINES
 #include "google/cloud/future_generic.h"
 #include "google/cloud/future_void.h"
 #include "google/cloud/version.h"
@@ -127,5 +127,5 @@ auto operator co_await(future<T> f) noexcept
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace google::cloud
 
-#endif  // GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine
+#endif  // GOOGLE_CLOUD_CPP_CPP_HAVE_COROUTINES
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_FUTURE_COROUTINES_H

--- a/google/cloud/internal/port_platform.h
+++ b/google/cloud/internal/port_platform.h
@@ -91,4 +91,10 @@
 
 // clang-format on
 
+// Applications may override the default by adding a -D option.
+#ifndef GOOGLE_CLOUD_CPP_HAVE_COROUTINES
+#define GOOGLE_CLOUD_CPP_HAVE_COROUTINES \
+  (GOOGLE_CLOUD_CPP_CPP_VERSION >= 202002L && __cpp_impl_coroutine)
+#endif  // GOOGLE_CLOUD_CPP_HAVE_COROUTINES
+
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_PORT_PLATFORM_H


### PR DESCRIPTION
Applications can disable coroutine support by adding
`-DGOOGLE_CLOUD_CPP_HAVE_COROUTINES=0` to the build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8571)
<!-- Reviewable:end -->
