### PR TITLE
cleanup: use `cc_binary()` for benchmarks

### DIFF
--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -32,22 +32,19 @@ cc_library(
 
 load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
 
-[cc_test(
-    name = test.replace("/", "_").replace(".cc", ""),
-    srcs = [test],
+[cc_binary(
+    name = program.replace("/", "_").replace(".cc", ""),
+    srcs = [program],
     linkopts = select({
         "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
-    tags = [
-        "integration-test",
-    ],
     deps = [
         ":bigtable_benchmark_common",
         "//:bigtable",
         "//:common",
     ],
-) for test in bigtable_benchmark_programs]
+) for program in bigtable_benchmark_programs]
 
 load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
 

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -30,6 +30,8 @@ cc_library(
         "//:common",
         "//:grpc_utils",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
+        # Do not sort: grpc++ must come last
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )
 
@@ -46,7 +48,6 @@ cc_library(
         ":google_cloud_cpp_pubsub",
         "//:common",
         "//:grpc_utils",
-        "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
         "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -18,10 +18,9 @@ licenses(["notice"])  # Apache 2.0
 
 load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs")
 
-[cc_test(
-    name = test.replace("/", "_").replace(".cc", ""),
-    timeout = "long",
-    srcs = [test],
+[cc_binary(
+    name = program.replace("/", "_").replace(".cc", ""),
+    srcs = [program],
     tags = [
         "integration-test",
     ],
@@ -31,6 +30,5 @@ load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs"
         "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_absl//absl/strings:str_format",
-        "@com_google_googletest//:gtest_main",
     ],
-) for test in pubsub_client_benchmark_programs]
+) for program in pubsub_client_benchmark_programs]

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -38,6 +38,8 @@ cc_library(
         "@com_google_googleapis//google/spanner/admin/database/v1:database_cc_grpc",
         "@com_google_googleapis//google/spanner/admin/instance/v1:instance_cc_grpc",
         "@com_google_googleapis//google/spanner/v1:spanner_cc_grpc",
+        # Do not sort: grpc++ must come last
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )
 

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -33,13 +33,9 @@ cc_library(
     ],
 )
 
-[cc_test(
-    name = test.replace("/", "_").replace(".cc", ""),
-    timeout = "long",
-    srcs = [test],
-    tags = [
-        "integration-test",
-    ],
+[cc_binary(
+    name = program.replace("/", "_").replace(".cc", ""),
+    srcs = [program],
     deps = [
         ":spanner_client_benchmarks",
         "//:common",
@@ -47,6 +43,5 @@ cc_library(
         "//:spanner_mocks",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
-        "@com_google_googletest//:gtest_main",
     ],
-) for test in spanner_client_benchmark_programs]
+) for program in spanner_client_benchmark_programs]

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -49,6 +49,8 @@ cc_library(
         "@com_google_absl//absl/time",
         "@com_google_googleapis//google/storage/v2:storage_cc_grpc",
         "@com_google_googleapis//google/storage/v2:storage_cc_proto",
+        # Do not sort: grpc++ must come last
+        "@com_github_grpc_grpc//:grpc++",
     ],
 )
 

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -38,16 +38,13 @@ cc_library(
 
 load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
 
-[cc_test(
-    name = test.replace("/", "_").replace(".cc", ""),
-    srcs = [test],
+[cc_binary(
+    name = program.replace("/", "_").replace(".cc", ""),
+    srcs = [program],
     linkopts = select({
         "@platforms//os:windows": [],
         "//conditions:default": ["-lpthread"],
     }),
-    tags = [
-        "integration-test",
-    ],
     deps = [
         ":storage_benchmarks",
         "//:common",
@@ -59,7 +56,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
         "@com_github_curl_curl//:curl",
         "@com_google_absl//absl/strings",
     ],
-) for test in storage_benchmark_programs]
+) for program in storage_benchmark_programs]
 
 load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
 


### PR DESCRIPTION
With Bazel we need to treat benchmarks as binaries, otherwise
`bazel run` behaves poorly: it merges `stdout` and `stderr`, and
injects extra output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8579)
<!-- Reviewable:end -->
