### PR TITLE
cleanup!: deprecate public pubsub bazel targets

### DIFF
--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -23,8 +23,8 @@ cc_library(
     srcs = google_cloud_cpp_pubsub_srcs,
     hdrs = google_cloud_cpp_pubsub_hdrs,
     visibility = [
+        ":__subpackages__",
         "//:__pkg__",
-        "//google/cloud/pubsub:__subpackages__",
     ],
     deps = [
         "//google/cloud:google_cloud_cpp_common",
@@ -36,9 +36,12 @@ cc_library(
 load(":pubsub_client_testing.bzl", "pubsub_client_testing_hdrs", "pubsub_client_testing_srcs")
 
 cc_library(
-    name = "pubsub_client_testing",
+    name = "pubsub_client_testing_private",
     srcs = pubsub_client_testing_srcs,
     hdrs = pubsub_client_testing_hdrs,
+    visibility = [
+        ":__subpackages__",
+    ],
     deps = [
         ":google_cloud_cpp_pubsub",
         "//google/cloud:google_cloud_cpp_common",
@@ -48,6 +51,18 @@ cc_library(
     ],
 )
 
+# TODO(#3701): Delete this target after 2023-04-01.
+cc_library(
+    name = "pubsub_client_testing",
+    deprecation = """
+    This target is deprecated and will be removed on or after 2023-04-01. More
+    info: https://github.com/googleapis/google-cloud-cpp/issues/3701
+    """,
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [":pubsub_client_testing_private"],
+)
+
 load(":google_cloud_cpp_pubsub_mocks.bzl", "google_cloud_cpp_pubsub_mocks_hdrs", "google_cloud_cpp_pubsub_mocks_srcs")
 
 cc_library(
@@ -55,8 +70,8 @@ cc_library(
     srcs = google_cloud_cpp_pubsub_mocks_srcs,
     hdrs = google_cloud_cpp_pubsub_mocks_hdrs,
     visibility = [
+        ":__subpackages__",
         "//:__pkg__",
-        "//google/cloud/pubsub:__subpackages__",
     ],
     deps = [
         ":google_cloud_cpp_pubsub",

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -28,7 +28,7 @@ load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs"
     deps = [
         "//:pubsub",
         "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud/pubsub:pubsub_client_testing",
+        "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_absl//absl/strings:str_format",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/pubsub/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsub/integration_tests/BUILD.bazel
@@ -28,7 +28,7 @@ load(":pubsub_client_integration_tests.bzl", "pubsub_client_integration_tests")
     deps = [
         "//:pubsub",
         "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud/pubsub:pubsub_client_testing",
+        "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -27,7 +27,7 @@ cc_library(
     deps = [
         "//:pubsub",
         "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud/pubsub:pubsub_client_testing",
+        "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
 )


### PR DESCRIPTION
Part of #3701

Marks all PubSub BUILD targets as private by default. cc_test targets
that were previously public are now private. The
`//google/cloud/pubsub:pubsub_client_testing` target was never
intended to be public and is now deprecated to be deleted in about a
year.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8582)
<!-- Reviewable:end -->
