### PR TITLE
cleanup!: deprecate //google/cloud:{common,grpc_utils} targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -249,13 +249,13 @@ cc_library(
 cc_library(
     name = "common",
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
+        "//google/cloud:google_cloud_cpp_common_private",
     ],
 )
 
 cc_library(
     name = "grpc_utils",
     deps = [
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//google/cloud:google_cloud_cpp_grpc_utils_private",
     ],
 )

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -24,7 +24,7 @@ cc_library(
     hdrs = google_cloud_cpp_generator_hdrs,
     deps = [
         ":generator_config_cc_proto",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "@com_github_nlohmann_json//:nlohmann_json",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
@@ -44,7 +44,7 @@ cc_library(
     hdrs = google_cloud_cpp_generator_testing_srcs,
     deps = [
         ":google_cloud_cpp_generator",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/generator/integration_tests/golden/BUILD.bazel
+++ b/generator/integration_tests/golden/BUILD.bazel
@@ -48,9 +48,9 @@ cc_library(
         "-I$(BINDIR)",
     ],
     deps = [
+        "//:common",
+        "//:grpc_utils",
         "//generator/integration_tests:google_cloud_cpp_generator_testing_cc_grpc",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/strings",
         "@com_google_googleapis//google/longrunning:longrunning_cc_grpc",
@@ -73,7 +73,7 @@ load(":google_cloud_cpp_generator_golden_tests.bzl", "google_cloud_cpp_generator
     ],
     deps = [
         ":google_cloud_cpp_generator_golden",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/BUILD.bazel
+++ b/google/cloud/BUILD.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-package(default_visibility = ["//visibility:public"])
+package(default_visibility = ["//visibility:private"])
 
 licenses(["notice"])  # Apache 2.0
 
@@ -35,15 +35,31 @@ sed -e "s;@CMAKE_CXX_FLAGS@;$(CC_FLAGS);" \
 load(":google_cloud_cpp_common.bzl", "google_cloud_cpp_common_hdrs", "google_cloud_cpp_common_srcs")
 
 cc_library(
-    name = "google_cloud_cpp_common",
+    name = "google_cloud_cpp_common_private",
     srcs = google_cloud_cpp_common_srcs + ["internal/build_info.cc"],
     hdrs = google_cloud_cpp_common_hdrs,
+    visibility = [
+        ":__subpackages__",
+        "//:__pkg__",
+    ],
     deps = [
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/time",
         "@com_google_absl//absl/types:optional",
         "@com_google_absl//absl/types:variant",
     ],
+)
+
+cc_library(
+    name = "google_cloud_cpp_common",
+    deprecation = """
+    This target is deprecated and will be removed on or after 2023-04-01. Use
+    //:common instead. More info:
+    https://github.com/googleapis/google-cloud-cpp/issues/3701
+    """,
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [":google_cloud_cpp_common_private"],
 )
 
 load(
@@ -81,13 +97,17 @@ load(":google_cloud_cpp_common_benchmarks.bzl", "google_cloud_cpp_common_benchma
 load(":google_cloud_cpp_grpc_utils.bzl", "google_cloud_cpp_grpc_utils_hdrs", "google_cloud_cpp_grpc_utils_srcs")
 
 cc_library(
-    name = "google_cloud_cpp_grpc_utils",
+    name = "google_cloud_cpp_grpc_utils_private",
     srcs = google_cloud_cpp_grpc_utils_srcs,
     # TODO(#3932) - remove the filtering comprehension.
     hdrs = [
         header
         for header in google_cloud_cpp_grpc_utils_hdrs
         if not "grpc_utils/" in header
+    ],
+    visibility = [
+        ":__subpackages__",
+        "//:__pkg__",
     ],
     deps = [
         ":google_cloud_cpp_common",
@@ -101,6 +121,18 @@ cc_library(
         "@com_google_googleapis//google/rpc:error_details_cc_proto",
         "@com_google_googleapis//google/rpc:status_cc_proto",
     ],
+)
+
+cc_library(
+    name = "google_cloud_cpp_grpc_utils",
+    deprecation = """
+    This target is deprecated and will be removed on or after 2023-04-01. Use
+    //:grpc_utils instead. More info:
+    https://github.com/googleapis/google-cloud-cpp/issues/3701
+    """,
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [":google_cloud_cpp_grpc_utils_private"],
 )
 
 load(":google_cloud_cpp_grpc_utils_unit_tests.bzl", "google_cloud_cpp_grpc_utils_unit_tests")

--- a/google/cloud/accessapproval/BUILD.bazel
+++ b/google/cloud/accessapproval/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/accessapproval/v1:accessapproval_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accessapproval",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/accesscontextmanager/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/identity/accesscontextmanager/v1:accesscontextmanager_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accesscontextmanager",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/apigateway/BUILD.bazel
+++ b/google/cloud/apigateway/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/apigateway/v1:apigateway_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigateway",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/apigeeconnect/BUILD.bazel
+++ b/google/cloud/apigeeconnect/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/apigeeconnect/v1:apigeeconnect_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigeeconnect",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/appengine/BUILD.bazel
+++ b/google/cloud/appengine/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/appengine/legacy:legacy_cc_grpc",
         "@com_google_googleapis//google/appengine/logging/v1:logging_cc_grpc",
         "@com_google_googleapis//google/appengine/v1:appengine_cc_grpc",
@@ -55,7 +55,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_appengine",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/artifactregistry/BUILD.bazel
+++ b/google/cloud/artifactregistry/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/devtools/artifactregistry/v1:artifactregistry_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_artifactregistry",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -42,8 +42,8 @@ cc_library(
     }),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/asset/v1:asset_cc_grpc",
     ],
 )
@@ -59,7 +59,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_asset",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -41,8 +41,8 @@ cc_library(
     }),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/assuredworkloads/v1:assuredworkloads_cc_grpc",
     ],
 )
@@ -58,7 +58,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_assuredworkloads",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/automl/BUILD.bazel
+++ b/google/cloud/automl/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/automl/v1:automl_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_automl",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -24,8 +24,8 @@ cc_library(
     hdrs = google_cloud_cpp_bigquery_hdrs,
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/bigquery/connection/v1:connection_cc_grpc",
         "@com_google_googleapis//google/cloud/bigquery/datatransfer/v1:datatransfer_cc_grpc",
         "@com_google_googleapis//google/cloud/bigquery/logging/v1:logging_cc_grpc",
@@ -44,7 +44,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_bigquery",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/bigquery/integration_tests/BUILD.bazel
+++ b/google/cloud/bigquery/integration_tests/BUILD.bazel
@@ -27,7 +27,7 @@ load(":bigquery_client_integration_tests.bzl", "bigquery_client_integration_test
     ],
     deps = [
         "//:bigquery",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/bigquery/samples/BUILD.bazel
+++ b/google/cloud/bigquery/samples/BUILD.bazel
@@ -29,7 +29,7 @@ load(":bigquery_client_samples.bzl", "bigquery_client_samples")
     ],
     deps = [
         "//:bigquery",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],
@@ -43,7 +43,7 @@ load(":bigquery_client_mock_samples.bzl", "bigquery_client_mock_samples")
     deps = [
         "//:bigquery",
         "//:bigquery_mocks",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -31,8 +31,8 @@ cc_library(
     ],
     # Do not sort: grpc++ must come last
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_absl//absl/memory",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
         "@com_google_googleapis//google/bigtable/v2:bigtable_cc_grpc",
@@ -54,7 +54,7 @@ cc_library(
     ],
     deps = [
         ":bigtable_client_internal",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],
@@ -69,8 +69,8 @@ cc_library(
     deps = [
         ":bigtable_client_internal",
         ":google_cloud_cpp_bigtable_mocks",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",
@@ -85,8 +85,8 @@ load(":bigtable_client_unit_tests.bzl", "bigtable_client_unit_tests")
     deps = [
         ":bigtable_client_internal",
         ":bigtable_client_testing",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_absl//absl/memory",
@@ -103,8 +103,8 @@ cc_test(
     deps = [
         ":bigtable_client_internal",
         ":bigtable_client_testing",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_absl//absl/memory",

--- a/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
+++ b/google/cloud/bigtable/admin/integration_tests/BUILD.bazel
@@ -30,8 +30,8 @@ load(
     ],
     deps = [
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -24,7 +24,7 @@ cc_library(
     hdrs = bigtable_benchmark_common_hdrs,
     deps = [
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
@@ -45,7 +45,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
     deps = [
         ":bigtable_benchmark_common",
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
     ],
 ) for test in bigtable_benchmark_programs]
 
@@ -61,7 +61,7 @@ load(":bigtable_benchmarks_unit_tests.bzl", "bigtable_benchmarks_unit_tests")
     deps = [
         ":bigtable_benchmark_common",
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -24,8 +24,8 @@ cc_library(
     hdrs = bigtable_examples_common_hdrs,
     deps = [
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googleapis//google/bigtable/admin/v2:admin_cc_grpc",
@@ -41,8 +41,8 @@ load(":bigtable_examples_unit_tests.bzl", "bigtable_examples_unit_tests")
     deps = [
         ":bigtable_examples_common",
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
@@ -60,8 +60,8 @@ load(":bigtable_examples.bzl", "bigtable_examples")
     deps = [
         ":bigtable_examples_common",
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/bigtable/tests/BUILD.bazel
+++ b/google/cloud/bigtable/tests/BUILD.bazel
@@ -30,8 +30,8 @@ load(
     ],
     deps = [
         "//:bigtable",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "//google/cloud/bigtable:bigtable_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/billing/BUILD.bazel
+++ b/google/cloud/billing/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/billing/budgets/v1:budgets_cc_grpc",
         "@com_google_googleapis//google/cloud/billing/v1:billing_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_billing",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/binaryauthorization/BUILD.bazel
+++ b/google/cloud/binaryauthorization/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/binaryauthorization/v1:binaryauthorization_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_binaryauthorization",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -42,8 +42,8 @@ cc_library(
     }),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/channel/v1:channel_cc_grpc",
     ],
 )
@@ -59,7 +59,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_channel",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/cloudbuild/BUILD.bazel
+++ b/google/cloud/cloudbuild/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/devtools/cloudbuild/v1:cloudbuild_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_cloudbuild",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/composer/BUILD.bazel
+++ b/google/cloud/composer/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/orchestration/airflow/service/v1:service_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_composer",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/contactcenterinsights/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/contactcenterinsights/v1:contactcenterinsights_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_contactcenterinsights",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/container/BUILD.bazel
+++ b/google/cloud/container/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/container/v1:container_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_container",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/containeranalysis/BUILD.bazel
+++ b/google/cloud/containeranalysis/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/devtools/containeranalysis/v1:containeranalysis_cc_grpc",
         "@com_google_googleapis//grafeas/v1:grafeas_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_containeranalysis",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/datacatalog/BUILD.bazel
+++ b/google/cloud/datacatalog/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/datacatalog/v1:datacatalog_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datacatalog",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/datamigration/BUILD.bazel
+++ b/google/cloud/datamigration/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/clouddms/logging/v1:logging_cc_grpc",
         "@com_google_googleapis//google/cloud/clouddms/v1:clouddms_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datamigration",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/dataproc/BUILD.bazel
+++ b/google/cloud/dataproc/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/dataproc/v1:dataproc_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataproc",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/debugger/BUILD.bazel
+++ b/google/cloud/debugger/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/devtools/clouddebugger/v2:clouddebugger_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_debugger",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/dlp/BUILD.bazel
+++ b/google/cloud/dlp/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/privacy/dlp/v2:dlp_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dlp",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/documentai/BUILD.bazel
+++ b/google/cloud/documentai/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/documentai/v1:documentai_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_documentai",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/eventarc/BUILD.bazel
+++ b/google/cloud/eventarc/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/eventarc/publishing/v1:publishing_cc_grpc",
         "@com_google_googleapis//google/cloud/eventarc/v1:eventarc_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_eventarc",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/examples/BUILD.bazel
+++ b/google/cloud/examples/BUILD.bazel
@@ -90,9 +90,9 @@ cc_test(
     deps = [
         ":hello_world_cc_grpc",
         ":hello_world_cc_proto",
+        "//:common",
         "//:iam",
         "//:spanner",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_github_curl_curl//:curl",

--- a/google/cloud/filestore/BUILD.bazel
+++ b/google/cloud/filestore/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/filestore/v1:filestore_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_filestore",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/functions/BUILD.bazel
+++ b/google/cloud/functions/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/functions/v1:functions_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_functions",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/gameservices/BUILD.bazel
+++ b/google/cloud/gameservices/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/gaming/v1:gaming_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gameservices",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/gkehub/BUILD.bazel
+++ b/google/cloud/gkehub/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/gkehub/v1:gkehub_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gkehub",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/grpc_utils/BUILD.bazel
+++ b/google/cloud/grpc_utils/BUILD.bazel
@@ -27,13 +27,13 @@ cc_library(
         "version.h",
     ],
     deprecation = (
-        "please use //google/cloud:google_cloud_cpp_grpc_utils instead." +
+        "please use //:grpc_utils instead." +
         " This target will be removed on or about 2023-01-01. More details at" +
         " https://github.com/googleapis/google-cloud-cpp/issues/3932"
     ),
     tags = ["manual"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/iam/BUILD.bazel
+++ b/google/cloud/iam/BUILD.bazel
@@ -25,8 +25,8 @@ cc_library(
     visibility = ["//:__pkg__"],
     # Do not sort: grpc++ must come last
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/iam/admin/v1:admin_cc_grpc",
         "@com_google_googleapis//google/iam/credentials/v1:credentials_cc_grpc",
         "@com_github_grpc_grpc//:grpc++",
@@ -42,8 +42,8 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iam",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/iam/admin/v1:admin_cc_grpc",
         "@com_google_googleapis//google/iam/credentials/v1:credentials_cc_grpc",
     ],

--- a/google/cloud/iam/integration_tests/BUILD.bazel
+++ b/google/cloud/iam/integration_tests/BUILD.bazel
@@ -26,8 +26,8 @@ load(":iam_client_integration_tests.bzl", "iam_client_integration_tests")
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:iam",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/iam/samples/BUILD.bazel
+++ b/google/cloud/iam/samples/BUILD.bazel
@@ -28,8 +28,8 @@ load(":iam_client_samples.bzl", "iam_client_samples")
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:iam",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],
@@ -41,9 +41,9 @@ load(":iam_client_mock_samples.bzl", "iam_client_mock_samples")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
+        "//:common",
         "//:iam",
         "//:iam_mocks",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/google/cloud/iap/BUILD.bazel
+++ b/google/cloud/iap/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/iap/v1:iap_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iap",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/ids/BUILD.bazel
+++ b/google/cloud/ids/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/ids/v1:ids_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_ids",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/iot/BUILD.bazel
+++ b/google/cloud/iot/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/iot/v1:iot_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iot",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/kms/BUILD.bazel
+++ b/google/cloud/kms/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/kms/v1:kms_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_kms",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/language/BUILD.bazel
+++ b/google/cloud/language/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/language/v1:language_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_language",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/logging/BUILD.bazel
+++ b/google/cloud/logging/BUILD.bazel
@@ -24,8 +24,8 @@ cc_library(
     hdrs = google_cloud_cpp_logging_hdrs,
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/logging/v2:logging_cc_grpc",
     ],
 )
@@ -39,7 +39,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_logging",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/logging/integration_tests/BUILD.bazel
+++ b/google/cloud/logging/integration_tests/BUILD.bazel
@@ -26,8 +26,8 @@ load(":logging_client_integration_tests.bzl", "logging_client_integration_tests"
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:experimental-logging",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/managedidentities/BUILD.bazel
+++ b/google/cloud/managedidentities/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/managedidentities/v1:managedidentities_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_managedidentities",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/memcache/BUILD.bazel
+++ b/google/cloud/memcache/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/memcache/v1:memcache_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_memcache",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/monitoring/BUILD.bazel
+++ b/google/cloud/monitoring/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/monitoring/dashboard/v1:dashboard_cc_grpc",
         "@com_google_googleapis//google/monitoring/metricsscope/v1:metricsscope_cc_grpc",
         "@com_google_googleapis//google/monitoring/v3:monitoring_cc_grpc",
@@ -55,7 +55,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_monitoring",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/networkmanagement/BUILD.bazel
+++ b/google/cloud/networkmanagement/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/networkmanagement/v1:networkmanagement_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkmanagement",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/notebooks/BUILD.bazel
+++ b/google/cloud/notebooks/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/notebooks/v1:notebooks_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_notebooks",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/orgpolicy/BUILD.bazel
+++ b/google/cloud/orgpolicy/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/orgpolicy/v2:orgpolicy_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_orgpolicy",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/osconfig/BUILD.bazel
+++ b/google/cloud/osconfig/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/osconfig/agentendpoint/v1:agentendpoint_cc_grpc",
         "@com_google_googleapis//google/cloud/osconfig/v1:osconfig_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_osconfig",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/oslogin/BUILD.bazel
+++ b/google/cloud/oslogin/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/oslogin/common:common_cc_grpc",
         "@com_google_googleapis//google/cloud/oslogin/v1:oslogin_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_oslogin",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/policytroubleshooter/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/policytroubleshooter/v1:policytroubleshooter_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_policytroubleshooter",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/privateca/BUILD.bazel
+++ b/google/cloud/privateca/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/security/privateca/v1:privateca_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_privateca",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/profiler/BUILD.bazel
+++ b/google/cloud/profiler/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/devtools/cloudprofiler/v2:cloudprofiler_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_profiler",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -27,8 +27,8 @@ cc_library(
         "//:__pkg__",
     ],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
     ],
 )
@@ -44,8 +44,8 @@ cc_library(
     ],
     deps = [
         ":google_cloud_cpp_pubsub",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
         "@com_google_googletest//:gtest",
     ],
@@ -75,8 +75,8 @@ cc_library(
     ],
     deps = [
         ":google_cloud_cpp_pubsub",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
     ],
 )
@@ -90,7 +90,7 @@ load(":pubsub_client_unit_tests.bzl", "pubsub_client_unit_tests")
         ":google_cloud_cpp_pubsub",
         ":google_cloud_cpp_pubsub_mocks",
         ":pubsub_client_testing",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_absl//absl/strings:str_format",

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -26,8 +26,8 @@ load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs"
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:pubsub",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_absl//absl/strings:str_format",

--- a/google/cloud/pubsub/integration_tests/BUILD.bazel
+++ b/google/cloud/pubsub/integration_tests/BUILD.bazel
@@ -26,8 +26,8 @@ load(":pubsub_client_integration_tests.bzl", "pubsub_client_integration_tests")
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:pubsub",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -25,8 +25,8 @@ cc_library(
     srcs = pubsub_samples_common_srcs,
     hdrs = pubsub_samples_common_hdrs,
     deps = [
+        "//:common",
         "//:pubsub",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/pubsub:pubsub_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
@@ -39,8 +39,8 @@ load(":pubsub_samples_unit_tests.bzl", "pubsub_samples_unit_tests")
     srcs = [test],
     deps = [
         ":pubsub_samples_common",
+        "//:common",
         "//:pubsub",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],
@@ -74,8 +74,8 @@ cc_proto_library(
     deps = [
         ":pubsub_samples_common",
         ":samples_cc_proto",
+        "//:common",
         "//:pubsub",
-        "//google/cloud:google_cloud_cpp_common",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in pubsub_client_integration_samples]
@@ -85,9 +85,9 @@ cc_proto_library(
     srcs = [test],
     deps = [
         ":pubsub_samples_common",
+        "//:common",
         "//:pubsub",
         "//:pubsub_mocks",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],

--- a/google/cloud/pubsublite/BUILD.bazel
+++ b/google/cloud/pubsublite/BUILD.bazel
@@ -24,8 +24,8 @@ cc_library(
     hdrs = google_cloud_cpp_pubsublite_hdrs,
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/pubsublite/v1:pubsublite_cc_grpc",
     ],
 )
@@ -39,8 +39,8 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_pubsublite",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )
 
@@ -53,8 +53,8 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_pubsublite",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )
 
@@ -68,7 +68,7 @@ load(":pubsublite_unit_tests.bzl", "pubsublite_unit_tests")
             ":google_cloud_cpp_pubsublite",
             ":google_cloud_cpp_pubsublite_mocks",
             ":pubsublite_testing",
-            "//google/cloud:google_cloud_cpp_common",
+            "//:common",
             "//google/cloud/testing_util:google_cloud_cpp_testing",
             "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
             "@com_google_googletest//:gtest_main",

--- a/google/cloud/recommender/BUILD.bazel
+++ b/google/cloud/recommender/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/recommender/v1:recommender_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_recommender",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/redis/BUILD.bazel
+++ b/google/cloud/redis/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/redis/v1:redis_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_redis",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/resourcemanager/BUILD.bazel
+++ b/google/cloud/resourcemanager/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/resourcemanager/v3:resourcemanager_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcemanager",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/resourcesettings/BUILD.bazel
+++ b/google/cloud/resourcesettings/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/resourcesettings/v1:resourcesettings_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcesettings",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/retail/BUILD.bazel
+++ b/google/cloud/retail/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/retail/v2:retail_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_retail",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/scheduler/BUILD.bazel
+++ b/google/cloud/scheduler/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/scheduler/v1:scheduler_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_scheduler",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/secretmanager/BUILD.bazel
+++ b/google/cloud/secretmanager/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/secretmanager/v1:secretmanager_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_secretmanager",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/securitycenter/v1:securitycenter_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_securitycenter",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/servicecontrol/BUILD.bazel
+++ b/google/cloud/servicecontrol/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/api/servicecontrol/v1:servicecontrol_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicecontrol",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/servicedirectory/BUILD.bazel
+++ b/google/cloud/servicedirectory/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/servicedirectory/v1:servicedirectory_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicedirectory",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/servicemanagement/BUILD.bazel
+++ b/google/cloud/servicemanagement/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/api/servicemanagement/v1:servicemanagement_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicemanagement",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/serviceusage/BUILD.bazel
+++ b/google/cloud/serviceusage/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/api/serviceusage/v1:serviceusage_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_serviceusage",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/shell/BUILD.bazel
+++ b/google/cloud/shell/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/shell/v1:shell_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_shell",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -27,8 +27,8 @@ cc_library(
         "//:__pkg__",
     ],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_absl//absl/container:fixed_array",
         "@com_google_absl//absl/memory",
         "@com_google_absl//absl/numeric:int128",
@@ -53,7 +53,7 @@ cc_library(
     ],
     deps = [
         ":google_cloud_cpp_spanner",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],
@@ -71,7 +71,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_spanner",
         ":google_cloud_cpp_spanner_mocks",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
     ],
@@ -98,7 +98,7 @@ load(":spanner_client_unit_tests.bzl", "spanner_client_unit_tests")
         ":google_cloud_cpp_spanner",
         ":google_cloud_cpp_spanner_mocks",
         ":spanner_client_testing",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",
         "@com_google_absl//absl/memory",
@@ -114,8 +114,8 @@ load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks")
     srcs = [benchmark],
     tags = ["benchmark"],
     deps = [
+        "//:common",
         "//:spanner",
-        "//google/cloud:google_cloud_cpp_common",
         "@com_google_benchmark//:benchmark_main",
     ],
 ) for benchmark in spanner_client_benchmarks]

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -24,9 +24,9 @@ cc_library(
     srcs = spanner_client_benchmarks_srcs,
     hdrs = spanner_client_benchmarks_hdrs,
     deps = [
+        "//:common",
         "//:spanner",
         "//:spanner_mocks",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
@@ -42,9 +42,9 @@ cc_library(
     ],
     deps = [
         ":spanner_client_benchmarks",
+        "//:common",
         "//:spanner",
         "//:spanner_mocks",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/spanner/integration_tests/BUILD.bazel
+++ b/google/cloud/spanner/integration_tests/BUILD.bazel
@@ -26,9 +26,9 @@ load(":spanner_client_integration_tests.bzl", "spanner_client_integration_tests"
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:spanner",
         "//:spanner_mocks",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing_grpc",

--- a/google/cloud/spanner/samples/BUILD.bazel
+++ b/google/cloud/spanner/samples/BUILD.bazel
@@ -29,8 +29,8 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
         "integration-test",
     ],
     deps = [
+        "//:common",
         "//:spanner",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
@@ -41,8 +41,8 @@ load(":spanner_client_unit_samples.bzl", "spanner_client_unit_samples")
     name = test.replace("/", "_").replace(".cc", ""),
     srcs = [test],
     deps = [
+        "//:common",
         "//:spanner",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/spanner:spanner_client_testing_private",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/speech/BUILD.bazel
+++ b/google/cloud/speech/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/speech/v1:speech_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_speech",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -37,7 +37,7 @@ cc_library(
     defines = ["GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC"],
     deps = [
         ":google_cloud_cpp_storage",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:grpc_utils",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
         "@com_github_curl_curl//:curl",
@@ -64,7 +64,7 @@ cc_library(
         "//google/cloud/storage:__subpackages__",
     ],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
         "@com_github_curl_curl//:curl",
@@ -91,7 +91,7 @@ cc_library(
     deps = [
         ":google_cloud_cpp_storage",
         ":google_cloud_cpp_storage_grpc",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
@@ -117,7 +117,7 @@ load(":storage_client_unit_tests.bzl", "storage_client_unit_tests")
     deps = [
         ":google_cloud_cpp_storage",
         ":storage_client_testing",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@boringssl//:crypto",
         "@boringssl//:ssl",

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -23,9 +23,9 @@ cc_library(
     srcs = storage_benchmarks_srcs,
     hdrs = storage_benchmarks_hdrs,
     deps = [
+        "//:common",
+        "//:grpc_utils",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@boringssl//:crypto",
@@ -50,8 +50,8 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
     ],
     deps = [
         ":storage_benchmarks",
+        "//:common",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@boringssl//:crypto",
@@ -72,8 +72,8 @@ load(":storage_benchmarks_unit_tests.bzl", "storage_benchmarks_unit_tests")
     }),
     deps = [
         ":storage_benchmarks",
+        "//:common",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@boringssl//:crypto",

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -23,8 +23,8 @@ cc_library(
     srcs = storage_examples_common_srcs,
     hdrs = storage_examples_common_hdrs,
     deps = [
+        "//:common",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
     ],
@@ -37,8 +37,8 @@ load(":storage_examples_unit_tests.bzl", "storage_examples_unit_tests")
     srcs = [test],
     deps = [
         ":storage_examples_common",
+        "//:common",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",
@@ -55,8 +55,8 @@ load(":storage_examples.bzl", "storage_examples")
     ],
     deps = [
         ":storage_examples_common",
+        "//:common",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:google_cloud_cpp_storage_grpc",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_googletest//:gtest_main",

--- a/google/cloud/storage/tests/BUILD.bazel
+++ b/google/cloud/storage/tests/BUILD.bazel
@@ -50,8 +50,8 @@ cc_proto_library(
     ],
     deps = [
         ":storage_conformance_tests_cc_proto",
+        "//:common",
         "//:storage",
-        "//google/cloud:google_cloud_cpp_common",
         "//google/cloud/storage:storage_client_testing",
         "//google/cloud/testing_util:google_cloud_cpp_testing",
         "@com_google_absl//absl/strings",

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/storagetransfer/v1:storagetransfer_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_storagetransfer",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/talent/BUILD.bazel
+++ b/google/cloud/talent/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/talent/v4:talent_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_talent",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/tasks/BUILD.bazel
+++ b/google/cloud/tasks/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/tasks/v2:tasks_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tasks",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -33,7 +33,7 @@ cc_library(
         "//conditions:default": [],
     }),
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "@com_google_absl//absl/debugging:failure_signal_handler",
         "@com_google_absl//absl/debugging:symbolize",
         "@com_google_googletest//:gtest_main",
@@ -47,7 +47,7 @@ load(":google_cloud_cpp_testing_unit_tests.bzl", "google_cloud_cpp_testing_unit_
     srcs = [test],
     deps = [
         ":google_cloud_cpp_testing",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "@com_google_googletest//:gtest_main",
     ],
 ) for test in google_cloud_cpp_testing_unit_tests]
@@ -59,8 +59,8 @@ cc_library(
     srcs = google_cloud_cpp_testing_grpc_srcs,
     hdrs = google_cloud_cpp_testing_grpc_hdrs,
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_googleapis//:googleapis_system_includes",
         "@com_google_googleapis//google/api:annotations_cc_proto",
@@ -76,7 +76,7 @@ load(":google_cloud_cpp_testing_grpc_unit_tests.bzl", "google_cloud_cpp_testing_
     srcs = [test],
     deps = [
         ":google_cloud_cpp_testing_grpc",
-        "//google/cloud:google_cloud_cpp_common",
+        "//:common",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
     ],

--- a/google/cloud/texttospeech/BUILD.bazel
+++ b/google/cloud/texttospeech/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/texttospeech/v1:texttospeech_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_texttospeech",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/tpu/BUILD.bazel
+++ b/google/cloud/tpu/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/tpu/v1:tpu_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tpu",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/trace/BUILD.bazel
+++ b/google/cloud/trace/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/devtools/cloudtrace/v2:cloudtrace_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_trace",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/translate/BUILD.bazel
+++ b/google/cloud/translate/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/translate/v3:translation_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_translate",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/videointelligence/BUILD.bazel
+++ b/google/cloud/videointelligence/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/videointelligence/v1:videointelligence_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_videointelligence",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/vision/BUILD.bazel
+++ b/google/cloud/vision/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/vision/v1:vision_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vision",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/vmmigration/BUILD.bazel
+++ b/google/cloud/vmmigration/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/vmmigration/v1:vmmigration_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vmmigration",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/vpcaccess/BUILD.bazel
+++ b/google/cloud/vpcaccess/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/vpcaccess/v1:vpcaccess_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vpcaccess",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/webrisk/BUILD.bazel
+++ b/google/cloud/webrisk/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/webrisk/v1:webrisk_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_webrisk",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/websecurityscanner/BUILD.bazel
+++ b/google/cloud/websecurityscanner/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/websecurityscanner/v1:websecurityscanner_cc_grpc",
     ],
 )
@@ -53,7 +53,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_websecurityscanner",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )

--- a/google/cloud/workflows/BUILD.bazel
+++ b/google/cloud/workflows/BUILD.bazel
@@ -36,8 +36,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//google/cloud/workflows/executions/v1:executions_cc_grpc",
         "@com_google_googleapis//google/cloud/workflows/v1:workflows_cc_grpc",
     ],
@@ -54,7 +54,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_workflows",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )


### PR DESCRIPTION
Part of #3701

Changes the default build visibility for `google/cloud/BUILD.bazel` to
be private. Deprecates the `//google/cloud` targets
`:google_cloud_cpp_common` and `:google_cloud_cpp_common_grpc_utils`
directding users to their top-level targets in `//:` instead.

Updates all of our code to use the undeprecated top-level targets.

Note to reviewers: The only manual edits were to:
* BUILD.bazel
* google/cloud/BUILD.bazel

The rest were generated w/ `perl -p -i -e ...`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8585)
<!-- Reviewable:end -->
