### PR TITLE
refactor(GCS+gRPC): parsing for `ResumableUploadResponse`

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -126,22 +126,10 @@ StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
   if (timeout.count() != 0) {
     context.set_deadline(std::chrono::system_clock::now() + timeout);
   }
-  auto status = stub_->QueryWriteStatus(
+  auto response = stub_->QueryWriteStatus(
       context, GrpcObjectRequestParser::ToProto(request));
-  if (!status) return std::move(status).status();
-
-  ResumableUploadResponse response;
-  response.upload_state = ResumableUploadResponse::kInProgress;
-  if (status->has_persisted_size()) {
-    response.committed_size =
-        static_cast<std::uint64_t>(status->persisted_size());
-  }
-  if (status->has_resource()) {
-    response.payload =
-        GrpcObjectMetadataParser::FromProto(status->resource(), options());
-    response.upload_state = ResumableUploadResponse::kDone;
-  }
-  return response;
+  if (!response) return std::move(response).status();
+  return GrpcObjectRequestParser::FromProto(*response, options());
 }
 
 StatusOr<std::unique_ptr<ResumableUploadSession>>

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -728,6 +728,23 @@ google::storage::v2::QueryWriteStatusRequest GrpcObjectRequestParser::ToProto(
   return r;
 }
 
+ResumableUploadResponse GrpcObjectRequestParser::FromProto(
+    google::storage::v2::QueryWriteStatusResponse const& response,
+    Options const& options) {
+  ResumableUploadResponse result;
+  result.upload_state = ResumableUploadResponse::kInProgress;
+  if (response.has_persisted_size()) {
+    result.committed_size =
+        static_cast<std::uint64_t>(response.persisted_size());
+  }
+  if (response.has_resource()) {
+    result.payload =
+        GrpcObjectMetadataParser::FromProto(response.resource(), options);
+    result.upload_state = ResumableUploadResponse::kDone;
+  }
+  return result;
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -70,6 +70,9 @@ struct GrpcObjectRequestParser {
 
   static google::storage::v2::QueryWriteStatusRequest ToProto(
       QueryResumableUploadRequest const& request);
+  static ResumableUploadResponse FromProto(
+      google::storage::v2::QueryWriteStatusResponse const& response,
+      Options const& options);
 };
 
 }  // namespace internal


### PR DESCRIPTION
Parsing from some protos related to resumable upload sessions was not
well tested.  With some refactoring it all looks good now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8588)
<!-- Reviewable:end -->
