### PR TITLE
feat(spanner): integration tests for Database.database_dialect

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -397,9 +397,10 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
   google::spanner::admin::database::v1::CreateDatabaseRequest creq;
   creq.set_parent(db.instance().FullName());
-  creq.set_create_statement(
-      absl::StrCat("CREATE DATABASE `", db.database_id(), "`"));
+  creq.set_create_statement(absl::StrCat("CREATE DATABASE ", db.database_id()));
   creq.mutable_encryption_config()->set_kms_key_name(encryption_key.FullName());
+  creq.set_database_dialect(
+      google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
   auto database = database_admin_client_.CreateDatabase(creq).get();
   ASSERT_STATUS_OK(database);
   EXPECT_TRUE(database->has_encryption_config());
@@ -408,6 +409,8 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
               encryption_key.FullName());
   }
   EXPECT_THAT(database->encryption_info(), IsEmpty());
+  EXPECT_EQ(database->database_dialect(),
+            google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
 
   auto database_get = database_admin_client_.GetDatabase(db.FullName());
   ASSERT_STATUS_OK(database_get);
@@ -417,6 +420,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
     EXPECT_EQ(database_get->encryption_config().kms_key_name(),
               encryption_key.FullName());
   }
+  EXPECT_EQ(database_get->database_dialect(), database->database_dialect());
 
   auto create_time =
       MakeTimestamp(database->create_time()).value().get<absl::Time>().value();
@@ -441,6 +445,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
     EXPECT_THAT(backup->encryption_info().kms_key_version(),
                 HasSubstr(encryption_key.FullName() + "/cryptoKeyVersions/"));
   }
+  EXPECT_EQ(backup->database_dialect(), database->database_dialect());
 
   EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
 
@@ -456,6 +461,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
     EXPECT_THAT(backup_get->encryption_info().kms_key_version(),
                 HasSubstr(encryption_key.FullName() + "/cryptoKeyVersions/"));
   }
+  EXPECT_EQ(backup_get->database_dialect(), database->database_dialect());
 
   Database restore_db(in, spanner_testing::RandomDatabaseName(generator_));
   google::spanner::admin::database::v1::RestoreDatabaseRequest rreq;
@@ -473,6 +479,15 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
     EXPECT_EQ(restored_database->encryption_config().kms_key_name(),
               encryption_key.FullName());
   }
+  if (restored_database->database_dialect() ==
+      google::spanner::admin::database::v1::DatabaseDialect::
+          DATABASE_DIALECT_UNSPECIFIED) {
+    // TODO(#8573): Remove when RestoreDatabase() returns correct dialect.
+    restored_database->set_database_dialect(
+        google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
+  }
+  EXPECT_EQ(restored_database->database_dialect(),
+            database->database_dialect());
 
   auto restored_get = database_admin_client_.GetDatabase(restore_db.FullName());
   ASSERT_STATUS_OK(restored_get);
@@ -482,6 +497,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
     EXPECT_EQ(restored_get->encryption_config().kms_key_name(),
               encryption_key.FullName());
   }
+  EXPECT_EQ(restored_get->database_dialect(), database->database_dialect());
 
   EXPECT_STATUS_OK(database_admin_client_.DropDatabase(restore_db.FullName()));
 
@@ -503,6 +519,7 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
             b->encryption_info().kms_key_version(),
             HasSubstr(encryption_key.FullName() + "/cryptoKeyVersions/"));
       }
+      EXPECT_EQ(b->database_dialect(), backup->database_dialect());
     }
   }
   EXPECT_TRUE(found);


### PR DESCRIPTION
Extend existing tests to also cover `database_dialect`by setting it
in the CreateDatabaseRequest, and expecting it in Database and Backup
responses.  Include allowances for these being invisible to the Spanner
emulator, and for pending bug #8573.

In particular, BackupIntegrationTest.BackupRestore leaves the dialect
unspecified in CreateDatabase() (but expects to see GOOGLE_STANDARD_SQL
in responses), while it is set explicitly to GOOGLE_STANDARD_SQL in
DatabaseAdminClientTest.VersionRetentionPeriodCreate, and to POSTGRESQL
in BackupExtraIntegrationTest.BackupRestoreWithCMEK.

DatabaseAdminClientTest.DatabasePostgreSQLBasics is a new test case
that also exercises the non-backup parts of an explicit POSTGRESQL
setting.

[Aside: These are only in the tests for the generated database admin
client.]

Finally, add ClientIntegrationTest.DatabaseDialect to enumerate the
`database_dialect` value from `INFORMATION_SCHEMA.DATABASE_OPTIONS`
for a default-dialect database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8589)
<!-- Reviewable:end -->
