### PR TITLE
cleanup(spanner): tweak spanner convenience namespace aliases

### DIFF
--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -38,7 +38,7 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 using ::google::cloud::spanner_mocks::MockConnection;
 using ::google::cloud::spanner_mocks::MockResultSetSource;
@@ -95,7 +95,7 @@ TEST(ClientTest, ReadSuccess) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -136,7 +136,7 @@ TEST(ClientTest, ReadFailure) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -182,7 +182,7 @@ TEST(ClientTest, ExecuteQuerySuccess) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -223,7 +223,7 @@ TEST(ClientTest, ExecuteQueryFailure) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -307,7 +307,7 @@ TEST(ClientTest, ExecuteBatchDmlError) {
 
 TEST(ClientTest, ExecutePartitionedDmlSuccess) {
   auto source = absl::make_unique<MockResultSetSource>();
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow()).WillRepeatedly(Return(Row()));
 
@@ -424,7 +424,7 @@ TEST(ClientTest, CommitMutatorSuccess) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -472,7 +472,7 @@ TEST(ClientTest, CommitMutatorRollback) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -514,7 +514,7 @@ TEST(ClientTest, CommitMutatorRollbackError) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -556,7 +556,7 @@ TEST(ClientTest, CommitMutatorException) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
@@ -983,7 +983,7 @@ TEST(ClientTest, ProfileQuerySuccess) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText0, &metadata));
   auto constexpr kText1 = R"pb(
     query_plan: { plan_nodes: { display_name: "test-node" } }
@@ -1047,7 +1047,7 @@ TEST(ClientTest, ProfileQueryWithOptionsSuccess) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata metadata;
+  spanner_proto::v1::ResultSetMetadata metadata;
   ASSERT_TRUE(TextFormat::ParseFromString(kText0, &metadata));
   auto constexpr kText1 = R"pb(
     query_plan: { plan_nodes: { display_name: "test-node" } }

--- a/google/cloud/spanner/database_admin_client.cc
+++ b/google/cloud/spanner/database_admin_client.cc
@@ -24,12 +24,12 @@ namespace cloud {
 namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::database::v1;
+namespace gcsa = ::google::spanner::admin::database;
 
 DatabaseAdminClient::DatabaseAdminClient(ConnectionOptions const& options)
     : conn_(MakeDatabaseAdminConnection(options)) {}
 
-future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
+future<StatusOr<gcsa::v1::Database>> DatabaseAdminClient::CreateDatabase(
     Database db, std::vector<std::string> extra_statements,
     EncryptionConfig encryption_config) {
   internal::OptionsSpan span(conn_->options());
@@ -37,18 +37,18 @@ future<StatusOr<gcsa::Database>> DatabaseAdminClient::CreateDatabase(
                                 std::move(encryption_config)});
 }
 
-StatusOr<gcsa::Database> DatabaseAdminClient::GetDatabase(Database db) {
+StatusOr<gcsa::v1::Database> DatabaseAdminClient::GetDatabase(Database db) {
   internal::OptionsSpan span(conn_->options());
   return conn_->GetDatabase({std::move(db)});
 }
 
-StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminClient::GetDatabaseDdl(
+StatusOr<gcsa::v1::GetDatabaseDdlResponse> DatabaseAdminClient::GetDatabaseDdl(
     Database db) {
   internal::OptionsSpan span(conn_->options());
   return conn_->GetDatabaseDdl({std::move(db)});
 }
 
-future<StatusOr<gcsa::UpdateDatabaseDdlMetadata>>
+future<StatusOr<gcsa::v1::UpdateDatabaseDdlMetadata>>
 DatabaseAdminClient::UpdateDatabase(Database db,
                                     std::vector<std::string> statements) {
   internal::OptionsSpan span(conn_->options());
@@ -65,14 +65,14 @@ Status DatabaseAdminClient::DropDatabase(Database db) {
   return conn_->DropDatabase({std::move(db)});
 }
 
-future<StatusOr<gcsa::Database>> DatabaseAdminClient::RestoreDatabase(
+future<StatusOr<gcsa::v1::Database>> DatabaseAdminClient::RestoreDatabase(
     Database db, Backup const& backup, EncryptionConfig encryption_config) {
   internal::OptionsSpan span(conn_->options());
   return conn_->RestoreDatabase(
       {std::move(db), backup.FullName(), std::move(encryption_config)});
 }
 
-future<StatusOr<gcsa::Database>> DatabaseAdminClient::RestoreDatabase(
+future<StatusOr<gcsa::v1::Database>> DatabaseAdminClient::RestoreDatabase(
     Database db, google::spanner::admin::database::v1::Backup const& backup,
     EncryptionConfig encryption_config) {
   internal::OptionsSpan span(conn_->options());
@@ -148,7 +148,7 @@ DatabaseAdminClient::TestIamPermissions(Database db,
   return conn_->TestIamPermissions({std::move(db), std::move(permissions)});
 }
 
-future<StatusOr<gcsa::Backup>> DatabaseAdminClient::CreateBackup(
+future<StatusOr<gcsa::v1::Backup>> DatabaseAdminClient::CreateBackup(
     Database db, std::string backup_id, Timestamp expire_time,
     absl::optional<Timestamp> version_time,
     EncryptionConfig encryption_config) {
@@ -163,16 +163,17 @@ future<StatusOr<gcsa::Backup>> DatabaseAdminClient::CreateBackup(
        expire_time, std::move(version_time), std::move(encryption_config)});
 }
 
-future<StatusOr<gcsa::Backup>> DatabaseAdminClient::CreateBackup(
+future<StatusOr<gcsa::v1::Backup>> DatabaseAdminClient::CreateBackup(
     Database db, std::string backup_id,
     std::chrono::system_clock::time_point expire_time) {
   internal::OptionsSpan span(conn_->options());
   auto ts = MakeTimestamp(expire_time);
-  if (!ts) return make_ready_future(StatusOr<gcsa::Backup>(ts.status()));
+  if (!ts) return make_ready_future(StatusOr<gcsa::v1::Backup>(ts.status()));
   return CreateBackup(std::move(db), std::move(backup_id), *ts);
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminClient::GetBackup(Backup const& backup) {
+StatusOr<gcsa::v1::Backup> DatabaseAdminClient::GetBackup(
+    Backup const& backup) {
   internal::OptionsSpan span(conn_->options());
   return conn_->GetBackup({backup.FullName()});
 }
@@ -194,7 +195,7 @@ ListBackupsRange DatabaseAdminClient::ListBackups(Instance in,
   return conn_->ListBackups({std::move(in), std::move(filter)});
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
+StatusOr<gcsa::v1::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
     google::spanner::admin::database::v1::Backup const& backup,
     Timestamp expire_time) {
   internal::OptionsSpan span(conn_->options());
@@ -206,7 +207,7 @@ StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
   return conn_->UpdateBackup({request});
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
+StatusOr<gcsa::v1::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
     Backup const& backup, Timestamp expire_time) {
   internal::OptionsSpan span(conn_->options());
   google::spanner::admin::database::v1::UpdateBackupRequest request;
@@ -217,7 +218,7 @@ StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
   return conn_->UpdateBackup({request});
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
+StatusOr<gcsa::v1::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
     google::spanner::admin::database::v1::Backup const& backup,
     std::chrono::system_clock::time_point const& expire_time) {
   auto ts = MakeTimestamp(expire_time);
@@ -225,7 +226,7 @@ StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
   return UpdateBackupExpireTime(backup, *ts);
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
+StatusOr<gcsa::v1::Backup> DatabaseAdminClient::UpdateBackupExpireTime(
     Backup const& backup,
     std::chrono::system_clock::time_point const& expire_time) {
   auto ts = MakeTimestamp(expire_time);

--- a/google/cloud/spanner/database_admin_connection.cc
+++ b/google/cloud/spanner/database_admin_connection.cc
@@ -31,7 +31,7 @@ namespace cloud {
 namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::database::v1;
+namespace gcsa = ::google::spanner::admin::database;
 
 using ::google::cloud::Idempotency;
 using ::google::cloud::internal::RetryLoop;
@@ -39,14 +39,14 @@ using ::google::cloud::internal::RetryLoop;
 future<StatusOr<google::spanner::admin::database::v1::Backup>>
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 DatabaseAdminConnection::CreateBackup(CreateBackupParams) {
-  return google::cloud::make_ready_future(StatusOr<gcsa::Backup>(
+  return google::cloud::make_ready_future(StatusOr<gcsa::v1::Backup>(
       Status(StatusCode::kUnimplemented, "not implemented")));
 }
 
 future<StatusOr<google::spanner::admin::database::v1::Database>>
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 DatabaseAdminConnection::RestoreDatabase(RestoreDatabaseParams) {
-  return google::cloud::make_ready_future(StatusOr<gcsa::Database>(
+  return google::cloud::make_ready_future(StatusOr<gcsa::v1::Database>(
       Status(StatusCode::kUnimplemented, "not implemented")));
 }
 
@@ -64,13 +64,13 @@ Status DatabaseAdminConnection::DeleteBackup(DeleteBackupParams) {
 // NOLINTNEXTLINE(performance-unnecessary-value-param)
 ListBackupsRange DatabaseAdminConnection::ListBackups(ListBackupsParams) {
   return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
-      gcsa::ListBackupsRequest{},
-      [](gcsa::ListBackupsRequest const&) {
-        return StatusOr<gcsa::ListBackupsResponse>(
+      gcsa::v1::ListBackupsRequest{},
+      [](gcsa::v1::ListBackupsRequest const&) {
+        return StatusOr<gcsa::v1::ListBackupsResponse>(
             Status(StatusCode::kUnimplemented, "not implemented"));
       },
-      [](gcsa::ListBackupsResponse const&) {
-        return std::vector<gcsa::Backup>{};
+      [](gcsa::v1::ListBackupsResponse const&) {
+        return std::vector<gcsa::v1::Backup>{};
       });
 }
 
@@ -85,12 +85,12 @@ ListBackupOperationsRange DatabaseAdminConnection::ListBackupOperations(
     ListBackupOperationsParams) {
   return google::cloud::internal::MakePaginationRange<
       ListBackupOperationsRange>(
-      gcsa::ListBackupOperationsRequest{},
-      [](gcsa::ListBackupOperationsRequest const&) {
-        return StatusOr<gcsa::ListBackupOperationsResponse>(
+      gcsa::v1::ListBackupOperationsRequest{},
+      [](gcsa::v1::ListBackupOperationsRequest const&) {
+        return StatusOr<gcsa::v1::ListBackupOperationsResponse>(
             Status(StatusCode::kUnimplemented, "not implemented"));
       },
-      [](gcsa::ListBackupOperationsResponse const&) {
+      [](gcsa::v1::ListBackupOperationsResponse const&) {
         return std::vector<google::longrunning::Operation>{};
       });
 }
@@ -100,12 +100,12 @@ ListDatabaseOperationsRange DatabaseAdminConnection::ListDatabaseOperations(
     ListDatabaseOperationsParams) {
   return google::cloud::internal::MakePaginationRange<
       ListDatabaseOperationsRange>(
-      gcsa::ListDatabaseOperationsRequest{},
-      [](gcsa::ListDatabaseOperationsRequest const&) {
-        return StatusOr<gcsa::ListDatabaseOperationsResponse>(
+      gcsa::v1::ListDatabaseOperationsRequest{},
+      [](gcsa::v1::ListDatabaseOperationsRequest const&) {
+        return StatusOr<gcsa::v1::ListDatabaseOperationsResponse>(
             Status(StatusCode::kUnimplemented, "not implemented"));
       },
-      [](gcsa::ListDatabaseOperationsResponse const&) {
+      [](gcsa::v1::ListDatabaseOperationsResponse const&) {
         return std::vector<google::longrunning::Operation>{};
       });
 }
@@ -133,12 +133,12 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   CreateDatabase(CreateDatabaseParams p) override {
-    gcsa::CreateDatabaseRequest request;
+    gcsa::v1::CreateDatabaseRequest request;
     request.set_parent(p.database.instance().FullName());
     request.set_create_statement("CREATE DATABASE `" +
                                  p.database.database_id() + "`");
     struct EncryptionVisitor {
-      explicit EncryptionVisitor(gcsa::CreateDatabaseRequest& request)
+      explicit EncryptionVisitor(gcsa::v1::CreateDatabaseRequest& request)
           : request_(request) {}
       void operator()(DefaultEncryption const&) const {
         // No encryption_config => GOOGLE_DEFAULT_ENCRYPTION.
@@ -150,18 +150,19 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         auto* config = request_.mutable_encryption_config();
         config->set_kms_key_name(cme.encryption_key().FullName());
       }
-      gcsa::CreateDatabaseRequest& request_;
+      gcsa::v1::CreateDatabaseRequest& request_;
     };
     absl::visit(EncryptionVisitor(request), p.encryption_config);
     for (auto& s : p.extra_statements) {
       *request.add_extra_statements() = std::move(s);
     }
     auto stub = stub_;
-    return google::cloud::internal::AsyncLongRunningOperation<gcsa::Database>(
+    return google::cloud::internal::AsyncLongRunningOperation<
+        gcsa::v1::Database>(
         background_threads_->cq(), std::move(request),
         [stub](google::cloud::CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
-               gcsa::CreateDatabaseRequest const& request) {
+               gcsa::v1::CreateDatabaseRequest const& request) {
           return stub->AsyncCreateDatabase(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -175,7 +176,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
           return stub->AsyncCancelOperation(cq, std::move(context), request);
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
-            gcsa::Database>,
+            gcsa::v1::Database>,
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kNonIdempotent, polling_policy_prototype_->clone(),
         __func__);
@@ -183,13 +184,13 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   StatusOr<google::spanner::admin::database::v1::Database> GetDatabase(
       GetDatabaseParams p) override {
-    gcsa::GetDatabaseRequest request;
+    gcsa::v1::GetDatabaseRequest request;
     request.set_name(p.database.FullName());
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::GetDatabaseRequest const& request) {
+               gcsa::v1::GetDatabaseRequest const& request) {
           return stub_->GetDatabase(context, request);
         },
         request, __func__);
@@ -197,13 +198,13 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   StatusOr<google::spanner::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(GetDatabaseDdlParams p) override {
-    gcsa::GetDatabaseDdlRequest request;
+    gcsa::v1::GetDatabaseDdlRequest request;
     request.set_database(p.database.FullName());
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::GetDatabaseDdlRequest const& request) {
+               gcsa::v1::GetDatabaseDdlRequest const& request) {
           return stub_->GetDatabaseDdl(context, request);
         },
         request, __func__);
@@ -212,18 +213,18 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
   future<
       StatusOr<google::spanner::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabase(UpdateDatabaseParams p) override {
-    gcsa::UpdateDatabaseDdlRequest request;
+    gcsa::v1::UpdateDatabaseDdlRequest request;
     request.set_database(p.database.FullName());
     for (auto& s : p.statements) {
       *request.add_statements() = std::move(s);
     }
     auto stub = stub_;
     return google::cloud::internal::AsyncLongRunningOperation<
-        gcsa::UpdateDatabaseDdlMetadata>(
+        gcsa::v1::UpdateDatabaseDdlMetadata>(
         background_threads_->cq(), std::move(request),
         [stub](google::cloud::CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
-               gcsa::UpdateDatabaseDdlRequest const& request) {
+               gcsa::v1::UpdateDatabaseDdlRequest const& request) {
           return stub->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -237,7 +238,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
           return stub->AsyncCancelOperation(cq, std::move(context), request);
         },
         &google::cloud::internal::ExtractLongRunningResultMetadata<
-            gcsa::UpdateDatabaseDdlMetadata>,
+            gcsa::v1::UpdateDatabaseDdlMetadata>,
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kNonIdempotent, polling_policy_prototype_->clone(),
         __func__);
@@ -250,14 +251,14 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::DropDatabaseRequest const& request) {
+               gcsa::v1::DropDatabaseRequest const& request) {
           return stub_->DropDatabase(context, request);
         },
         request, __func__);
   }
 
   ListDatabaseRange ListDatabases(ListDatabasesParams p) override {
-    gcsa::ListDatabasesRequest request;
+    gcsa::v1::ListDatabasesRequest request;
     request.set_parent(p.instance.FullName());
     request.clear_page_token();
     auto stub = stub_;
@@ -272,17 +273,17 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
     return google::cloud::internal::MakePaginationRange<ListDatabaseRange>(
         std::move(request),
         [stub, retry, backoff,
-         function_name](gcsa::ListDatabasesRequest const& r) {
+         function_name](gcsa::v1::ListDatabasesRequest const& r) {
           return RetryLoop(
               retry->clone(), backoff->clone(), Idempotency::kIdempotent,
               [stub](grpc::ClientContext& context,
-                     gcsa::ListDatabasesRequest const& request) {
+                     gcsa::v1::ListDatabasesRequest const& request) {
                 return stub->ListDatabases(context, request);
               },
               r, function_name);
         },
-        [](gcsa::ListDatabasesResponse r) {
-          std::vector<gcsa::Database> result(r.databases().size());
+        [](gcsa::v1::ListDatabasesResponse r) {
+          std::vector<gcsa::v1::Database> result(r.databases().size());
           auto& dbs = *r.mutable_databases();
           std::move(dbs.begin(), dbs.end(), result.begin());
           return result;
@@ -291,12 +292,12 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   future<StatusOr<google::spanner::admin::database::v1::Database>>
   RestoreDatabase(RestoreDatabaseParams p) override {
-    gcsa::RestoreDatabaseRequest request;
+    gcsa::v1::RestoreDatabaseRequest request;
     request.set_parent(p.database.instance().FullName());
     request.set_database_id(p.database.database_id());
     request.set_backup(std::move(p.backup_full_name));
     struct EncryptionVisitor {
-      explicit EncryptionVisitor(gcsa::RestoreDatabaseRequest& request)
+      explicit EncryptionVisitor(gcsa::v1::RestoreDatabaseRequest& request)
           : request_(request) {}
       void operator()(DefaultEncryption const&) const {
         // No encryption_config => USE_CONFIG_DEFAULT_OR_BACKUP_ENCRYPTION.
@@ -304,24 +305,25 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       }
       void operator()(GoogleEncryption const&) const {
         auto* config = request_.mutable_encryption_config();
-        config->set_encryption_type(
-            gcsa::RestoreDatabaseEncryptionConfig::GOOGLE_DEFAULT_ENCRYPTION);
+        config->set_encryption_type(gcsa::v1::RestoreDatabaseEncryptionConfig::
+                                        GOOGLE_DEFAULT_ENCRYPTION);
       }
       void operator()(CustomerManagedEncryption const& cme) const {
         auto* config = request_.mutable_encryption_config();
-        config->set_encryption_type(
-            gcsa::RestoreDatabaseEncryptionConfig::CUSTOMER_MANAGED_ENCRYPTION);
+        config->set_encryption_type(gcsa::v1::RestoreDatabaseEncryptionConfig::
+                                        CUSTOMER_MANAGED_ENCRYPTION);
         config->set_kms_key_name(cme.encryption_key().FullName());
       }
-      gcsa::RestoreDatabaseRequest& request_;
+      gcsa::v1::RestoreDatabaseRequest& request_;
     };
     absl::visit(EncryptionVisitor(request), p.encryption_config);
     auto stub = stub_;
-    return google::cloud::internal::AsyncLongRunningOperation<gcsa::Database>(
+    return google::cloud::internal::AsyncLongRunningOperation<
+        gcsa::v1::Database>(
         background_threads_->cq(), std::move(request),
         [stub](google::cloud::CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
-               gcsa::RestoreDatabaseRequest const& request) {
+               gcsa::v1::RestoreDatabaseRequest const& request) {
           return stub->AsyncRestoreDatabase(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -335,7 +337,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
           return stub->AsyncCancelOperation(cq, std::move(context), request);
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
-            gcsa::Database>,
+            gcsa::v1::Database>,
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kNonIdempotent, polling_policy_prototype_->clone(),
         __func__);
@@ -390,8 +392,9 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         request, __func__);
   }
 
-  future<StatusOr<gcsa::Backup>> CreateBackup(CreateBackupParams p) override {
-    gcsa::CreateBackupRequest request;
+  future<StatusOr<gcsa::v1::Backup>> CreateBackup(
+      CreateBackupParams p) override {
+    gcsa::v1::CreateBackupRequest request;
     request.set_parent(p.database.instance().FullName());
     request.set_backup_id(p.backup_id);
     auto& backup = *request.mutable_backup();
@@ -404,7 +407,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
           p.version_time->get<protobuf::Timestamp>().value();
     }
     struct EncryptionVisitor {
-      explicit EncryptionVisitor(gcsa::CreateBackupRequest& request)
+      explicit EncryptionVisitor(gcsa::v1::CreateBackupRequest& request)
           : request_(request) {}
       void operator()(DefaultEncryption const&) const {
         // No encryption_config => USE_DATABASE_ENCRYPTION.
@@ -413,23 +416,23 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
       void operator()(GoogleEncryption const&) const {
         auto* config = request_.mutable_encryption_config();
         config->set_encryption_type(
-            gcsa::CreateBackupEncryptionConfig::GOOGLE_DEFAULT_ENCRYPTION);
+            gcsa::v1::CreateBackupEncryptionConfig::GOOGLE_DEFAULT_ENCRYPTION);
       }
       void operator()(CustomerManagedEncryption const& cme) const {
         auto* config = request_.mutable_encryption_config();
-        config->set_encryption_type(
-            gcsa::CreateBackupEncryptionConfig::CUSTOMER_MANAGED_ENCRYPTION);
+        config->set_encryption_type(gcsa::v1::CreateBackupEncryptionConfig::
+                                        CUSTOMER_MANAGED_ENCRYPTION);
         config->set_kms_key_name(cme.encryption_key().FullName());
       }
-      gcsa::CreateBackupRequest& request_;
+      gcsa::v1::CreateBackupRequest& request_;
     };
     absl::visit(EncryptionVisitor(request), p.encryption_config);
     auto stub = stub_;
-    return google::cloud::internal::AsyncLongRunningOperation<gcsa::Backup>(
+    return google::cloud::internal::AsyncLongRunningOperation<gcsa::v1::Backup>(
         background_threads_->cq(), std::move(request),
         [stub](google::cloud::CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
-               gcsa::CreateBackupRequest const& request) {
+               gcsa::v1::CreateBackupRequest const& request) {
           return stub->AsyncCreateBackup(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -443,7 +446,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
           return stub->AsyncCancelOperation(cq, std::move(context), request);
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
-            gcsa::Backup>,
+            gcsa::v1::Backup>,
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kNonIdempotent, polling_policy_prototype_->clone(),
         __func__);
@@ -451,13 +454,13 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   StatusOr<google::spanner::admin::database::v1::Backup> GetBackup(
       GetBackupParams p) override {
-    gcsa::GetBackupRequest request;
+    gcsa::v1::GetBackupRequest request;
     request.set_name(p.backup_full_name);
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::GetBackupRequest const& request) {
+               gcsa::v1::GetBackupRequest const& request) {
           return stub_->GetBackup(context, request);
         },
         request, __func__);
@@ -470,14 +473,14 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::DeleteBackupRequest const& request) {
+               gcsa::v1::DeleteBackupRequest const& request) {
           return stub_->DeleteBackup(context, request);
         },
         request, __func__);
   }
 
   ListBackupsRange ListBackups(ListBackupsParams p) override {
-    gcsa::ListBackupsRequest request;
+    gcsa::v1::ListBackupsRequest request;
     request.set_parent(p.instance.FullName());
     request.set_filter(std::move(p.filter));
     auto stub = stub_;
@@ -492,17 +495,17 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
     return google::cloud::internal::MakePaginationRange<ListBackupsRange>(
         std::move(request),
         [stub, retry, backoff,
-         function_name](gcsa::ListBackupsRequest const& r) {
+         function_name](gcsa::v1::ListBackupsRequest const& r) {
           return RetryLoop(
               retry->clone(), backoff->clone(), Idempotency::kIdempotent,
               [stub](grpc::ClientContext& context,
-                     gcsa::ListBackupsRequest const& request) {
+                     gcsa::v1::ListBackupsRequest const& request) {
                 return stub->ListBackups(context, request);
               },
               r, function_name);
         },
-        [](gcsa::ListBackupsResponse r) {
-          std::vector<gcsa::Backup> result(r.backups().size());
+        [](gcsa::v1::ListBackupsResponse r) {
+          std::vector<gcsa::v1::Backup> result(r.backups().size());
           auto& backups = *r.mutable_backups();
           std::move(backups.begin(), backups.end(), result.begin());
           return result;
@@ -515,7 +518,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::UpdateBackupRequest const& request) {
+               gcsa::v1::UpdateBackupRequest const& request) {
           return stub_->UpdateBackup(context, request);
         },
         p.request, __func__);
@@ -523,7 +526,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   ListBackupOperationsRange ListBackupOperations(
       ListBackupOperationsParams p) override {
-    gcsa::ListBackupOperationsRequest request;
+    gcsa::v1::ListBackupOperationsRequest request;
     request.set_parent(p.instance.FullName());
     request.set_filter(std::move(p.filter));
     auto stub = stub_;
@@ -539,16 +542,16 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         ListBackupOperationsRange>(
         std::move(request),
         [stub, retry, backoff,
-         function_name](gcsa::ListBackupOperationsRequest const& r) {
+         function_name](gcsa::v1::ListBackupOperationsRequest const& r) {
           return RetryLoop(
               retry->clone(), backoff->clone(), Idempotency::kIdempotent,
               [stub](grpc::ClientContext& context,
-                     gcsa::ListBackupOperationsRequest const& request) {
+                     gcsa::v1::ListBackupOperationsRequest const& request) {
                 return stub->ListBackupOperations(context, request);
               },
               r, function_name);
         },
-        [](gcsa::ListBackupOperationsResponse r) {
+        [](gcsa::v1::ListBackupOperationsResponse r) {
           std::vector<google::longrunning::Operation> result(
               r.operations().size());
           auto& operations = *r.mutable_operations();
@@ -559,7 +562,7 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
 
   ListDatabaseOperationsRange ListDatabaseOperations(
       ListDatabaseOperationsParams p) override {
-    gcsa::ListDatabaseOperationsRequest request;
+    gcsa::v1::ListDatabaseOperationsRequest request;
     request.set_parent(p.instance.FullName());
     request.set_filter(std::move(p.filter));
     auto stub = stub_;
@@ -575,16 +578,16 @@ class DatabaseAdminConnectionImpl : public DatabaseAdminConnection {
         ListDatabaseOperationsRange>(
         std::move(request),
         [stub, retry, backoff,
-         function_name](gcsa::ListDatabaseOperationsRequest const& r) {
+         function_name](gcsa::v1::ListDatabaseOperationsRequest const& r) {
           return RetryLoop(
               retry->clone(), backoff->clone(), Idempotency::kIdempotent,
               [stub](grpc::ClientContext& context,
-                     gcsa::ListDatabaseOperationsRequest const& request) {
+                     gcsa::v1::ListDatabaseOperationsRequest const& request) {
                 return stub->ListDatabaseOperations(context, request);
               },
               r, function_name);
         },
-        [](gcsa::ListDatabaseOperationsResponse r) {
+        [](gcsa::v1::ListDatabaseOperationsResponse r) {
           std::vector<google::longrunning::Operation> result(
               r.operations().size());
           auto& operations = *r.mutable_operations();

--- a/google/cloud/spanner/database_admin_connection_test.cc
+++ b/google/cloud/spanner/database_admin_connection_test.cc
@@ -35,6 +35,8 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace gcsa = ::google::spanner::admin::database;
+
 using ::google::cloud::spanner_testing::MockDatabaseAdminStub;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
@@ -45,7 +47,6 @@ using ::testing::AtMost;
 using ::testing::ElementsAre;
 using ::testing::IsEmpty;
 using ::testing::Return;
-namespace gcsa = ::google::spanner::admin::database::v1;
 
 std::shared_ptr<DatabaseAdminConnection> CreateTestingConnection(
     std::shared_ptr<spanner_internal::DatabaseAdminStub> mock) {
@@ -71,7 +72,7 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseSuccess) {
 
   EXPECT_CALL(*mock, AsyncCreateDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateDatabaseRequest const& request) {
+                   gcsa::v1::CreateDatabaseRequest const& request) {
         EXPECT_FALSE(request.has_encryption_config());
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
@@ -86,9 +87,9 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseSuccess) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::Database response;
+        gcsa::v1::Database response;
         response.set_name(database_name);
-        response.set_state(gcsa::Database::READY);
+        response.set_state(gcsa::v1::Database::READY);
         op.mutable_response()->PackFrom(response);
         return make_ready_future(make_status_or(std::move(op)));
       });
@@ -100,7 +101,7 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseSuccess) {
   auto response = fut.get();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), database_name);
-  EXPECT_EQ(response->state(), gcsa::Database::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Database::READY);
   EXPECT_FALSE(response->has_encryption_config());
 }
 
@@ -112,7 +113,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
 
   EXPECT_CALL(*mock, AsyncCreateDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateDatabaseRequest const& request) {
+                   gcsa::v1::CreateDatabaseRequest const& request) {
         EXPECT_TRUE(request.has_encryption_config());
         if (request.has_encryption_config()) {
           EXPECT_EQ(request.encryption_config().kms_key_name(),
@@ -132,9 +133,9 @@ TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::Database response;
+        gcsa::v1::Database response;
         response.set_name(database_name);
-        response.set_state(gcsa::Database::READY);
+        response.set_state(gcsa::v1::Database::READY);
         response.mutable_encryption_config()->set_kms_key_name(
             "projects/test-project/locations/some-location/keyRings/"
             "a-key-ring/cryptoKeys/some-key-name");
@@ -152,7 +153,7 @@ TEST(DatabaseAdminClientTest, CreateDatabaseWithEncryption) {
   auto response = fut.get();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), database_name);
-  EXPECT_EQ(response->state(), gcsa::Database::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Database::READY);
   EXPECT_TRUE(response->has_encryption_config());
   if (response->has_encryption_config()) {
     EXPECT_EQ(
@@ -169,7 +170,7 @@ TEST(DatabaseAdminConnectionTest, HandleCreateDatabaseError) {
 
   EXPECT_CALL(*mock, AsyncCreateDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateDatabaseRequest const&) {
+                   gcsa::v1::CreateDatabaseRequest const&) {
         return make_ready_future(StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));
       });
@@ -203,17 +204,17 @@ TEST(DatabaseAdminConnectionTest, GetDatabase) {
     earliest_version_time { seconds: 1625696199 nanos: 123456789 }
     default_leader: "us-east5"
   )pb";
-  gcsa::Database expected_response;
+  gcsa::v1::Database expected_response;
   ASSERT_TRUE(TextFormat::ParseFromString(kResponseText, &expected_response));
 
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   EXPECT_CALL(*mock, GetDatabase)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce(
-          [&](grpc::ClientContext&, gcsa::GetDatabaseRequest const& request) {
-            EXPECT_EQ(request.name(), expected_response.name());
-            return expected_response;
-          });
+      .WillOnce([&](grpc::ClientContext&,
+                    gcsa::v1::GetDatabaseRequest const& request) {
+        EXPECT_EQ(request.name(), expected_response.name());
+        return expected_response;
+      });
 
   auto conn = CreateTestingConnection(std::move(mock));
   auto response =
@@ -257,13 +258,14 @@ TEST(DatabaseAdminConnectionTest, GetDatabaseDdlSuccess) {
 
   EXPECT_CALL(*mock, GetDatabaseDdl)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
-      .WillOnce([&expected_name](grpc::ClientContext&,
-                                 gcsa::GetDatabaseDdlRequest const& request) {
-        EXPECT_EQ(expected_name, request.database());
-        gcsa::GetDatabaseDdlResponse response;
-        response.add_statements("CREATE DATABASE test-database");
-        return response;
-      });
+      .WillOnce(
+          [&expected_name](grpc::ClientContext&,
+                           gcsa::v1::GetDatabaseDdlRequest const& request) {
+            EXPECT_EQ(expected_name, request.database());
+            gcsa::v1::GetDatabaseDdlResponse response;
+            response.add_statements("CREATE DATABASE test-database");
+            return response;
+          });
 
   auto conn = CreateTestingConnection(std::move(mock));
   auto response = conn->GetDatabaseDdl(
@@ -306,7 +308,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseSuccess) {
 
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::UpdateDatabaseDdlRequest const&) {
+                   gcsa::v1::UpdateDatabaseDdlRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
         op.set_done(false);
@@ -319,7 +321,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseSuccess) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::UpdateDatabaseDdlMetadata metadata;
+        gcsa::v1::UpdateDatabaseDdlMetadata metadata;
         metadata.set_database("test-database");
         op.mutable_metadata()->PackFrom(metadata);
         return make_ready_future(make_status_or(std::move(op)));
@@ -341,7 +343,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseErrorInPoll) {
 
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::UpdateDatabaseDdlRequest const&) {
+                   gcsa::v1::UpdateDatabaseDdlRequest const&) {
         return make_ready_future(StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));
       });
@@ -360,7 +362,7 @@ TEST(DatabaseAdminConnectionTest, CreateDatabaseErrorInPoll) {
 
   EXPECT_CALL(*mock, AsyncCreateDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateDatabaseRequest const&) {
+                   gcsa::v1::CreateDatabaseRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
         op.set_done(false);
@@ -390,7 +392,7 @@ TEST(DatabaseAdminConnectionTest, UpdateDatabaseGetOperationError) {
 
   EXPECT_CALL(*mock, AsyncUpdateDatabaseDdl)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::UpdateDatabaseDdlRequest const&) {
+                   gcsa::v1::UpdateDatabaseDdlRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
         op.set_done(false);
@@ -521,7 +523,7 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
         default_leader: "us-east5"
       )pb",
   };
-  gcsa::Database expected_databases[5];
+  gcsa::v1::Database expected_databases[5];
   ASSERT_TRUE(
       TextFormat::ParseFromString(kDatabaseText[0], &expected_databases[0]));
   ASSERT_TRUE(
@@ -537,41 +539,41 @@ TEST(DatabaseAdminConnectionTest, ListDatabases) {
   std::string const expected_parent = in.FullName();
   auto mock = std::make_shared<MockDatabaseAdminStub>();
   EXPECT_CALL(*mock, ListDatabases)
-      .WillOnce(
-          [&](grpc::ClientContext&, gcsa::ListDatabasesRequest const& request) {
-            EXPECT_EQ(expected_parent, request.parent());
-            EXPECT_TRUE(request.page_token().empty());
+      .WillOnce([&](grpc::ClientContext&,
+                    gcsa::v1::ListDatabasesRequest const& request) {
+        EXPECT_EQ(expected_parent, request.parent());
+        EXPECT_TRUE(request.page_token().empty());
 
-            gcsa::ListDatabasesResponse page;
-            page.set_next_page_token("page-1");
-            *page.add_databases() = expected_databases[0];
-            *page.add_databases() = expected_databases[1];
-            return make_status_or(page);
-          })
-      .WillOnce(
-          [&](grpc::ClientContext&, gcsa::ListDatabasesRequest const& request) {
-            EXPECT_EQ(expected_parent, request.parent());
-            EXPECT_EQ("page-1", request.page_token());
+        gcsa::v1::ListDatabasesResponse page;
+        page.set_next_page_token("page-1");
+        *page.add_databases() = expected_databases[0];
+        *page.add_databases() = expected_databases[1];
+        return make_status_or(page);
+      })
+      .WillOnce([&](grpc::ClientContext&,
+                    gcsa::v1::ListDatabasesRequest const& request) {
+        EXPECT_EQ(expected_parent, request.parent());
+        EXPECT_EQ("page-1", request.page_token());
 
-            gcsa::ListDatabasesResponse page;
-            page.set_next_page_token("page-2");
-            *page.add_databases() = expected_databases[2];
-            *page.add_databases() = expected_databases[3];
-            return make_status_or(page);
-          })
-      .WillOnce(
-          [&](grpc::ClientContext&, gcsa::ListDatabasesRequest const& request) {
-            EXPECT_EQ(expected_parent, request.parent());
-            EXPECT_EQ("page-2", request.page_token());
+        gcsa::v1::ListDatabasesResponse page;
+        page.set_next_page_token("page-2");
+        *page.add_databases() = expected_databases[2];
+        *page.add_databases() = expected_databases[3];
+        return make_status_or(page);
+      })
+      .WillOnce([&](grpc::ClientContext&,
+                    gcsa::v1::ListDatabasesRequest const& request) {
+        EXPECT_EQ(expected_parent, request.parent());
+        EXPECT_EQ("page-2", request.page_token());
 
-            gcsa::ListDatabasesResponse page;
-            page.clear_next_page_token();
-            *page.add_databases() = expected_databases[4];
-            return make_status_or(page);
-          });
+        gcsa::v1::ListDatabasesResponse page;
+        page.clear_next_page_token();
+        *page.add_databases() = expected_databases[4];
+        return make_status_or(page);
+      });
 
   auto conn = CreateTestingConnection(std::move(mock));
-  std::vector<gcsa::Database> actual_databases;
+  std::vector<gcsa::v1::Database> actual_databases;
   for (auto const& database : conn->ListDatabases({in})) {
     ASSERT_STATUS_OK(database);
     actual_databases.push_back(*database);
@@ -621,7 +623,7 @@ TEST(DatabaseAdminConnectionTest, RestoreDatabaseSuccess) {
 
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::RestoreDatabaseRequest const& request) {
+                   gcsa::v1::RestoreDatabaseRequest const& request) {
         EXPECT_EQ(request.database_id(), "test-database");
         EXPECT_FALSE(request.has_encryption_config());
         google::longrunning::Operation op;
@@ -637,9 +639,9 @@ TEST(DatabaseAdminConnectionTest, RestoreDatabaseSuccess) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::Database response;
+        gcsa::v1::Database response;
         response.set_name(database_name);
-        response.set_state(gcsa::Database::READY);
+        response.set_state(gcsa::v1::Database::READY);
         op.mutable_response()->PackFrom(response);
         return make_ready_future(make_status_or(std::move(op)));
       });
@@ -652,7 +654,7 @@ TEST(DatabaseAdminConnectionTest, RestoreDatabaseSuccess) {
   auto response = fut.get();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), database_name);
-  EXPECT_EQ(response->state(), gcsa::Database::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Database::READY);
   EXPECT_FALSE(response->has_encryption_config());
 }
 
@@ -664,12 +666,12 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseWithEncryption) {
 
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::RestoreDatabaseRequest const& request) {
+                   gcsa::v1::RestoreDatabaseRequest const& request) {
         EXPECT_EQ(request.database_id(), "test-database");
         EXPECT_TRUE(request.has_encryption_config());
         if (request.has_encryption_config()) {
           EXPECT_EQ(request.encryption_config().encryption_type(),
-                    gcsa::RestoreDatabaseEncryptionConfig::
+                    gcsa::v1::RestoreDatabaseEncryptionConfig::
                         CUSTOMER_MANAGED_ENCRYPTION);
           EXPECT_EQ(request.encryption_config().kms_key_name(),
                     "projects/test-project/locations/some-location/keyRings/"
@@ -688,9 +690,9 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseWithEncryption) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::Database response;
+        gcsa::v1::Database response;
         response.set_name(database_name);
-        response.set_state(gcsa::Database::READY);
+        response.set_state(gcsa::v1::Database::READY);
         response.mutable_encryption_config()->set_kms_key_name(
             "projects/test-project/locations/some-location/keyRings/"
             "a-key-ring/cryptoKeys/restore-key-name");
@@ -710,7 +712,7 @@ TEST(DatabaseAdminClientTest, RestoreDatabaseWithEncryption) {
   auto response = fut.get();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), database_name);
-  EXPECT_EQ(response->state(), gcsa::Database::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Database::READY);
   EXPECT_TRUE(response->has_encryption_config());
   if (response->has_encryption_config()) {
     EXPECT_EQ(
@@ -727,7 +729,7 @@ TEST(DatabaseAdminConnectionTest, HandleRestoreDatabaseError) {
 
   EXPECT_CALL(*mock, AsyncRestoreDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::RestoreDatabaseRequest const&) {
+                   gcsa::v1::RestoreDatabaseRequest const&) {
         return make_ready_future(StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));
       });
@@ -952,7 +954,7 @@ TEST(DatabaseAdminConnectionTest, CreateBackupSuccess) {
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce([&dbase, &expire_time, &version_time](
                     CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                    gcsa::CreateBackupRequest const& request) {
+                    gcsa::v1::CreateBackupRequest const& request) {
         EXPECT_EQ(request.parent(), dbase.instance().FullName());
         EXPECT_EQ(request.backup_id(), "test-backup");
         auto const& backup = request.backup();
@@ -972,9 +974,9 @@ TEST(DatabaseAdminConnectionTest, CreateBackupSuccess) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::Backup response;
+        gcsa::v1::Backup response;
         response.set_name("test-backup");
-        response.set_state(gcsa::Backup::READY);
+        response.set_state(gcsa::v1::Backup::READY);
         *response.mutable_expire_time() =
             expire_time.get<protobuf::Timestamp>().value();
         *response.mutable_version_time() =
@@ -993,7 +995,7 @@ TEST(DatabaseAdminConnectionTest, CreateBackupSuccess) {
   auto response = fut.get();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), "test-backup");
-  EXPECT_EQ(response->state(), gcsa::Backup::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Backup::READY);
   EXPECT_EQ(MakeTimestamp(response->expire_time()).value(), expire_time);
   EXPECT_EQ(MakeTimestamp(response->version_time()).value(), version_time);
   EXPECT_GT(MakeTimestamp(response->create_time()).value(), version_time);
@@ -1007,15 +1009,15 @@ TEST(DatabaseAdminClientTest, CreateBackupWithEncryption) {
 
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce([&dbase](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                         gcsa::CreateBackupRequest const& request) {
+                         gcsa::v1::CreateBackupRequest const& request) {
         EXPECT_EQ(request.parent(), dbase.instance().FullName());
         EXPECT_EQ(request.backup_id(), "test-backup");
         EXPECT_EQ(request.backup().database(), dbase.FullName());
         EXPECT_TRUE(request.has_encryption_config());
         if (request.has_encryption_config()) {
-          EXPECT_EQ(
-              request.encryption_config().encryption_type(),
-              gcsa::CreateBackupEncryptionConfig::GOOGLE_DEFAULT_ENCRYPTION);
+          EXPECT_EQ(request.encryption_config().encryption_type(),
+                    gcsa::v1::CreateBackupEncryptionConfig::
+                        GOOGLE_DEFAULT_ENCRYPTION);
           EXPECT_THAT(request.encryption_config().kms_key_name(), IsEmpty());
         }
         google::longrunning::Operation op;
@@ -1030,11 +1032,11 @@ TEST(DatabaseAdminClientTest, CreateBackupWithEncryption) {
         google::longrunning::Operation op;
         op.set_name(r.name());
         op.set_done(true);
-        gcsa::Backup response;
+        gcsa::v1::Backup response;
         response.set_name("test-backup");
-        response.set_state(gcsa::Backup::READY);
+        response.set_state(gcsa::v1::Backup::READY);
         response.mutable_encryption_info()->set_encryption_type(
-            gcsa::EncryptionInfo::GOOGLE_DEFAULT_ENCRYPTION);
+            gcsa::v1::EncryptionInfo::GOOGLE_DEFAULT_ENCRYPTION);
         op.mutable_response()->PackFrom(response);
         return make_ready_future(make_status_or(std::move(op)));
       });
@@ -1045,11 +1047,11 @@ TEST(DatabaseAdminClientTest, CreateBackupWithEncryption) {
   auto response = fut.get();
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), "test-backup");
-  EXPECT_EQ(response->state(), gcsa::Backup::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Backup::READY);
   EXPECT_TRUE(response->has_encryption_info());
   if (response->has_encryption_info()) {
     EXPECT_EQ(response->encryption_info().encryption_type(),
-              gcsa::EncryptionInfo::GOOGLE_DEFAULT_ENCRYPTION);
+              gcsa::v1::EncryptionInfo::GOOGLE_DEFAULT_ENCRYPTION);
     EXPECT_THAT(response->encryption_info().kms_key_version(), IsEmpty());
   }
 }
@@ -1061,7 +1063,7 @@ TEST(DatabaseAdminConnectionTest, CreateBackupCancel) {
 
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateBackupRequest const&) {
+                   gcsa::v1::CreateBackupRequest const&) {
         google::longrunning::Operation op;
         op.set_name("test-operation-name");
         op.set_done(false);
@@ -1112,7 +1114,7 @@ TEST(DatabaseAdminConnectionTest, HandleCreateBackupError) {
 
   EXPECT_CALL(*mock, AsyncCreateBackup)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateBackupRequest const&) {
+                   gcsa::v1::CreateBackupRequest const&) {
         return make_ready_future(StatusOr<google::longrunning::Operation>(
             Status(StatusCode::kPermissionDenied, "uh-oh")));
       });
@@ -1134,11 +1136,11 @@ TEST(DatabaseAdminConnectionTest, GetBackupSuccess) {
   EXPECT_CALL(*mock, GetBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
-                                 gcsa::GetBackupRequest const& request) {
+                                 gcsa::v1::GetBackupRequest const& request) {
         EXPECT_EQ(expected_name, request.name());
-        gcsa::Backup response;
+        gcsa::v1::Backup response;
         response.set_name(request.name());
-        response.set_state(gcsa::Backup::READY);
+        response.set_state(gcsa::v1::Backup::READY);
         return response;
       });
 
@@ -1147,7 +1149,7 @@ TEST(DatabaseAdminConnectionTest, GetBackupSuccess) {
       {Backup(Instance("test-project", "test-instance"), "test-backup")
            .FullName()});
   ASSERT_STATUS_OK(response);
-  EXPECT_EQ(gcsa::Backup::READY, response->state());
+  EXPECT_EQ(gcsa::v1::Backup::READY, response->state());
   EXPECT_EQ(expected_name, response->name());
   EXPECT_FALSE(response->has_encryption_info());
 }
@@ -1161,13 +1163,13 @@ TEST(DatabaseAdminClientTest, GetBackupWithEncryption) {
   EXPECT_CALL(*mock, GetBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
-                                 gcsa::GetBackupRequest const& request) {
+                                 gcsa::v1::GetBackupRequest const& request) {
         EXPECT_EQ(expected_name, request.name());
-        gcsa::Backup response;
+        gcsa::v1::Backup response;
         response.set_name(request.name());
-        response.set_state(gcsa::Backup::READY);
+        response.set_state(gcsa::v1::Backup::READY);
         response.mutable_encryption_info()->set_encryption_type(
-            gcsa::EncryptionInfo::CUSTOMER_MANAGED_ENCRYPTION);
+            gcsa::v1::EncryptionInfo::CUSTOMER_MANAGED_ENCRYPTION);
         response.mutable_encryption_info()->set_kms_key_version(
             "projects/test-project/locations/some-location/keyRings/a-key-ring/"
             "cryptoKeys/a-key-name/cryptoKeyVersions/1");
@@ -1180,11 +1182,11 @@ TEST(DatabaseAdminClientTest, GetBackupWithEncryption) {
            .FullName()});
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->name(), expected_name);
-  EXPECT_EQ(response->state(), gcsa::Backup::READY);
+  EXPECT_EQ(response->state(), gcsa::v1::Backup::READY);
   EXPECT_TRUE(response->has_encryption_info());
   if (response->has_encryption_info()) {
     EXPECT_EQ(response->encryption_info().encryption_type(),
-              gcsa::EncryptionInfo::CUSTOMER_MANAGED_ENCRYPTION);
+              gcsa::v1::EncryptionInfo::CUSTOMER_MANAGED_ENCRYPTION);
     EXPECT_EQ(
         response->encryption_info().kms_key_version(),
         "projects/test-project/locations/some-location/keyRings/a-key-ring/"
@@ -1230,7 +1232,7 @@ TEST(DatabaseAdminConnectionTest, DeleteBackupSuccess) {
   EXPECT_CALL(*mock, DeleteBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
-                                 gcsa::DeleteBackupRequest const& request) {
+                                 gcsa::v1::DeleteBackupRequest const& request) {
         EXPECT_EQ(expected_name, request.name());
         return google::cloud::Status();
       });
@@ -1274,38 +1276,41 @@ TEST(DatabaseAdminConnectionTest, ListBackups) {
   std::string const expected_parent = in.FullName();
 
   EXPECT_CALL(*mock, ListBackups)
-      .WillOnce([&expected_parent](grpc::ClientContext&,
-                                   gcsa::ListBackupsRequest const& request) {
-        EXPECT_EQ(expected_parent, request.parent());
-        EXPECT_TRUE(request.page_token().empty());
+      .WillOnce(
+          [&expected_parent](grpc::ClientContext&,
+                             gcsa::v1::ListBackupsRequest const& request) {
+            EXPECT_EQ(expected_parent, request.parent());
+            EXPECT_TRUE(request.page_token().empty());
 
-        gcsa::ListBackupsResponse page;
-        page.set_next_page_token("page-1");
-        page.add_backups()->set_name("backup-1");
-        page.add_backups()->set_name("backup-2");
-        return make_status_or(page);
-      })
-      .WillOnce([&expected_parent](grpc::ClientContext&,
-                                   gcsa::ListBackupsRequest const& request) {
-        EXPECT_EQ(expected_parent, request.parent());
-        EXPECT_EQ("page-1", request.page_token());
+            gcsa::v1::ListBackupsResponse page;
+            page.set_next_page_token("page-1");
+            page.add_backups()->set_name("backup-1");
+            page.add_backups()->set_name("backup-2");
+            return make_status_or(page);
+          })
+      .WillOnce(
+          [&expected_parent](grpc::ClientContext&,
+                             gcsa::v1::ListBackupsRequest const& request) {
+            EXPECT_EQ(expected_parent, request.parent());
+            EXPECT_EQ("page-1", request.page_token());
 
-        gcsa::ListBackupsResponse page;
-        page.set_next_page_token("page-2");
-        page.add_backups()->set_name("backup-3");
-        page.add_backups()->set_name("backup-4");
-        return make_status_or(page);
-      })
-      .WillOnce([&expected_parent](grpc::ClientContext&,
-                                   gcsa::ListBackupsRequest const& request) {
-        EXPECT_EQ(expected_parent, request.parent());
-        EXPECT_EQ("page-2", request.page_token());
+            gcsa::v1::ListBackupsResponse page;
+            page.set_next_page_token("page-2");
+            page.add_backups()->set_name("backup-3");
+            page.add_backups()->set_name("backup-4");
+            return make_status_or(page);
+          })
+      .WillOnce(
+          [&expected_parent](grpc::ClientContext&,
+                             gcsa::v1::ListBackupsRequest const& request) {
+            EXPECT_EQ(expected_parent, request.parent());
+            EXPECT_EQ("page-2", request.page_token());
 
-        gcsa::ListBackupsResponse page;
-        page.clear_next_page_token();
-        page.add_backups()->set_name("backup-5");
-        return make_status_or(page);
-      });
+            gcsa::v1::ListBackupsResponse page;
+            page.clear_next_page_token();
+            page.add_backups()->set_name("backup-5");
+            return make_status_or(page);
+          });
 
   auto conn = CreateTestingConnection(std::move(mock));
   std::vector<std::string> actual_names;
@@ -1355,11 +1360,11 @@ TEST(DatabaseAdminConnectionTest, UpdateBackupSuccess) {
   EXPECT_CALL(*mock, UpdateBackup)
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&expected_name](grpc::ClientContext&,
-                                 gcsa::UpdateBackupRequest const& request) {
+                                 gcsa::v1::UpdateBackupRequest const& request) {
         EXPECT_EQ(expected_name, request.backup().name());
-        gcsa::Backup response;
+        gcsa::v1::Backup response;
         response.set_name(request.backup().name());
-        response.set_state(gcsa::Backup::READY);
+        response.set_state(gcsa::v1::Backup::READY);
         return response;
       });
 
@@ -1370,7 +1375,7 @@ TEST(DatabaseAdminConnectionTest, UpdateBackupSuccess) {
           .FullName());
   auto response = conn->UpdateBackup({request});
   EXPECT_STATUS_OK(response);
-  EXPECT_EQ(gcsa::Backup::READY, response->state());
+  EXPECT_EQ(gcsa::v1::Backup::READY, response->state());
   EXPECT_EQ(expected_name, response->name());
 }
 
@@ -1408,41 +1413,41 @@ TEST(DatabaseAdminConnectionTest, ListBackupOperations) {
   std::string const expected_parent = in.FullName();
 
   EXPECT_CALL(*mock, ListBackupOperations)
-      .WillOnce(
-          [&expected_parent](grpc::ClientContext&,
-                             gcsa::ListBackupOperationsRequest const& request) {
-            EXPECT_EQ(expected_parent, request.parent());
-            EXPECT_TRUE(request.page_token().empty());
+      .WillOnce([&expected_parent](
+                    grpc::ClientContext&,
+                    gcsa::v1::ListBackupOperationsRequest const& request) {
+        EXPECT_EQ(expected_parent, request.parent());
+        EXPECT_TRUE(request.page_token().empty());
 
-            gcsa::ListBackupOperationsResponse page;
-            page.set_next_page_token("page-1");
-            page.add_operations()->set_name("op-1");
-            page.add_operations()->set_name("op-2");
-            return make_status_or(page);
-          })
-      .WillOnce(
-          [&expected_parent](grpc::ClientContext&,
-                             gcsa::ListBackupOperationsRequest const& request) {
-            EXPECT_EQ(expected_parent, request.parent());
-            EXPECT_EQ("page-1", request.page_token());
+        gcsa::v1::ListBackupOperationsResponse page;
+        page.set_next_page_token("page-1");
+        page.add_operations()->set_name("op-1");
+        page.add_operations()->set_name("op-2");
+        return make_status_or(page);
+      })
+      .WillOnce([&expected_parent](
+                    grpc::ClientContext&,
+                    gcsa::v1::ListBackupOperationsRequest const& request) {
+        EXPECT_EQ(expected_parent, request.parent());
+        EXPECT_EQ("page-1", request.page_token());
 
-            gcsa::ListBackupOperationsResponse page;
-            page.set_next_page_token("page-2");
-            page.add_operations()->set_name("op-3");
-            page.add_operations()->set_name("op-4");
-            return make_status_or(page);
-          })
-      .WillOnce(
-          [&expected_parent](grpc::ClientContext&,
-                             gcsa::ListBackupOperationsRequest const& request) {
-            EXPECT_EQ(expected_parent, request.parent());
-            EXPECT_EQ("page-2", request.page_token());
+        gcsa::v1::ListBackupOperationsResponse page;
+        page.set_next_page_token("page-2");
+        page.add_operations()->set_name("op-3");
+        page.add_operations()->set_name("op-4");
+        return make_status_or(page);
+      })
+      .WillOnce([&expected_parent](
+                    grpc::ClientContext&,
+                    gcsa::v1::ListBackupOperationsRequest const& request) {
+        EXPECT_EQ(expected_parent, request.parent());
+        EXPECT_EQ("page-2", request.page_token());
 
-            gcsa::ListBackupOperationsResponse page;
-            page.clear_next_page_token();
-            page.add_operations()->set_name("op-5");
-            return make_status_or(page);
-          });
+        gcsa::v1::ListBackupOperationsResponse page;
+        page.clear_next_page_token();
+        page.add_operations()->set_name("op-5");
+        return make_status_or(page);
+      });
 
   auto conn = CreateTestingConnection(std::move(mock));
   std::vector<std::string> actual_names;
@@ -1492,11 +1497,11 @@ TEST(DatabaseAdminConnectionTest, ListDatabaseOperations) {
   EXPECT_CALL(*mock, ListDatabaseOperations)
       .WillOnce([&expected_parent](
                     grpc::ClientContext&,
-                    gcsa::ListDatabaseOperationsRequest const& request) {
+                    gcsa::v1::ListDatabaseOperationsRequest const& request) {
         EXPECT_EQ(expected_parent, request.parent());
         EXPECT_TRUE(request.page_token().empty());
 
-        gcsa::ListDatabaseOperationsResponse page;
+        gcsa::v1::ListDatabaseOperationsResponse page;
         page.set_next_page_token("page-1");
         page.add_operations()->set_name("op-1");
         page.add_operations()->set_name("op-2");
@@ -1504,11 +1509,11 @@ TEST(DatabaseAdminConnectionTest, ListDatabaseOperations) {
       })
       .WillOnce([&expected_parent](
                     grpc::ClientContext&,
-                    gcsa::ListDatabaseOperationsRequest const& request) {
+                    gcsa::v1::ListDatabaseOperationsRequest const& request) {
         EXPECT_EQ(expected_parent, request.parent());
         EXPECT_EQ("page-1", request.page_token());
 
-        gcsa::ListDatabaseOperationsResponse page;
+        gcsa::v1::ListDatabaseOperationsResponse page;
         page.set_next_page_token("page-2");
         page.add_operations()->set_name("op-3");
         page.add_operations()->set_name("op-4");
@@ -1516,11 +1521,11 @@ TEST(DatabaseAdminConnectionTest, ListDatabaseOperations) {
       })
       .WillOnce([&expected_parent](
                     grpc::ClientContext&,
-                    gcsa::ListDatabaseOperationsRequest const& request) {
+                    gcsa::v1::ListDatabaseOperationsRequest const& request) {
         EXPECT_EQ(expected_parent, request.parent());
         EXPECT_EQ("page-2", request.page_token());
 
-        gcsa::ListDatabaseOperationsResponse page;
+        gcsa::v1::ListDatabaseOperationsResponse page;
         page.clear_next_page_token();
         page.add_operations()->set_name("op-5");
         return make_status_or(page);

--- a/google/cloud/spanner/instance_admin_client_test.cc
+++ b/google/cloud/spanner/instance_admin_client_test.cc
@@ -26,12 +26,13 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace gcsa = ::google::spanner::admin::instance;
+
 using ::google::cloud::testing_util::StatusIs;
 using spanner_mocks::MockInstanceAdminConnection;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
-namespace gcsa = ::google::spanner::admin::instance::v1;
 
 TEST(InstanceAdminClientTest, CopyAndMove) {
   auto conn1 = std::make_shared<MockInstanceAdminConnection>();
@@ -95,13 +96,13 @@ TEST(InstanceAdminClientTest, ListInstanceConfigs) {
             EXPECT_EQ("test-project", p.project_id);
             return google::cloud::internal::MakePaginationRange<
                 ListInstanceConfigsRange>(
-                gcsa::ListInstanceConfigsRequest{},
-                [](gcsa::ListInstanceConfigsRequest const&) {
-                  return StatusOr<gcsa::ListInstanceConfigsResponse>(
+                gcsa::v1::ListInstanceConfigsRequest{},
+                [](gcsa::v1::ListInstanceConfigsRequest const&) {
+                  return StatusOr<gcsa::v1::ListInstanceConfigsResponse>(
                       Status(StatusCode::kPermissionDenied, "uh-oh"));
                 },
-                [](gcsa::ListInstanceConfigsResponse const&) {
-                  return std::vector<gcsa::InstanceConfig>{};
+                [](gcsa::v1::ListInstanceConfigsResponse const&) {
+                  return std::vector<gcsa::v1::InstanceConfig>{};
                 });
           });
 
@@ -121,13 +122,13 @@ TEST(InstanceAdminClientTest, ListInstances) {
         EXPECT_EQ("labels.test-key:test-value", p.filter);
 
         return google::cloud::internal::MakePaginationRange<ListInstancesRange>(
-            gcsa::ListInstancesRequest{},
-            [](gcsa::ListInstancesRequest const&) {
-              return StatusOr<gcsa::ListInstancesResponse>(
+            gcsa::v1::ListInstancesRequest{},
+            [](gcsa::v1::ListInstancesRequest const&) {
+              return StatusOr<gcsa::v1::ListInstancesResponse>(
                   Status(StatusCode::kPermissionDenied, "uh-oh"));
             },
-            [](gcsa::ListInstancesResponse const&) {
-              return std::vector<gcsa::Instance>{};
+            [](gcsa::v1::ListInstancesResponse const&) {
+              return std::vector<gcsa::v1::Instance>{};
             });
       });
 

--- a/google/cloud/spanner/instance_admin_connection.cc
+++ b/google/cloud/spanner/instance_admin_connection.cc
@@ -28,8 +28,8 @@ namespace cloud {
 namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
-namespace giam = ::google::iam::v1;
+namespace gcsa = ::google::spanner::admin::instance;
+
 using ::google::cloud::Idempotency;
 
 namespace {
@@ -51,27 +51,28 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
   Options options() override { return opts_; }
 
-  StatusOr<gcsa::Instance> GetInstance(GetInstanceParams gip) override {
-    gcsa::GetInstanceRequest request;
+  StatusOr<gcsa::v1::Instance> GetInstance(GetInstanceParams gip) override {
+    gcsa::v1::GetInstanceRequest request;
     request.set_name(std::move(gip.instance_name));
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::GetInstanceRequest const& request) {
+               gcsa::v1::GetInstanceRequest const& request) {
           return stub_->GetInstance(context, request);
         },
         request, __func__);
   }
 
-  future<StatusOr<gcsa::Instance>> CreateInstance(
+  future<StatusOr<gcsa::v1::Instance>> CreateInstance(
       CreateInstanceParams p) override {
     auto stub = stub_;
-    return google::cloud::internal::AsyncLongRunningOperation<gcsa::Instance>(
+    return google::cloud::internal::AsyncLongRunningOperation<
+        gcsa::v1::Instance>(
         background_threads_->cq(), std::move(p.request),
         [stub](google::cloud::CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
-               gcsa::CreateInstanceRequest const& request) {
+               gcsa::v1::CreateInstanceRequest const& request) {
           return stub->AsyncCreateInstance(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -85,20 +86,21 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
           return stub->AsyncCancelOperation(cq, std::move(context), request);
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
-            gcsa::Instance>,
+            gcsa::v1::Instance>,
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kNonIdempotent, polling_policy_prototype_->clone(),
         __func__);
   }
 
-  future<StatusOr<gcsa::Instance>> UpdateInstance(
+  future<StatusOr<gcsa::v1::Instance>> UpdateInstance(
       UpdateInstanceParams p) override {
     auto stub = stub_;
-    return google::cloud::internal::AsyncLongRunningOperation<gcsa::Instance>(
+    return google::cloud::internal::AsyncLongRunningOperation<
+        gcsa::v1::Instance>(
         background_threads_->cq(), std::move(p.request),
         [stub](google::cloud::CompletionQueue& cq,
                std::unique_ptr<grpc::ClientContext> context,
-               gcsa::UpdateInstanceRequest const& request) {
+               gcsa::v1::UpdateInstanceRequest const& request) {
           return stub->AsyncUpdateInstance(cq, std::move(context), request);
         },
         [stub](google::cloud::CompletionQueue& cq,
@@ -112,33 +114,33 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
           return stub->AsyncCancelOperation(cq, std::move(context), request);
         },
         &google::cloud::internal::ExtractLongRunningResultResponse<
-            gcsa::Instance>,
+            gcsa::v1::Instance>,
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent, polling_policy_prototype_->clone(), __func__);
   }
 
   Status DeleteInstance(DeleteInstanceParams p) override {
-    gcsa::DeleteInstanceRequest request;
+    gcsa::v1::DeleteInstanceRequest request;
     request.set_name(std::move(p.instance_name));
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::DeleteInstanceRequest const& request) {
+               gcsa::v1::DeleteInstanceRequest const& request) {
           return stub_->DeleteInstance(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
+  StatusOr<gcsa::v1::InstanceConfig> GetInstanceConfig(
       GetInstanceConfigParams p) override {
-    gcsa::GetInstanceConfigRequest request;
+    gcsa::v1::GetInstanceConfigRequest request;
     request.set_name(std::move(p.instance_config_name));
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               gcsa::GetInstanceConfigRequest const& request) {
+               gcsa::v1::GetInstanceConfigRequest const& request) {
           return stub_->GetInstanceConfig(context, request);
         },
         request, __func__);
@@ -146,7 +148,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
 
   ListInstanceConfigsRange ListInstanceConfigs(
       ListInstanceConfigsParams params) override {
-    gcsa::ListInstanceConfigsRequest request;
+    gcsa::v1::ListInstanceConfigsRequest request;
     request.set_parent("projects/" + params.project_id);
     request.clear_page_token();
     auto stub = stub_;
@@ -161,17 +163,18 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         ListInstanceConfigsRange>(
         std::move(request),
         [stub, retry, backoff,
-         function_name](gcsa::ListInstanceConfigsRequest const& r) {
+         function_name](gcsa::v1::ListInstanceConfigsRequest const& r) {
           return RetryLoop(
               retry->clone(), backoff->clone(), Idempotency::kIdempotent,
               [stub](grpc::ClientContext& context,
-                     gcsa::ListInstanceConfigsRequest const& request) {
+                     gcsa::v1::ListInstanceConfigsRequest const& request) {
                 return stub->ListInstanceConfigs(context, request);
               },
               r, function_name);
         },
-        [](gcsa::ListInstanceConfigsResponse r) {
-          std::vector<gcsa::InstanceConfig> result(r.instance_configs().size());
+        [](gcsa::v1::ListInstanceConfigsResponse r) {
+          std::vector<gcsa::v1::InstanceConfig> result(
+              r.instance_configs().size());
           auto& configs = *r.mutable_instance_configs();
           std::move(configs.begin(), configs.end(), result.begin());
           return result;
@@ -179,7 +182,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
   }
 
   ListInstancesRange ListInstances(ListInstancesParams params) override {
-    gcsa::ListInstancesRequest request;
+    gcsa::v1::ListInstancesRequest request;
     request.set_parent("projects/" + params.project_id);
     request.set_filter(std::move(params.filter));
     request.clear_page_token();
@@ -194,37 +197,39 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
     return google::cloud::internal::MakePaginationRange<ListInstancesRange>(
         std::move(request),
         [stub, retry, backoff,
-         function_name](gcsa::ListInstancesRequest const& r) {
+         function_name](gcsa::v1::ListInstancesRequest const& r) {
           return RetryLoop(
               retry->clone(), backoff->clone(), Idempotency::kIdempotent,
               [stub](grpc::ClientContext& context,
-                     gcsa::ListInstancesRequest const& request) {
+                     gcsa::v1::ListInstancesRequest const& request) {
                 return stub->ListInstances(context, request);
               },
               r, function_name);
         },
-        [](gcsa::ListInstancesResponse r) {
-          std::vector<gcsa::Instance> result(r.instances().size());
+        [](gcsa::v1::ListInstancesResponse r) {
+          std::vector<gcsa::v1::Instance> result(r.instances().size());
           auto& instances = *r.mutable_instances();
           std::move(instances.begin(), instances.end(), result.begin());
           return result;
         });
   }
 
-  StatusOr<giam::Policy> GetIamPolicy(GetIamPolicyParams p) override {
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
+      GetIamPolicyParams p) override {
     google::iam::v1::GetIamPolicyRequest request;
     request.set_resource(std::move(p.instance_name));
     return RetryLoop(
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               giam::GetIamPolicyRequest const& request) {
+               google::iam::v1::GetIamPolicyRequest const& request) {
           return stub_->GetIamPolicy(context, request);
         },
         request, __func__);
   }
 
-  StatusOr<giam::Policy> SetIamPolicy(SetIamPolicyParams p) override {
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
+      SetIamPolicyParams p) override {
     google::iam::v1::SetIamPolicyRequest request;
     request.set_resource(std::move(p.instance_name));
     *request.mutable_policy() = std::move(p.policy);
@@ -235,7 +240,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         idempotency,
         [this](grpc::ClientContext& context,
-               giam::SetIamPolicyRequest const& request) {
+               google::iam::v1::SetIamPolicyRequest const& request) {
           return stub_->SetIamPolicy(context, request);
         },
         request, __func__);
@@ -252,7 +257,7 @@ class InstanceAdminConnectionImpl : public InstanceAdminConnection {
         retry_policy_prototype_->clone(), backoff_policy_prototype_->clone(),
         Idempotency::kIdempotent,
         [this](grpc::ClientContext& context,
-               giam::TestIamPermissionsRequest const& request) {
+               google::iam::v1::TestIamPermissionsRequest const& request) {
           return stub_->TestIamPermissions(context, request);
         },
         request, __func__);

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -35,6 +35,8 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+namespace spanner_proto = ::google::spanner;
+
 using ::google::cloud::Idempotency;
 
 class DefaultPartialResultSetReader : public PartialResultSetReader {
@@ -68,28 +70,26 @@ class DefaultPartialResultSetReader : public PartialResultSetReader {
       reader_;
 };
 
-namespace spanner_proto = ::google::spanner::v1;
-
-spanner_proto::TransactionOptions PartitionedDmlTransactionOptions() {
-  spanner_proto::TransactionOptions options;
+spanner_proto::v1::TransactionOptions PartitionedDmlTransactionOptions() {
+  spanner_proto::v1::TransactionOptions options;
   *options.mutable_partitioned_dml() =
-      spanner_proto::TransactionOptions_PartitionedDml();
+      spanner_proto::v1::TransactionOptions_PartitionedDml();
   return options;
 }
 
-spanner_proto::RequestOptions_Priority ProtoRequestPriority(
+spanner_proto::v1::RequestOptions_Priority ProtoRequestPriority(
     absl::optional<spanner::RequestPriority> const& request_priority) {
   if (request_priority) {
     switch (*request_priority) {
       case spanner::RequestPriority::kLow:
-        return spanner_proto::RequestOptions::PRIORITY_LOW;
+        return spanner_proto::v1::RequestOptions::PRIORITY_LOW;
       case spanner::RequestPriority::kMedium:
-        return spanner_proto::RequestOptions::PRIORITY_MEDIUM;
+        return spanner_proto::v1::RequestOptions::PRIORITY_MEDIUM;
       case spanner::RequestPriority::kHigh:
-        return spanner_proto::RequestOptions::PRIORITY_HIGH;
+        return spanner_proto::v1::RequestOptions::PRIORITY_HIGH;
     }
   }
-  return spanner_proto::RequestOptions::PRIORITY_UNSPECIFIED;
+  return spanner_proto::v1::RequestOptions::PRIORITY_UNSPECIFIED;
 }
 
 // Operations that set `TransactionSelector::begin` in the request and receive
@@ -113,74 +113,76 @@ ConnectionImpl::ConnectionImpl(
                                     background_threads_->cq(), opts_)) {}
 
 spanner::RowStream ConnectionImpl::Read(ReadParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t) {
-                 return ReadImpl(session, s, tag, std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t) {
+        return ReadImpl(session, s, tag, std::move(params));
+      });
 }
 
 StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionRead(
     PartitionReadParams params) {
-  return Visit(std::move(params.read_params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t) {
-                 return PartitionReadImpl(session, s, tag, params.read_params,
-                                          params.partition_options);
-               });
+  return Visit(
+      std::move(params.read_params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t) {
+        return PartitionReadImpl(session, s, tag, params.read_params,
+                                 params.partition_options);
+      });
 }
 
 spanner::RowStream ConnectionImpl::ExecuteQuery(SqlParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t seqno) {
-                 return ExecuteQueryImpl(session, s, tag, seqno,
-                                         std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t seqno) {
+        return ExecuteQueryImpl(session, s, tag, seqno, std::move(params));
+      });
 }
 
 StatusOr<spanner::DmlResult> ConnectionImpl::ExecuteDml(SqlParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t seqno) {
-                 return ExecuteDmlImpl(session, s, tag, seqno,
-                                       std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t seqno) {
+        return ExecuteDmlImpl(session, s, tag, seqno, std::move(params));
+      });
 }
 
 spanner::ProfileQueryResult ConnectionImpl::ProfileQuery(SqlParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t seqno) {
-                 return ProfileQueryImpl(session, s, tag, seqno,
-                                         std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t seqno) {
+        return ProfileQueryImpl(session, s, tag, seqno, std::move(params));
+      });
 }
 
 StatusOr<spanner::ProfileDmlResult> ConnectionImpl::ProfileDml(
     SqlParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t seqno) {
-                 return ProfileDmlImpl(session, s, tag, seqno,
-                                       std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t seqno) {
+        return ProfileDmlImpl(session, s, tag, seqno, std::move(params));
+      });
 }
 
 StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSql(SqlParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t seqno) {
-                 return AnalyzeSqlImpl(session, s, tag, seqno,
-                                       std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t seqno) {
+        return AnalyzeSqlImpl(session, s, tag, seqno, std::move(params));
+      });
 }
 
 StatusOr<spanner::PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
@@ -188,7 +190,7 @@ StatusOr<spanner::PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
   auto txn = spanner::MakeReadOnlyTransaction();  // becomes partitioned DML
   return Visit(txn, [this, &params](
                         SessionHolder& session,
-                        StatusOr<spanner_proto::TransactionSelector>& s,
+                        StatusOr<spanner_proto::v1::TransactionSelector>& s,
                         std::string const& tag, std::int64_t seqno) {
     return ExecutePartitionedDmlImpl(session, s, tag, seqno, std::move(params));
   });
@@ -196,38 +198,40 @@ StatusOr<spanner::PartitionedDmlResult> ConnectionImpl::ExecutePartitionedDml(
 
 StatusOr<std::vector<spanner::QueryPartition>> ConnectionImpl::PartitionQuery(
     PartitionQueryParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t) {
-                 return PartitionQueryImpl(session, s, tag, params);
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t) {
+        return PartitionQueryImpl(session, s, tag, params);
+      });
 }
 
 StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDml(
     ExecuteBatchDmlParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t seqno) {
-                 return ExecuteBatchDmlImpl(session, s, tag, seqno,
-                                            std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t seqno) {
+        return ExecuteBatchDmlImpl(session, s, tag, seqno, std::move(params));
+      });
 }
 
 StatusOr<spanner::CommitResult> ConnectionImpl::Commit(CommitParams params) {
-  return Visit(std::move(params.transaction),
-               [this, &params](SessionHolder& session,
-                               StatusOr<spanner_proto::TransactionSelector>& s,
-                               std::string const& tag, std::int64_t) {
-                 return this->CommitImpl(session, s, tag, std::move(params));
-               });
+  return Visit(
+      std::move(params.transaction),
+      [this, &params](SessionHolder& session,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
+                      std::string const& tag, std::int64_t) {
+        return this->CommitImpl(session, s, tag, std::move(params));
+      });
 }
 
 Status ConnectionImpl::Rollback(RollbackParams params) {
   return Visit(std::move(params.transaction),
                [this](SessionHolder& session,
-                      StatusOr<spanner_proto::TransactionSelector>& s,
+                      StatusOr<spanner_proto::v1::TransactionSelector>& s,
                       std::string const& tag, std::int64_t) {
                  return this->RollbackImpl(session, s, tag);
                });
@@ -261,12 +265,12 @@ ResultType MakeStatusOnlyResult(Status status) {
 class DmlResultSetSource : public ResultSourceInterface {
  public:
   static StatusOr<std::unique_ptr<ResultSourceInterface>> Create(
-      spanner_proto::ResultSet result_set) {
+      spanner_proto::v1::ResultSet result_set) {
     return std::unique_ptr<ResultSourceInterface>(
         new DmlResultSetSource(std::move(result_set)));
   }
 
-  explicit DmlResultSetSource(spanner_proto::ResultSet result_set)
+  explicit DmlResultSetSource(spanner_proto::v1::ResultSet result_set)
       : result_set_(std::move(result_set)) {}
   ~DmlResultSetSource() override = default;
 
@@ -287,7 +291,7 @@ class DmlResultSetSource : public ResultSourceInterface {
   }
 
  private:
-  spanner_proto::ResultSet result_set_;
+  spanner_proto::v1::ResultSet result_set_;
 };
 
 // Used as an intermediary for streaming PartitionedDml operations.
@@ -386,11 +390,11 @@ Status ConnectionImpl::PrepareSession(SessionHolder& session,
  * @param func identifies the calling function for logging purposes.
  *   It should generally be passed the value of `__func__`.
  */
-StatusOr<spanner_proto::Transaction> ConnectionImpl::BeginTransaction(
-    SessionHolder& session, spanner_proto::TransactionOptions options,
+StatusOr<spanner_proto::v1::Transaction> ConnectionImpl::BeginTransaction(
+    SessionHolder& session, spanner_proto::v1::TransactionOptions options,
     std::string request_tag, std::string const& transaction_tag,
     char const* func) {
-  spanner_proto::BeginTransactionRequest begin;
+  spanner_proto::v1::BeginTransactionRequest begin;
   begin.set_session(session->session_name());
   *begin.mutable_options() = std::move(options);
   // `begin.request_options.priority` is ignored. To set the priority
@@ -404,7 +408,7 @@ StatusOr<spanner_proto::Transaction> ConnectionImpl::BeginTransaction(
       RetryPolicyPrototype()->clone(), BackoffPolicyPrototype()->clone(),
       Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
-              spanner_proto::BeginTransactionRequest const& request) {
+              spanner_proto::v1::BeginTransactionRequest const& request) {
         return stub->BeginTransaction(context, request);
       },
       begin, func);
@@ -417,7 +421,7 @@ StatusOr<spanner_proto::Transaction> ConnectionImpl::BeginTransaction(
 }
 
 spanner::RowStream ConnectionImpl::ReadImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, ReadParams params) {
   if (!s.ok()) {
     return MakeStatusOnlyResult<spanner::RowStream>(s.status());
@@ -428,7 +432,7 @@ spanner::RowStream ConnectionImpl::ReadImpl(
     return MakeStatusOnlyResult<spanner::RowStream>(std::move(prepare_status));
   }
 
-  auto request = std::make_shared<spanner_proto::ReadRequest>();
+  auto request = std::make_shared<spanner_proto::v1::ReadRequest>();
   request->set_session(session->session_name());
   *request->mutable_transaction() = *s;
   request->set_table(std::move(params.table));
@@ -503,7 +507,7 @@ spanner::RowStream ConnectionImpl::ReadImpl(
 }
 
 StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, ReadParams const& params,
     spanner::PartitionOptions const& partition_options) {
   if (!s.ok()) {
@@ -517,7 +521,7 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
     return prepare_status;
   }
 
-  spanner_proto::PartitionReadRequest request;
+  spanner_proto::v1::PartitionReadRequest request;
   request.set_session(session->session_name());
   *request.mutable_transaction() = *s;
   request.set_table(params.table);
@@ -534,7 +538,7 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
         RetryPolicyPrototype()->clone(), BackoffPolicyPrototype()->clone(),
         Idempotency::kIdempotent,
         [&stub](grpc::ClientContext& context,
-                spanner_proto::PartitionReadRequest const& request) {
+                spanner_proto::v1::PartitionReadRequest const& request) {
           return stub->PartitionRead(context, request);
         },
         request, __func__);
@@ -577,7 +581,7 @@ StatusOr<std::vector<spanner::ReadPartition>> ConnectionImpl::PartitionReadImpl(
 
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode,
     std::function<StatusOr<std::unique_ptr<ResultSourceInterface>>(
@@ -587,7 +591,7 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
     return s.status();
   }
 
-  spanner_proto::ExecuteSqlRequest request;
+  spanner_proto::v1::ExecuteSqlRequest request;
   request.set_session(session->session_name());
   *request.mutable_transaction() = *s;
   auto sql_statement = ToProto(std::move(params.statement));
@@ -647,7 +651,7 @@ StatusOr<ResultType> ConnectionImpl::ExecuteSqlImpl(
 
 template <typename ResultType>
 ResultType ConnectionImpl::CommonQueryImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   if (!s.ok()) {
@@ -668,7 +672,7 @@ ResultType ConnectionImpl::CommonQueryImpl(
   auto const& tracing_options = RpcTracingOptions();
   auto retry_resume_fn =
       [stub, retry_policy_prototype, backoff_policy_prototype, tracing_enabled,
-       tracing_options](spanner_proto::ExecuteSqlRequest& request) mutable
+       tracing_options](spanner_proto::v1::ExecuteSqlRequest& request) mutable
       -> StatusOr<std::unique_ptr<ResultSourceInterface>> {
     auto factory = [stub, request, tracing_enabled,
                     tracing_options](std::string const& resume_token) mutable {
@@ -702,24 +706,24 @@ ResultType ConnectionImpl::CommonQueryImpl(
 }
 
 spanner::RowStream ConnectionImpl::ExecuteQueryImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<spanner::RowStream>(
       session, s, transaction_tag, seqno, std::move(params),
-      spanner_proto::ExecuteSqlRequest::NORMAL);
+      spanner_proto::v1::ExecuteSqlRequest::NORMAL);
 }
 
 spanner::ProfileQueryResult ConnectionImpl::ProfileQueryImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonQueryImpl<spanner::ProfileQueryResult>(
       session, s, transaction_tag, seqno, std::move(params),
-      spanner_proto::ExecuteSqlRequest::PROFILE);
+      spanner_proto::v1::ExecuteSqlRequest::PROFILE);
 }
 
 template <typename ResultType>
 StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params,
     google::spanner::v1::ExecuteSqlRequest::QueryMode query_mode) {
   if (!s.ok()) {
@@ -739,13 +743,13 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
 
   auto retry_resume_fn =
       [function_name, stub, retry_policy_prototype, backoff_policy_prototype,
-       session](spanner_proto::ExecuteSqlRequest& request) mutable
+       session](spanner_proto::v1::ExecuteSqlRequest& request) mutable
       -> StatusOr<std::unique_ptr<ResultSourceInterface>> {
-    StatusOr<spanner_proto::ResultSet> response = RetryLoop(
+    StatusOr<spanner_proto::v1::ResultSet> response = RetryLoop(
         retry_policy_prototype->clone(), backoff_policy_prototype->clone(),
         Idempotency::kIdempotent,
         [stub](grpc::ClientContext& context,
-               spanner_proto::ExecuteSqlRequest const& request) {
+               spanner_proto::v1::ExecuteSqlRequest const& request) {
           return stub->ExecuteSql(context, request);
         },
         request, function_name);
@@ -762,27 +766,27 @@ StatusOr<ResultType> ConnectionImpl::CommonDmlImpl(
 }
 
 StatusOr<spanner::DmlResult> ConnectionImpl::ExecuteDmlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<spanner::DmlResult>(
       session, s, transaction_tag, seqno, std::move(params),
-      spanner_proto::ExecuteSqlRequest::NORMAL);
+      spanner_proto::v1::ExecuteSqlRequest::NORMAL);
 }
 
 StatusOr<spanner::ProfileDmlResult> ConnectionImpl::ProfileDmlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   return CommonDmlImpl<spanner::ProfileDmlResult>(
       session, s, transaction_tag, seqno, std::move(params),
-      spanner_proto::ExecuteSqlRequest::PROFILE);
+      spanner_proto::v1::ExecuteSqlRequest::PROFILE);
 }
 
 StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno, SqlParams params) {
   auto result = CommonDmlImpl<spanner::ProfileDmlResult>(
       session, s, transaction_tag, seqno, std::move(params),
-      spanner_proto::ExecuteSqlRequest::PLAN);
+      spanner_proto::v1::ExecuteSqlRequest::PLAN);
   if (result.status().ok()) {
     return *result->ExecutionPlan();
   }
@@ -791,7 +795,7 @@ StatusOr<spanner::ExecutionPlan> ConnectionImpl::AnalyzeSqlImpl(
 
 StatusOr<std::vector<spanner::QueryPartition>>
 ConnectionImpl::PartitionQueryImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, PartitionQueryParams const& params) {
   if (!s.ok()) {
     return s.status();
@@ -804,7 +808,7 @@ ConnectionImpl::PartitionQueryImpl(
     return prepare_status;
   }
 
-  spanner_proto::PartitionQueryRequest request;
+  spanner_proto::v1::PartitionQueryRequest request;
   request.set_session(session->session_name());
   *request.mutable_transaction() = *s;
   auto sql_statement = ToProto(params.statement);
@@ -821,7 +825,7 @@ ConnectionImpl::PartitionQueryImpl(
         RetryPolicyPrototype()->clone(), BackoffPolicyPrototype()->clone(),
         Idempotency::kIdempotent,
         [&stub](grpc::ClientContext& context,
-                spanner_proto::PartitionQueryRequest const& request) {
+                spanner_proto::v1::PartitionQueryRequest const& request) {
           return stub->PartitionQuery(context, request);
         },
         request, __func__);
@@ -861,7 +865,7 @@ ConnectionImpl::PartitionQueryImpl(
 }
 
 StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno,
     ExecuteBatchDmlParams params) {
   if (!s.ok()) {
@@ -873,7 +877,7 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
     return prepare_status;
   }
 
-  spanner_proto::ExecuteBatchDmlRequest request;
+  spanner_proto::v1::ExecuteBatchDmlRequest request;
   request.set_session(session->session_name());
   request.set_seqno(seqno);
   *request.mutable_transaction() = *s;
@@ -884,7 +888,7 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
       params.options.has<spanner::RequestPriorityOption>()
           ? ProtoRequestPriority(
                 params.options.get<spanner::RequestPriorityOption>())
-          : spanner_proto::RequestOptions::PRIORITY_UNSPECIFIED);
+          : spanner_proto::v1::RequestOptions::PRIORITY_UNSPECIFIED);
   auto const& request_tag = params.options.get<spanner::RequestTagOption>();
   request.mutable_request_options()->set_request_tag(request_tag);
   request.mutable_request_options()->set_transaction_tag(transaction_tag);
@@ -895,7 +899,7 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
         RetryPolicyPrototype()->clone(), BackoffPolicyPrototype()->clone(),
         Idempotency::kIdempotent,
         [&stub](grpc::ClientContext& context,
-                spanner_proto::ExecuteBatchDmlRequest const& request) {
+                spanner_proto::v1::ExecuteBatchDmlRequest const& request) {
           return stub->ExecuteBatchDml(context, request);
         },
         request, __func__);
@@ -933,7 +937,7 @@ StatusOr<spanner::BatchDmlResult> ConnectionImpl::ExecuteBatchDmlImpl(
 
 StatusOr<spanner::PartitionedDmlResult>
 ConnectionImpl::ExecutePartitionedDmlImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, std::int64_t seqno,
     ExecutePartitionedDmlParams params) {
   if (!s.ok()) {
@@ -961,7 +965,7 @@ ConnectionImpl::ExecutePartitionedDmlImpl(
                         /*partition_token=*/{}});
   auto dml_result = CommonQueryImpl<StreamingPartitionedDmlResult>(
       session, s, transaction_tag, seqno, std::move(sql_params),
-      spanner_proto::ExecuteSqlRequest::NORMAL);
+      spanner_proto::v1::ExecuteSqlRequest::NORMAL);
   auto rows_modified = dml_result.RowsModifiedLowerBound();
   if (!rows_modified.ok()) {
     auto status = std::move(rows_modified).status();
@@ -974,7 +978,7 @@ ConnectionImpl::ExecutePartitionedDmlImpl(
 }
 
 StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag, CommitParams params) {
   if (!s.ok()) {
     // Fail the commit if the transaction has been invalidated.
@@ -986,7 +990,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
     return prepare_status;
   }
 
-  spanner_proto::CommitRequest request;
+  spanner_proto::v1::CommitRequest request;
   request.set_session(session->session_name());
   for (auto&& m : params.mutations) {
     *request.add_mutations() = std::move(m).as_proto();
@@ -1000,7 +1004,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
   // ignored (for a user-supplied transaction).
   request.mutable_request_options()->set_transaction_tag(transaction_tag);
 
-  if (s->selector_case() != spanner_proto::TransactionSelector::kId) {
+  if (s->selector_case() != spanner_proto::v1::TransactionSelector::kId) {
     auto begin =
         BeginTransaction(session, s->has_begin() ? s->begin() : s->single_use(),
                          std::string(), transaction_tag, __func__);
@@ -1017,7 +1021,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
       RetryPolicyPrototype()->clone(), BackoffPolicyPrototype()->clone(),
       Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
-              spanner_proto::CommitRequest const& request) {
+              spanner_proto::v1::CommitRequest const& request) {
         return stub->Commit(context, request);
       },
       request, __func__);
@@ -1046,7 +1050,7 @@ StatusOr<spanner::CommitResult> ConnectionImpl::CommitImpl(
 }
 
 Status ConnectionImpl::RollbackImpl(
-    SessionHolder& session, StatusOr<spanner_proto::TransactionSelector>& s,
+    SessionHolder& session, StatusOr<spanner_proto::v1::TransactionSelector>& s,
     std::string const& transaction_tag) {
   if (!s.ok()) {
     return s.status();
@@ -1071,7 +1075,7 @@ Status ConnectionImpl::RollbackImpl(
     s->set_id(begin->id());
   }
 
-  spanner_proto::RollbackRequest request;
+  spanner_proto::v1::RollbackRequest request;
   request.set_session(session->session_name());
   request.set_transaction_id(s->id());
   auto stub = session_pool_->GetStub(*session);
@@ -1079,7 +1083,7 @@ Status ConnectionImpl::RollbackImpl(
       RetryPolicyPrototype()->clone(), BackoffPolicyPrototype()->clone(),
       Idempotency::kIdempotent,
       [&stub](grpc::ClientContext& context,
-              spanner_proto::RollbackRequest const& request) {
+              spanner_proto::v1::RollbackRequest const& request) {
         return stub->Rollback(context, request);
       },
       request, __func__);

--- a/google/cloud/spanner/internal/database_admin_logging.cc
+++ b/google/cloud/spanner/internal/database_admin_logging.cc
@@ -21,36 +21,38 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::database::v1;
+namespace gcsa = ::google::spanner::admin::database;
+
 using ::google::cloud::internal::LogWrapper;
 
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminLogging::AsyncCreateDatabase(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::CreateDatabaseRequest const& request) {
+    gcsa::v1::CreateDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             gcsa::CreateDatabaseRequest const& request) {
+             gcsa::v1::CreateDatabaseRequest const& request) {
         return child_->AsyncCreateDatabase(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::Database> DatabaseAdminLogging::GetDatabase(
-    grpc::ClientContext& context, gcsa::GetDatabaseRequest const& request) {
+StatusOr<gcsa::v1::Database> DatabaseAdminLogging::GetDatabase(
+    grpc::ClientContext& context, gcsa::v1::GetDatabaseRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::GetDatabaseRequest const& request) {
+             gcsa::v1::GetDatabaseRequest const& request) {
         return child_->GetDatabase(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminLogging::GetDatabaseDdl(
-    grpc::ClientContext& context, gcsa::GetDatabaseDdlRequest const& request) {
+StatusOr<gcsa::v1::GetDatabaseDdlResponse> DatabaseAdminLogging::GetDatabaseDdl(
+    grpc::ClientContext& context,
+    gcsa::v1::GetDatabaseDdlRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::GetDatabaseDdlRequest const& request) {
+             gcsa::v1::GetDatabaseDdlRequest const& request) {
         return child_->GetDatabaseDdl(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -59,10 +61,10 @@ StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminLogging::GetDatabaseDdl(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminLogging::AsyncUpdateDatabaseDdl(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::UpdateDatabaseDdlRequest const& request) {
+    gcsa::v1::UpdateDatabaseDdlRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             gcsa::UpdateDatabaseDdlRequest const& request) {
+             gcsa::v1::UpdateDatabaseDdlRequest const& request) {
         return child_->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
@@ -73,7 +75,7 @@ Status DatabaseAdminLogging::DropDatabase(
     google::spanner::admin::database::v1::DropDatabaseRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::DropDatabaseRequest const& request) {
+             gcsa::v1::DropDatabaseRequest const& request) {
         return child_->DropDatabase(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -93,10 +95,10 @@ DatabaseAdminLogging::ListDatabases(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminLogging::AsyncRestoreDatabase(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::RestoreDatabaseRequest const& request) {
+    gcsa::v1::RestoreDatabaseRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             gcsa::RestoreDatabaseRequest const& request) {
+             gcsa::v1::RestoreDatabaseRequest const& request) {
         return child_->AsyncRestoreDatabase(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
@@ -139,20 +141,20 @@ DatabaseAdminLogging::TestIamPermissions(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminLogging::AsyncCreateBackup(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::CreateBackupRequest const& request) {
+    gcsa::v1::CreateBackupRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             gcsa::CreateBackupRequest const& request) {
+             gcsa::v1::CreateBackupRequest const& request) {
         return child_->AsyncCreateBackup(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminLogging::GetBackup(
-    grpc::ClientContext& context, gcsa::GetBackupRequest const& request) {
+StatusOr<gcsa::v1::Backup> DatabaseAdminLogging::GetBackup(
+    grpc::ClientContext& context, gcsa::v1::GetBackupRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::GetBackupRequest const& request) {
+             gcsa::v1::GetBackupRequest const& request) {
         return child_->GetBackup(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -163,7 +165,7 @@ Status DatabaseAdminLogging::DeleteBackup(
     google::spanner::admin::database::v1::DeleteBackupRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::DeleteBackupRequest const& request) {
+             gcsa::v1::DeleteBackupRequest const& request) {
         return child_->DeleteBackup(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -180,11 +182,12 @@ DatabaseAdminLogging::ListBackups(
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminLogging::UpdateBackup(
-    grpc::ClientContext& context, gcsa::UpdateBackupRequest const& request) {
+StatusOr<gcsa::v1::Backup> DatabaseAdminLogging::UpdateBackup(
+    grpc::ClientContext& context,
+    gcsa::v1::UpdateBackupRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::UpdateBackupRequest const& request) {
+             gcsa::v1::UpdateBackupRequest const& request) {
         return child_->UpdateBackup(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/google/cloud/spanner/internal/database_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/database_admin_logging_test.cc
@@ -28,10 +28,11 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace gcsa = ::google::spanner::admin::database;
+
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
-namespace gcsa = ::google::spanner::admin::database::v1;
 
 class DatabaseAdminLoggingTest : public ::testing::Test {
  protected:
@@ -50,7 +51,7 @@ class DatabaseAdminLoggingTest : public ::testing::Test {
 TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateDatabaseRequest const&) {
+                   gcsa::v1::CreateDatabaseRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -60,7 +61,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateDatabase) {
   CompletionQueue cq;
   auto response =
       stub.AsyncCreateDatabase(cq, absl::make_unique<grpc::ClientContext>(),
-                               gcsa::CreateDatabaseRequest{});
+                               gcsa::v1::CreateDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -74,7 +75,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response = stub.GetDatabase(context, gcsa::GetDatabaseRequest{});
+  auto response = stub.GetDatabase(context, gcsa::v1::GetDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -88,7 +89,8 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response = stub.GetDatabaseDdl(context, gcsa::GetDatabaseDdlRequest{});
+  auto response =
+      stub.GetDatabaseDdl(context, gcsa::v1::GetDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -99,7 +101,7 @@ TEST_F(DatabaseAdminLoggingTest, GetDatabaseDdl) {
 TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::UpdateDatabaseDdlRequest const&) {
+                   gcsa::v1::UpdateDatabaseDdlRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -109,7 +111,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateDatabase) {
   CompletionQueue cq;
   auto response =
       stub.AsyncUpdateDatabaseDdl(cq, absl::make_unique<grpc::ClientContext>(),
-                                  gcsa::UpdateDatabaseDdlRequest{});
+                                  gcsa::v1::UpdateDatabaseDdlRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -123,7 +125,7 @@ TEST_F(DatabaseAdminLoggingTest, DropDatabase) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto status = stub.DropDatabase(context, gcsa::DropDatabaseRequest{});
+  auto status = stub.DropDatabase(context, gcsa::v1::DropDatabaseRequest{});
   EXPECT_EQ(TransientError(), status);
 
   auto const log_lines = log_.ExtractLines();
@@ -137,7 +139,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response = stub.ListDatabases(context, gcsa::ListDatabasesRequest{});
+  auto response = stub.ListDatabases(context, gcsa::v1::ListDatabasesRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -148,7 +150,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabases) {
 TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   EXPECT_CALL(*mock_, AsyncRestoreDatabase)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::RestoreDatabaseRequest const&) {
+                   gcsa::v1::RestoreDatabaseRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -158,7 +160,7 @@ TEST_F(DatabaseAdminLoggingTest, RestoreDatabase) {
   CompletionQueue cq;
   auto response =
       stub.AsyncRestoreDatabase(cq, absl::make_unique<grpc::ClientContext>(),
-                                gcsa::RestoreDatabaseRequest{});
+                                gcsa::v1::RestoreDatabaseRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -214,7 +216,7 @@ TEST_F(DatabaseAdminLoggingTest, TestIamPermissions) {
 TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateBackupRequest const&) {
+                   gcsa::v1::CreateBackupRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -224,7 +226,7 @@ TEST_F(DatabaseAdminLoggingTest, CreateBackup) {
   CompletionQueue cq;
   auto response =
       stub.AsyncCreateBackup(cq, absl::make_unique<grpc::ClientContext>(),
-                             gcsa::CreateBackupRequest{});
+                             gcsa::v1::CreateBackupRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -238,7 +240,7 @@ TEST_F(DatabaseAdminLoggingTest, GetBackup) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto status = stub.GetBackup(context, gcsa::GetBackupRequest{});
+  auto status = stub.GetBackup(context, gcsa::v1::GetBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -252,7 +254,7 @@ TEST_F(DatabaseAdminLoggingTest, DeleteBackup) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto status = stub.DeleteBackup(context, gcsa::DeleteBackupRequest{});
+  auto status = stub.DeleteBackup(context, gcsa::v1::DeleteBackupRequest{});
   EXPECT_EQ(TransientError(), status);
 
   auto const log_lines = log_.ExtractLines();
@@ -266,7 +268,7 @@ TEST_F(DatabaseAdminLoggingTest, ListBackups) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response = stub.ListBackups(context, gcsa::ListBackupsRequest{});
+  auto response = stub.ListBackups(context, gcsa::v1::ListBackupsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -280,7 +282,7 @@ TEST_F(DatabaseAdminLoggingTest, UpdateBackup) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto status = stub.UpdateBackup(context, gcsa::UpdateBackupRequest{});
+  auto status = stub.UpdateBackup(context, gcsa::v1::UpdateBackupRequest{});
   EXPECT_EQ(TransientError(), status.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -294,8 +296,8 @@ TEST_F(DatabaseAdminLoggingTest, ListBackupOperations) {
   DatabaseAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response =
-      stub.ListBackupOperations(context, gcsa::ListBackupOperationsRequest{});
+  auto response = stub.ListBackupOperations(
+      context, gcsa::v1::ListBackupOperationsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -311,7 +313,7 @@ TEST_F(DatabaseAdminLoggingTest, ListDatabaseOperations) {
 
   grpc::ClientContext context;
   auto response = stub.ListDatabaseOperations(
-      context, gcsa::ListDatabaseOperationsRequest{});
+      context, gcsa::v1::ListDatabaseOperationsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();

--- a/google/cloud/spanner/internal/database_admin_metadata.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata.cc
@@ -21,7 +21,7 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::database::v1;
+namespace gcsa = ::google::spanner::admin::database;
 
 DatabaseAdminMetadata::DatabaseAdminMetadata(
     std::shared_ptr<DatabaseAdminStub> child)
@@ -31,19 +31,21 @@ DatabaseAdminMetadata::DatabaseAdminMetadata(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminMetadata::AsyncCreateDatabase(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::CreateDatabaseRequest const& request) {
+    gcsa::v1::CreateDatabaseRequest const& request) {
   SetMetadata(*context, "parent=" + request.parent());
   return child_->AsyncCreateDatabase(cq, std::move(context), request);
 }
 
-StatusOr<gcsa::Database> DatabaseAdminMetadata::GetDatabase(
-    grpc::ClientContext& context, gcsa::GetDatabaseRequest const& request) {
+StatusOr<gcsa::v1::Database> DatabaseAdminMetadata::GetDatabase(
+    grpc::ClientContext& context, gcsa::v1::GetDatabaseRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetDatabase(context, request);
 }
 
-StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminMetadata::GetDatabaseDdl(
-    grpc::ClientContext& context, gcsa::GetDatabaseDdlRequest const& request) {
+StatusOr<gcsa::v1::GetDatabaseDdlResponse>
+DatabaseAdminMetadata::GetDatabaseDdl(
+    grpc::ClientContext& context,
+    gcsa::v1::GetDatabaseDdlRequest const& request) {
   SetMetadata(context, "database=" + request.database());
   return child_->GetDatabaseDdl(context, request);
 }
@@ -51,7 +53,7 @@ StatusOr<gcsa::GetDatabaseDdlResponse> DatabaseAdminMetadata::GetDatabaseDdl(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminMetadata::AsyncUpdateDatabaseDdl(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::UpdateDatabaseDdlRequest const& request) {
+    gcsa::v1::UpdateDatabaseDdlRequest const& request) {
   SetMetadata(*context, "database=" + request.database());
   return child_->AsyncUpdateDatabaseDdl(cq, std::move(context), request);
 }
@@ -74,7 +76,7 @@ DatabaseAdminMetadata::ListDatabases(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminMetadata::AsyncRestoreDatabase(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::RestoreDatabaseRequest const& request) {
+    gcsa::v1::RestoreDatabaseRequest const& request) {
   SetMetadata(*context, "parent=" + request.parent());
   return child_->AsyncRestoreDatabase(cq, std::move(context), request);
 }
@@ -104,13 +106,13 @@ DatabaseAdminMetadata::TestIamPermissions(
 future<StatusOr<google::longrunning::Operation>>
 DatabaseAdminMetadata::AsyncCreateBackup(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::CreateBackupRequest const& request) {
+    gcsa::v1::CreateBackupRequest const& request) {
   SetMetadata(*context, "parent=" + request.parent());
   return child_->AsyncCreateBackup(cq, std::move(context), request);
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminMetadata::GetBackup(
-    grpc::ClientContext& context, gcsa::GetBackupRequest const& request) {
+StatusOr<gcsa::v1::Backup> DatabaseAdminMetadata::GetBackup(
+    grpc::ClientContext& context, gcsa::v1::GetBackupRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetBackup(context, request);
 }
@@ -130,8 +132,9 @@ DatabaseAdminMetadata::ListBackups(
   return child_->ListBackups(context, request);
 }
 
-StatusOr<gcsa::Backup> DatabaseAdminMetadata::UpdateBackup(
-    grpc::ClientContext& context, gcsa::UpdateBackupRequest const& request) {
+StatusOr<gcsa::v1::Backup> DatabaseAdminMetadata::UpdateBackup(
+    grpc::ClientContext& context,
+    gcsa::v1::UpdateBackupRequest const& request) {
   SetMetadata(context, "backup.name=" + request.backup().name());
   return child_->UpdateBackup(context, request);
 }

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -29,8 +29,9 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace gcsa = ::google::spanner::admin::database;
+
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-namespace gcsa = ::google::spanner::admin::database::v1;
 
 class DatabaseAdminMetadataTest : public ::testing::Test {
  protected:
@@ -59,7 +60,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gcsa::CreateDatabaseRequest const&) {
+                       gcsa::v1::CreateDatabaseRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -70,7 +71,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  gcsa::CreateDatabaseRequest request;
+  gcsa::v1::CreateDatabaseRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -84,7 +85,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gcsa::UpdateDatabaseDdlRequest const&) {
+                       gcsa::v1::UpdateDatabaseDdlRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -95,7 +96,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  gcsa::UpdateDatabaseDdlRequest request;
+  gcsa::v1::UpdateDatabaseDdlRequest request;
   request.set_database(
       google::cloud::spanner::Database(
           google::cloud::spanner::Instance(
@@ -110,7 +111,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
   EXPECT_CALL(*mock_, DropDatabase)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::DropDatabaseRequest const&) {
+                       gcsa::v1::DropDatabaseRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -120,7 +121,7 @@ TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::DropDatabaseRequest request;
+  gcsa::v1::DropDatabaseRequest request;
   request.set_database(
       google::cloud::spanner::Database(
           google::cloud::spanner::Instance(
@@ -134,7 +135,7 @@ TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
 TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
   EXPECT_CALL(*mock_, ListDatabases)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::ListDatabasesRequest const&) {
+                       gcsa::v1::ListDatabasesRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -144,7 +145,7 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::ListDatabasesRequest request;
+  gcsa::v1::ListDatabasesRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -157,7 +158,7 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
   EXPECT_CALL(*mock_, AsyncRestoreDatabase)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gcsa::RestoreDatabaseRequest const&) {
+                       gcsa::v1::RestoreDatabaseRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -168,7 +169,7 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  gcsa::RestoreDatabaseRequest request;
+  gcsa::v1::RestoreDatabaseRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -260,7 +261,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gcsa::CreateBackupRequest const&) {
+                       gcsa::v1::CreateBackupRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -271,7 +272,7 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
-  gcsa::CreateBackupRequest request;
+  gcsa::v1::CreateBackupRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -283,18 +284,18 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
 
 TEST_F(DatabaseAdminMetadataTest, GetBackup) {
   EXPECT_CALL(*mock_, GetBackup)
-      .WillOnce(
-          [this](grpc::ClientContext& context, gcsa::GetBackupRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
-                context,
-                "google.spanner.admin.database.v1.DatabaseAdmin."
-                "GetBackup"));
-            return TransientError();
-          });
+      .WillOnce([this](grpc::ClientContext& context,
+                       gcsa::v1::GetBackupRequest const&) {
+        EXPECT_STATUS_OK(
+            IsContextMDValid(context,
+                             "google.spanner.admin.database.v1.DatabaseAdmin."
+                             "GetBackup"));
+        return TransientError();
+      });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::GetBackupRequest request;
+  gcsa::v1::GetBackupRequest request;
   request.set_name(
       google::cloud::spanner::Backup(
           google::cloud::spanner::Instance(
@@ -308,7 +309,7 @@ TEST_F(DatabaseAdminMetadataTest, GetBackup) {
 TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
   EXPECT_CALL(*mock_, DeleteBackup)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::DeleteBackupRequest const&) {
+                       gcsa::v1::DeleteBackupRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -318,7 +319,7 @@ TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::DeleteBackupRequest request;
+  gcsa::v1::DeleteBackupRequest request;
   request.set_name(
       google::cloud::spanner::Backup(
           google::cloud::spanner::Instance(
@@ -332,7 +333,7 @@ TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
 TEST_F(DatabaseAdminMetadataTest, ListBackups) {
   EXPECT_CALL(*mock_, ListBackups)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::ListBackupsRequest const&) {
+                       gcsa::v1::ListBackupsRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -342,7 +343,7 @@ TEST_F(DatabaseAdminMetadataTest, ListBackups) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::ListBackupsRequest request;
+  gcsa::v1::ListBackupsRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -354,7 +355,7 @@ TEST_F(DatabaseAdminMetadataTest, ListBackups) {
 TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
   EXPECT_CALL(*mock_, UpdateBackup)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::UpdateBackupRequest const&) {
+                       gcsa::v1::UpdateBackupRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -364,7 +365,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::UpdateBackupRequest request;
+  gcsa::v1::UpdateBackupRequest request;
   request.mutable_backup()->set_name(
       google::cloud::spanner::Backup(
           google::cloud::spanner::Instance(
@@ -378,7 +379,7 @@ TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
 TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
   EXPECT_CALL(*mock_, ListBackupOperations)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::ListBackupOperationsRequest const&) {
+                       gcsa::v1::ListBackupOperationsRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -388,7 +389,7 @@ TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::ListBackupOperationsRequest request;
+  gcsa::v1::ListBackupOperationsRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -400,7 +401,7 @@ TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
 TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
   EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::ListDatabaseOperationsRequest const&) {
+                       gcsa::v1::ListDatabaseOperationsRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
@@ -410,7 +411,7 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::ListDatabaseOperationsRequest request;
+  gcsa::v1::ListDatabaseOperationsRequest request;
   request.set_parent(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")

--- a/google/cloud/spanner/internal/database_admin_stub.cc
+++ b/google/cloud/spanner/internal/database_admin_stub.cc
@@ -26,14 +26,14 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::database::v1;
+namespace gcsa = ::google::spanner::admin::database;
 
 DatabaseAdminStub::~DatabaseAdminStub() = default;
 
 class DefaultDatabaseAdminStub : public DatabaseAdminStub {
  public:
   DefaultDatabaseAdminStub(
-      std::unique_ptr<gcsa::DatabaseAdmin::StubInterface> database_admin,
+      std::unique_ptr<gcsa::v1::DatabaseAdmin::StubInterface> database_admin,
       std::unique_ptr<google::longrunning::Operations::StubInterface>
           operations)
       : database_admin_(std::move(database_admin)),
@@ -43,20 +43,20 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateDatabase(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-      gcsa::CreateDatabaseRequest const& request) override {
+      gcsa::v1::CreateDatabaseRequest const& request) override {
     return cq.MakeUnaryRpc(
         [this](grpc::ClientContext* context,
-               gcsa::CreateDatabaseRequest const& request,
+               gcsa::v1::CreateDatabaseRequest const& request,
                grpc::CompletionQueue* cq) {
           return database_admin_->AsyncCreateDatabase(context, request, cq);
         },
         request, std::move(context));
   }
 
-  StatusOr<gcsa::Database> GetDatabase(
+  StatusOr<gcsa::v1::Database> GetDatabase(
       grpc::ClientContext& client_context,
-      gcsa::GetDatabaseRequest const& request) override {
-    gcsa::Database response;
+      gcsa::v1::GetDatabaseRequest const& request) override {
+    gcsa::v1::Database response;
     auto status =
         database_admin_->GetDatabase(&client_context, request, &response);
     if (!status.ok()) {
@@ -65,10 +65,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return response;
   }
 
-  StatusOr<gcsa::GetDatabaseDdlResponse> GetDatabaseDdl(
+  StatusOr<gcsa::v1::GetDatabaseDdlResponse> GetDatabaseDdl(
       grpc::ClientContext& client_context,
-      gcsa::GetDatabaseDdlRequest const& request) override {
-    gcsa::GetDatabaseDdlResponse response;
+      gcsa::v1::GetDatabaseDdlRequest const& request) override {
+    gcsa::v1::GetDatabaseDdlResponse response;
     auto status =
         database_admin_->GetDatabaseDdl(&client_context, request, &response);
     if (!status.ok()) {
@@ -79,10 +79,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncUpdateDatabaseDdl(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-      gcsa::UpdateDatabaseDdlRequest const& request) override {
+      gcsa::v1::UpdateDatabaseDdlRequest const& request) override {
     return cq.MakeUnaryRpc(
         [this](grpc::ClientContext* context,
-               gcsa::UpdateDatabaseDdlRequest const& request,
+               gcsa::v1::UpdateDatabaseDdlRequest const& request,
                grpc::CompletionQueue* cq) {
           return database_admin_->AsyncUpdateDatabaseDdl(context, request, cq);
         },
@@ -90,7 +90,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
   }
 
   Status DropDatabase(grpc::ClientContext& client_context,
-                      gcsa::DropDatabaseRequest const& request) override {
+                      gcsa::v1::DropDatabaseRequest const& request) override {
     google::protobuf::Empty response;
     grpc::Status status =
         database_admin_->DropDatabase(&client_context, request, &response);
@@ -100,10 +100,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return google::cloud::Status();
   }
 
-  StatusOr<gcsa::ListDatabasesResponse> ListDatabases(
+  StatusOr<gcsa::v1::ListDatabasesResponse> ListDatabases(
       grpc::ClientContext& client_context,
-      gcsa::ListDatabasesRequest const& request) override {
-    gcsa::ListDatabasesResponse response;
+      gcsa::v1::ListDatabasesRequest const& request) override {
+    gcsa::v1::ListDatabasesResponse response;
     auto status =
         database_admin_->ListDatabases(&client_context, request, &response);
     if (!status.ok()) {
@@ -114,10 +114,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncRestoreDatabase(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-      gcsa::RestoreDatabaseRequest const& request) override {
+      gcsa::v1::RestoreDatabaseRequest const& request) override {
     return cq.MakeUnaryRpc(
         [this](grpc::ClientContext* context,
-               gcsa::RestoreDatabaseRequest const& request,
+               gcsa::v1::RestoreDatabaseRequest const& request,
                grpc::CompletionQueue* cq) {
           return database_admin_->AsyncRestoreDatabase(context, request, cq);
         },
@@ -162,10 +162,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateBackup(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-      gcsa::CreateBackupRequest const& request) override {
+      gcsa::v1::CreateBackupRequest const& request) override {
     return cq.MakeUnaryRpc(
         [this](grpc::ClientContext* context,
-               gcsa::CreateBackupRequest const& request,
+               gcsa::v1::CreateBackupRequest const& request,
                grpc::CompletionQueue* cq) {
           return database_admin_->AsyncCreateBackup(context, request, cq);
         },
@@ -186,7 +186,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
   }
 
   Status DeleteBackup(grpc::ClientContext& client_context,
-                      gcsa::DeleteBackupRequest const& request) override {
+                      gcsa::v1::DeleteBackupRequest const& request) override {
     google::protobuf::Empty response;
     grpc::Status status =
         database_admin_->DeleteBackup(&client_context, request, &response);
@@ -196,10 +196,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return google::cloud::Status();
   }
 
-  StatusOr<gcsa::ListBackupsResponse> ListBackups(
+  StatusOr<gcsa::v1::ListBackupsResponse> ListBackups(
       grpc::ClientContext& client_context,
-      gcsa::ListBackupsRequest const& request) override {
-    gcsa::ListBackupsResponse response;
+      gcsa::v1::ListBackupsRequest const& request) override {
+    gcsa::v1::ListBackupsResponse response;
     auto status =
         database_admin_->ListBackups(&client_context, request, &response);
     if (!status.ok()) {
@@ -221,10 +221,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return response;
   }
 
-  StatusOr<gcsa::ListBackupOperationsResponse> ListBackupOperations(
+  StatusOr<gcsa::v1::ListBackupOperationsResponse> ListBackupOperations(
       grpc::ClientContext& client_context,
-      gcsa::ListBackupOperationsRequest const& request) override {
-    gcsa::ListBackupOperationsResponse response;
+      gcsa::v1::ListBackupOperationsRequest const& request) override {
+    gcsa::v1::ListBackupOperationsResponse response;
     auto status = database_admin_->ListBackupOperations(&client_context,
                                                         request, &response);
     if (!status.ok()) {
@@ -233,10 +233,10 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
     return response;
   }
 
-  StatusOr<gcsa::ListDatabaseOperationsResponse> ListDatabaseOperations(
+  StatusOr<gcsa::v1::ListDatabaseOperationsResponse> ListDatabaseOperations(
       grpc::ClientContext& client_context,
-      gcsa::ListDatabaseOperationsRequest const& request) override {
-    gcsa::ListDatabaseOperationsResponse response;
+      gcsa::v1::ListDatabaseOperationsRequest const& request) override {
+    gcsa::v1::ListDatabaseOperationsResponse response;
     auto status = database_admin_->ListDatabaseOperations(&client_context,
                                                           request, &response);
     if (!status.ok()) {
@@ -274,7 +274,7 @@ class DefaultDatabaseAdminStub : public DatabaseAdminStub {
   }
 
  private:
-  std::unique_ptr<gcsa::DatabaseAdmin::StubInterface> database_admin_;
+  std::unique_ptr<gcsa::v1::DatabaseAdmin::StubInterface> database_admin_;
   std::unique_ptr<google::longrunning::Operations::StubInterface> operations_;
 };
 
@@ -284,7 +284,7 @@ std::shared_ptr<DatabaseAdminStub> CreateDefaultDatabaseAdminStub(
   auto channel =
       grpc::CreateCustomChannel(opts.get<EndpointOption>(),
                                 opts.get<GrpcCredentialOption>(), channel_args);
-  auto spanner_grpc_stub = gcsa::DatabaseAdmin::NewStub(channel);
+  auto spanner_grpc_stub = gcsa::v1::DatabaseAdmin::NewStub(channel);
   auto longrunning_grpc_stub =
       google::longrunning::Operations::NewStub(channel);
 

--- a/google/cloud/spanner/internal/instance_admin_logging.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging.cc
@@ -21,14 +21,15 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
+namespace gcsa = ::google::spanner::admin::instance;
+
 using ::google::cloud::internal::LogWrapper;
 
-StatusOr<gcsa::Instance> InstanceAdminLogging::GetInstance(
-    grpc::ClientContext& context, gcsa::GetInstanceRequest const& request) {
+StatusOr<gcsa::v1::Instance> InstanceAdminLogging::GetInstance(
+    grpc::ClientContext& context, gcsa::v1::GetInstanceRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::GetInstanceRequest const& request) {
+             gcsa::v1::GetInstanceRequest const& request) {
         return child_->GetInstance(context, request);
       },
       context, request, __func__, tracing_options_);
@@ -37,10 +38,10 @@ StatusOr<gcsa::Instance> InstanceAdminLogging::GetInstance(
 future<StatusOr<google::longrunning::Operation>>
 InstanceAdminLogging::AsyncCreateInstance(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::CreateInstanceRequest const& request) {
+    gcsa::v1::CreateInstanceRequest const& request) {
   return LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             gcsa::CreateInstanceRequest const& request) {
+             gcsa::v1::CreateInstanceRequest const& request) {
         return child_->AsyncCreateInstance(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
@@ -49,53 +50,55 @@ InstanceAdminLogging::AsyncCreateInstance(
 future<StatusOr<google::longrunning::Operation>>
 InstanceAdminLogging::AsyncUpdateInstance(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::UpdateInstanceRequest const& request) {
+    gcsa::v1::UpdateInstanceRequest const& request) {
   return google::cloud::internal::LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             gcsa::UpdateInstanceRequest const& request) {
+             gcsa::v1::UpdateInstanceRequest const& request) {
         return child_->AsyncUpdateInstance(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
 Status InstanceAdminLogging::DeleteInstance(
-    grpc::ClientContext& context, gcsa::DeleteInstanceRequest const& request) {
+    grpc::ClientContext& context,
+    gcsa::v1::DeleteInstanceRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::DeleteInstanceRequest const& request) {
+             gcsa::v1::DeleteInstanceRequest const& request) {
         return child_->DeleteInstance(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::InstanceConfig> InstanceAdminLogging::GetInstanceConfig(
+StatusOr<gcsa::v1::InstanceConfig> InstanceAdminLogging::GetInstanceConfig(
     grpc::ClientContext& context,
-    gcsa::GetInstanceConfigRequest const& request) {
+    gcsa::v1::GetInstanceConfigRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::GetInstanceConfigRequest const& request) {
+             gcsa::v1::GetInstanceConfigRequest const& request) {
         return child_->GetInstanceConfig(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::ListInstanceConfigsResponse>
+StatusOr<gcsa::v1::ListInstanceConfigsResponse>
 InstanceAdminLogging::ListInstanceConfigs(
     grpc::ClientContext& context,
-    gcsa::ListInstanceConfigsRequest const& request) {
+    gcsa::v1::ListInstanceConfigsRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::ListInstanceConfigsRequest const& request) {
+             gcsa::v1::ListInstanceConfigsRequest const& request) {
         return child_->ListInstanceConfigs(context, request);
       },
       context, request, __func__, tracing_options_);
 }
 
-StatusOr<gcsa::ListInstancesResponse> InstanceAdminLogging::ListInstances(
-    grpc::ClientContext& context, gcsa::ListInstancesRequest const& request) {
+StatusOr<gcsa::v1::ListInstancesResponse> InstanceAdminLogging::ListInstances(
+    grpc::ClientContext& context,
+    gcsa::v1::ListInstancesRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             gcsa::ListInstancesRequest const& request) {
+             gcsa::v1::ListInstancesRequest const& request) {
         return child_->ListInstances(context, request);
       },
       context, request, __func__, tracing_options_);

--- a/google/cloud/spanner/internal/instance_admin_logging_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_logging_test.cc
@@ -28,10 +28,11 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace gcsa = ::google::spanner::admin::instance;
+
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
-namespace gcsa = ::google::spanner::admin::instance::v1;
 
 class InstanceAdminLoggingTest : public ::testing::Test {
  protected:
@@ -53,7 +54,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response = stub.GetInstance(context, gcsa::GetInstanceRequest{});
+  auto response = stub.GetInstance(context, gcsa::v1::GetInstanceRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -64,7 +65,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstance) {
 TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   EXPECT_CALL(*mock_, AsyncCreateInstance)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::CreateInstanceRequest const&) {
+                   gcsa::v1::CreateInstanceRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -74,7 +75,7 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
   CompletionQueue cq;
   auto response =
       stub.AsyncCreateInstance(cq, absl::make_unique<grpc::ClientContext>(),
-                               gcsa::CreateInstanceRequest{});
+                               gcsa::v1::CreateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -85,7 +86,7 @@ TEST_F(InstanceAdminLoggingTest, CreateInstance) {
 TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   EXPECT_CALL(*mock_, AsyncUpdateInstance)
       .WillOnce([](CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
-                   gcsa::UpdateInstanceRequest const&) {
+                   gcsa::v1::UpdateInstanceRequest const&) {
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -95,7 +96,7 @@ TEST_F(InstanceAdminLoggingTest, UpdateInstance) {
   CompletionQueue cq;
   auto response =
       stub.AsyncUpdateInstance(cq, absl::make_unique<grpc::ClientContext>(),
-                               gcsa::UpdateInstanceRequest{});
+                               gcsa::v1::UpdateInstanceRequest{});
   EXPECT_EQ(TransientError(), response.get().status());
 
   auto const log_lines = log_.ExtractLines();
@@ -109,7 +110,7 @@ TEST_F(InstanceAdminLoggingTest, DeleteInstance) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto status = stub.DeleteInstance(context, gcsa::DeleteInstanceRequest{});
+  auto status = stub.DeleteInstance(context, gcsa::v1::DeleteInstanceRequest{});
   EXPECT_EQ(TransientError(), status);
 
   auto const log_lines = log_.ExtractLines();
@@ -124,7 +125,7 @@ TEST_F(InstanceAdminLoggingTest, GetInstanceConfig) {
 
   grpc::ClientContext context;
   auto response =
-      stub.GetInstanceConfig(context, gcsa::GetInstanceConfigRequest{});
+      stub.GetInstanceConfig(context, gcsa::v1::GetInstanceConfigRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -139,7 +140,7 @@ TEST_F(InstanceAdminLoggingTest, ListInstanceConfigs) {
 
   grpc::ClientContext context;
   auto response =
-      stub.ListInstanceConfigs(context, gcsa::ListInstanceConfigsRequest{});
+      stub.ListInstanceConfigs(context, gcsa::v1::ListInstanceConfigsRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -153,7 +154,7 @@ TEST_F(InstanceAdminLoggingTest, ListInstances) {
   InstanceAdminLogging stub(mock_, TracingOptions{});
 
   grpc::ClientContext context;
-  auto response = stub.ListInstances(context, gcsa::ListInstancesRequest{});
+  auto response = stub.ListInstances(context, gcsa::v1::ListInstancesRequest{});
   EXPECT_EQ(TransientError(), response.status());
 
   auto const log_lines = log_.ExtractLines();

--- a/google/cloud/spanner/internal/instance_admin_metadata.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata.cc
@@ -21,15 +21,15 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
+namespace gcsa = ::google::spanner::admin::instance;
 
 InstanceAdminMetadata::InstanceAdminMetadata(
     std::shared_ptr<InstanceAdminStub> child)
     : child_(std::move(child)),
       api_client_header_(google::cloud::internal::ApiClientHeader()) {}
 
-StatusOr<gcsa::Instance> InstanceAdminMetadata::GetInstance(
-    grpc::ClientContext& context, gcsa::GetInstanceRequest const& request) {
+StatusOr<gcsa::v1::Instance> InstanceAdminMetadata::GetInstance(
+    grpc::ClientContext& context, gcsa::v1::GetInstanceRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetInstance(context, request);
 }
@@ -37,7 +37,7 @@ StatusOr<gcsa::Instance> InstanceAdminMetadata::GetInstance(
 future<StatusOr<google::longrunning::Operation>>
 InstanceAdminMetadata::AsyncCreateInstance(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::CreateInstanceRequest const& request) {
+    gcsa::v1::CreateInstanceRequest const& request) {
   SetMetadata(*context, "parent=" + request.parent());
   return child_->AsyncCreateInstance(cq, std::move(context), request);
 }
@@ -45,34 +45,36 @@ InstanceAdminMetadata::AsyncCreateInstance(
 future<StatusOr<google::longrunning::Operation>>
 InstanceAdminMetadata::AsyncUpdateInstance(
     CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-    gcsa::UpdateInstanceRequest const& request) {
+    gcsa::v1::UpdateInstanceRequest const& request) {
   SetMetadata(*context, "instance.name=" + request.instance().name());
   return child_->AsyncUpdateInstance(cq, std::move(context), request);
 }
 
 Status InstanceAdminMetadata::DeleteInstance(
-    grpc::ClientContext& context, gcsa::DeleteInstanceRequest const& request) {
+    grpc::ClientContext& context,
+    gcsa::v1::DeleteInstanceRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->DeleteInstance(context, request);
 }
 
-StatusOr<gcsa::InstanceConfig> InstanceAdminMetadata::GetInstanceConfig(
+StatusOr<gcsa::v1::InstanceConfig> InstanceAdminMetadata::GetInstanceConfig(
     grpc::ClientContext& context,
-    gcsa::GetInstanceConfigRequest const& request) {
+    gcsa::v1::GetInstanceConfigRequest const& request) {
   SetMetadata(context, "name=" + request.name());
   return child_->GetInstanceConfig(context, request);
 }
 
-StatusOr<gcsa::ListInstanceConfigsResponse>
+StatusOr<gcsa::v1::ListInstanceConfigsResponse>
 InstanceAdminMetadata::ListInstanceConfigs(
     grpc::ClientContext& context,
-    gcsa::ListInstanceConfigsRequest const& request) {
+    gcsa::v1::ListInstanceConfigsRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListInstanceConfigs(context, request);
 }
 
-StatusOr<gcsa::ListInstancesResponse> InstanceAdminMetadata::ListInstances(
-    grpc::ClientContext& context, gcsa::ListInstancesRequest const& request) {
+StatusOr<gcsa::v1::ListInstancesResponse> InstanceAdminMetadata::ListInstances(
+    grpc::ClientContext& context,
+    gcsa::v1::ListInstancesRequest const& request) {
   SetMetadata(context, "parent=" + request.parent());
   return child_->ListInstances(context, request);
 }

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -28,8 +28,9 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace gcsa = ::google::spanner::admin::instance;
+
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-namespace gcsa = ::google::spanner::admin::instance::v1;
 
 class InstanceAdminMetadataTest : public ::testing::Test {
  protected:
@@ -57,7 +58,7 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 TEST_F(InstanceAdminMetadataTest, GetInstance) {
   EXPECT_CALL(*mock_, GetInstance)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::GetInstanceRequest const&) {
+                       gcsa::v1::GetInstanceRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -67,7 +68,7 @@ TEST_F(InstanceAdminMetadataTest, GetInstance) {
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::GetInstanceRequest request;
+  gcsa::v1::GetInstanceRequest request;
   request.set_name(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -79,7 +80,7 @@ TEST_F(InstanceAdminMetadataTest, GetInstance) {
 TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
   EXPECT_CALL(*mock_, GetInstanceConfig)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::GetInstanceConfigRequest const&) {
+                       gcsa::v1::GetInstanceConfigRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -89,7 +90,7 @@ TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::GetInstanceConfigRequest request;
+  gcsa::v1::GetInstanceConfigRequest request;
   request.set_name(google::cloud::Project("test-project-id").FullName() +
                    "/instanceConfigs/test-instance-config-id");
   auto response = stub.GetInstanceConfig(context, request);
@@ -99,7 +100,7 @@ TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
 TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
   EXPECT_CALL(*mock_, ListInstanceConfigs)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::ListInstanceConfigsRequest const&) {
+                       gcsa::v1::ListInstanceConfigsRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -109,7 +110,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::ListInstanceConfigsRequest request;
+  gcsa::v1::ListInstanceConfigsRequest request;
   request.set_parent(google::cloud::Project("test-project-id").FullName());
   auto response = stub.ListInstanceConfigs(context, request);
   EXPECT_EQ(TransientError(), response.status());
@@ -119,7 +120,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
   EXPECT_CALL(*mock_, AsyncCreateInstance)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gcsa::CreateInstanceRequest const&) {
+                       gcsa::v1::CreateInstanceRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -130,7 +131,7 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
 
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
-  gcsa::CreateInstanceRequest request;
+  gcsa::v1::CreateInstanceRequest request;
   request.set_parent(google::cloud::Project("test-project-id").FullName());
   request.set_instance_id("test-instance-id");
   auto response = stub.AsyncCreateInstance(
@@ -142,7 +143,7 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
   EXPECT_CALL(*mock_, AsyncUpdateInstance)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gcsa::UpdateInstanceRequest const&) {
+                       gcsa::v1::UpdateInstanceRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(*context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -153,7 +154,7 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 
   InstanceAdminMetadata stub(mock_);
   CompletionQueue cq;
-  gcsa::UpdateInstanceRequest request;
+  gcsa::v1::UpdateInstanceRequest request;
   request.mutable_instance()->set_name(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -166,7 +167,7 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
   EXPECT_CALL(*mock_, DeleteInstance)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::DeleteInstanceRequest const&) {
+                       gcsa::v1::DeleteInstanceRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -176,7 +177,7 @@ TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::DeleteInstanceRequest request;
+  gcsa::v1::DeleteInstanceRequest request;
   request.set_name(
       google::cloud::spanner::Instance(
           google::cloud::Project("test-project-id"), "test-instance-id")
@@ -188,7 +189,7 @@ TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
 TEST_F(InstanceAdminMetadataTest, ListInstances) {
   EXPECT_CALL(*mock_, ListInstances)
       .WillOnce([this](grpc::ClientContext& context,
-                       gcsa::ListInstancesRequest const&) {
+                       gcsa::v1::ListInstancesRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
@@ -198,7 +199,7 @@ TEST_F(InstanceAdminMetadataTest, ListInstances) {
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;
-  gcsa::ListInstancesRequest request;
+  gcsa::v1::ListInstancesRequest request;
   request.set_parent(google::cloud::Project("test-project-id").FullName());
   auto response = stub.ListInstances(context, request);
   EXPECT_EQ(TransientError(), response.status());

--- a/google/cloud/spanner/internal/instance_admin_stub.cc
+++ b/google/cloud/spanner/internal/instance_admin_stub.cc
@@ -29,15 +29,14 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace gcsa = ::google::spanner::admin::instance::v1;
-namespace giam = ::google::iam::v1;
+namespace gcsa = ::google::spanner::admin::instance;
 
 InstanceAdminStub::~InstanceAdminStub() = default;
 
 class DefaultInstanceAdminStub : public InstanceAdminStub {
  public:
   DefaultInstanceAdminStub(
-      std::unique_ptr<gcsa::InstanceAdmin::StubInterface> instance_admin,
+      std::unique_ptr<gcsa::v1::InstanceAdmin::StubInterface> instance_admin,
       std::unique_ptr<google::longrunning::Operations::StubInterface>
           operations)
       : instance_admin_(std::move(instance_admin)),
@@ -45,10 +44,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
 
   ~DefaultInstanceAdminStub() override = default;
 
-  StatusOr<gcsa::Instance> GetInstance(
+  StatusOr<gcsa::v1::Instance> GetInstance(
       grpc::ClientContext& context,
-      gcsa::GetInstanceRequest const& request) override {
-    gcsa::Instance response;
+      gcsa::v1::GetInstanceRequest const& request) override {
+    gcsa::v1::Instance response;
     auto status = instance_admin_->GetInstance(&context, request, &response);
     if (!status.ok()) {
       return google::cloud::MakeStatusFromRpcError(status);
@@ -58,10 +57,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncCreateInstance(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-      gcsa::CreateInstanceRequest const& request) override {
+      gcsa::v1::CreateInstanceRequest const& request) override {
     return cq.MakeUnaryRpc(
         [this](grpc::ClientContext* context,
-               gcsa::CreateInstanceRequest const& request,
+               gcsa::v1::CreateInstanceRequest const& request,
                grpc::CompletionQueue* cq) {
           return instance_admin_->AsyncCreateInstance(context, request, cq);
         },
@@ -70,18 +69,19 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
 
   future<StatusOr<google::longrunning::Operation>> AsyncUpdateInstance(
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-      gcsa::UpdateInstanceRequest const& request) override {
+      gcsa::v1::UpdateInstanceRequest const& request) override {
     return cq.MakeUnaryRpc(
         [this](grpc::ClientContext* context,
-               gcsa::UpdateInstanceRequest const& request,
+               gcsa::v1::UpdateInstanceRequest const& request,
                grpc::CompletionQueue* cq) {
           return instance_admin_->AsyncUpdateInstance(context, request, cq);
         },
         request, std::move(context));
   }
 
-  Status DeleteInstance(grpc::ClientContext& context,
-                        gcsa::DeleteInstanceRequest const& request) override {
+  Status DeleteInstance(
+      grpc::ClientContext& context,
+      gcsa::v1::DeleteInstanceRequest const& request) override {
     google::protobuf::Empty response;
     grpc::Status status =
         instance_admin_->DeleteInstance(&context, request, &response);
@@ -91,10 +91,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return google::cloud::Status();
   }
 
-  StatusOr<gcsa::InstanceConfig> GetInstanceConfig(
+  StatusOr<gcsa::v1::InstanceConfig> GetInstanceConfig(
       grpc::ClientContext& context,
-      gcsa::GetInstanceConfigRequest const& request) override {
-    gcsa::InstanceConfig response;
+      gcsa::v1::GetInstanceConfigRequest const& request) override {
+    gcsa::v1::InstanceConfig response;
     auto status =
         instance_admin_->GetInstanceConfig(&context, request, &response);
     if (!status.ok()) {
@@ -103,10 +103,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
-  StatusOr<gcsa::ListInstanceConfigsResponse> ListInstanceConfigs(
+  StatusOr<gcsa::v1::ListInstanceConfigsResponse> ListInstanceConfigs(
       grpc::ClientContext& context,
-      gcsa::ListInstanceConfigsRequest const& request) override {
-    gcsa::ListInstanceConfigsResponse response;
+      gcsa::v1::ListInstanceConfigsRequest const& request) override {
+    gcsa::v1::ListInstanceConfigsResponse response;
     auto status =
         instance_admin_->ListInstanceConfigs(&context, request, &response);
     if (!status.ok()) {
@@ -115,10 +115,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
-  StatusOr<gcsa::ListInstancesResponse> ListInstances(
+  StatusOr<gcsa::v1::ListInstancesResponse> ListInstances(
       grpc::ClientContext& context,
-      gcsa::ListInstancesRequest const& request) override {
-    gcsa::ListInstancesResponse response;
+      gcsa::v1::ListInstancesRequest const& request) override {
+    gcsa::v1::ListInstancesResponse response;
     auto status = instance_admin_->ListInstances(&context, request, &response);
     if (!status.ok()) {
       return google::cloud::MakeStatusFromRpcError(status);
@@ -126,10 +126,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
-  StatusOr<giam::Policy> GetIamPolicy(
+  StatusOr<google::iam::v1::Policy> GetIamPolicy(
       grpc::ClientContext& context,
-      giam::GetIamPolicyRequest const& request) override {
-    giam::Policy response;
+      google::iam::v1::GetIamPolicyRequest const& request) override {
+    google::iam::v1::Policy response;
     auto status = instance_admin_->GetIamPolicy(&context, request, &response);
     if (!status.ok()) {
       return google::cloud::MakeStatusFromRpcError(status);
@@ -137,10 +137,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
-  StatusOr<giam::Policy> SetIamPolicy(
+  StatusOr<google::iam::v1::Policy> SetIamPolicy(
       grpc::ClientContext& context,
-      giam::SetIamPolicyRequest const& request) override {
-    giam::Policy response;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    google::iam::v1::Policy response;
     auto status = instance_admin_->SetIamPolicy(&context, request, &response);
     if (!status.ok()) {
       return google::cloud::MakeStatusFromRpcError(status);
@@ -148,10 +148,10 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
     return response;
   }
 
-  StatusOr<giam::TestIamPermissionsResponse> TestIamPermissions(
+  StatusOr<google::iam::v1::TestIamPermissionsResponse> TestIamPermissions(
       grpc::ClientContext& context,
-      giam::TestIamPermissionsRequest const& request) override {
-    giam::TestIamPermissionsResponse response;
+      google::iam::v1::TestIamPermissionsRequest const& request) override {
+    google::iam::v1::TestIamPermissionsResponse response;
     auto status =
         instance_admin_->TestIamPermissions(&context, request, &response);
     if (!status.ok()) {
@@ -189,7 +189,7 @@ class DefaultInstanceAdminStub : public InstanceAdminStub {
   }
 
  private:
-  std::unique_ptr<gcsa::InstanceAdmin::StubInterface> instance_admin_;
+  std::unique_ptr<gcsa::v1::InstanceAdmin::StubInterface> instance_admin_;
   std::unique_ptr<google::longrunning::Operations::StubInterface> operations_;
 };
 
@@ -199,7 +199,7 @@ std::shared_ptr<InstanceAdminStub> CreateDefaultInstanceAdminStub(
   auto channel =
       grpc::CreateCustomChannel(opts.get<EndpointOption>(),
                                 opts.get<GrpcCredentialOption>(), channel_args);
-  auto spanner_grpc_stub = gcsa::InstanceAdmin::NewStub(channel);
+  auto spanner_grpc_stub = gcsa::v1::InstanceAdmin::NewStub(channel);
   auto longrunning_grpc_stub =
       google::longrunning::Operations::NewStub(channel);
 

--- a/google/cloud/spanner/internal/logging_result_set_reader_test.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader_test.cc
@@ -27,9 +27,10 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace spanner_proto = ::google::spanner;
+
 using ::testing::Contains;
 using ::testing::HasSubstr;
-namespace spanner_proto = ::google::spanner::v1;
 
 class LoggingResultSetReaderTest : public ::testing::Test {
  protected:
@@ -49,7 +50,7 @@ TEST_F(LoggingResultSetReaderTest, Read) {
   auto mock = absl::make_unique<spanner_testing::MockPartialResultSetReader>();
   EXPECT_CALL(*mock, Read())
       .WillOnce([] {
-        spanner_proto::PartialResultSet result;
+        spanner_proto::v1::PartialResultSet result;
         result.set_resume_token("test-token");
         return PartialResultSet{std::move(result), false};
       })

--- a/google/cloud/spanner/internal/logging_spanner_stub.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub.cc
@@ -21,63 +21,65 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
+
 using ::google::cloud::internal::LogWrapper;
 
-StatusOr<spanner_proto::Session> LoggingSpannerStub::CreateSession(
+StatusOr<spanner_proto::v1::Session> LoggingSpannerStub::CreateSession(
     grpc::ClientContext& client_context,
-    spanner_proto::CreateSessionRequest const& request) {
+    spanner_proto::v1::CreateSessionRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::CreateSessionRequest const& request) {
+             spanner_proto::v1::CreateSessionRequest const& request) {
         return child_->CreateSession(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::BatchCreateSessionsResponse>
+StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>
 LoggingSpannerStub::BatchCreateSessions(
     grpc::ClientContext& client_context,
-    spanner_proto::BatchCreateSessionsRequest const& request) {
+    spanner_proto::v1::BatchCreateSessionsRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::BatchCreateSessionsRequest const& request) {
+             spanner_proto::v1::BatchCreateSessionsRequest const& request) {
         return child_->BatchCreateSessions(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
+future<StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>>
 LoggingSpannerStub::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::BatchCreateSessionsRequest const& request) {
+    spanner_proto::v1::BatchCreateSessionsRequest const& request) {
   return LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             spanner_proto::BatchCreateSessionsRequest const& request) {
+             spanner_proto::v1::BatchCreateSessionsRequest const& request) {
         return child_->AsyncBatchCreateSessions(cq, std::move(context),
                                                 request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::Session> LoggingSpannerStub::GetSession(
+StatusOr<spanner_proto::v1::Session> LoggingSpannerStub::GetSession(
     grpc::ClientContext& client_context,
-    spanner_proto::GetSessionRequest const& request) {
+    spanner_proto::v1::GetSessionRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::GetSessionRequest const& request) {
+             spanner_proto::v1::GetSessionRequest const& request) {
         return child_->GetSession(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::ListSessionsResponse> LoggingSpannerStub::ListSessions(
+StatusOr<spanner_proto::v1::ListSessionsResponse>
+LoggingSpannerStub::ListSessions(
     grpc::ClientContext& client_context,
-    spanner_proto::ListSessionsRequest const& request) {
+    spanner_proto::v1::ListSessionsRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::ListSessionsRequest const& request) {
+             spanner_proto::v1::ListSessionsRequest const& request) {
         return child_->ListSessions(context, request);
       },
       client_context, request, __func__, tracing_options_);
@@ -85,10 +87,10 @@ StatusOr<spanner_proto::ListSessionsResponse> LoggingSpannerStub::ListSessions(
 
 Status LoggingSpannerStub::DeleteSession(
     grpc::ClientContext& client_context,
-    spanner_proto::DeleteSessionRequest const& request) {
+    spanner_proto::v1::DeleteSessionRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::DeleteSessionRequest const& request) {
+             spanner_proto::v1::DeleteSessionRequest const& request) {
         return child_->DeleteSession(context, request);
       },
       client_context, request, __func__, tracing_options_);
@@ -97,90 +99,94 @@ Status LoggingSpannerStub::DeleteSession(
 future<Status> LoggingSpannerStub::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::DeleteSessionRequest const& request) {
+    spanner_proto::v1::DeleteSessionRequest const& request) {
   return LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             spanner_proto::DeleteSessionRequest const& request) {
+             spanner_proto::v1::DeleteSessionRequest const& request) {
         return child_->AsyncDeleteSession(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::ResultSet> LoggingSpannerStub::ExecuteSql(
+StatusOr<spanner_proto::v1::ResultSet> LoggingSpannerStub::ExecuteSql(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::ExecuteSqlRequest const& request) {
+             spanner_proto::v1::ExecuteSqlRequest const& request) {
         return child_->ExecuteSql(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-future<StatusOr<spanner_proto::ResultSet>> LoggingSpannerStub::AsyncExecuteSql(
+future<StatusOr<spanner_proto::v1::ResultSet>>
+LoggingSpannerStub::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   return LogWrapper(
       [this](CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
-             spanner_proto::ExecuteSqlRequest const& request) {
+             spanner_proto::v1::ExecuteSqlRequest const& request) {
         return child_->AsyncExecuteSql(cq, std::move(context), request);
       },
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
+std::unique_ptr<
+    grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
 LoggingSpannerStub::ExecuteStreamingSql(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::ExecuteSqlRequest const& request) {
+             spanner_proto::v1::ExecuteSqlRequest const& request) {
         return child_->ExecuteStreamingSql(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::ExecuteBatchDmlResponse>
+StatusOr<spanner_proto::v1::ExecuteBatchDmlResponse>
 LoggingSpannerStub::ExecuteBatchDml(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteBatchDmlRequest const& request) {
+    spanner_proto::v1::ExecuteBatchDmlRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::ExecuteBatchDmlRequest const& request) {
+             spanner_proto::v1::ExecuteBatchDmlRequest const& request) {
         return child_->ExecuteBatchDml(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
-LoggingSpannerStub::StreamingRead(grpc::ClientContext& client_context,
-                                  spanner_proto::ReadRequest const& request) {
+std::unique_ptr<
+    grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
+LoggingSpannerStub::StreamingRead(
+    grpc::ClientContext& client_context,
+    spanner_proto::v1::ReadRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::ReadRequest const& request) {
+             spanner_proto::v1::ReadRequest const& request) {
         return child_->StreamingRead(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::Transaction> LoggingSpannerStub::BeginTransaction(
+StatusOr<spanner_proto::v1::Transaction> LoggingSpannerStub::BeginTransaction(
     grpc::ClientContext& client_context,
-    spanner_proto::BeginTransactionRequest const& request) {
+    spanner_proto::v1::BeginTransactionRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::BeginTransactionRequest const& request) {
+             spanner_proto::v1::BeginTransactionRequest const& request) {
         return child_->BeginTransaction(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::CommitResponse> LoggingSpannerStub::Commit(
+StatusOr<spanner_proto::v1::CommitResponse> LoggingSpannerStub::Commit(
     grpc::ClientContext& client_context,
-    spanner_proto::CommitRequest const& request) {
+    spanner_proto::v1::CommitRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::CommitRequest const& request) {
+             spanner_proto::v1::CommitRequest const& request) {
         return child_->Commit(context, request);
       },
       client_context, request, __func__, tracing_options_);
@@ -188,32 +194,34 @@ StatusOr<spanner_proto::CommitResponse> LoggingSpannerStub::Commit(
 
 Status LoggingSpannerStub::Rollback(
     grpc::ClientContext& client_context,
-    spanner_proto::RollbackRequest const& request) {
+    spanner_proto::v1::RollbackRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::RollbackRequest const& request) {
+             spanner_proto::v1::RollbackRequest const& request) {
         return child_->Rollback(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::PartitionResponse> LoggingSpannerStub::PartitionQuery(
+StatusOr<spanner_proto::v1::PartitionResponse>
+LoggingSpannerStub::PartitionQuery(
     grpc::ClientContext& client_context,
-    spanner_proto::PartitionQueryRequest const& request) {
+    spanner_proto::v1::PartitionQueryRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::PartitionQueryRequest const& request) {
+             spanner_proto::v1::PartitionQueryRequest const& request) {
         return child_->PartitionQuery(context, request);
       },
       client_context, request, __func__, tracing_options_);
 }
 
-StatusOr<spanner_proto::PartitionResponse> LoggingSpannerStub::PartitionRead(
+StatusOr<spanner_proto::v1::PartitionResponse>
+LoggingSpannerStub::PartitionRead(
     grpc::ClientContext& client_context,
-    spanner_proto::PartitionReadRequest const& request) {
+    spanner_proto::v1::PartitionReadRequest const& request) {
   return LogWrapper(
       [this](grpc::ClientContext& context,
-             spanner_proto::PartitionReadRequest const& request) {
+             spanner_proto::v1::PartitionReadRequest const& request) {
         return child_->PartitionRead(context, request);
       },
       client_context, request, __func__, tracing_options_);

--- a/google/cloud/spanner/internal/logging_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/logging_spanner_stub_test.cc
@@ -27,10 +27,11 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace spanner_proto = ::google::spanner;
+
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::Return;
-namespace spanner_proto = ::google::spanner::v1;
 
 class LoggingSpannerStubTest : public ::testing::Test {
  protected:
@@ -54,14 +55,14 @@ class LoggingSpannerStubTest : public ::testing::Test {
  * result, because that makes the tests easier to write.
  */
 TEST_F(LoggingSpannerStubTest, CreateSessionSuccess) {
-  spanner_proto::Session session;
+  spanner_proto::v1::Session session;
   session.set_name("test-session-name");
   EXPECT_CALL(*mock_, CreateSession).WillOnce(Return(session));
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.CreateSession(context, spanner_proto::CreateSessionRequest());
+      stub.CreateSession(context, spanner_proto::v1::CreateSessionRequest());
   EXPECT_STATUS_OK(status);
 
   auto const log_lines = log_.ExtractLines();
@@ -75,7 +76,7 @@ TEST_F(LoggingSpannerStubTest, CreateSession) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.CreateSession(context, spanner_proto::CreateSessionRequest());
+      stub.CreateSession(context, spanner_proto::v1::CreateSessionRequest());
   EXPECT_EQ(TransientError(), status.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -89,7 +90,7 @@ TEST_F(LoggingSpannerStubTest, BatchCreateSessions) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status = stub.BatchCreateSessions(
-      context, spanner_proto::BatchCreateSessionsRequest());
+      context, spanner_proto::v1::BatchCreateSessionsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -102,7 +103,8 @@ TEST_F(LoggingSpannerStubTest, GetSession) {
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status = stub.GetSession(context, spanner_proto::GetSessionRequest());
+  auto status =
+      stub.GetSession(context, spanner_proto::v1::GetSessionRequest());
   EXPECT_EQ(TransientError(), status.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -116,7 +118,7 @@ TEST_F(LoggingSpannerStubTest, ListSessions) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.ListSessions(context, spanner_proto::ListSessionsRequest());
+      stub.ListSessions(context, spanner_proto::v1::ListSessionsRequest());
   EXPECT_EQ(TransientError(), status.status());
 
   auto const log_lines = log_.ExtractLines();
@@ -130,7 +132,7 @@ TEST_F(LoggingSpannerStubTest, DeleteSession) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.DeleteSession(context, spanner_proto::DeleteSessionRequest());
+      stub.DeleteSession(context, spanner_proto::v1::DeleteSessionRequest());
   EXPECT_EQ(TransientError(), status);
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("DeleteSession")));
@@ -142,7 +144,8 @@ TEST_F(LoggingSpannerStubTest, ExecuteSql) {
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status = stub.ExecuteSql(context, spanner_proto::ExecuteSqlRequest());
+  auto status =
+      stub.ExecuteSql(context, spanner_proto::v1::ExecuteSqlRequest());
   EXPECT_EQ(TransientError(), status.status());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ExecuteSql")));
@@ -151,16 +154,16 @@ TEST_F(LoggingSpannerStubTest, ExecuteSql) {
 
 TEST_F(LoggingSpannerStubTest, ExecuteStreamingSql) {
   EXPECT_CALL(*mock_, ExecuteStreamingSql)
-      .WillOnce(
-          [](grpc::ClientContext&, spanner_proto::ExecuteSqlRequest const&) {
-            return std::unique_ptr<
-                grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
-          });
+      .WillOnce([](grpc::ClientContext&,
+                   spanner_proto::v1::ExecuteSqlRequest const&) {
+        return std::unique_ptr<
+            grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>{};
+      });
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.ExecuteStreamingSql(context, spanner_proto::ExecuteSqlRequest());
+      stub.ExecuteStreamingSql(context, spanner_proto::v1::ExecuteSqlRequest());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ExecuteStreamingSql")));
   EXPECT_THAT(log_lines, Contains(HasSubstr(" null stream")));
@@ -171,8 +174,8 @@ TEST_F(LoggingSpannerStubTest, ExecuteBatchDml) {
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status =
-      stub.ExecuteBatchDml(context, spanner_proto::ExecuteBatchDmlRequest());
+  auto status = stub.ExecuteBatchDml(
+      context, spanner_proto::v1::ExecuteBatchDmlRequest());
   EXPECT_EQ(TransientError(), status.status());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("ExecuteBatchDml")));
@@ -181,14 +184,15 @@ TEST_F(LoggingSpannerStubTest, ExecuteBatchDml) {
 
 TEST_F(LoggingSpannerStubTest, StreamingRead) {
   EXPECT_CALL(*mock_, StreamingRead)
-      .WillOnce([](grpc::ClientContext&, spanner_proto::ReadRequest const&) {
+      .WillOnce([](grpc::ClientContext&,
+                   spanner_proto::v1::ReadRequest const&) {
         return std::unique_ptr<
-            grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
+            grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>{};
       });
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status = stub.StreamingRead(context, spanner_proto::ReadRequest());
+  auto status = stub.StreamingRead(context, spanner_proto::v1::ReadRequest());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("StreamingRead")));
   EXPECT_THAT(log_lines, Contains(HasSubstr("null stream")));
@@ -199,8 +203,8 @@ TEST_F(LoggingSpannerStubTest, BeginTransaction) {
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status =
-      stub.BeginTransaction(context, spanner_proto::BeginTransactionRequest());
+  auto status = stub.BeginTransaction(
+      context, spanner_proto::v1::BeginTransactionRequest());
   EXPECT_EQ(TransientError(), status.status());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("BeginTransaction")));
@@ -212,7 +216,7 @@ TEST_F(LoggingSpannerStubTest, Commit) {
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status = stub.Commit(context, spanner_proto::CommitRequest());
+  auto status = stub.Commit(context, spanner_proto::v1::CommitRequest());
   EXPECT_EQ(TransientError(), status.status());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("Commit")));
@@ -224,7 +228,7 @@ TEST_F(LoggingSpannerStubTest, Rollback) {
 
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
-  auto status = stub.Rollback(context, spanner_proto::RollbackRequest());
+  auto status = stub.Rollback(context, spanner_proto::v1::RollbackRequest());
   EXPECT_EQ(TransientError(), status);
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("Rollback")));
@@ -237,7 +241,7 @@ TEST_F(LoggingSpannerStubTest, PartitionQuery) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.PartitionQuery(context, spanner_proto::PartitionQueryRequest());
+      stub.PartitionQuery(context, spanner_proto::v1::PartitionQueryRequest());
   EXPECT_EQ(TransientError(), status.status());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("PartitionQuery")));
@@ -250,7 +254,7 @@ TEST_F(LoggingSpannerStubTest, PartitionRead) {
   LoggingSpannerStub stub(mock_, TracingOptions{});
   grpc::ClientContext context;
   auto status =
-      stub.PartitionRead(context, spanner_proto::PartitionReadRequest());
+      stub.PartitionRead(context, spanner_proto::v1::PartitionReadRequest());
   EXPECT_EQ(TransientError(), status.status());
   auto const log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("PartitionRead")));

--- a/google/cloud/spanner/internal/metadata_spanner_stub.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub.cc
@@ -24,7 +24,7 @@ namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 MetadataSpannerStub::MetadataSpannerStub(std::shared_ptr<SpannerStub> child,
                                          std::string resource_prefix_header)
@@ -32,14 +32,14 @@ MetadataSpannerStub::MetadataSpannerStub(std::shared_ptr<SpannerStub> child,
       api_client_header_(google::cloud::internal::ApiClientHeader()),
       resource_prefix_header_(std::move(resource_prefix_header)) {}
 
-StatusOr<spanner_proto::Session> MetadataSpannerStub::CreateSession(
+StatusOr<spanner_proto::v1::Session> MetadataSpannerStub::CreateSession(
     grpc::ClientContext& client_context,
-    spanner_proto::CreateSessionRequest const& request) {
+    spanner_proto::v1::CreateSessionRequest const& request) {
   SetMetadata(client_context, "database=" + request.database());
   return child_->CreateSession(client_context, request);
 }
 
-StatusOr<spanner_proto::BatchCreateSessionsResponse>
+StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>
 MetadataSpannerStub::BatchCreateSessions(
     grpc::ClientContext& client_context,
     google::spanner::v1::BatchCreateSessionsRequest const& request) {
@@ -47,32 +47,33 @@ MetadataSpannerStub::BatchCreateSessions(
   return child_->BatchCreateSessions(client_context, request);
 }
 
-future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
+future<StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>>
 MetadataSpannerStub::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::BatchCreateSessionsRequest const& request) {
+    spanner_proto::v1::BatchCreateSessionsRequest const& request) {
   SetMetadata(*context, "database=" + request.database());
   return child_->AsyncBatchCreateSessions(cq, std::move(context), request);
 }
 
-StatusOr<spanner_proto::Session> MetadataSpannerStub::GetSession(
+StatusOr<spanner_proto::v1::Session> MetadataSpannerStub::GetSession(
     grpc::ClientContext& client_context,
-    spanner_proto::GetSessionRequest const& request) {
+    spanner_proto::v1::GetSessionRequest const& request) {
   SetMetadata(client_context, "name=" + request.name());
   return child_->GetSession(client_context, request);
 }
 
-StatusOr<spanner_proto::ListSessionsResponse> MetadataSpannerStub::ListSessions(
+StatusOr<spanner_proto::v1::ListSessionsResponse>
+MetadataSpannerStub::ListSessions(
     grpc::ClientContext& client_context,
-    spanner_proto::ListSessionsRequest const& request) {
+    spanner_proto::v1::ListSessionsRequest const& request) {
   SetMetadata(client_context, "database=" + request.database());
   return child_->ListSessions(client_context, request);
 }
 
 Status MetadataSpannerStub::DeleteSession(
     grpc::ClientContext& client_context,
-    spanner_proto::DeleteSessionRequest const& request) {
+    spanner_proto::v1::DeleteSessionRequest const& request) {
   SetMetadata(client_context, "name=" + request.name());
   return child_->DeleteSession(client_context, request);
 }
@@ -80,80 +81,86 @@ Status MetadataSpannerStub::DeleteSession(
 future<Status> MetadataSpannerStub::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::DeleteSessionRequest const& request) {
+    spanner_proto::v1::DeleteSessionRequest const& request) {
   SetMetadata(*context, "name=" + request.name());
   return child_->AsyncDeleteSession(cq, std::move(context), request);
 }
 
-StatusOr<spanner_proto::ResultSet> MetadataSpannerStub::ExecuteSql(
+StatusOr<spanner_proto::v1::ResultSet> MetadataSpannerStub::ExecuteSql(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->ExecuteSql(client_context, request);
 }
 
-future<StatusOr<spanner_proto::ResultSet>> MetadataSpannerStub::AsyncExecuteSql(
+future<StatusOr<spanner_proto::v1::ResultSet>>
+MetadataSpannerStub::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   SetMetadata(*context, "session=" + request.session());
   return child_->AsyncExecuteSql(cq, std::move(context), request);
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
+std::unique_ptr<
+    grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
 MetadataSpannerStub::ExecuteStreamingSql(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->ExecuteStreamingSql(client_context, request);
 }
 
-StatusOr<spanner_proto::ExecuteBatchDmlResponse>
+StatusOr<spanner_proto::v1::ExecuteBatchDmlResponse>
 MetadataSpannerStub::ExecuteBatchDml(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteBatchDmlRequest const& request) {
+    spanner_proto::v1::ExecuteBatchDmlRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->ExecuteBatchDml(client_context, request);
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
-MetadataSpannerStub::StreamingRead(grpc::ClientContext& client_context,
-                                   spanner_proto::ReadRequest const& request) {
+std::unique_ptr<
+    grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
+MetadataSpannerStub::StreamingRead(
+    grpc::ClientContext& client_context,
+    spanner_proto::v1::ReadRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->StreamingRead(client_context, request);
 }
 
-StatusOr<spanner_proto::Transaction> MetadataSpannerStub::BeginTransaction(
+StatusOr<spanner_proto::v1::Transaction> MetadataSpannerStub::BeginTransaction(
     grpc::ClientContext& client_context,
-    spanner_proto::BeginTransactionRequest const& request) {
+    spanner_proto::v1::BeginTransactionRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->BeginTransaction(client_context, request);
 }
 
-StatusOr<spanner_proto::CommitResponse> MetadataSpannerStub::Commit(
+StatusOr<spanner_proto::v1::CommitResponse> MetadataSpannerStub::Commit(
     grpc::ClientContext& client_context,
-    spanner_proto::CommitRequest const& request) {
+    spanner_proto::v1::CommitRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->Commit(client_context, request);
 }
 
 Status MetadataSpannerStub::Rollback(
     grpc::ClientContext& client_context,
-    spanner_proto::RollbackRequest const& request) {
+    spanner_proto::v1::RollbackRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->Rollback(client_context, request);
 }
 
-StatusOr<spanner_proto::PartitionResponse> MetadataSpannerStub::PartitionQuery(
+StatusOr<spanner_proto::v1::PartitionResponse>
+MetadataSpannerStub::PartitionQuery(
     grpc::ClientContext& client_context,
-    spanner_proto::PartitionQueryRequest const& request) {
+    spanner_proto::v1::PartitionQueryRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->PartitionQuery(client_context, request);
 }
 
-StatusOr<spanner_proto::PartitionResponse> MetadataSpannerStub::PartitionRead(
+StatusOr<spanner_proto::v1::PartitionResponse>
+MetadataSpannerStub::PartitionRead(
     grpc::ClientContext& client_context,
-    spanner_proto::PartitionReadRequest const& request) {
+    spanner_proto::v1::PartitionReadRequest const& request) {
   SetMetadata(client_context, "session=" + request.session());
   return child_->PartitionRead(client_context, request);
 }

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -27,11 +27,12 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace spanner_proto = ::google::spanner;
+
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
 using ::testing::Not;
 using ::testing::Pair;
-namespace spanner_proto = ::google::spanner::v1;
 
 // This ugly macro and the supporting template member function refactor most
 // of this test to one-liners.
@@ -106,14 +107,14 @@ class MetadataSpannerStubTest : public ::testing::Test {
 TEST_F(MetadataSpannerStubTest, UserProject) {
   EXPECT_CALL(*mock_, CreateSession)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::CreateSessionRequest const&) {
+                       spanner_proto::v1::CreateSessionRequest const&) {
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     Not(Contains(Pair("x-goog-user-project", ::testing::_))));
         return TransientError();
       })
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::CreateSessionRequest const&) {
+                       spanner_proto::v1::CreateSessionRequest const&) {
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     Contains(Pair("x-goog-user-project", "test-project")));
@@ -121,7 +122,7 @@ TEST_F(MetadataSpannerStubTest, UserProject) {
       });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
-  spanner_proto::CreateSessionRequest request;
+  spanner_proto::v1::CreateSessionRequest request;
   request.set_database(db_.FullName());
   {
     internal::OptionsSpan span(Options{});
@@ -142,7 +143,7 @@ TEST_F(MetadataSpannerStubTest, UserProject) {
 TEST_F(MetadataSpannerStubTest, CreateSession) {
   EXPECT_CALL(*mock_, CreateSession)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::CreateSessionRequest const&) {
+                       spanner_proto::v1::CreateSessionRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.spanner.v1.Spanner.CreateSession"));
         return TransientError();
@@ -150,7 +151,7 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::CreateSessionRequest request;
+  spanner_proto::v1::CreateSessionRequest request;
   request.set_database(db_.FullName());
   auto status = stub.CreateSession(context, request);
   EXPECT_EQ(TransientError(), status.status());
@@ -159,7 +160,7 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
 TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
   EXPECT_CALL(*mock_, BatchCreateSessions)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::BatchCreateSessionsRequest const&) {
+                       spanner_proto::v1::BatchCreateSessionsRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.spanner.v1.Spanner.BatchCreateSessions"));
         return TransientError();
@@ -167,7 +168,7 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::BatchCreateSessionsRequest request;
+  spanner_proto::v1::BatchCreateSessionsRequest request;
   request.set_database(db_.FullName());
   request.set_session_count(3);
   auto status = stub.BatchCreateSessions(context, request);
@@ -177,7 +178,7 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
 TEST_F(MetadataSpannerStubTest, GetSession) {
   EXPECT_CALL(*mock_, GetSession)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::GetSessionRequest const&) {
+                       spanner_proto::v1::GetSessionRequest const&) {
         EXPECT_STATUS_OK(
             IsContextMDValid(context, "google.spanner.v1.Spanner.GetSession"));
         return TransientError();
@@ -185,7 +186,7 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::GetSessionRequest request;
+  spanner_proto::v1::GetSessionRequest request;
   request.set_name(
       google::cloud::spanner::Database(
           google::cloud::spanner::Instance(
@@ -200,7 +201,7 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
 TEST_F(MetadataSpannerStubTest, ListSessions) {
   EXPECT_CALL(*mock_, ListSessions)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::ListSessionsRequest const&) {
+                       spanner_proto::v1::ListSessionsRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.spanner.v1.Spanner.ListSessions"));
         return TransientError();
@@ -208,7 +209,7 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::ListSessionsRequest request;
+  spanner_proto::v1::ListSessionsRequest request;
   request.set_database(db_.FullName());
   auto status = stub.ListSessions(context, request);
   EXPECT_EQ(TransientError(), status.status());
@@ -217,7 +218,7 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
 TEST_F(MetadataSpannerStubTest, DeleteSession) {
   EXPECT_CALL(*mock_, DeleteSession)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::DeleteSessionRequest const&) {
+                       spanner_proto::v1::DeleteSessionRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.spanner.v1.Spanner.DeleteSession"));
         return TransientError();
@@ -225,7 +226,7 @@ TEST_F(MetadataSpannerStubTest, DeleteSession) {
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::DeleteSessionRequest request;
+  spanner_proto::v1::DeleteSessionRequest request;
   request.set_name(
       google::cloud::spanner::Database(
           google::cloud::spanner::Instance(
@@ -238,22 +239,22 @@ TEST_F(MetadataSpannerStubTest, DeleteSession) {
 }
 
 TEST_F(MetadataSpannerStubTest, ExecuteSql) {
-  SESSION_TEST(ExecuteSql, spanner_proto::ExecuteSqlRequest);
+  SESSION_TEST(ExecuteSql, spanner_proto::v1::ExecuteSqlRequest);
 }
 
 TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
   EXPECT_CALL(*mock_, ExecuteStreamingSql)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::ExecuteSqlRequest const&) {
+                       spanner_proto::v1::ExecuteSqlRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.spanner.v1.Spanner.ExecuteStreamingSql"));
         return std::unique_ptr<
-            grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
+            grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>{};
       });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::ExecuteSqlRequest request;
+  spanner_proto::v1::ExecuteSqlRequest request;
   request.set_session(
       google::cloud::spanner::Database(
           google::cloud::spanner::Instance(
@@ -266,22 +267,22 @@ TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
 }
 
 TEST_F(MetadataSpannerStubTest, ExecuteBatchDml) {
-  SESSION_TEST(ExecuteBatchDml, spanner_proto::ExecuteBatchDmlRequest);
+  SESSION_TEST(ExecuteBatchDml, spanner_proto::v1::ExecuteBatchDmlRequest);
 }
 
 TEST_F(MetadataSpannerStubTest, StreamingRead) {
   EXPECT_CALL(*mock_, StreamingRead)
       .WillOnce([this](grpc::ClientContext& context,
-                       spanner_proto::ReadRequest const&) {
+                       spanner_proto::v1::ReadRequest const&) {
         EXPECT_STATUS_OK(IsContextMDValid(
             context, "google.spanner.v1.Spanner.StreamingRead"));
         return std::unique_ptr<
-            grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>{};
+            grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>{};
       });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
-  spanner_proto::ReadRequest request;
+  spanner_proto::v1::ReadRequest request;
   request.set_session(
       google::cloud::spanner::Database(
           google::cloud::spanner::Instance(
@@ -294,23 +295,23 @@ TEST_F(MetadataSpannerStubTest, StreamingRead) {
 }
 
 TEST_F(MetadataSpannerStubTest, BeginTransaction) {
-  SESSION_TEST(BeginTransaction, spanner_proto::BeginTransactionRequest);
+  SESSION_TEST(BeginTransaction, spanner_proto::v1::BeginTransactionRequest);
 }
 
 TEST_F(MetadataSpannerStubTest, Commit) {
-  SESSION_TEST(Commit, spanner_proto::CommitRequest);
+  SESSION_TEST(Commit, spanner_proto::v1::CommitRequest);
 }
 
 TEST_F(MetadataSpannerStubTest, Rollback) {
-  SESSION_TEST(Rollback, spanner_proto::RollbackRequest);
+  SESSION_TEST(Rollback, spanner_proto::v1::RollbackRequest);
 }
 
 TEST_F(MetadataSpannerStubTest, PartitionQuery) {
-  SESSION_TEST(PartitionQuery, spanner_proto::PartitionQueryRequest);
+  SESSION_TEST(PartitionQuery, spanner_proto::v1::PartitionQueryRequest);
 }
 
 TEST_F(MetadataSpannerStubTest, PartitionRead) {
-  SESSION_TEST(PartitionRead, spanner_proto::PartitionReadRequest);
+  SESSION_TEST(PartitionRead, spanner_proto::v1::PartitionReadRequest);
 }
 
 }  // namespace

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -30,7 +30,7 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 using ::google::cloud::Idempotency;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
@@ -42,7 +42,7 @@ using ::testing::HasSubstr;
 using ::testing::Return;
 
 absl::optional<PartialResultSet> ReadReturn(
-    spanner_proto::PartialResultSet response) {
+    spanner_proto::v1::PartialResultSet response) {
   return PartialResultSet{std::move(response), false};
 }
 
@@ -66,7 +66,7 @@ std::unique_ptr<PartialResultSetReader> MakeTestResume(
 }
 
 TEST(PartialResultSetResume, Success) {
-  spanner_proto::PartialResultSet response;
+  spanner_proto::v1::PartialResultSet response;
   auto constexpr kText =
       R"pb(
     metadata: {
@@ -122,7 +122,7 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
     values: { string_value: "value-1" }
     values: { string_value: "value-2" }
   )pb";
-  spanner_proto::PartialResultSet r0;
+  spanner_proto::v1::PartialResultSet r0;
   ASSERT_TRUE(TextFormat::ParseFromString(kText0, &r0));
 
   auto constexpr kText1 = R"pb(
@@ -130,7 +130,7 @@ TEST(PartialResultSetResume, SuccessWithRestart) {
     values: { string_value: "value-3" }
     values: { string_value: "value-4" }
   )pb";
-  spanner_proto::PartialResultSet r1;
+  spanner_proto::v1::PartialResultSet r1;
   ASSERT_TRUE(TextFormat::ParseFromString(kText1, &r1));
 
   MockFactory mock_factory;
@@ -194,7 +194,7 @@ TEST(PartialResultSetResume, PermanentError) {
     values: { string_value: "value-1" }
     values: { string_value: "value-2" }
       )pb";
-  spanner_proto::PartialResultSet r0;
+  spanner_proto::v1::PartialResultSet r0;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &r0));
 
   MockFactory mock_factory;
@@ -246,7 +246,7 @@ TEST(PartialResultSetResume, TransientNonIdempotent) {
     values: { string_value: "value-1" }
     values: { string_value: "value-2" }
   )pb";
-  spanner_proto::PartialResultSet r0;
+  spanner_proto::v1::PartialResultSet r0;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &r0));
 
   MockFactory mock_factory;

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -33,7 +33,7 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 using ::google::cloud::spanner::MakeTestRow;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
@@ -81,7 +81,7 @@ std::function<T()> ResultMock(T const& result) {
 }
 
 absl::optional<PartialResultSet> ReadResult(
-    spanner_proto::PartialResultSet response) {
+    spanner_proto::v1::PartialResultSet response) {
   return PartialResultSet{std::move(response), false};
 }
 
@@ -122,7 +122,7 @@ TEST(PartialResultSetSourceTest, ReadSuccessThenFailure) {
     }
     values: { string_value: "80" }
   )pb";
-  spanner_proto::PartialResultSet response;
+  spanner_proto::v1::PartialResultSet response;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
   EXPECT_CALL(*grpc_reader, Read())
       .WillOnce(ResultMock(ReadResult(response)))
@@ -144,7 +144,7 @@ TEST(PartialResultSetSourceTest, ReadSuccessThenFailure) {
 /// @test Verify the behavior when the first response does not contain metadata.
 TEST(PartialResultSetSourceTest, MissingMetadata) {
   auto grpc_reader = absl::make_unique<MockPartialResultSetReader>();
-  spanner_proto::PartialResultSet response;
+  spanner_proto::v1::PartialResultSet response;
   EXPECT_CALL(*grpc_reader, Read()).WillOnce(ResultMock(ReadResult(response)));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(ResultMock(Status()));
   // The destructor should try to cancel the RPC to avoid deadlocks.
@@ -163,7 +163,7 @@ TEST(PartialResultSetSourceTest, MissingMetadata) {
 TEST(PartialResultSetSourceTest, MissingRowTypeNoData) {
   auto grpc_reader = absl::make_unique<MockPartialResultSetReader>();
   auto constexpr kText = R"pb(metadata: {})pb";
-  spanner_proto::PartialResultSet response;
+  spanner_proto::v1::PartialResultSet response;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
   EXPECT_CALL(*grpc_reader, Read())
       .WillOnce(ResultMock(ReadResult(response)))
@@ -186,7 +186,7 @@ TEST(PartialResultSetSourceTest, MissingRowTypeWithData) {
   auto constexpr kText = R"pb(
     metadata: {}
     values: { string_value: "10" })pb";
-  spanner_proto::PartialResultSet response;
+  spanner_proto::v1::PartialResultSet response;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
   EXPECT_CALL(*grpc_reader, Read()).WillOnce(ResultMock(ReadResult(response)));
   EXPECT_CALL(*grpc_reader, Finish()).WillOnce(ResultMock(Status()));
@@ -240,7 +240,7 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
       }
     }
   )pb";
-  spanner_proto::PartialResultSet response;
+  spanner_proto::v1::PartialResultSet response;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &response));
   EXPECT_CALL(*grpc_reader, Read())
       .WillOnce(ResultMock(ReadResult(response)))
@@ -265,7 +265,7 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
       }
     }
   )pb";
-  spanner_proto::ResultSetMetadata expected_metadata;
+  spanner_proto::v1::ResultSetMetadata expected_metadata;
   ASSERT_TRUE(
       TextFormat::ParseFromString(kTextExpectedMetadata, &expected_metadata));
   auto actual_metadata = (*reader)->Metadata();
@@ -298,7 +298,7 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
       }
     }
   )pb";
-  spanner_proto::ResultSetStats expected_stats;
+  spanner_proto::v1::ResultSetStats expected_stats;
   ASSERT_TRUE(TextFormat::ParseFromString(kTextExpectedStats, &expected_stats));
   auto actual_stats = (*reader)->Stats();
   EXPECT_TRUE(actual_stats.has_value());
@@ -357,7 +357,7 @@ TEST(PartialResultSetSourceTest, MultipleResponses) {
         }
       )pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -416,7 +416,7 @@ TEST(PartialResultSetSourceTest, ResponseWithNoValues) {
         values: { string_value: "22" }
       )pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -479,7 +479,7 @@ TEST(PartialResultSetSourceTest, ChunkedStringValueWellFormed) {
         values: { string_value: "still not_chunked" }
       )pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -531,7 +531,7 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoValue) {
       )pb",
       R"pb(chunked_value: true)pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -575,7 +575,7 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetNoFollowingValue) {
       )pb",
       R"pb()pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -619,7 +619,7 @@ TEST(PartialResultSetSourceTest, ChunkedValueSetAtEndOfStream) {
         chunked_value: true
       )pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -666,7 +666,7 @@ TEST(PartialResultSetSourceTest, ChunkedValueMergeFailure) {
         values: { number_value: 99 }
       )pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));
@@ -738,7 +738,7 @@ TEST(PartialResultSetSourceTest, ErrorOnIncompleteRow) {
         }
       )pb",
   }};
-  std::array<spanner_proto::PartialResultSet, text.size()> response;
+  std::array<spanner_proto::v1::PartialResultSet, text.size()> response;
   for (std::size_t i = 0; i != text.size(); ++i) {
     SCOPED_TRACE("Converting text to proto [" + std::to_string(i) + "]");
     ASSERT_TRUE(TextFormat::ParseFromString(text[i], &response[i]));

--- a/google/cloud/spanner/internal/spanner_stub.cc
+++ b/google/cloud/spanner/internal/spanner_stub.cc
@@ -30,7 +30,7 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 /**
  * DefaultSpannerStub - a stub that calls Spanner's gRPC interface.
@@ -38,75 +38,78 @@ namespace spanner_proto = ::google::spanner::v1;
 class DefaultSpannerStub : public SpannerStub {
  public:
   explicit DefaultSpannerStub(
-      std::unique_ptr<spanner_proto::Spanner::StubInterface> grpc_stub)
+      std::unique_ptr<spanner_proto::v1::Spanner::StubInterface> grpc_stub)
       : grpc_stub_(std::move(grpc_stub)) {}
 
   DefaultSpannerStub(DefaultSpannerStub const&) = delete;
   DefaultSpannerStub& operator=(DefaultSpannerStub const&) = delete;
 
-  StatusOr<spanner_proto::Session> CreateSession(
+  StatusOr<spanner_proto::v1::Session> CreateSession(
       grpc::ClientContext& client_context,
-      spanner_proto::CreateSessionRequest const& request) override;
-  StatusOr<spanner_proto::BatchCreateSessionsResponse> BatchCreateSessions(
+      spanner_proto::v1::CreateSessionRequest const& request) override;
+  StatusOr<spanner_proto::v1::BatchCreateSessionsResponse> BatchCreateSessions(
       grpc::ClientContext& client_context,
-      spanner_proto::BatchCreateSessionsRequest const& request) override;
-  future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
+      spanner_proto::v1::BatchCreateSessionsRequest const& request) override;
+  future<StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>>
   AsyncBatchCreateSessions(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      spanner_proto::BatchCreateSessionsRequest const& request) override;
-  StatusOr<spanner_proto::Session> GetSession(
+      spanner_proto::v1::BatchCreateSessionsRequest const& request) override;
+  StatusOr<spanner_proto::v1::Session> GetSession(
       grpc::ClientContext& client_context,
-      spanner_proto::GetSessionRequest const& request) override;
-  StatusOr<spanner_proto::ListSessionsResponse> ListSessions(
+      spanner_proto::v1::GetSessionRequest const& request) override;
+  StatusOr<spanner_proto::v1::ListSessionsResponse> ListSessions(
       grpc::ClientContext& client_context,
-      spanner_proto::ListSessionsRequest const& request) override;
+      spanner_proto::v1::ListSessionsRequest const& request) override;
   Status DeleteSession(
       grpc::ClientContext& client_context,
-      spanner_proto::DeleteSessionRequest const& request) override;
+      spanner_proto::v1::DeleteSessionRequest const& request) override;
   future<Status> AsyncDeleteSession(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      spanner_proto::DeleteSessionRequest const& request) override;
-  StatusOr<spanner_proto::ResultSet> ExecuteSql(
+      spanner_proto::v1::DeleteSessionRequest const& request) override;
+  StatusOr<spanner_proto::v1::ResultSet> ExecuteSql(
       grpc::ClientContext& client_context,
-      spanner_proto::ExecuteSqlRequest const& request) override;
-  future<StatusOr<spanner_proto::ResultSet>> AsyncExecuteSql(
+      spanner_proto::v1::ExecuteSqlRequest const& request) override;
+  future<StatusOr<spanner_proto::v1::ResultSet>> AsyncExecuteSql(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
-      spanner_proto::ExecuteSqlRequest const& request) override;
-  std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
-  ExecuteStreamingSql(grpc::ClientContext& client_context,
-                      spanner_proto::ExecuteSqlRequest const& request) override;
-  StatusOr<spanner_proto::ExecuteBatchDmlResponse> ExecuteBatchDml(
+      spanner_proto::v1::ExecuteSqlRequest const& request) override;
+  std::unique_ptr<
+      grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
+  ExecuteStreamingSql(
       grpc::ClientContext& client_context,
-      spanner_proto::ExecuteBatchDmlRequest const& request) override;
-  std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
+      spanner_proto::v1::ExecuteSqlRequest const& request) override;
+  StatusOr<spanner_proto::v1::ExecuteBatchDmlResponse> ExecuteBatchDml(
+      grpc::ClientContext& client_context,
+      spanner_proto::v1::ExecuteBatchDmlRequest const& request) override;
+  std::unique_ptr<
+      grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
   StreamingRead(grpc::ClientContext& client_context,
-                spanner_proto::ReadRequest const& request) override;
-  StatusOr<spanner_proto::Transaction> BeginTransaction(
+                spanner_proto::v1::ReadRequest const& request) override;
+  StatusOr<spanner_proto::v1::Transaction> BeginTransaction(
       grpc::ClientContext& client_context,
-      spanner_proto::BeginTransactionRequest const& request) override;
-  StatusOr<spanner_proto::CommitResponse> Commit(
+      spanner_proto::v1::BeginTransactionRequest const& request) override;
+  StatusOr<spanner_proto::v1::CommitResponse> Commit(
       grpc::ClientContext& client_context,
-      spanner_proto::CommitRequest const& request) override;
+      spanner_proto::v1::CommitRequest const& request) override;
   Status Rollback(grpc::ClientContext& client_context,
-                  spanner_proto::RollbackRequest const& request) override;
-  StatusOr<spanner_proto::PartitionResponse> PartitionQuery(
+                  spanner_proto::v1::RollbackRequest const& request) override;
+  StatusOr<spanner_proto::v1::PartitionResponse> PartitionQuery(
       grpc::ClientContext& client_context,
-      spanner_proto::PartitionQueryRequest const& request) override;
-  StatusOr<spanner_proto::PartitionResponse> PartitionRead(
+      spanner_proto::v1::PartitionQueryRequest const& request) override;
+  StatusOr<spanner_proto::v1::PartitionResponse> PartitionRead(
       grpc::ClientContext& client_context,
-      spanner_proto::PartitionReadRequest const& request) override;
+      spanner_proto::v1::PartitionReadRequest const& request) override;
 
  private:
-  std::unique_ptr<spanner_proto::Spanner::StubInterface> grpc_stub_;
+  std::unique_ptr<spanner_proto::v1::Spanner::StubInterface> grpc_stub_;
 };
 
-StatusOr<spanner_proto::Session> DefaultSpannerStub::CreateSession(
+StatusOr<spanner_proto::v1::Session> DefaultSpannerStub::CreateSession(
     grpc::ClientContext& client_context,
-    spanner_proto::CreateSessionRequest const& request) {
-  spanner_proto::Session response;
+    spanner_proto::v1::CreateSessionRequest const& request) {
+  spanner_proto::v1::Session response;
   grpc::Status grpc_status =
       grpc_stub_->CreateSession(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -115,11 +118,11 @@ StatusOr<spanner_proto::Session> DefaultSpannerStub::CreateSession(
   return response;
 }
 
-StatusOr<spanner_proto::BatchCreateSessionsResponse>
+StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>
 DefaultSpannerStub::BatchCreateSessions(
     grpc::ClientContext& client_context,
-    spanner_proto::BatchCreateSessionsRequest const& request) {
-  spanner_proto::BatchCreateSessionsResponse response;
+    spanner_proto::v1::BatchCreateSessionsRequest const& request) {
+  spanner_proto::v1::BatchCreateSessionsResponse response;
   grpc::Status grpc_status =
       grpc_stub_->BatchCreateSessions(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -128,24 +131,24 @@ DefaultSpannerStub::BatchCreateSessions(
   return response;
 }
 
-future<StatusOr<spanner_proto::BatchCreateSessionsResponse>>
+future<StatusOr<spanner_proto::v1::BatchCreateSessionsResponse>>
 DefaultSpannerStub::AsyncBatchCreateSessions(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::BatchCreateSessionsRequest const& request) {
+    spanner_proto::v1::BatchCreateSessionsRequest const& request) {
   return cq.MakeUnaryRpc(
       [this](grpc::ClientContext* context,
-             spanner_proto::BatchCreateSessionsRequest const& request,
+             spanner_proto::v1::BatchCreateSessionsRequest const& request,
              grpc::CompletionQueue* cq) {
         return grpc_stub_->AsyncBatchCreateSessions(context, request, cq);
       },
       request, std::move(context));
 }
 
-StatusOr<spanner_proto::Session> DefaultSpannerStub::GetSession(
+StatusOr<spanner_proto::v1::Session> DefaultSpannerStub::GetSession(
     grpc::ClientContext& client_context,
-    spanner_proto::GetSessionRequest const& request) {
-  spanner_proto::Session response;
+    spanner_proto::v1::GetSessionRequest const& request) {
+  spanner_proto::v1::Session response;
   grpc::Status grpc_status =
       grpc_stub_->GetSession(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -154,10 +157,11 @@ StatusOr<spanner_proto::Session> DefaultSpannerStub::GetSession(
   return response;
 }
 
-StatusOr<spanner_proto::ListSessionsResponse> DefaultSpannerStub::ListSessions(
+StatusOr<spanner_proto::v1::ListSessionsResponse>
+DefaultSpannerStub::ListSessions(
     grpc::ClientContext& client_context,
-    spanner_proto::ListSessionsRequest const& request) {
-  spanner_proto::ListSessionsResponse response;
+    spanner_proto::v1::ListSessionsRequest const& request) {
+  spanner_proto::v1::ListSessionsResponse response;
   grpc::Status grpc_status =
       grpc_stub_->ListSessions(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -168,7 +172,7 @@ StatusOr<spanner_proto::ListSessionsResponse> DefaultSpannerStub::ListSessions(
 
 Status DefaultSpannerStub::DeleteSession(
     grpc::ClientContext& client_context,
-    spanner_proto::DeleteSessionRequest const& request) {
+    spanner_proto::v1::DeleteSessionRequest const& request) {
   google::protobuf::Empty response;
   grpc::Status grpc_status =
       grpc_stub_->DeleteSession(&client_context, request, &response);
@@ -178,11 +182,11 @@ Status DefaultSpannerStub::DeleteSession(
 future<Status> DefaultSpannerStub::AsyncDeleteSession(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::DeleteSessionRequest const& request) {
+    spanner_proto::v1::DeleteSessionRequest const& request) {
   return cq
       .MakeUnaryRpc(
           [this](grpc::ClientContext* context,
-                 spanner_proto::DeleteSessionRequest const& request,
+                 spanner_proto::v1::DeleteSessionRequest const& request,
                  grpc::CompletionQueue* cq) {
             return grpc_stub_->AsyncDeleteSession(context, request, cq);
           },
@@ -192,10 +196,10 @@ future<Status> DefaultSpannerStub::AsyncDeleteSession(
       });
 }
 
-StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::ExecuteSql(
+StatusOr<spanner_proto::v1::ResultSet> DefaultSpannerStub::ExecuteSql(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request) {
-  spanner_proto::ResultSet response;
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
+  spanner_proto::v1::ResultSet response;
   grpc::Status grpc_status =
       grpc_stub_->ExecuteSql(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -204,31 +208,33 @@ StatusOr<spanner_proto::ResultSet> DefaultSpannerStub::ExecuteSql(
   return response;
 }
 
-future<StatusOr<spanner_proto::ResultSet>> DefaultSpannerStub::AsyncExecuteSql(
+future<StatusOr<spanner_proto::v1::ResultSet>>
+DefaultSpannerStub::AsyncExecuteSql(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   return cq.MakeUnaryRpc(
       [this](grpc::ClientContext* context,
-             spanner_proto::ExecuteSqlRequest const& request,
+             spanner_proto::v1::ExecuteSqlRequest const& request,
              grpc::CompletionQueue* cq) {
         return grpc_stub_->AsyncExecuteSql(context, request, cq);
       },
       request, std::move(context));
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
+std::unique_ptr<
+    grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
 DefaultSpannerStub::ExecuteStreamingSql(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteSqlRequest const& request) {
+    spanner_proto::v1::ExecuteSqlRequest const& request) {
   return grpc_stub_->ExecuteStreamingSql(&client_context, request);
 }
 
-StatusOr<spanner_proto::ExecuteBatchDmlResponse>
+StatusOr<spanner_proto::v1::ExecuteBatchDmlResponse>
 DefaultSpannerStub::ExecuteBatchDml(
     grpc::ClientContext& client_context,
-    spanner_proto::ExecuteBatchDmlRequest const& request) {
-  spanner_proto::ExecuteBatchDmlResponse response;
+    spanner_proto::v1::ExecuteBatchDmlRequest const& request) {
+  spanner_proto::v1::ExecuteBatchDmlResponse response;
   grpc::Status grpc_status =
       grpc_stub_->ExecuteBatchDml(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -237,16 +243,18 @@ DefaultSpannerStub::ExecuteBatchDml(
   return response;
 }
 
-std::unique_ptr<grpc::ClientReaderInterface<spanner_proto::PartialResultSet>>
-DefaultSpannerStub::StreamingRead(grpc::ClientContext& client_context,
-                                  spanner_proto::ReadRequest const& request) {
+std::unique_ptr<
+    grpc::ClientReaderInterface<spanner_proto::v1::PartialResultSet>>
+DefaultSpannerStub::StreamingRead(
+    grpc::ClientContext& client_context,
+    spanner_proto::v1::ReadRequest const& request) {
   return grpc_stub_->StreamingRead(&client_context, request);
 }
 
-StatusOr<spanner_proto::Transaction> DefaultSpannerStub::BeginTransaction(
+StatusOr<spanner_proto::v1::Transaction> DefaultSpannerStub::BeginTransaction(
     grpc::ClientContext& client_context,
-    spanner_proto::BeginTransactionRequest const& request) {
-  spanner_proto::Transaction response;
+    spanner_proto::v1::BeginTransactionRequest const& request) {
+  spanner_proto::v1::Transaction response;
   grpc::Status grpc_status =
       grpc_stub_->BeginTransaction(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -255,10 +263,10 @@ StatusOr<spanner_proto::Transaction> DefaultSpannerStub::BeginTransaction(
   return response;
 }
 
-StatusOr<spanner_proto::CommitResponse> DefaultSpannerStub::Commit(
+StatusOr<spanner_proto::v1::CommitResponse> DefaultSpannerStub::Commit(
     grpc::ClientContext& client_context,
-    spanner_proto::CommitRequest const& request) {
-  spanner_proto::CommitResponse response;
+    spanner_proto::v1::CommitRequest const& request) {
+  spanner_proto::v1::CommitResponse response;
   grpc::Status grpc_status =
       grpc_stub_->Commit(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -269,17 +277,18 @@ StatusOr<spanner_proto::CommitResponse> DefaultSpannerStub::Commit(
 
 Status DefaultSpannerStub::Rollback(
     grpc::ClientContext& client_context,
-    spanner_proto::RollbackRequest const& request) {
+    spanner_proto::v1::RollbackRequest const& request) {
   google::protobuf::Empty response;
   grpc::Status grpc_status =
       grpc_stub_->Rollback(&client_context, request, &response);
   return google::cloud::MakeStatusFromRpcError(grpc_status);
 }
 
-StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionQuery(
+StatusOr<spanner_proto::v1::PartitionResponse>
+DefaultSpannerStub::PartitionQuery(
     grpc::ClientContext& client_context,
-    spanner_proto::PartitionQueryRequest const& request) {
-  spanner_proto::PartitionResponse response;
+    spanner_proto::v1::PartitionQueryRequest const& request) {
+  spanner_proto::v1::PartitionResponse response;
   grpc::Status grpc_status =
       grpc_stub_->PartitionQuery(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -288,10 +297,11 @@ StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionQuery(
   return response;
 }
 
-StatusOr<spanner_proto::PartitionResponse> DefaultSpannerStub::PartitionRead(
+StatusOr<spanner_proto::v1::PartitionResponse>
+DefaultSpannerStub::PartitionRead(
     grpc::ClientContext& client_context,
-    spanner_proto::PartitionReadRequest const& request) {
-  spanner_proto::PartitionResponse response;
+    spanner_proto::v1::PartitionReadRequest const& request) {
+  spanner_proto::v1::PartitionResponse response;
   grpc::Status grpc_status =
       grpc_stub_->PartitionRead(&client_context, request, &response);
   if (!grpc_status.ok()) {
@@ -314,7 +324,7 @@ std::shared_ptr<SpannerStub> CreateDefaultSpannerStub(
 
   auto channel =
       auth->CreateChannel(opts.get<EndpointOption>(), channel_arguments);
-  auto spanner_grpc_stub = spanner_proto::Spanner::NewStub(channel);
+  auto spanner_grpc_stub = spanner_proto::v1::Spanner::NewStub(channel);
   std::shared_ptr<SpannerStub> stub =
       std::make_shared<DefaultSpannerStub>(std::move(spanner_grpc_stub));
 

--- a/google/cloud/spanner/mutations_test.cc
+++ b/google/cloud/spanner/mutations_test.cc
@@ -33,7 +33,7 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::protobuf::TextFormat;
@@ -76,7 +76,7 @@ TEST(MutationsTest, InsertSimple) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -110,7 +110,7 @@ TEST(MutationsTest, InsertComplex) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -137,7 +137,7 @@ TEST(MutationsTest, UpdateSimple) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -173,7 +173,7 @@ TEST(MutationsTest, UpdateComplex) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -200,7 +200,7 @@ TEST(MutationsTest, InsertOrUpdateSimple) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -238,7 +238,7 @@ TEST(MutationsTest, InsertOrUpdateComplex) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -265,7 +265,7 @@ TEST(MutationsTest, ReplaceSimple) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -295,7 +295,7 @@ TEST(MutationsTest, ReplaceComplex) {
       }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -315,7 +315,7 @@ TEST(MutationsTest, DeleteSimple) {
       key_set: { keys: { values { string_value: "key-to-delete" } } }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -416,7 +416,7 @@ TEST(MutationsTest, FluentDeleteBuilder) {
       key_set: { keys: { values { string_value: "key-to-delete" } } }
     }
   )pb";
-  spanner_proto::Mutation expected;
+  spanner_proto::v1::Mutation expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -30,7 +30,7 @@ namespace spanner {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-namespace spanner_proto = ::google::spanner::v1;
+namespace spanner_proto = ::google::spanner;
 
 using ::google::cloud::spanner_mocks::MockResultSetSource;
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -119,7 +119,7 @@ TEST(RowStream, IterateError) {
 
 TEST(RowStream, TimestampNoTransaction) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
-  spanner_proto::ResultSetMetadata no_transaction;
+  spanner_proto::v1::ResultSetMetadata no_transaction;
   EXPECT_CALL(*mock_source, Metadata()).WillOnce(Return(no_transaction));
 
   RowStream rows(std::move(mock_source));
@@ -128,7 +128,7 @@ TEST(RowStream, TimestampNoTransaction) {
 
 TEST(RowStream, TimestampNotPresent) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
-  spanner_proto::ResultSetMetadata transaction_no_timestamp;
+  spanner_proto::v1::ResultSetMetadata transaction_no_timestamp;
   transaction_no_timestamp.mutable_transaction()->set_id("placeholder");
   EXPECT_CALL(*mock_source, Metadata())
       .WillOnce(Return(transaction_no_timestamp));
@@ -139,7 +139,7 @@ TEST(RowStream, TimestampNotPresent) {
 
 TEST(RowStream, TimestampPresent) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
-  spanner_proto::ResultSetMetadata transaction_with_timestamp;
+  spanner_proto::v1::ResultSetMetadata transaction_with_timestamp;
   transaction_with_timestamp.mutable_transaction()->set_id("placeholder2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =
@@ -153,7 +153,7 @@ TEST(RowStream, TimestampPresent) {
 
 TEST(ProfileQueryResult, TimestampPresent) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
-  spanner_proto::ResultSetMetadata transaction_with_timestamp;
+  spanner_proto::v1::ResultSetMetadata transaction_with_timestamp;
   transaction_with_timestamp.mutable_transaction()->set_id("placeholder2");
   Timestamp timestamp = MakeTimestamp(std::chrono::system_clock::now()).value();
   *transaction_with_timestamp.mutable_transaction()->mutable_read_timestamp() =


### PR DESCRIPTION
Move the proto version outside the `spanner_proto` and `gcsa`
namespace aliases used in the implementation.  This means that
these Spanner proto names won't require special transformation
rules when imported into an environment that uses a different
gRPC service namespace.

Also remove the `giam` alias altogether, as it wasn't pulling
its weight.

I contemplated removing the `gcsa` alias too, partly because
it has different definitions in different files (or to at least
move the `database` and `instance` parts outside the aliases),
but that can wait for another rainy day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8602)
<!-- Reviewable:end -->
