### PR TITLE
chore: add missing dependencies for proto library

### DIFF
--- a/external/googleapis/protodeps/artifactregistry.deps
+++ b/external/googleapis/protodeps/artifactregistry.deps
@@ -3,5 +3,9 @@
 @com_google_googleapis//google/api:field_behavior_proto
 @com_google_googleapis//google/api:http_proto
 @com_google_googleapis//google/api:resource_proto
+@com_google_googleapis//google/iam/v1:iam_policy_proto
+@com_google_googleapis//google/iam/v1:options_proto
 @com_google_googleapis//google/iam/v1:policy_proto
+@com_google_googleapis//google/longrunning:operations_proto
+@com_google_googleapis//google/rpc:status_proto
 @com_google_googleapis//google/type:expr_proto

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -60,7 +60,11 @@ target_link_libraries(
            google-cloud-cpp::api_field_behavior_protos
            google-cloud-cpp::api_http_protos
            google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::iam_v1_options_protos
+           google-cloud-cpp::iam_v1_iam_policy_protos
            google-cloud-cpp::iam_v1_policy_protos
+           google-cloud-cpp::longrunning_operations_protos
+           google-cloud-cpp::rpc_status_protos
            google-cloud-cpp::type_expr_protos)
 
 file(


### PR DESCRIPTION
This should happen automatically after each update to the googleapis SHA, but for now we do it manually.