### PR TITLE
feat(bigtable): implement ping and warm

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -327,6 +327,7 @@ if (BUILD_TESTING)
         table_bulk_apply_test.cc
         table_check_and_mutate_row_test.cc
         table_config_test.cc
+        table_ping_and_warm_test.cc
         table_readmodifywriterow_test.cc
         table_readrow_test.cc
         table_readrows_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -64,6 +64,7 @@ bigtable_client_unit_tests = [
     "table_bulk_apply_test.cc",
     "table_check_and_mutate_row_test.cc",
     "table_config_test.cc",
+    "table_ping_and_warm_test.cc",
     "table_readmodifywriterow_test.cc",
     "table_readrow_test.cc",
     "table_readrows_test.cc",

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -94,6 +94,13 @@ class DefaultDataClient : public DataClient {
     return impl_.Stub()->AsyncCheckAndMutateRow(context, request, cq);
   }
 
+  grpc::Status PingAndWarm(grpc::ClientContext* context,
+                           btproto::PingAndWarmRequest const& request,
+                           btproto::PingAndWarmResponse* response) override {
+    ApplyOptions(context);
+    return impl_.Stub()->PingAndWarm(context, request, response);
+  }
+
   grpc::Status ReadModifyWriteRow(
       grpc::ClientContext* context,
       btproto::ReadModifyWriteRowRequest const& request,

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -118,6 +118,10 @@ class DataClient {
       grpc::ClientContext* context,
       google::bigtable::v2::CheckAndMutateRowRequest const& request,
       grpc::CompletionQueue* cq) = 0;
+  virtual grpc::Status PingAndWarm(
+      grpc::ClientContext* context,
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::bigtable::v2::PingAndWarmResponse* response) = 0;
   virtual grpc::Status ReadModifyWriteRow(
       grpc::ClientContext* context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request,

--- a/google/cloud/bigtable/internal/logging_data_client.cc
+++ b/google/cloud/bigtable/internal/logging_data_client.cc
@@ -70,6 +70,18 @@ LoggingDataClient::AsyncCheckAndMutateRow(
   return child_->AsyncCheckAndMutateRow(context, request, cq);
 }
 
+grpc::Status LoggingDataClient::PingAndWarm(
+    grpc::ClientContext* context, btproto::PingAndWarmRequest const& request,
+    btproto::PingAndWarmResponse* response) {
+  return LogWrapper(
+      [this](grpc::ClientContext* context,
+             btproto::PingAndWarmRequest const& request,
+             btproto::PingAndWarmResponse* response) {
+        return child_->PingAndWarm(context, request, response);
+      },
+      context, request, response, __func__, tracing_options_);
+}
+
 grpc::Status LoggingDataClient::ReadModifyWriteRow(
     grpc::ClientContext* context,
     btproto::ReadModifyWriteRowRequest const& request,

--- a/google/cloud/bigtable/internal/logging_data_client.h
+++ b/google/cloud/bigtable/internal/logging_data_client.h
@@ -75,6 +75,10 @@ class LoggingDataClient : public DataClient {
       google::bigtable::v2::CheckAndMutateRowRequest const& request,
       grpc::CompletionQueue* cq) override;
 
+  grpc::Status PingAndWarm(grpc::ClientContext* context,
+                           btproto::PingAndWarmRequest const& request,
+                           btproto::PingAndWarmResponse* response) override;
+
   grpc::Status ReadModifyWriteRow(
       grpc::ClientContext* context,
       btproto::ReadModifyWriteRowRequest const& request,

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -654,6 +654,24 @@ class Table {
       std::vector<Mutation> false_mutations);
 
   /**
+   * Warm up associated **instance** metadata for this connection.
+   *
+   * This call is not required but may be useful for connection keep-alive.
+   *
+   * @par Idempotency
+   * This operation is always treated as idempotent.
+   *
+   * @par Thread-safety
+   * Two threads concurrently calling this member function on the same instance
+   * of this class are **not** guaranteed to work. Consider copying the object
+   * and using different copies in each thread.
+   *
+   * @par Examples
+   * @snippet data_snippets.cc ping and warm
+   */
+  StatusOr<google::bigtable::v2::PingAndWarmResponse> PingAndWarm();
+
+  /**
    * Sample of the row keys in the table, including approximate data sizes.
    *
    * @note The sample may only include one element for small tables.  In

--- a/google/cloud/bigtable/table_ping_and_warm_test.cc
+++ b/google/cloud/bigtable/table_ping_and_warm_test.cc
@@ -1,0 +1,106 @@
+// Copyright 2022 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/rpc_retry_policy.h"
+#include "google/cloud/bigtable/table.h"
+#include "google/cloud/bigtable/testing/table_test_fixture.h"
+#include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/testing_util/validate_metadata.h"
+#include <chrono>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::google::cloud::testing_util::ValidateMetadataFixture;
+
+class TablePingAndWarmTest : public bigtable::testing::TableTestFixture {
+ protected:
+  TablePingAndWarmTest() : TableTestFixture(CompletionQueue{}) {}
+
+  Status IsContextMDValid(grpc::ClientContext& context,
+                          std::string const& method) {
+    return validate_metadata_fixture_.IsContextMDValid(
+        context, method, google::cloud::internal::ApiClientHeader());
+  }
+
+  std::function<grpc::Status(grpc::ClientContext* context,
+                             google::bigtable::v2::PingAndWarmRequest const&,
+                             google::bigtable::v2::PingAndWarmResponse*)>
+  CreatePingAndWarmMock(grpc::Status const& status) {
+    return
+        [this, status](grpc::ClientContext* context,
+                       google::bigtable::v2::PingAndWarmRequest const& request,
+                       google::bigtable::v2::PingAndWarmResponse*) {
+          EXPECT_EQ(request.name(), kInstanceName);
+          EXPECT_STATUS_OK(IsContextMDValid(
+              *context, "google.bigtable.v2.Bigtable.PingAndWarm"));
+          return status;
+        };
+  }
+
+ private:
+  ValidateMetadataFixture validate_metadata_fixture_;
+};
+
+TEST_F(TablePingAndWarmTest, Success) {
+  EXPECT_CALL(*client_, PingAndWarm)
+      .WillOnce(CreatePingAndWarmMock(grpc::Status::OK));
+
+  auto status = table_.PingAndWarm();
+  ASSERT_STATUS_OK(status);
+}
+
+TEST_F(TablePingAndWarmTest, PermanentFailure) {
+  EXPECT_CALL(*client_, PingAndWarm)
+      .WillRepeatedly(CreatePingAndWarmMock(
+          grpc::Status(grpc::StatusCode::FAILED_PRECONDITION, "uh-oh")));
+
+  auto status = table_.PingAndWarm();
+  EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TablePingAndWarmTest, RetryThenSuccess) {
+  EXPECT_CALL(*client_, PingAndWarm)
+      .WillOnce(CreatePingAndWarmMock(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")))
+      .WillOnce(CreatePingAndWarmMock((grpc::Status::OK)));
+
+  auto status = table_.PingAndWarm();
+  ASSERT_STATUS_OK(status);
+}
+
+TEST_F(TablePingAndWarmTest, RetryPolicyExhausted) {
+  auto constexpr kNumRetries = 2;
+
+  EXPECT_CALL(*client_, PingAndWarm)
+      .Times(kNumRetries + 1)
+      .WillRepeatedly(CreatePingAndWarmMock(
+          grpc::Status(grpc::StatusCode::UNAVAILABLE, "try-again")));
+
+  auto table =
+      Table(client_, kTableId, LimitedErrorCountRetryPolicy(kNumRetries));
+  auto status = table.PingAndWarm();
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/testing/inprocess_data_client.cc
+++ b/google/cloud/bigtable/testing/inprocess_data_client.cc
@@ -56,6 +56,12 @@ InProcessDataClient::AsyncCheckAndMutateRow(
       google::bigtable::v2::CheckAndMutateRowResponse>>(result.release());
 }
 
+grpc::Status InProcessDataClient::PingAndWarm(
+    grpc::ClientContext* context, btproto::PingAndWarmRequest const& request,
+    btproto::PingAndWarmResponse* response) {
+  return Stub()->PingAndWarm(context, request, response);
+}
+
 grpc::Status InProcessDataClient::ReadModifyWriteRow(
     grpc::ClientContext* context,
     btproto::ReadModifyWriteRowRequest const& request,

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -72,6 +72,10 @@ class InProcessDataClient : public bigtable::DataClient {
       grpc::ClientContext* context,
       google::bigtable::v2::CheckAndMutateRowRequest const& request,
       grpc::CompletionQueue* cq) override;
+  grpc::Status PingAndWarm(
+      grpc::ClientContext* context,
+      google::bigtable::v2::PingAndWarmRequest const& request,
+      google::bigtable::v2::PingAndWarmResponse* response) override;
   grpc::Status ReadModifyWriteRow(
       grpc::ClientContext* context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request,

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -63,6 +63,11 @@ class MockDataClient : public bigtable::DataClient {
                google::bigtable::v2::CheckAndMutateRowRequest const&,
                grpc::CompletionQueue*),
               (override));
+  MOCK_METHOD(grpc::Status, PingAndWarm,
+              (grpc::ClientContext*,
+               google::bigtable::v2::PingAndWarmRequest const&,
+               google::bigtable::v2::PingAndWarmResponse*),
+              (override));
   MOCK_METHOD(grpc::Status, ReadModifyWriteRow,
               (grpc::ClientContext*,
                google::bigtable::v2::ReadModifyWriteRowRequest const&,

--- a/google/cloud/bigtable/testing/table_test_fixture.h
+++ b/google/cloud/bigtable/testing/table_test_fixture.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/table.h"
 #include "google/cloud/bigtable/testing/mock_data_client.h"
 #include "google/cloud/testing_util/fake_completion_queue_impl.h"
+#include <chrono>
 #include <string>
 
 namespace google {
@@ -43,7 +44,10 @@ class TableTestFixture : public ::testing::Test {
       cq_impl_;
   CompletionQueue cq_;
   std::shared_ptr<MockDataClient> client_;
-  bigtable::Table table_ = bigtable::Table(client_, kTableId);
+  bigtable::Table table_ =
+      bigtable::Table(client_, kTableId,
+                      ExponentialBackoffPolicy(std::chrono::milliseconds(0),
+                                               std::chrono::milliseconds(0)));
 };
 
 google::bigtable::v2::ReadRowsResponse ReadRowsResponseFromString(

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -28,6 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::StatusIs;
 using ::std::chrono::duration_cast;
 using ::std::chrono::microseconds;
 using ::std::chrono::milliseconds;
@@ -75,6 +76,17 @@ std::string const kFamily1 = "family1";
 std::string const kFamily2 = "family2";
 std::string const kFamily3 = "family3";
 std::string const kFamily4 = "family4";
+
+TEST_F(DataIntegrationTest, TablePingAndWarm) {
+  auto table = GetTable();
+  auto resp = table.PingAndWarm();
+  // TODO(#8609) - Remove check once emulator supports PingAndWarm.
+  if (UsingCloudBigtableEmulator()) {
+    EXPECT_THAT(resp, StatusIs(StatusCode::kUnimplemented));
+  } else {
+    EXPECT_STATUS_OK(resp);
+  }
+}
 
 TEST_F(DataIntegrationTest, TableApply) {
   auto table = GetTable();


### PR DESCRIPTION
I decided to implement the RPC in `Table` instead of creating a new `Instance` class. I decided to return `StatusOr<PingAndWarmResponse>` (even though it is an empty message) because it is just as easy to check whether the response is valid as a `Status`.

A separate issue was opened to track emulator support for this RPC.

Speed up some integration tests by using a no-backoff policy for the `TableTestFixture`.