### PR TITLE
feat(pubsublite): pubsub to pubsublite translation layer

### DIFF
--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -30,6 +30,7 @@ cc_library(
         "//:common",
         "//:grpc_utils",
         "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
+        "@com_google_googleapis//google/cloud/pubsublite/v1:pubsublite_cc_grpc",
         # Do not sort: grpc++ must come last
         "@com_github_grpc_grpc//:grpc++",
     ],

--- a/google/cloud/pubsub/internal/defaults.h
+++ b/google/cloud/pubsub/internal/defaults.h
@@ -15,8 +15,11 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULTS_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_DEFAULTS_H
 
+#include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/options.h"
+#include "google/cloud/status_or.h"
+#include <google/cloud/pubsublite/v1/common.pb.h>
 
 namespace google {
 namespace cloud {
@@ -34,6 +37,9 @@ Options DefaultPublisherOptionsOnly(Options opts);
 Options DefaultSubscriberOptions(Options opts);
 
 Options DefaultSubscriberOptionsOnly(Options opts);
+
+StatusOr<google::cloud::pubsublite::v1::SequencedMessage>
+DefaultPublishMessageTransformer(const google::cloud::pubsub::Message&);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -39,10 +39,14 @@
  */
 
 #include "google/cloud/pubsub/backoff_policy.h"
+#include "google/cloud/pubsub/message.h"
 #include "google/cloud/pubsub/retry_policy.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/options.h"
+#include "google/cloud/status_or.h"
+#include <google/cloud/pubsublite/v1/common.pb.h>
 #include <chrono>
+#include <functional>
 
 namespace google {
 namespace cloud {
@@ -263,6 +267,15 @@ struct MaxOutstandingBytesOption {
  */
 struct MaxConcurrencyOption {
   using Type = std::size_t;
+};
+
+/**
+ * A function to convert a Pub/Sub message to a Pub/Sub Lite message.
+ */
+struct PublishMessageTransformer {
+  using Type =
+      std::function<StatusOr<google::cloud::pubsublite::v1::SequencedMessage>(
+          google::cloud::pubsub::Message)>;
 };
 
 /**


### PR DESCRIPTION
This PR implements the translation layer to convert Pub/Sub messages to Pub/Sub Lite messages.

TODO: update CMake build configs with Pub/Sub Lite protos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8612)
<!-- Reviewable:end -->
