### PR TITLE
cleanup: force LF line endings on git checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force the use of Unix LF style line endings
+* text eol=lf
+
+# Our ABI dumps should not be modified. Mark them as binary.
+*.gz binary


### PR DESCRIPTION
Seems like Windows might automatically convert line endings from LF to CRLF, depending on the `core.autocrlf` git setting. (See: https://git-scm.com/book/en/v2/Customizing-Git-Git-Configuration)

I followed instructions [here](https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings) to add a `.gitattributes` file to prevent this from happening. (I think...)

Inspired by #8613

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8614)
<!-- Reviewable:end -->
