### PR TITLE
fix(storage)!: return initial session state

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -88,9 +88,8 @@ ObjectWriteStream Client::WriteObjectImpl(
     internal::ResumableUploadRequest const& request) {
   auto create = raw_client_->CreateResumableSession(request);
   if (!create) {
-    auto status = std::move(create).status();
-    auto error =
-        absl::make_unique<internal::ResumableUploadSessionError>(status);
+    auto error = absl::make_unique<internal::ResumableUploadSessionError>(
+        std::move(create).status());
 
     ObjectWriteStream error_stream(
         absl::make_unique<internal::ObjectWriteStreambuf>(
@@ -225,7 +224,7 @@ StatusOr<ObjectMetadata> Client::UploadStreamResumable(
   if (!create) return std::move(create).status();
 
   // The upload is already done.
-  if (create->state.payload) return std::move(create->state.payload.value());
+  if (create->state.payload) return *std::move(create->state.payload);
 
   // How many bytes of the local file are uploaded to the GCS server.
   auto server_size = create->state.committed_size.value_or(0);

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -664,7 +664,7 @@ StatusOr<CreateResumableSessionResponse> CurlClient::CreateResumableSession(
   return CreateResumableSessionResponse{
       absl::make_unique<CurlResumableUploadSession>(shared_from_this(), request,
                                                     std::move(session_url)),
-      ResumableUploadResponse{response->upload_session_url,
+      ResumableUploadResponse{std::move(response->upload_session_url),
                               ResumableUploadResponse::kInProgress,
                               /*.committed_size=*/0, /*.payload=*/absl::nullopt,
                               /*.annotations=*/{}}};

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -228,14 +228,15 @@ StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
   return AsStatus(*response);
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
+StatusOr<CreateResumableSessionResponse>
 CurlClient::FullyRestoreResumableSession(ResumableUploadRequest const& request,
                                          std::string const& session_id) {
   auto session = absl::make_unique<CurlResumableUploadSession>(
       shared_from_this(), request, session_id);
   auto response = session->ResetSession();
-  if (!response) std::move(response).status();
-  return std::unique_ptr<ResumableUploadSession>(std::move(session));
+  if (!response) return std::move(response).status();
+  return CreateResumableSessionResponse{std::move(session),
+                                        *std::move(response)};
 }
 
 StatusOr<ListBucketsResponse> CurlClient::ListBuckets(
@@ -597,8 +598,8 @@ StatusOr<RewriteObjectResponse> CurlClient::RewriteObject(
   return RewriteObjectResponse::FromHttpResponse(response->payload);
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
-CurlClient::CreateResumableSession(ResumableUploadRequest const& request) {
+StatusOr<CreateResumableSessionResponse> CurlClient::CreateResumableSession(
+    ResumableUploadRequest const& request) {
   auto session_id = request.GetOption<UseResumableUploadSession>().value_or("");
   if (!session_id.empty()) {
     return FullyRestoreResumableSession(request, session_id);
@@ -659,10 +660,14 @@ CurlClient::CreateResumableSession(ResumableUploadRequest const& request) {
     os << __func__ << " - invalid server response, parsed to " << *response;
     return Status(StatusCode::kInternal, std::move(os).str());
   }
-  return std::unique_ptr<ResumableUploadSession>(
-      absl::make_unique<CurlResumableUploadSession>(
-          shared_from_this(), request,
-          std::move(response->upload_session_url)));
+  auto session_url = response->upload_session_url;
+  return CreateResumableSessionResponse{
+      absl::make_unique<CurlResumableUploadSession>(shared_from_this(), request,
+                                                    std::move(session_url)),
+      ResumableUploadResponse{response->upload_session_url,
+                              ResumableUploadResponse::kInProgress,
+                              /*.committed_size=*/0, /*.payload=*/absl::nullopt,
+                              /*.annotations=*/{}}};
 }
 
 StatusOr<EmptyResponse> CurlClient::DeleteResumableUpload(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -79,9 +79,8 @@ class CurlClient : public RawClient,
       UploadChunkRequest const&);
   virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);
-  StatusOr<std::unique_ptr<ResumableUploadSession>>
-  FullyRestoreResumableSession(ResumableUploadRequest const& request,
-                               std::string const& session_id);
+  StatusOr<CreateResumableSessionResponse> FullyRestoreResumableSession(
+      ResumableUploadRequest const& request, std::string const& session_id);
   //@}
 
   ClientOptions const& client_options() const override {
@@ -124,7 +123,7 @@ class CurlClient : public RawClient,
       PatchObjectRequest const& request) override;
   StatusOr<ObjectMetadata> ComposeObject(
       ComposeObjectRequest const& request) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+  StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -69,9 +69,8 @@ class GrpcClient : public RawClient,
       std::unique_ptr<grpc::ClientContext> context);
   virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
       QueryResumableUploadRequest const&);
-  StatusOr<std::unique_ptr<ResumableUploadSession>>
-  FullyRestoreResumableSession(ResumableUploadRequest const& request,
-                               std::string const& upload_url);
+  StatusOr<CreateResumableSessionResponse> FullyRestoreResumableSession(
+      ResumableUploadRequest const& request, std::string const& upload_url);
   //@}
 
   Options const& options() const { return options_; }
@@ -118,7 +117,7 @@ class GrpcClient : public RawClient,
       ComposeObjectRequest const& request) override;
   StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+  StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -133,8 +133,8 @@ StatusOr<RewriteObjectResponse> HybridClient::RewriteObject(
   return curl_->RewriteObject(request);
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
-HybridClient::CreateResumableSession(ResumableUploadRequest const& request) {
+StatusOr<CreateResumableSessionResponse> HybridClient::CreateResumableSession(
+    ResumableUploadRequest const& request) {
   return grpc_->CreateResumableSession(request);
 }
 

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -74,7 +74,7 @@ class HybridClient : public RawClient {
       ComposeObjectRequest const& request) override;
   StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+  StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -190,16 +190,17 @@ StatusOr<RewriteObjectResponse> LoggingClient::RewriteObject(
   return MakeCall(*client_, &RawClient::RewriteObject, request, __func__);
 }
 
-StatusOr<std::unique_ptr<ResumableUploadSession>>
-LoggingClient::CreateResumableSession(ResumableUploadRequest const& request) {
+StatusOr<CreateResumableSessionResponse> LoggingClient::CreateResumableSession(
+    ResumableUploadRequest const& request) {
   auto result = MakeCallNoResponseLogging(
       *client_, &RawClient::CreateResumableSession, request, __func__);
   if (!result.ok()) {
     GCP_LOG(INFO) << __func__ << "() >> status={" << result.status() << "}";
     return std::move(result).status();
   }
-  return std::unique_ptr<ResumableUploadSession>(
-      absl::make_unique<LoggingResumableUploadSession>(*std::move(result)));
+  result->session = absl::make_unique<LoggingResumableUploadSession>(
+      std::move(result->session));
+  return result;
 }
 
 StatusOr<EmptyResponse> LoggingClient::DeleteResumableUpload(

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -72,7 +72,7 @@ class LoggingClient : public RawClient {
       ComposeObjectRequest const& request) override;
   StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+  StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -95,8 +95,9 @@ class RawClient {
       ComposeObjectRequest const&) = 0;
   virtual StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) = 0;
-  virtual StatusOr<std::unique_ptr<ResumableUploadSession>>
-  CreateResumableSession(ResumableUploadRequest const& request) = 0;
+
+  virtual StatusOr<CreateResumableSessionResponse> CreateResumableSession(
+      ResumableUploadRequest const& request) = 0;
   /// @deprecated this function is no longer used, see #7282 for details.
   GOOGLE_CLOUD_CPP_STORAGE_RESTORE_UPLOAD_DEPRECATED()
   virtual StatusOr<std::unique_ptr<ResumableUploadSession>>

--- a/google/cloud/storage/internal/resumable_upload_session.h
+++ b/google/cloud/storage/internal/resumable_upload_session.h
@@ -108,6 +108,21 @@ bool operator!=(ResumableUploadResponse const& lhs,
 std::ostream& operator<<(std::ostream& os, ResumableUploadResponse const& r);
 
 /**
+ * The return type for functions creating or restoring resumable upload
+ * sessions.
+ *
+ * Restoring a session produces both a new object to manage the session and the
+ * initial result of querying the session state.
+ *
+ * TODO(#8559) - this will become simply the resumable upload response as the
+ *   code evolves towards session-less resumable uploads.
+ */
+struct CreateResumableSessionResponse {
+  std::unique_ptr<ResumableUploadSession> session;
+  ResumableUploadResponse state;
+};
+
+/**
  * A resumable upload session that always returns an error.
  *
  * When an unrecoverable error is detected (or the policies to recover from an

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -83,7 +83,7 @@ class RetryClient : public RawClient,
       ComposeObjectRequest const& request) override;
   StatusOr<RewriteObjectResponse> RewriteObject(
       RewriteObjectRequest const&) override;
-  StatusOr<std::unique_ptr<ResumableUploadSession>> CreateResumableSession(
+  StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -39,6 +39,24 @@ StatusOr<ResumableUploadResponse> ReturnError(Status const& last_status,
 }
 }  // namespace
 
+RetryResumableUploadSession::RetryResumableUploadSession(
+    std::unique_ptr<ResumableUploadSession> session,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy)
+    : session_(std::move(session)),
+      retry_policy_prototype_(std::move(retry_policy)),
+      backoff_policy_prototype_(std::move(backoff_policy)) {}
+
+RetryResumableUploadSession::RetryResumableUploadSession(
+    std::unique_ptr<ResumableUploadSession> session,
+    std::unique_ptr<RetryPolicy> retry_policy,
+    std::unique_ptr<BackoffPolicy> backoff_policy,
+    ResumableUploadResponse const& last_response)
+    : session_(std::move(session)),
+      committed_size_(last_response.committed_size.value_or(0)),
+      retry_policy_prototype_(std::move(retry_policy)),
+      backoff_policy_prototype_(std::move(backoff_policy)) {}
+
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
   return UploadGenericChunk(__func__, buffers,

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -42,10 +42,13 @@ class RetryResumableUploadSession : public ResumableUploadSession {
   explicit RetryResumableUploadSession(
       std::unique_ptr<ResumableUploadSession> session,
       std::unique_ptr<RetryPolicy> retry_policy,
-      std::unique_ptr<BackoffPolicy> backoff_policy)
-      : session_(std::move(session)),
-        retry_policy_prototype_(std::move(retry_policy)),
-        backoff_policy_prototype_(std::move(backoff_policy)) {}
+      std::unique_ptr<BackoffPolicy> backoff_policy);
+
+  explicit RetryResumableUploadSession(
+      std::unique_ptr<ResumableUploadSession> session,
+      std::unique_ptr<RetryPolicy> retry_policy,
+      std::unique_ptr<BackoffPolicy> backoff_policy,
+      ResumableUploadResponse const& last_response);
 
   StatusOr<ResumableUploadResponse> UploadChunk(
       ConstBufferSequence const& buffers) override;
@@ -68,7 +71,7 @@ class RetryResumableUploadSession : public ResumableUploadSession {
       char const* caller, ConstBufferSequence buffers,
       UploadChunkFunction upload);
 
-  // Handle a response that uncommits some bytes
+  // Handle a response that un-commits some bytes
   Status HandleUncommitError(char const* caller,
                              ResumableUploadResponse const&);
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -78,7 +78,7 @@ class MockClient : public google::cloud::storage::internal::RawClient {
               (internal::ComposeObjectRequest const&), (override));
   MOCK_METHOD(StatusOr<internal::RewriteObjectResponse>, RewriteObject,
               (internal::RewriteObjectRequest const&), (override));
-  MOCK_METHOD(StatusOr<std::unique_ptr<internal::ResumableUploadSession>>,
+  MOCK_METHOD(StatusOr<internal::CreateResumableSessionResponse>,
               CreateResumableSession, (internal::ResumableUploadRequest const&),
               (override));
   MOCK_METHOD(StatusOr<std::unique_ptr<internal::ResumableUploadSession>>,
@@ -200,6 +200,20 @@ Client ClientFromMock(std::shared_ptr<MockClient> const& mock,
                       Policies&&... p) {
   return internal::ClientImplDetails::CreateClient(
       mock, std::forward<Policies>(p)...);
+}
+
+/// Simulate an initial resumable upload session response.
+inline internal::ResumableUploadResponse MockResumableUploadSessionInit() {
+  return internal::ResumableUploadResponse{
+      "", internal::ResumableUploadResponse::kInProgress, absl::nullopt,
+      absl::nullopt, std::string{}};
+}
+
+/// Simulate the final resumable upload session response.
+inline internal::ResumableUploadResponse MockResumableUploadSessionFinal() {
+  return internal::ResumableUploadResponse{
+      "", internal::ResumableUploadResponse::kDone, absl::nullopt,
+      ObjectMetadata(), std::string{}};
 }
 
 }  // namespace testing

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -202,20 +202,6 @@ Client ClientFromMock(std::shared_ptr<MockClient> const& mock,
       mock, std::forward<Policies>(p)...);
 }
 
-/// Simulate an initial resumable upload session response.
-inline internal::ResumableUploadResponse MockResumableUploadSessionInit() {
-  return internal::ResumableUploadResponse{
-      "", internal::ResumableUploadResponse::kInProgress, absl::nullopt,
-      absl::nullopt, std::string{}};
-}
-
-/// Simulate the final resumable upload session response.
-inline internal::ResumableUploadResponse MockResumableUploadSessionFinal() {
-  return internal::ResumableUploadResponse{
-      "", internal::ResumableUploadResponse::kDone, absl::nullopt,
-      ObjectMetadata(), std::string{}};
-}
-
 }  // namespace testing
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -46,13 +46,12 @@ class ObjectWriteStreambufIntegrationTest
     ResumableUploadRequest request(bucket_name_, object_name);
     request.set_multiple_options(IfGenerationMatch(0));
 
-    StatusOr<std::unique_ptr<ResumableUploadSession>> session =
-        internal::ClientImplDetails::GetRawClient(*client)
-            ->CreateResumableSession(request);
-    ASSERT_STATUS_OK(session);
+    auto create = internal::ClientImplDetails::GetRawClient(*client)
+                      ->CreateResumableSession(request);
+    ASSERT_STATUS_OK(create);
 
     ObjectWriteStream writer(absl::make_unique<ObjectWriteStreambuf>(
-        *std::move(session),
+        std::move(create->session),
         internal::ClientImplDetails::GetRawClient(*client)
             ->client_options()
             .upload_buffer_size(),


### PR DESCRIPTION
When creating new resumable upload sessions we need to return the
initial session state. Otherwise, any resumed sessions have an incorrect
value for the committed bytes and whether the upload is completed or
not.  In this change we just return the state, but do not use it.

Part of the work for #8621 and #8559

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8622)
<!-- Reviewable:end -->
