### PR TITLE
test: add bazel testonly attributes to test libraries and byproducts

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -115,6 +115,7 @@ GA_LIBRARIES = [
 
 [cc_library(
     name = "experimental-{library}_mocks".format(library = library),
+    testonly = 1,
     deps = [
         "//google/cloud/{library}:google_cloud_cpp_{library}_mocks".format(library = library),
     ],
@@ -131,6 +132,7 @@ GA_LIBRARIES = [
 
 [cc_library(
     name = "experimental-{library}_mocks".format(library = library),
+    testonly = 1,
     deprecation = "this library is now GA, please use //:{library}_mocks instead.".format(library = library),
     tags = ["manual"],
     deps = [
@@ -147,6 +149,7 @@ GA_LIBRARIES = [
 
 [cc_library(
     name = "{library}_mocks".format(library = library),
+    testonly = 1,
     deps = [
         "//google/cloud/{library}:google_cloud_cpp_{library}_mocks".format(library = library),
     ],
@@ -161,6 +164,7 @@ cc_library(
 
 cc_library(
     name = "bigquery-mocks",
+    testonly = 1,
     deprecation = "please use //:bigquery_mocks instead.",
     tags = ["manual"],
     deps = [
@@ -170,6 +174,7 @@ cc_library(
 
 cc_library(
     name = "bigquery_mocks",
+    testonly = 1,
     deps = [
         "//google/cloud/bigquery:google_cloud_cpp_bigquery_mocks",
     ],
@@ -191,6 +196,7 @@ cc_library(
 
 cc_library(
     name = "iam-mocks",
+    testonly = 1,
     deprecation = "please use //:iam_mocks instead.",
     tags = ["manual"],
     deps = [
@@ -200,6 +206,7 @@ cc_library(
 
 cc_library(
     name = "iam_mocks",
+    testonly = 1,
     deps = [
         "//google/cloud/iam:google_cloud_cpp_iam_mocks",
     ],
@@ -214,6 +221,7 @@ cc_library(
 
 cc_library(
     name = "pubsub_mocks",
+    testonly = 1,
     deps = [
         "//google/cloud/pubsub:google_cloud_cpp_pubsub_mocks",
     ],
@@ -228,6 +236,7 @@ cc_library(
 
 cc_library(
     name = "spanner_mocks",
+    testonly = 1,
     deps = [
         "//google/cloud/spanner:google_cloud_cpp_spanner_mocks",
     ],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -115,7 +115,7 @@ GA_LIBRARIES = [
 
 [cc_library(
     name = "experimental-{library}_mocks".format(library = library),
-    testonly = 1,
+    testonly = True,
     deps = [
         "//google/cloud/{library}:google_cloud_cpp_{library}_mocks".format(library = library),
     ],
@@ -132,7 +132,7 @@ GA_LIBRARIES = [
 
 [cc_library(
     name = "experimental-{library}_mocks".format(library = library),
-    testonly = 1,
+    testonly = True,
     deprecation = "this library is now GA, please use //:{library}_mocks instead.".format(library = library),
     tags = ["manual"],
     deps = [
@@ -149,7 +149,7 @@ GA_LIBRARIES = [
 
 [cc_library(
     name = "{library}_mocks".format(library = library),
-    testonly = 1,
+    testonly = True,
     deps = [
         "//google/cloud/{library}:google_cloud_cpp_{library}_mocks".format(library = library),
     ],
@@ -164,7 +164,7 @@ cc_library(
 
 cc_library(
     name = "bigquery-mocks",
-    testonly = 1,
+    testonly = True,
     deprecation = "please use //:bigquery_mocks instead.",
     tags = ["manual"],
     deps = [
@@ -174,7 +174,7 @@ cc_library(
 
 cc_library(
     name = "bigquery_mocks",
-    testonly = 1,
+    testonly = True,
     deps = [
         "//google/cloud/bigquery:google_cloud_cpp_bigquery_mocks",
     ],
@@ -196,7 +196,7 @@ cc_library(
 
 cc_library(
     name = "iam-mocks",
-    testonly = 1,
+    testonly = True,
     deprecation = "please use //:iam_mocks instead.",
     tags = ["manual"],
     deps = [
@@ -206,7 +206,7 @@ cc_library(
 
 cc_library(
     name = "iam_mocks",
-    testonly = 1,
+    testonly = True,
     deps = [
         "//google/cloud/iam:google_cloud_cpp_iam_mocks",
     ],
@@ -221,7 +221,7 @@ cc_library(
 
 cc_library(
     name = "pubsub_mocks",
-    testonly = 1,
+    testonly = True,
     deps = [
         "//google/cloud/pubsub:google_cloud_cpp_pubsub_mocks",
     ],
@@ -236,7 +236,7 @@ cc_library(
 
 cc_library(
     name = "spanner_mocks",
-    testonly = 1,
+    testonly = True,
     deps = [
         "//google/cloud/spanner:google_cloud_cpp_spanner_mocks",
     ],

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -40,7 +40,7 @@ load(":google_cloud_cpp_generator_testing.bzl", "google_cloud_cpp_generator_test
 
 cc_library(
     name = "google_cloud_cpp_generator_testing",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_generator_testing_hdrs,
     hdrs = google_cloud_cpp_generator_testing_srcs,
     deps = [

--- a/generator/BUILD.bazel
+++ b/generator/BUILD.bazel
@@ -40,6 +40,7 @@ load(":google_cloud_cpp_generator_testing.bzl", "google_cloud_cpp_generator_test
 
 cc_library(
     name = "google_cloud_cpp_generator_testing",
+    testonly = 1,
     srcs = google_cloud_cpp_generator_testing_hdrs,
     hdrs = google_cloud_cpp_generator_testing_srcs,
     deps = [

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -43,6 +43,7 @@ load(":google_cloud_cpp_bigtable_mocks.bzl", "google_cloud_cpp_bigtable_mocks_hd
 
 cc_library(
     name = "google_cloud_cpp_bigtable_mocks",
+    testonly = 1,
     srcs = google_cloud_cpp_bigtable_mocks_srcs,
     hdrs = google_cloud_cpp_bigtable_mocks_hdrs,
     visibility = [
@@ -61,6 +62,7 @@ load(":bigtable_client_testing.bzl", "bigtable_client_testing_hdrs", "bigtable_c
 
 cc_library(
     name = "bigtable_client_testing",
+    testonly = 1,
     srcs = bigtable_client_testing_srcs,
     hdrs = bigtable_client_testing_hdrs,
     visibility = ["//visibility:public"],

--- a/google/cloud/bigtable/BUILD.bazel
+++ b/google/cloud/bigtable/BUILD.bazel
@@ -43,7 +43,7 @@ load(":google_cloud_cpp_bigtable_mocks.bzl", "google_cloud_cpp_bigtable_mocks_hd
 
 cc_library(
     name = "google_cloud_cpp_bigtable_mocks",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_bigtable_mocks_srcs,
     hdrs = google_cloud_cpp_bigtable_mocks_hdrs,
     visibility = [
@@ -62,7 +62,7 @@ load(":bigtable_client_testing.bzl", "bigtable_client_testing_hdrs", "bigtable_c
 
 cc_library(
     name = "bigtable_client_testing",
-    testonly = 1,
+    testonly = True,
     srcs = bigtable_client_testing_srcs,
     hdrs = bigtable_client_testing_hdrs,
     visibility = ["//visibility:public"],

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -20,6 +20,7 @@ load(":bigtable_benchmark_common.bzl", "bigtable_benchmark_common_hdrs", "bigtab
 
 cc_library(
     name = "bigtable_benchmark_common",
+    testonly = 1,
     srcs = bigtable_benchmark_common_srcs,
     hdrs = bigtable_benchmark_common_hdrs,
     deps = [
@@ -34,6 +35,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
+    testonly = 1,
     srcs = [program],
     linkopts = select({
         "@platforms//os:windows": [],

--- a/google/cloud/bigtable/benchmarks/BUILD.bazel
+++ b/google/cloud/bigtable/benchmarks/BUILD.bazel
@@ -20,7 +20,7 @@ load(":bigtable_benchmark_common.bzl", "bigtable_benchmark_common_hdrs", "bigtab
 
 cc_library(
     name = "bigtable_benchmark_common",
-    testonly = 1,
+    testonly = True,
     srcs = bigtable_benchmark_common_srcs,
     hdrs = bigtable_benchmark_common_hdrs,
     deps = [
@@ -35,7 +35,7 @@ load(":bigtable_benchmark_programs.bzl", "bigtable_benchmark_programs")
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
-    testonly = 1,
+    testonly = True,
     srcs = [program],
     linkopts = select({
         "@platforms//os:windows": [],

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -20,7 +20,7 @@ load(":bigtable_examples_common.bzl", "bigtable_examples_common_hdrs", "bigtable
 
 cc_library(
     name = "bigtable_examples_common",
-    testonly = 1,
+    testonly = True,
     srcs = bigtable_examples_common_srcs,
     hdrs = bigtable_examples_common_hdrs,
     deps = [

--- a/google/cloud/bigtable/examples/BUILD.bazel
+++ b/google/cloud/bigtable/examples/BUILD.bazel
@@ -20,6 +20,7 @@ load(":bigtable_examples_common.bzl", "bigtable_examples_common_hdrs", "bigtable
 
 cc_library(
     name = "bigtable_examples_common",
+    testonly = 1,
     srcs = bigtable_examples_common_srcs,
     hdrs = bigtable_examples_common_hdrs,
     deps = [

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -39,6 +39,7 @@ load(":pubsub_client_testing.bzl", "pubsub_client_testing_hdrs", "pubsub_client_
 
 cc_library(
     name = "pubsub_client_testing_private",
+    testonly = 1,
     srcs = pubsub_client_testing_srcs,
     hdrs = pubsub_client_testing_hdrs,
     visibility = [
@@ -55,6 +56,7 @@ cc_library(
 # TODO(#3701): Delete this target after 2023-04-01.
 cc_library(
     name = "pubsub_client_testing",
+    testonly = 1,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701
@@ -68,6 +70,7 @@ load(":google_cloud_cpp_pubsub_mocks.bzl", "google_cloud_cpp_pubsub_mocks_hdrs",
 
 cc_library(
     name = "google_cloud_cpp_pubsub_mocks",
+    testonly = 1,
     srcs = google_cloud_cpp_pubsub_mocks_srcs,
     hdrs = google_cloud_cpp_pubsub_mocks_hdrs,
     visibility = [

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -39,7 +39,7 @@ load(":pubsub_client_testing.bzl", "pubsub_client_testing_hdrs", "pubsub_client_
 
 cc_library(
     name = "pubsub_client_testing_private",
-    testonly = 1,
+    testonly = True,
     srcs = pubsub_client_testing_srcs,
     hdrs = pubsub_client_testing_hdrs,
     visibility = [
@@ -56,7 +56,7 @@ cc_library(
 # TODO(#3701): Delete this target after 2023-04-01.
 cc_library(
     name = "pubsub_client_testing",
-    testonly = 1,
+    testonly = True,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701
@@ -70,7 +70,7 @@ load(":google_cloud_cpp_pubsub_mocks.bzl", "google_cloud_cpp_pubsub_mocks_hdrs",
 
 cc_library(
     name = "google_cloud_cpp_pubsub_mocks",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_pubsub_mocks_srcs,
     hdrs = google_cloud_cpp_pubsub_mocks_hdrs,
     visibility = [

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -20,6 +20,7 @@ load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs"
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
+    testonly = 1,
     srcs = [program],
     tags = [
         "integration-test",

--- a/google/cloud/pubsub/benchmarks/BUILD.bazel
+++ b/google/cloud/pubsub/benchmarks/BUILD.bazel
@@ -20,7 +20,7 @@ load(":pubsub_client_benchmark_programs.bzl", "pubsub_client_benchmark_programs"
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
-    testonly = 1,
+    testonly = True,
     srcs = [program],
     tags = [
         "integration-test",

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -22,7 +22,7 @@ load(":pubsub_samples_common.bzl", "pubsub_samples_common_hdrs", "pubsub_samples
 
 cc_library(
     name = "pubsub_samples_common",
-    testonly = 1,
+    testonly = True,
     srcs = pubsub_samples_common_srcs,
     hdrs = pubsub_samples_common_hdrs,
     deps = [

--- a/google/cloud/pubsub/samples/BUILD.bazel
+++ b/google/cloud/pubsub/samples/BUILD.bazel
@@ -22,6 +22,7 @@ load(":pubsub_samples_common.bzl", "pubsub_samples_common_hdrs", "pubsub_samples
 
 cc_library(
     name = "pubsub_samples_common",
+    testonly = 1,
     srcs = pubsub_samples_common_srcs,
     hdrs = pubsub_samples_common_hdrs,
     deps = [

--- a/google/cloud/pubsublite/BUILD.bazel
+++ b/google/cloud/pubsublite/BUILD.bazel
@@ -34,6 +34,7 @@ load(":google_cloud_cpp_pubsublite_mocks.bzl", "google_cloud_cpp_pubsublite_mock
 
 cc_library(
     name = "google_cloud_cpp_pubsublite_mocks",
+    testonly = 1,
     srcs = google_cloud_cpp_pubsublite_mocks_srcs,
     hdrs = google_cloud_cpp_pubsublite_mocks_hdrs,
     visibility = ["//:__pkg__"],
@@ -48,6 +49,7 @@ load(":pubsublite_testing.bzl", "pubsublite_testing_hdrs", "pubsublite_testing_s
 
 cc_library(
     name = "pubsublite_testing",
+    testonly = 1,
     srcs = pubsublite_testing_srcs,
     hdrs = pubsublite_testing_hdrs,
     visibility = ["//:__pkg__"],

--- a/google/cloud/pubsublite/BUILD.bazel
+++ b/google/cloud/pubsublite/BUILD.bazel
@@ -34,7 +34,7 @@ load(":google_cloud_cpp_pubsublite_mocks.bzl", "google_cloud_cpp_pubsublite_mock
 
 cc_library(
     name = "google_cloud_cpp_pubsublite_mocks",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_pubsublite_mocks_srcs,
     hdrs = google_cloud_cpp_pubsublite_mocks_hdrs,
     visibility = ["//:__pkg__"],
@@ -49,7 +49,7 @@ load(":pubsublite_testing.bzl", "pubsublite_testing_hdrs", "pubsublite_testing_s
 
 cc_library(
     name = "pubsublite_testing",
-    testonly = 1,
+    testonly = True,
     srcs = pubsublite_testing_srcs,
     hdrs = pubsublite_testing_hdrs,
     visibility = ["//:__pkg__"],

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -47,7 +47,7 @@ load(":google_cloud_cpp_spanner_mocks.bzl", "google_cloud_cpp_spanner_mocks_hdrs
 
 cc_library(
     name = "google_cloud_cpp_spanner_mocks",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_spanner_mocks_srcs,
     hdrs = google_cloud_cpp_spanner_mocks_hdrs,
     visibility = [
@@ -66,7 +66,7 @@ load(":spanner_client_testing.bzl", "spanner_client_testing_hdrs", "spanner_clie
 
 cc_library(
     name = "spanner_client_testing_private",
-    testonly = 1,
+    testonly = True,
     srcs = spanner_client_testing_srcs,
     hdrs = spanner_client_testing_hdrs,
     visibility = [
@@ -84,7 +84,7 @@ cc_library(
 # TODO(#3701): Delete this target after 2023-04-01.
 cc_library(
     name = "spanner_client_testing",
-    testonly = 1,
+    testonly = True,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701

--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -47,6 +47,7 @@ load(":google_cloud_cpp_spanner_mocks.bzl", "google_cloud_cpp_spanner_mocks_hdrs
 
 cc_library(
     name = "google_cloud_cpp_spanner_mocks",
+    testonly = 1,
     srcs = google_cloud_cpp_spanner_mocks_srcs,
     hdrs = google_cloud_cpp_spanner_mocks_hdrs,
     visibility = [
@@ -65,6 +66,7 @@ load(":spanner_client_testing.bzl", "spanner_client_testing_hdrs", "spanner_clie
 
 cc_library(
     name = "spanner_client_testing_private",
+    testonly = 1,
     srcs = spanner_client_testing_srcs,
     hdrs = spanner_client_testing_hdrs,
     visibility = [
@@ -82,6 +84,7 @@ cc_library(
 # TODO(#3701): Delete this target after 2023-04-01.
 cc_library(
     name = "spanner_client_testing",
+    testonly = 1,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -21,7 +21,7 @@ load(":spanner_client_benchmark_programs.bzl", "spanner_client_benchmark_program
 
 cc_library(
     name = "spanner_client_benchmarks",
-    testonly = 1,
+    testonly = True,
     srcs = spanner_client_benchmarks_srcs,
     hdrs = spanner_client_benchmarks_hdrs,
     deps = [
@@ -36,7 +36,7 @@ cc_library(
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
-    testonly = 1,
+    testonly = True,
     srcs = [program],
     deps = [
         ":spanner_client_benchmarks",

--- a/google/cloud/spanner/benchmarks/BUILD.bazel
+++ b/google/cloud/spanner/benchmarks/BUILD.bazel
@@ -21,6 +21,7 @@ load(":spanner_client_benchmark_programs.bzl", "spanner_client_benchmark_program
 
 cc_library(
     name = "spanner_client_benchmarks",
+    testonly = 1,
     srcs = spanner_client_benchmarks_srcs,
     hdrs = spanner_client_benchmarks_hdrs,
     deps = [
@@ -35,6 +36,7 @@ cc_library(
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
+    testonly = 1,
     srcs = [program],
     deps = [
         ":spanner_client_benchmarks",

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -85,6 +85,7 @@ load(":storage_client_testing.bzl", "storage_client_testing_hdrs", "storage_clie
 
 cc_library(
     name = "storage_client_testing",
+    testonly = 1,
     srcs = storage_client_testing_srcs,
     hdrs = storage_client_testing_hdrs,
     copts = select({

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -85,7 +85,7 @@ load(":storage_client_testing.bzl", "storage_client_testing_hdrs", "storage_clie
 
 cc_library(
     name = "storage_client_testing",
-    testonly = 1,
+    testonly = True,
     srcs = storage_client_testing_srcs,
     hdrs = storage_client_testing_hdrs,
     copts = select({

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -20,6 +20,7 @@ load(":storage_benchmarks.bzl", "storage_benchmarks_hdrs", "storage_benchmarks_s
 
 cc_library(
     name = "storage_benchmarks",
+    testonly = 1,
     srcs = storage_benchmarks_srcs,
     hdrs = storage_benchmarks_hdrs,
     deps = [
@@ -40,6 +41,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
+    testonly = 1,
     srcs = [program],
     linkopts = select({
         "@platforms//os:windows": [],

--- a/google/cloud/storage/benchmarks/BUILD.bazel
+++ b/google/cloud/storage/benchmarks/BUILD.bazel
@@ -20,7 +20,7 @@ load(":storage_benchmarks.bzl", "storage_benchmarks_hdrs", "storage_benchmarks_s
 
 cc_library(
     name = "storage_benchmarks",
-    testonly = 1,
+    testonly = True,
     srcs = storage_benchmarks_srcs,
     hdrs = storage_benchmarks_hdrs,
     deps = [
@@ -41,7 +41,7 @@ load(":storage_benchmark_programs.bzl", "storage_benchmark_programs")
 
 [cc_binary(
     name = program.replace("/", "_").replace(".cc", ""),
-    testonly = 1,
+    testonly = True,
     srcs = [program],
     linkopts = select({
         "@platforms//os:windows": [],

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -20,6 +20,7 @@ load(":storage_examples_common.bzl", "storage_examples_common_hdrs", "storage_ex
 
 cc_library(
     name = "storage_examples_common",
+    testonly = 1,
     srcs = storage_examples_common_srcs,
     hdrs = storage_examples_common_hdrs,
     deps = [

--- a/google/cloud/storage/examples/BUILD.bazel
+++ b/google/cloud/storage/examples/BUILD.bazel
@@ -20,7 +20,7 @@ load(":storage_examples_common.bzl", "storage_examples_common_hdrs", "storage_ex
 
 cc_library(
     name = "storage_examples_common",
-    testonly = 1,
+    testonly = True,
     srcs = storage_examples_common_srcs,
     hdrs = storage_examples_common_hdrs,
     deps = [

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -22,7 +22,7 @@ load(":google_cloud_cpp_testing.bzl", "google_cloud_cpp_testing_hdrs", "google_c
 
 cc_library(
     name = "google_cloud_cpp_testing_private",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_testing_srcs,
     hdrs = google_cloud_cpp_testing_hdrs,
     defines = select({
@@ -45,7 +45,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_testing",
-    testonly = 1,
+    testonly = True,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701
@@ -71,7 +71,7 @@ load(":google_cloud_cpp_testing_grpc.bzl", "google_cloud_cpp_testing_grpc_hdrs",
 
 cc_library(
     name = "google_cloud_cpp_testing_grpc_private",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_testing_grpc_srcs,
     hdrs = google_cloud_cpp_testing_grpc_hdrs,
     deps = [
@@ -87,7 +87,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_testing_grpc",
-    testonly = 1,
+    testonly = True,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701
@@ -114,7 +114,7 @@ load(":google_cloud_cpp_testing_rest.bzl", "google_cloud_cpp_testing_rest_hdrs",
 
 cc_library(
     name = "google_cloud_cpp_testing_rest_private",
-    testonly = 1,
+    testonly = True,
     srcs = google_cloud_cpp_testing_rest_srcs,
     hdrs = google_cloud_cpp_testing_rest_hdrs,
     deps = [
@@ -125,7 +125,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_testing_rest",
-    testonly = 1,
+    testonly = True,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701

--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -22,6 +22,7 @@ load(":google_cloud_cpp_testing.bzl", "google_cloud_cpp_testing_hdrs", "google_c
 
 cc_library(
     name = "google_cloud_cpp_testing_private",
+    testonly = 1,
     srcs = google_cloud_cpp_testing_srcs,
     hdrs = google_cloud_cpp_testing_hdrs,
     defines = select({
@@ -44,6 +45,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_testing",
+    testonly = 1,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701
@@ -69,6 +71,7 @@ load(":google_cloud_cpp_testing_grpc.bzl", "google_cloud_cpp_testing_grpc_hdrs",
 
 cc_library(
     name = "google_cloud_cpp_testing_grpc_private",
+    testonly = 1,
     srcs = google_cloud_cpp_testing_grpc_srcs,
     hdrs = google_cloud_cpp_testing_grpc_hdrs,
     deps = [
@@ -84,6 +87,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_testing_grpc",
+    testonly = 1,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701
@@ -110,6 +114,7 @@ load(":google_cloud_cpp_testing_rest.bzl", "google_cloud_cpp_testing_rest_hdrs",
 
 cc_library(
     name = "google_cloud_cpp_testing_rest_private",
+    testonly = 1,
     srcs = google_cloud_cpp_testing_rest_srcs,
     hdrs = google_cloud_cpp_testing_rest_hdrs,
     deps = [
@@ -120,6 +125,7 @@ cc_library(
 
 cc_library(
     name = "google_cloud_cpp_testing_rest",
+    testonly = 1,
     deprecation = """
     This target is deprecated and will be removed on or after 2023-04-01. More
     info: https://github.com/googleapis/google-cloud-cpp/issues/3701


### PR DESCRIPTION
Use the bazel testonly attribute to ensure that test code does not
end up in the production libraries.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8623)
<!-- Reviewable:end -->
