### PR TITLE
test(storage): fix client-per-thread implementation

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -60,7 +60,7 @@ using ClientProvider =
  * Create the list of upload experiments based on the @p options.
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
-    ThroughputOptions const& options, ClientProvider provider);
+    ThroughputOptions const& options, ClientProvider const& provider);
 
 /**
  * Create the list of download experiments based on the @p options.
@@ -69,7 +69,8 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
  * they depend on the upload experiment to create the objects to be downloaded.
  */
 std::vector<std::unique_ptr<ThroughputExperiment>> CreateDownloadExperiments(
-    ThroughputOptions const& options, ClientProvider provider, int thread_id);
+    ThroughputOptions const& options, ClientProvider const& provider,
+    int thread_id);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud


### PR DESCRIPTION
The benchmark was creating different clients per thread regardless of
the `--client-per-thread` option value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8624)
<!-- Reviewable:end -->
