### PR TITLE
cleanup: avoid genrule() on Windows

### DIFF
--- a/bazel/configure_template.bzl
+++ b/bazel/configure_template.bzl
@@ -16,7 +16,7 @@
 Define a rule to configure .in template files.
 
 We use custom *.BUILD files for two external dependencies that do not natively support Bazel: crc32c and libcurl.
-Both require configuring a `.in` file, this creates a rules to perform this configuration.
+Both require configuring a `.in` file. This creates a rules to perform this configuration.
 """
 
 def _configure_template_impl(ctx):

--- a/bazel/configure_template.bzl
+++ b/bazel/configure_template.bzl
@@ -1,0 +1,39 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Define a rule to configure .in template files.
+
+We use custom *.BUILD files for two external dependencies that do not natively support Bazel: crc32c and libcurl.
+Both require configuring a `.in` file, this creates a rules to perform this configuration.
+"""
+
+def _configure_template_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = ctx.outputs.output,
+        substitutions = ctx.attr.substitutions,
+    )
+
+configure_template = rule(
+    implementation = _configure_template_impl,
+    attrs = {
+        "substitutions": attr.string_dict(default = {}),
+        "template": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+        "output": attr.output(mandatory = True),
+    },
+)

--- a/bazel/crc32c.BUILD
+++ b/bazel/crc32c.BUILD
@@ -89,22 +89,23 @@ sse42_enabled = select({
     "//conditions:default": "0",
 })
 
-genrule(
+load("@com_github_googleapis_google_cloud_cpp//bazel:configure_template.bzl", "configure_template")
+
+configure_template(
     name = "generate_config",
-    srcs = ["src/crc32c_config.h.in"],
-    outs = ["crc32c/crc32c_config.h"],
-    cmd = """
-sed -e 's/#cmakedefine01/#define/' \
-    -e 's/ BYTE_ORDER_BIG_ENDIAN/ BYTE_ORDER_BIG_ENDIAN 0/' \
-    -e 's/ HAVE_BUILTIN_PREFETCH/ HAVE_BUILTIN_PREFETCH 0/' \
-    -e 's/ HAVE_MM_PREFETCH/ HAVE_MM_PREFETCH 0/' \
-    -e 's/ HAVE_SSE42/ HAVE_SSE42 1/' \
-    -e 's/ HAVE_ARM64_CRC32C/ HAVE_ARM64_CRC32C 0/' \
-    -e 's/ HAVE_STRONG_GETAUXVAL/ HAVE_STRONG_GETAUXVAL 0/' \
-    -e 's/ HAVE_WEAK_GETAUXVAL/ HAVE_WEAK_GETAUXVAL 0/' \
-    -e 's/ CRC32C_TESTS_BUILT_WITH_GLOG/ CRC32C_TESTS_BUILT_WITH_GLOG 0/' \
-    < $< > $@
-""",
+    output = "crc32c/crc32c_config.h",
+    substitutions = {
+        "#cmakedefine01": "#define",
+        " BYTE_ORDER_BIG_ENDIAN": " BYTE_ORDER_BIG_ENDIAN 0",
+        " HAVE_BUILTIN_PREFETCH": " HAVE_BUILTIN_PREFETCH 0",
+        " HAVE_MM_PREFETCH": " HAVE_MM_PREFETCH 0",
+        " HAVE_SSE42": " HAVE_SSE42 1",
+        " HAVE_ARM64_CRC32C": " HAVE_ARM64_CRC32C 0",
+        " HAVE_STRONG_GETAUXVAL": " HAVE_STRONG_GETAUXVAL 0",
+        " HAVE_WEAK_GETAUXVAL": " HAVE_WEAK_GETAUXVAL 0",
+        " CRC32C_TESTS_BUILT_WITH_GLOG": " CRC32C_TESTS_BUILT_WITH_GLOG 0",
+    },
+    template = "src/crc32c_config.h.in",
 )
 
 cc_library(

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -55,7 +55,9 @@ config_setting(
 
 # This just generates a header file with the right value for the CURL_CA_BUNDLE
 # macro. The file is included by curl_config.h if the macro is *not* provided
-# in the build line using -DCURL_CA_BUNDLE=<some-path>:
+# in the build line using -DCURL_CA_BUNDLE=<some-path>.  Note that this rule
+# only runs on Linux, the dependency is suppressed (via a `select()`) on other
+# platforms.
 genrule(
     name = "gen-ca-bundle-linux",
     outs = ["include/curl_ca_bundle_location.h"],
@@ -450,11 +452,12 @@ cc_library(
     }),
 )
 
-genrule(
+load("@bazel_skylib//rules:write_file.bzl", "write_file")
+
+write_file(
     name = "configure",
-    outs = ["include/curl_config.h"],
-    cmd = "\n".join([
-        "cat <<'EOF' >$@",
+    out = "include/curl_config.h",
+    content = [
         "#ifndef EXTERNAL_CURL_INCLUDE_CURL_CONFIG_H_",
         "#define EXTERNAL_CURL_INCLUDE_CURL_CONFIG_H_",
         "",
@@ -719,6 +722,5 @@ genrule(
         "#endif",
         "",
         "#endif  // EXTERNAL_CURL_INCLUDE_CURL_CONFIG_H_",
-        "EOF",
-    ]),
+    ],
 )

--- a/bazel/curl.BUILD
+++ b/bazel/curl.BUILD
@@ -56,7 +56,7 @@ config_setting(
 # This just generates a header file with the right value for the CURL_CA_BUNDLE
 # macro. The file is included by curl_config.h if the macro is *not* provided
 # in the build line using -DCURL_CA_BUNDLE=<some-path>.  Note that this rule
-# only runs on Linux, the dependency is suppressed (via a `select()`) on other
+# only runs on Linux; the dependency is suppressed (via a `select()`) on other
 # platforms.
 genrule(
     name = "gen-ca-bundle-linux",


### PR DESCRIPTION
With this PR Windows builds should not require `bash(1)`. This PR
removes all references to `genrule()` on Windows (there is one left, but
only takes effect on Linux).

Part of the work for #8613

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8632)
<!-- Reviewable:end -->
