### PR TITLE
ci: tweak the integration-test logging configuration

### DIFF
--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -30,9 +30,9 @@ $env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
 
 # A number of options to improve logging during the CI builds. They are useful
 # when troubleshooting problems.
-$env:GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
+$env:GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,256,WARNING"
 $env:GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
-$env:GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
+$env:GOOGLE_CLOUD_CPP_TRACING_OPTIONS="single_line_mode=off,truncate_string_field_longer_than=512"
 $env:CLOUD_STORAGE_ENABLE_TRACING="raw-client"
 
 # Cloud Bigtable configuration parameters

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -38,9 +38,9 @@ export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
 
 # A number of options to improve logging during the CI builds. They are useful
 # when troubleshooting problems.
-export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,100,WARNING"
+export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,256,WARNING"
 export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
-export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="truncate_string_field_longer_than=512"
+export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="single_line_mode=off,truncate_string_field_longer_than=512"
 export CLOUD_STORAGE_ENABLE_TRACING="raw-client"
 
 # Cloud Bigtable configuration parameters


### PR DESCRIPTION
- Bump the size of the "lastN" buffer from 100 to 256.  This
  will help catch the entirety of long-running operations.

- Turn off "single line" mode.  I've found that the protobuf
  tracing is significantly easier to read this way.  It is
  certainly nicer when attaching a trace to a bug report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8634)
<!-- Reviewable:end -->
