### PR TITLE
ci: use checkers image for generate-libraries build

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -26,6 +26,7 @@ RUN dnf makecache && \
         clang-tools-extra \
         diffutils \
         findutils \
+        gcc-c++ \
         git \
         patch \
         python-pip \

--- a/ci/cloudbuild/triggers/generate-libraries-ci.yaml
+++ b/ci/cloudbuild/triggers/generate-libraries-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: generate-libraries-ci
 substitutions:
   _BUILD_NAME: generate-libraries
-  _DISTRO: fedora-34
+  _DISTRO: checkers
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/generate-libraries-pr.yaml
+++ b/ci/cloudbuild/triggers/generate-libraries-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: generate-libraries-pr
 substitutions:
   _BUILD_NAME: generate-libraries
-  _DISTRO: fedora-34
+  _DISTRO: checkers
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
The checkers build and the generate-libraries build need to change
atomically. Both reformat all the C++ code, so we better use the same
version of `clang-format` in both builds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8638)
<!-- Reviewable:end -->
