### PR TITLE
ci(spanner): decrease LRO polling-time limit for backup tests

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -93,7 +93,7 @@ class BackupExtraIntegrationTest
                         .clone())
                 .set<spanner_admin::DatabaseAdminPollingPolicyOption>(
                     GenericPollingPolicy<>(
-                        LimitedTimeRetryPolicy(std::chrono::hours(3)),
+                        LimitedTimeRetryPolicy(std::chrono::minutes(90)),
                         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                                  std::chrono::minutes(1), 2.0))
                         .clone())) {}

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -82,7 +82,7 @@ class BackupIntegrationTest
                         .clone())
                 .set<spanner_admin::DatabaseAdminPollingPolicyOption>(
                     GenericPollingPolicy<>(
-                        LimitedTimeRetryPolicy(std::chrono::hours(3)),
+                        LimitedTimeRetryPolicy(std::chrono::minutes(90)),
                         ExponentialBackoffPolicy(std::chrono::seconds(1),
                                                  std::chrono::minutes(1), 2.0))
                         .clone())) {}

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -82,7 +82,7 @@ class BackupExtraIntegrationTest
                                      std::chrono::minutes(1), 2.0)
                 .clone(),
             GenericPollingPolicy<>(
-                LimitedTimeRetryPolicy(std::chrono::hours(3)),
+                LimitedTimeRetryPolicy(std::chrono::minutes(90)),
                 ExponentialBackoffPolicy(std::chrono::seconds(1),
                                          std::chrono::minutes(1), 2.0))
                 .clone())) {}

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -72,7 +72,7 @@ class BackupIntegrationTest
                                      std::chrono::minutes(1), 2.0)
                 .clone(),
             GenericPollingPolicy<>(
-                LimitedTimeRetryPolicy(std::chrono::hours(3)),
+                LimitedTimeRetryPolicy(std::chrono::minutes(90)),
                 ExponentialBackoffPolicy(std::chrono::seconds(1),
                                          std::chrono::minutes(1), 2.0))
                 .clone())) {}


### PR DESCRIPTION
Decrease the polling-time limit from 3 hours to 90 minutes.  The
test infrastructure has a 3h timeout itself, and if that hits first
then we won't see the RPC tracing needed to figure out what is going
wrong.  Successful runs indicate that the backup should only take
about 30-45m, so the 90m limit should still be sufficient to only
catch problematic cases.

Part of #8616 and #8628.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8639)
<!-- Reviewable:end -->
