### PR TITLE
ci: move more builds to Fedora:35

### DIFF
--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -17,7 +17,7 @@
 # than to the extent that certain distros offer certain versions of software
 # that the build needs. It's fine to add more deps that are needed by the
 # `checkers.sh` build.
-FROM fedora:34
+FROM fedora:35
 ARG NCPU=4
 
 RUN dnf makecache && \

--- a/google/cloud/accessapproval/access_approval_connection.cc
+++ b/google/cloud/accessapproval/access_approval_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AccessApprovalConnection::~AccessApprovalConnection() = default;
 
 StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>
-    AccessApprovalConnection::ListApprovalRequests(
-        google::cloud::accessapproval::v1::
-            ListApprovalRequestsMessage) {  // NOLINT(performance-unnecessary-value-param)
+AccessApprovalConnection::ListApprovalRequests(
+    google::cloud::accessapproval::v1::
+        ListApprovalRequestsMessage) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>>();
 }

--- a/google/cloud/accesscontextmanager/access_context_manager_connection.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AccessContextManagerConnection::~AccessContextManagerConnection() = default;
 
 StreamRange<google::identity::accesscontextmanager::v1::AccessPolicy>
-    AccessContextManagerConnection::ListAccessPolicies(
-        google::identity::accesscontextmanager::v1::
-            ListAccessPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
+AccessContextManagerConnection::ListAccessPolicies(
+    google::identity::accesscontextmanager::v1::
+        ListAccessPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::identity::accesscontextmanager::v1::AccessPolicy>>();
 }
@@ -77,9 +77,9 @@ AccessContextManagerConnection::DeleteAccessPolicy(
 }
 
 StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>
-    AccessContextManagerConnection::ListAccessLevels(
-        google::identity::accesscontextmanager::v1::
-            ListAccessLevelsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AccessContextManagerConnection::ListAccessLevels(
+    google::identity::accesscontextmanager::v1::
+        ListAccessLevelsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::identity::accesscontextmanager::v1::AccessLevel>>();
 }
@@ -130,9 +130,9 @@ AccessContextManagerConnection::ReplaceAccessLevels(
 }
 
 StreamRange<google::identity::accesscontextmanager::v1::ServicePerimeter>
-    AccessContextManagerConnection::ListServicePerimeters(
-        google::identity::accesscontextmanager::v1::
-            ListServicePerimetersRequest) {  // NOLINT(performance-unnecessary-value-param)
+AccessContextManagerConnection::ListServicePerimeters(
+    google::identity::accesscontextmanager::v1::
+        ListServicePerimetersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::identity::accesscontextmanager::v1::ServicePerimeter>>();
 }
@@ -196,9 +196,9 @@ AccessContextManagerConnection::CommitServicePerimeters(
 }
 
 StreamRange<google::identity::accesscontextmanager::v1::GcpUserAccessBinding>
-    AccessContextManagerConnection::ListGcpUserAccessBindings(
-        google::identity::accesscontextmanager::v1::
-            ListGcpUserAccessBindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AccessContextManagerConnection::ListGcpUserAccessBindings(
+    google::identity::accesscontextmanager::v1::
+        ListGcpUserAccessBindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::identity::accesscontextmanager::v1::GcpUserAccessBinding>>();
 }

--- a/google/cloud/apigateway/api_gateway_connection.cc
+++ b/google/cloud/apigateway/api_gateway_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ApiGatewayServiceConnection::~ApiGatewayServiceConnection() = default;
 
 StreamRange<google::cloud::apigateway::v1::Gateway>
-    ApiGatewayServiceConnection::ListGateways(
-        google::cloud::apigateway::v1::
-            ListGatewaysRequest) {  // NOLINT(performance-unnecessary-value-param)
+ApiGatewayServiceConnection::ListGateways(
+    google::cloud::apigateway::v1::
+        ListGatewaysRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::apigateway::v1::Gateway>>();
 }
@@ -73,9 +73,9 @@ ApiGatewayServiceConnection::DeleteGateway(
 }
 
 StreamRange<google::cloud::apigateway::v1::Api>
-    ApiGatewayServiceConnection::ListApis(
-        google::cloud::apigateway::v1::
-            ListApisRequest) {  // NOLINT(performance-unnecessary-value-param)
+ApiGatewayServiceConnection::ListApis(
+    google::cloud::apigateway::v1::
+        ListApisRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::apigateway::v1::Api>>();
 }
@@ -111,9 +111,9 @@ ApiGatewayServiceConnection::DeleteApi(
 }
 
 StreamRange<google::cloud::apigateway::v1::ApiConfig>
-    ApiGatewayServiceConnection::ListApiConfigs(
-        google::cloud::apigateway::v1::
-            ListApiConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ApiGatewayServiceConnection::ListApiConfigs(
+    google::cloud::apigateway::v1::
+        ListApiConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::apigateway::v1::ApiConfig>>();
 }

--- a/google/cloud/apigeeconnect/connection_connection.cc
+++ b/google/cloud/apigeeconnect/connection_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConnectionServiceConnection::~ConnectionServiceConnection() = default;
 
 StreamRange<google::cloud::apigeeconnect::v1::Connection>
-    ConnectionServiceConnection::ListConnections(
-        google::cloud::apigeeconnect::v1::
-            ListConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ConnectionServiceConnection::ListConnections(
+    google::cloud::apigeeconnect::v1::
+        ListConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::apigeeconnect::v1::Connection>>();
 }

--- a/google/cloud/appengine/authorized_certificates_connection.cc
+++ b/google/cloud/appengine/authorized_certificates_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AuthorizedCertificatesConnection::~AuthorizedCertificatesConnection() = default;
 
 StreamRange<google::appengine::v1::AuthorizedCertificate>
-    AuthorizedCertificatesConnection::ListAuthorizedCertificates(
-        google::appengine::v1::
-            ListAuthorizedCertificatesRequest) {  // NOLINT(performance-unnecessary-value-param)
+AuthorizedCertificatesConnection::ListAuthorizedCertificates(
+    google::appengine::v1::
+        ListAuthorizedCertificatesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::appengine::v1::AuthorizedCertificate>>();
 }

--- a/google/cloud/appengine/authorized_domains_connection.cc
+++ b/google/cloud/appengine/authorized_domains_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AuthorizedDomainsConnection::~AuthorizedDomainsConnection() = default;
 
 StreamRange<google::appengine::v1::AuthorizedDomain>
-    AuthorizedDomainsConnection::ListAuthorizedDomains(
-        google::appengine::v1::
-            ListAuthorizedDomainsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AuthorizedDomainsConnection::ListAuthorizedDomains(
+    google::appengine::v1::
+        ListAuthorizedDomainsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::appengine::v1::AuthorizedDomain>>();
 }

--- a/google/cloud/appengine/domain_mappings_connection.cc
+++ b/google/cloud/appengine/domain_mappings_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DomainMappingsConnection::~DomainMappingsConnection() = default;
 
 StreamRange<google::appengine::v1::DomainMapping>
-    DomainMappingsConnection::ListDomainMappings(
-        google::appengine::v1::
-            ListDomainMappingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DomainMappingsConnection::ListDomainMappings(
+    google::appengine::v1::
+        ListDomainMappingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::appengine::v1::DomainMapping>>();
 }

--- a/google/cloud/appengine/firewall_connection.cc
+++ b/google/cloud/appengine/firewall_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 FirewallConnection::~FirewallConnection() = default;
 
 StreamRange<google::appengine::v1::FirewallRule>
-    FirewallConnection::ListIngressRules(
-        google::appengine::v1::
-            ListIngressRulesRequest) {  // NOLINT(performance-unnecessary-value-param)
+FirewallConnection::ListIngressRules(
+    google::appengine::v1::
+        ListIngressRulesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::appengine::v1::FirewallRule>>();
 }

--- a/google/cloud/artifactregistry/artifact_registry_connection.cc
+++ b/google/cloud/artifactregistry/artifact_registry_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ArtifactRegistryConnection::~ArtifactRegistryConnection() = default;
 
 StreamRange<google::devtools::artifactregistry::v1::DockerImage>
-    ArtifactRegistryConnection::ListDockerImages(
-        google::devtools::artifactregistry::v1::
-            ListDockerImagesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ArtifactRegistryConnection::ListDockerImages(
+    google::devtools::artifactregistry::v1::
+        ListDockerImagesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::artifactregistry::v1::DockerImage>>();
 }
@@ -67,9 +67,9 @@ ArtifactRegistryConnection::ImportYumArtifacts(
 }
 
 StreamRange<google::devtools::artifactregistry::v1::Repository>
-    ArtifactRegistryConnection::ListRepositories(
-        google::devtools::artifactregistry::v1::
-            ListRepositoriesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ArtifactRegistryConnection::ListRepositories(
+    google::devtools::artifactregistry::v1::
+        ListRepositoriesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::artifactregistry::v1::Repository>>();
 }
@@ -103,9 +103,9 @@ ArtifactRegistryConnection::DeleteRepository(
 }
 
 StreamRange<google::devtools::artifactregistry::v1::Package>
-    ArtifactRegistryConnection::ListPackages(
-        google::devtools::artifactregistry::v1::
-            ListPackagesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ArtifactRegistryConnection::ListPackages(
+    google::devtools::artifactregistry::v1::
+        ListPackagesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::artifactregistry::v1::Package>>();
 }
@@ -125,9 +125,9 @@ ArtifactRegistryConnection::DeletePackage(
 }
 
 StreamRange<google::devtools::artifactregistry::v1::Version>
-    ArtifactRegistryConnection::ListVersions(
-        google::devtools::artifactregistry::v1::
-            ListVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ArtifactRegistryConnection::ListVersions(
+    google::devtools::artifactregistry::v1::
+        ListVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::artifactregistry::v1::Version>>();
 }
@@ -147,9 +147,9 @@ ArtifactRegistryConnection::DeleteVersion(
 }
 
 StreamRange<google::devtools::artifactregistry::v1::File>
-    ArtifactRegistryConnection::ListFiles(
-        google::devtools::artifactregistry::v1::
-            ListFilesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ArtifactRegistryConnection::ListFiles(
+    google::devtools::artifactregistry::v1::
+        ListFilesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::artifactregistry::v1::File>>();
 }
@@ -161,9 +161,9 @@ ArtifactRegistryConnection::GetFile(
 }
 
 StreamRange<google::devtools::artifactregistry::v1::Tag>
-    ArtifactRegistryConnection::ListTags(
-        google::devtools::artifactregistry::v1::
-            ListTagsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ArtifactRegistryConnection::ListTags(
+    google::devtools::artifactregistry::v1::
+        ListTagsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::artifactregistry::v1::Tag>>();
 }

--- a/google/cloud/asset/asset_connection.cc
+++ b/google/cloud/asset/asset_connection.cc
@@ -82,17 +82,17 @@ Status AssetServiceConnection::DeleteFeed(
 }
 
 StreamRange<google::cloud::asset::v1::ResourceSearchResult>
-    AssetServiceConnection::SearchAllResources(
-        google::cloud::asset::v1::
-            SearchAllResourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
+AssetServiceConnection::SearchAllResources(
+    google::cloud::asset::v1::
+        SearchAllResourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::asset::v1::ResourceSearchResult>>();
 }
 
 StreamRange<google::cloud::asset::v1::IamPolicySearchResult>
-    AssetServiceConnection::SearchAllIamPolicies(
-        google::cloud::asset::v1::
-            SearchAllIamPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
+AssetServiceConnection::SearchAllIamPolicies(
+    google::cloud::asset::v1::
+        SearchAllIamPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::asset::v1::IamPolicySearchResult>>();
 }

--- a/google/cloud/assuredworkloads/assured_workloads_connection.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_connection.cc
@@ -61,9 +61,9 @@ AssuredWorkloadsServiceConnection::GetWorkload(
 }
 
 StreamRange<google::cloud::assuredworkloads::v1::Workload>
-    AssuredWorkloadsServiceConnection::ListWorkloads(
-        google::cloud::assuredworkloads::v1::
-            ListWorkloadsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AssuredWorkloadsServiceConnection::ListWorkloads(
+    google::cloud::assuredworkloads::v1::
+        ListWorkloadsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::assuredworkloads::v1::Workload>>();
 }

--- a/google/cloud/automl/auto_ml_connection.cc
+++ b/google/cloud/automl/auto_ml_connection.cc
@@ -153,9 +153,9 @@ AutoMlConnection::GetModelEvaluation(
 }
 
 StreamRange<google::cloud::automl::v1::ModelEvaluation>
-    AutoMlConnection::ListModelEvaluations(
-        google::cloud::automl::v1::
-            ListModelEvaluationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AutoMlConnection::ListModelEvaluations(
+    google::cloud::automl::v1::
+        ListModelEvaluationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::automl::v1::ModelEvaluation>>();
 }

--- a/google/cloud/bigquery/connection_connection.cc
+++ b/google/cloud/bigquery/connection_connection.cc
@@ -47,9 +47,9 @@ ConnectionServiceConnection::GetConnection(
 }
 
 StreamRange<google::cloud::bigquery::connection::v1::Connection>
-    ConnectionServiceConnection::ListConnections(
-        google::cloud::bigquery::connection::v1::
-            ListConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ConnectionServiceConnection::ListConnections(
+    google::cloud::bigquery::connection::v1::
+        ListConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::connection::v1::Connection>>();
 }

--- a/google/cloud/bigquery/data_transfer_connection.cc
+++ b/google/cloud/bigquery/data_transfer_connection.cc
@@ -41,9 +41,9 @@ DataTransferServiceConnection::GetDataSource(
 }
 
 StreamRange<google::cloud::bigquery::datatransfer::v1::DataSource>
-    DataTransferServiceConnection::ListDataSources(
-        google::cloud::bigquery::datatransfer::v1::
-            ListDataSourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataTransferServiceConnection::ListDataSources(
+    google::cloud::bigquery::datatransfer::v1::
+        ListDataSourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::datatransfer::v1::DataSource>>();
 }
@@ -76,9 +76,9 @@ DataTransferServiceConnection::GetTransferConfig(
 }
 
 StreamRange<google::cloud::bigquery::datatransfer::v1::TransferConfig>
-    DataTransferServiceConnection::ListTransferConfigs(
-        google::cloud::bigquery::datatransfer::v1::
-            ListTransferConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataTransferServiceConnection::ListTransferConfigs(
+    google::cloud::bigquery::datatransfer::v1::
+        ListTransferConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::datatransfer::v1::TransferConfig>>();
 }
@@ -112,17 +112,17 @@ Status DataTransferServiceConnection::DeleteTransferRun(
 }
 
 StreamRange<google::cloud::bigquery::datatransfer::v1::TransferRun>
-    DataTransferServiceConnection::ListTransferRuns(
-        google::cloud::bigquery::datatransfer::v1::
-            ListTransferRunsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataTransferServiceConnection::ListTransferRuns(
+    google::cloud::bigquery::datatransfer::v1::
+        ListTransferRunsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::datatransfer::v1::TransferRun>>();
 }
 
 StreamRange<google::cloud::bigquery::datatransfer::v1::TransferMessage>
-    DataTransferServiceConnection::ListTransferLogs(
-        google::cloud::bigquery::datatransfer::v1::
-            ListTransferLogsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataTransferServiceConnection::ListTransferLogs(
+    google::cloud::bigquery::datatransfer::v1::
+        ListTransferLogsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::bigquery::datatransfer::v1::TransferMessage>>();
 }

--- a/google/cloud/bigquery/reservation_connection.cc
+++ b/google/cloud/bigquery/reservation_connection.cc
@@ -41,9 +41,9 @@ ReservationServiceConnection::CreateReservation(
 }
 
 StreamRange<google::cloud::bigquery::reservation::v1::Reservation>
-    ReservationServiceConnection::ListReservations(
-        google::cloud::bigquery::reservation::v1::
-            ListReservationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ReservationServiceConnection::ListReservations(
+    google::cloud::bigquery::reservation::v1::
+        ListReservationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::reservation::v1::Reservation>>();
 }
@@ -73,9 +73,9 @@ ReservationServiceConnection::CreateCapacityCommitment(
 }
 
 StreamRange<google::cloud::bigquery::reservation::v1::CapacityCommitment>
-    ReservationServiceConnection::ListCapacityCommitments(
-        google::cloud::bigquery::reservation::v1::
-            ListCapacityCommitmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ReservationServiceConnection::ListCapacityCommitments(
+    google::cloud::bigquery::reservation::v1::
+        ListCapacityCommitmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::bigquery::reservation::v1::CapacityCommitment>>();
 }
@@ -122,9 +122,9 @@ ReservationServiceConnection::CreateAssignment(
 }
 
 StreamRange<google::cloud::bigquery::reservation::v1::Assignment>
-    ReservationServiceConnection::ListAssignments(
-        google::cloud::bigquery::reservation::v1::
-            ListAssignmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ReservationServiceConnection::ListAssignments(
+    google::cloud::bigquery::reservation::v1::
+        ListAssignmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::reservation::v1::Assignment>>();
 }
@@ -135,17 +135,17 @@ Status ReservationServiceConnection::DeleteAssignment(
 }
 
 StreamRange<google::cloud::bigquery::reservation::v1::Assignment>
-    ReservationServiceConnection::SearchAssignments(
-        google::cloud::bigquery::reservation::v1::
-            SearchAssignmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ReservationServiceConnection::SearchAssignments(
+    google::cloud::bigquery::reservation::v1::
+        SearchAssignmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::reservation::v1::Assignment>>();
 }
 
 StreamRange<google::cloud::bigquery::reservation::v1::Assignment>
-    ReservationServiceConnection::SearchAllAssignments(
-        google::cloud::bigquery::reservation::v1::
-            SearchAllAssignmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ReservationServiceConnection::SearchAllAssignments(
+    google::cloud::bigquery::reservation::v1::
+        SearchAllAssignmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::bigquery::reservation::v1::Assignment>>();
 }

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
@@ -127,9 +127,9 @@ BigtableInstanceAdminConnection::GetAppProfile(
 }
 
 StreamRange<google::bigtable::admin::v2::AppProfile>
-    BigtableInstanceAdminConnection::ListAppProfiles(
-        google::bigtable::admin::v2::
-            ListAppProfilesRequest) {  // NOLINT(performance-unnecessary-value-param)
+BigtableInstanceAdminConnection::ListAppProfiles(
+    google::bigtable::admin::v2::
+        ListAppProfilesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::bigtable::admin::v2::AppProfile>>();
 }
@@ -164,9 +164,9 @@ BigtableInstanceAdminConnection::TestIamPermissions(
 }
 
 StreamRange<google::bigtable::admin::v2::HotTablet>
-    BigtableInstanceAdminConnection::ListHotTablets(
-        google::bigtable::admin::v2::
-            ListHotTabletsRequest) {  // NOLINT(performance-unnecessary-value-param)
+BigtableInstanceAdminConnection::ListHotTablets(
+    google::bigtable::admin::v2::
+        ListHotTabletsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::bigtable::admin::v2::HotTablet>>();
 }

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
@@ -41,9 +41,9 @@ BigtableTableAdminConnection::CreateTable(
 }
 
 StreamRange<google::bigtable::admin::v2::Table>
-    BigtableTableAdminConnection::ListTables(
-        google::bigtable::admin::v2::
-            ListTablesRequest) {  // NOLINT(performance-unnecessary-value-param)
+BigtableTableAdminConnection::ListTables(
+    google::bigtable::admin::v2::
+        ListTablesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::bigtable::admin::v2::Table>>();
 }
@@ -108,9 +108,9 @@ Status BigtableTableAdminConnection::DeleteBackup(
 }
 
 StreamRange<google::bigtable::admin::v2::Backup>
-    BigtableTableAdminConnection::ListBackups(
-        google::bigtable::admin::v2::
-            ListBackupsRequest) {  // NOLINT(performance-unnecessary-value-param)
+BigtableTableAdminConnection::ListBackups(
+    google::bigtable::admin::v2::
+        ListBackupsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::bigtable::admin::v2::Backup>>();
 }

--- a/google/cloud/billing/budget_connection.cc
+++ b/google/cloud/billing/budget_connection.cc
@@ -53,9 +53,9 @@ BudgetServiceConnection::GetBudget(
 }
 
 StreamRange<google::cloud::billing::budgets::v1::Budget>
-    BudgetServiceConnection::ListBudgets(
-        google::cloud::billing::budgets::v1::
-            ListBudgetsRequest) {  // NOLINT(performance-unnecessary-value-param)
+BudgetServiceConnection::ListBudgets(
+    google::cloud::billing::budgets::v1::
+        ListBudgetsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::billing::budgets::v1::Budget>>();
 }

--- a/google/cloud/billing/cloud_billing_connection.cc
+++ b/google/cloud/billing/cloud_billing_connection.cc
@@ -41,9 +41,9 @@ CloudBillingConnection::GetBillingAccount(
 }
 
 StreamRange<google::cloud::billing::v1::BillingAccount>
-    CloudBillingConnection::ListBillingAccounts(
-        google::cloud::billing::v1::
-            ListBillingAccountsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudBillingConnection::ListBillingAccounts(
+    google::cloud::billing::v1::
+        ListBillingAccountsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::billing::v1::BillingAccount>>();
 }
@@ -61,9 +61,9 @@ CloudBillingConnection::CreateBillingAccount(
 }
 
 StreamRange<google::cloud::billing::v1::ProjectBillingInfo>
-    CloudBillingConnection::ListProjectBillingInfo(
-        google::cloud::billing::v1::
-            ListProjectBillingInfoRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudBillingConnection::ListProjectBillingInfo(
+    google::cloud::billing::v1::
+        ListProjectBillingInfoRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::billing::v1::ProjectBillingInfo>>();
 }

--- a/google/cloud/billing/cloud_catalog_connection.cc
+++ b/google/cloud/billing/cloud_catalog_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudCatalogConnection::~CloudCatalogConnection() = default;
 
 StreamRange<google::cloud::billing::v1::Service>
-    CloudCatalogConnection::ListServices(
-        google::cloud::billing::v1::
-            ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudCatalogConnection::ListServices(
+    google::cloud::billing::v1::
+        ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::billing::v1::Service>>();
 }

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.cc
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.cc
@@ -66,9 +66,9 @@ BinauthzManagementServiceV1Connection::UpdateAttestor(
 }
 
 StreamRange<google::cloud::binaryauthorization::v1::Attestor>
-    BinauthzManagementServiceV1Connection::ListAttestors(
-        google::cloud::binaryauthorization::v1::
-            ListAttestorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+BinauthzManagementServiceV1Connection::ListAttestors(
+    google::cloud::binaryauthorization::v1::
+        ListAttestorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::binaryauthorization::v1::Attestor>>();
 }

--- a/google/cloud/channel/cloud_channel_connection.cc
+++ b/google/cloud/channel/cloud_channel_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudChannelServiceConnection::~CloudChannelServiceConnection() = default;
 
 StreamRange<google::cloud::channel::v1::Customer>
-    CloudChannelServiceConnection::ListCustomers(
-        google::cloud::channel::v1::
-            ListCustomersRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListCustomers(
+    google::cloud::channel::v1::
+        ListCustomersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::Customer>>();
 }
@@ -86,25 +86,25 @@ CloudChannelServiceConnection::ProvisionCloudIdentity(
 }
 
 StreamRange<google::cloud::channel::v1::Entitlement>
-    CloudChannelServiceConnection::ListEntitlements(
-        google::cloud::channel::v1::
-            ListEntitlementsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListEntitlements(
+    google::cloud::channel::v1::
+        ListEntitlementsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::Entitlement>>();
 }
 
 StreamRange<google::cloud::channel::v1::TransferableSku>
-    CloudChannelServiceConnection::ListTransferableSkus(
-        google::cloud::channel::v1::
-            ListTransferableSkusRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListTransferableSkus(
+    google::cloud::channel::v1::
+        ListTransferableSkusRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::TransferableSku>>();
 }
 
 StreamRange<google::cloud::channel::v1::TransferableOffer>
-    CloudChannelServiceConnection::ListTransferableOffers(
-        google::cloud::channel::v1::
-            ListTransferableOffersRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListTransferableOffers(
+    google::cloud::channel::v1::
+        ListTransferableOffersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::TransferableOffer>>();
 }
@@ -196,9 +196,9 @@ CloudChannelServiceConnection::TransferEntitlementsToGoogle(
 }
 
 StreamRange<google::cloud::channel::v1::ChannelPartnerLink>
-    CloudChannelServiceConnection::ListChannelPartnerLinks(
-        google::cloud::channel::v1::
-            ListChannelPartnerLinksRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListChannelPartnerLinks(
+    google::cloud::channel::v1::
+        ListChannelPartnerLinksRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::ChannelPartnerLink>>();
 }
@@ -228,41 +228,41 @@ CloudChannelServiceConnection::LookupOffer(
 }
 
 StreamRange<google::cloud::channel::v1::Product>
-    CloudChannelServiceConnection::ListProducts(
-        google::cloud::channel::v1::
-            ListProductsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListProducts(
+    google::cloud::channel::v1::
+        ListProductsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::Product>>();
 }
 
 StreamRange<google::cloud::channel::v1::Sku>
-    CloudChannelServiceConnection::ListSkus(
-        google::cloud::channel::v1::
-            ListSkusRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListSkus(
+    google::cloud::channel::v1::
+        ListSkusRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::Sku>>();
 }
 
 StreamRange<google::cloud::channel::v1::Offer>
-    CloudChannelServiceConnection::ListOffers(
-        google::cloud::channel::v1::
-            ListOffersRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListOffers(
+    google::cloud::channel::v1::
+        ListOffersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::Offer>>();
 }
 
 StreamRange<google::cloud::channel::v1::PurchasableSku>
-    CloudChannelServiceConnection::ListPurchasableSkus(
-        google::cloud::channel::v1::
-            ListPurchasableSkusRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListPurchasableSkus(
+    google::cloud::channel::v1::
+        ListPurchasableSkusRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::PurchasableSku>>();
 }
 
 StreamRange<google::cloud::channel::v1::PurchasableOffer>
-    CloudChannelServiceConnection::ListPurchasableOffers(
-        google::cloud::channel::v1::
-            ListPurchasableOffersRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudChannelServiceConnection::ListPurchasableOffers(
+    google::cloud::channel::v1::
+        ListPurchasableOffersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::channel::v1::PurchasableOffer>>();
 }

--- a/google/cloud/cloudbuild/cloud_build_connection.cc
+++ b/google/cloud/cloudbuild/cloud_build_connection.cc
@@ -49,9 +49,9 @@ CloudBuildConnection::GetBuild(
 }
 
 StreamRange<google::devtools::cloudbuild::v1::Build>
-    CloudBuildConnection::ListBuilds(
-        google::devtools::cloudbuild::v1::
-            ListBuildsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudBuildConnection::ListBuilds(
+    google::devtools::cloudbuild::v1::
+        ListBuildsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::cloudbuild::v1::Build>>();
 }
@@ -91,9 +91,9 @@ CloudBuildConnection::GetBuildTrigger(
 }
 
 StreamRange<google::devtools::cloudbuild::v1::BuildTrigger>
-    CloudBuildConnection::ListBuildTriggers(
-        google::devtools::cloudbuild::v1::
-            ListBuildTriggersRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudBuildConnection::ListBuildTriggers(
+    google::devtools::cloudbuild::v1::
+        ListBuildTriggersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::cloudbuild::v1::BuildTrigger>>();
 }
@@ -155,9 +155,9 @@ CloudBuildConnection::UpdateWorkerPool(
 }
 
 StreamRange<google::devtools::cloudbuild::v1::WorkerPool>
-    CloudBuildConnection::ListWorkerPools(
-        google::devtools::cloudbuild::v1::
-            ListWorkerPoolsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudBuildConnection::ListWorkerPools(
+    google::devtools::cloudbuild::v1::
+        ListWorkerPoolsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::devtools::cloudbuild::v1::WorkerPool>>();
 }

--- a/google/cloud/composer/environments_connection.cc
+++ b/google/cloud/composer/environments_connection.cc
@@ -52,9 +52,9 @@ EnvironmentsConnection::GetEnvironment(
 }
 
 StreamRange<google::cloud::orchestration::airflow::service::v1::Environment>
-    EnvironmentsConnection::ListEnvironments(
-        google::cloud::orchestration::airflow::service::v1::
-            ListEnvironmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+EnvironmentsConnection::ListEnvironments(
+    google::cloud::orchestration::airflow::service::v1::
+        ListEnvironmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::orchestration::airflow::service::v1::Environment>>();
 }

--- a/google/cloud/composer/image_versions_connection.cc
+++ b/google/cloud/composer/image_versions_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ImageVersionsConnection::~ImageVersionsConnection() = default;
 
 StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>
-    ImageVersionsConnection::ListImageVersions(
-        google::cloud::orchestration::airflow::service::v1::
-            ListImageVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ImageVersionsConnection::ListImageVersions(
+    google::cloud::orchestration::airflow::service::v1::
+        ListImageVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::orchestration::airflow::service::v1::ImageVersion>>();
 }

--- a/google/cloud/contactcenterinsights/contact_center_insights_connection.cc
+++ b/google/cloud/contactcenterinsights/contact_center_insights_connection.cc
@@ -55,9 +55,9 @@ ContactCenterInsightsConnection::GetConversation(
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::Conversation>
-    ContactCenterInsightsConnection::ListConversations(
-        google::cloud::contactcenterinsights::v1::
-            ListConversationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ContactCenterInsightsConnection::ListConversations(
+    google::cloud::contactcenterinsights::v1::
+        ListConversationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::contactcenterinsights::v1::Conversation>>();
 }
@@ -83,9 +83,9 @@ ContactCenterInsightsConnection::GetAnalysis(
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::Analysis>
-    ContactCenterInsightsConnection::ListAnalyses(
-        google::cloud::contactcenterinsights::v1::
-            ListAnalysesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ContactCenterInsightsConnection::ListAnalyses(
+    google::cloud::contactcenterinsights::v1::
+        ListAnalysesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::contactcenterinsights::v1::Analysis>>();
 }
@@ -199,9 +199,9 @@ ContactCenterInsightsConnection::GetPhraseMatcher(
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::PhraseMatcher>
-    ContactCenterInsightsConnection::ListPhraseMatchers(
-        google::cloud::contactcenterinsights::v1::
-            ListPhraseMatchersRequest) {  // NOLINT(performance-unnecessary-value-param)
+ContactCenterInsightsConnection::ListPhraseMatchers(
+    google::cloud::contactcenterinsights::v1::
+        ListPhraseMatchersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::contactcenterinsights::v1::PhraseMatcher>>();
 }
@@ -250,9 +250,9 @@ ContactCenterInsightsConnection::GetView(
 }
 
 StreamRange<google::cloud::contactcenterinsights::v1::View>
-    ContactCenterInsightsConnection::ListViews(
-        google::cloud::contactcenterinsights::v1::
-            ListViewsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ContactCenterInsightsConnection::ListViews(
+    google::cloud::contactcenterinsights::v1::
+        ListViewsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::contactcenterinsights::v1::View>>();
 }

--- a/google/cloud/container/cluster_manager_connection.cc
+++ b/google/cloud/container/cluster_manager_connection.cc
@@ -217,9 +217,9 @@ ClusterManagerConnection::SetMaintenancePolicy(
 }
 
 StreamRange<google::container::v1::UsableSubnetwork>
-    ClusterManagerConnection::ListUsableSubnetworks(
-        google::container::v1::
-            ListUsableSubnetworksRequest) {  // NOLINT(performance-unnecessary-value-param)
+ClusterManagerConnection::ListUsableSubnetworks(
+    google::container::v1::
+        ListUsableSubnetworksRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::container::v1::UsableSubnetwork>>();
 }

--- a/google/cloud/datacatalog/data_catalog_connection.cc
+++ b/google/cloud/datacatalog/data_catalog_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DataCatalogConnection::~DataCatalogConnection() = default;
 
 StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>
-    DataCatalogConnection::SearchCatalog(
-        google::cloud::datacatalog::v1::
-            SearchCatalogRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataCatalogConnection::SearchCatalog(
+    google::cloud::datacatalog::v1::
+        SearchCatalogRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>>();
 }
@@ -66,9 +66,9 @@ Status DataCatalogConnection::DeleteEntryGroup(
 }
 
 StreamRange<google::cloud::datacatalog::v1::EntryGroup>
-    DataCatalogConnection::ListEntryGroups(
-        google::cloud::datacatalog::v1::
-            ListEntryGroupsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataCatalogConnection::ListEntryGroups(
+    google::cloud::datacatalog::v1::
+        ListEntryGroupsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::datacatalog::v1::EntryGroup>>();
 }
@@ -102,9 +102,9 @@ DataCatalogConnection::LookupEntry(
 }
 
 StreamRange<google::cloud::datacatalog::v1::Entry>
-    DataCatalogConnection::ListEntries(
-        google::cloud::datacatalog::v1::
-            ListEntriesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataCatalogConnection::ListEntries(
+    google::cloud::datacatalog::v1::
+        ListEntriesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::datacatalog::v1::Entry>>();
 }
@@ -190,9 +190,9 @@ Status DataCatalogConnection::DeleteTag(
 }
 
 StreamRange<google::cloud::datacatalog::v1::Tag>
-    DataCatalogConnection::ListTags(
-        google::cloud::datacatalog::v1::
-            ListTagsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataCatalogConnection::ListTags(
+    google::cloud::datacatalog::v1::
+        ListTagsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::datacatalog::v1::Tag>>();
 }

--- a/google/cloud/datacatalog/policy_tag_manager_connection.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_connection.cc
@@ -52,9 +52,9 @@ PolicyTagManagerConnection::UpdateTaxonomy(
 }
 
 StreamRange<google::cloud::datacatalog::v1::Taxonomy>
-    PolicyTagManagerConnection::ListTaxonomies(
-        google::cloud::datacatalog::v1::
-            ListTaxonomiesRequest) {  // NOLINT(performance-unnecessary-value-param)
+PolicyTagManagerConnection::ListTaxonomies(
+    google::cloud::datacatalog::v1::
+        ListTaxonomiesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::datacatalog::v1::Taxonomy>>();
 }
@@ -83,9 +83,9 @@ PolicyTagManagerConnection::UpdatePolicyTag(
 }
 
 StreamRange<google::cloud::datacatalog::v1::PolicyTag>
-    PolicyTagManagerConnection::ListPolicyTags(
-        google::cloud::datacatalog::v1::
-            ListPolicyTagsRequest) {  // NOLINT(performance-unnecessary-value-param)
+PolicyTagManagerConnection::ListPolicyTags(
+    google::cloud::datacatalog::v1::
+        ListPolicyTagsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::datacatalog::v1::PolicyTag>>();
 }

--- a/google/cloud/datamigration/data_migration_connection.cc
+++ b/google/cloud/datamigration/data_migration_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DataMigrationServiceConnection::~DataMigrationServiceConnection() = default;
 
 StreamRange<google::cloud::clouddms::v1::MigrationJob>
-    DataMigrationServiceConnection::ListMigrationJobs(
-        google::cloud::clouddms::v1::
-            ListMigrationJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataMigrationServiceConnection::ListMigrationJobs(
+    google::cloud::clouddms::v1::
+        ListMigrationJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::clouddms::v1::MigrationJob>>();
 }
@@ -127,9 +127,9 @@ DataMigrationServiceConnection::GenerateSshScript(
 }
 
 StreamRange<google::cloud::clouddms::v1::ConnectionProfile>
-    DataMigrationServiceConnection::ListConnectionProfiles(
-        google::cloud::clouddms::v1::
-            ListConnectionProfilesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DataMigrationServiceConnection::ListConnectionProfiles(
+    google::cloud::clouddms::v1::
+        ListConnectionProfilesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::clouddms::v1::ConnectionProfile>>();
 }

--- a/google/cloud/dataproc/autoscaling_policy_connection.cc
+++ b/google/cloud/dataproc/autoscaling_policy_connection.cc
@@ -54,9 +54,9 @@ AutoscalingPolicyServiceConnection::GetAutoscalingPolicy(
 }
 
 StreamRange<google::cloud::dataproc::v1::AutoscalingPolicy>
-    AutoscalingPolicyServiceConnection::ListAutoscalingPolicies(
-        google::cloud::dataproc::v1::
-            ListAutoscalingPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
+AutoscalingPolicyServiceConnection::ListAutoscalingPolicies(
+    google::cloud::dataproc::v1::
+        ListAutoscalingPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::dataproc::v1::AutoscalingPolicy>>();
 }

--- a/google/cloud/dataproc/batch_controller_connection.cc
+++ b/google/cloud/dataproc/batch_controller_connection.cc
@@ -49,9 +49,9 @@ BatchControllerConnection::GetBatch(
 }
 
 StreamRange<google::cloud::dataproc::v1::Batch>
-    BatchControllerConnection::ListBatches(
-        google::cloud::dataproc::v1::
-            ListBatchesRequest) {  // NOLINT(performance-unnecessary-value-param)
+BatchControllerConnection::ListBatches(
+    google::cloud::dataproc::v1::
+        ListBatchesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::dataproc::v1::Batch>>();
 }

--- a/google/cloud/dataproc/cluster_controller_connection.cc
+++ b/google/cloud/dataproc/cluster_controller_connection.cc
@@ -81,9 +81,9 @@ ClusterControllerConnection::GetCluster(
 }
 
 StreamRange<google::cloud::dataproc::v1::Cluster>
-    ClusterControllerConnection::ListClusters(
-        google::cloud::dataproc::v1::
-            ListClustersRequest) {  // NOLINT(performance-unnecessary-value-param)
+ClusterControllerConnection::ListClusters(
+    google::cloud::dataproc::v1::
+        ListClustersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::dataproc::v1::Cluster>>();
 }

--- a/google/cloud/dataproc/workflow_template_connection.cc
+++ b/google/cloud/dataproc/workflow_template_connection.cc
@@ -71,9 +71,9 @@ WorkflowTemplateServiceConnection::UpdateWorkflowTemplate(
 }
 
 StreamRange<google::cloud::dataproc::v1::WorkflowTemplate>
-    WorkflowTemplateServiceConnection::ListWorkflowTemplates(
-        google::cloud::dataproc::v1::
-            ListWorkflowTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
+WorkflowTemplateServiceConnection::ListWorkflowTemplates(
+    google::cloud::dataproc::v1::
+        ListWorkflowTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::dataproc::v1::WorkflowTemplate>>();
 }

--- a/google/cloud/dlp/dlp_connection.cc
+++ b/google/cloud/dlp/dlp_connection.cc
@@ -83,9 +83,9 @@ DlpServiceConnection::GetInspectTemplate(
 }
 
 StreamRange<google::privacy::dlp::v2::InspectTemplate>
-    DlpServiceConnection::ListInspectTemplates(
-        google::privacy::dlp::v2::
-            ListInspectTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DlpServiceConnection::ListInspectTemplates(
+    google::privacy::dlp::v2::
+        ListInspectTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::privacy::dlp::v2::InspectTemplate>>();
 }
@@ -114,9 +114,9 @@ DlpServiceConnection::GetDeidentifyTemplate(
 }
 
 StreamRange<google::privacy::dlp::v2::DeidentifyTemplate>
-    DlpServiceConnection::ListDeidentifyTemplates(
-        google::privacy::dlp::v2::
-            ListDeidentifyTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DlpServiceConnection::ListDeidentifyTemplates(
+    google::privacy::dlp::v2::
+        ListDeidentifyTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::privacy::dlp::v2::DeidentifyTemplate>>();
 }
@@ -151,9 +151,9 @@ DlpServiceConnection::GetJobTrigger(
 }
 
 StreamRange<google::privacy::dlp::v2::JobTrigger>
-    DlpServiceConnection::ListJobTriggers(
-        google::privacy::dlp::v2::
-            ListJobTriggersRequest) {  // NOLINT(performance-unnecessary-value-param)
+DlpServiceConnection::ListJobTriggers(
+    google::privacy::dlp::v2::
+        ListJobTriggersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::privacy::dlp::v2::JobTrigger>>();
 }
@@ -215,9 +215,9 @@ DlpServiceConnection::GetStoredInfoType(
 }
 
 StreamRange<google::privacy::dlp::v2::StoredInfoType>
-    DlpServiceConnection::ListStoredInfoTypes(
-        google::privacy::dlp::v2::
-            ListStoredInfoTypesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DlpServiceConnection::ListStoredInfoTypes(
+    google::privacy::dlp::v2::
+        ListStoredInfoTypesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::privacy::dlp::v2::StoredInfoType>>();
 }

--- a/google/cloud/eventarc/eventarc_connection.cc
+++ b/google/cloud/eventarc/eventarc_connection.cc
@@ -40,9 +40,9 @@ StatusOr<google::cloud::eventarc::v1::Trigger> EventarcConnection::GetTrigger(
 }
 
 StreamRange<google::cloud::eventarc::v1::Trigger>
-    EventarcConnection::ListTriggers(
-        google::cloud::eventarc::v1::
-            ListTriggersRequest) {  // NOLINT(performance-unnecessary-value-param)
+EventarcConnection::ListTriggers(
+    google::cloud::eventarc::v1::
+        ListTriggersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::eventarc::v1::Trigger>>();
 }
@@ -77,9 +77,9 @@ StatusOr<google::cloud::eventarc::v1::Channel> EventarcConnection::GetChannel(
 }
 
 StreamRange<google::cloud::eventarc::v1::Channel>
-    EventarcConnection::ListChannels(
-        google::cloud::eventarc::v1::
-            ListChannelsRequest) {  // NOLINT(performance-unnecessary-value-param)
+EventarcConnection::ListChannels(
+    google::cloud::eventarc::v1::
+        ListChannelsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::eventarc::v1::Channel>>();
 }
@@ -115,9 +115,9 @@ EventarcConnection::GetChannelConnection(
 }
 
 StreamRange<google::cloud::eventarc::v1::ChannelConnection>
-    EventarcConnection::ListChannelConnections(
-        google::cloud::eventarc::v1::
-            ListChannelConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+EventarcConnection::ListChannelConnections(
+    google::cloud::eventarc::v1::
+        ListChannelConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::eventarc::v1::ChannelConnection>>();
 }

--- a/google/cloud/filestore/cloud_filestore_manager_connection.cc
+++ b/google/cloud/filestore/cloud_filestore_manager_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudFilestoreManagerConnection::~CloudFilestoreManagerConnection() = default;
 
 StreamRange<google::cloud::filestore::v1::Instance>
-    CloudFilestoreManagerConnection::ListInstances(
-        google::cloud::filestore::v1::
-            ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudFilestoreManagerConnection::ListInstances(
+    google::cloud::filestore::v1::
+        ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::filestore::v1::Instance>>();
 }
@@ -81,9 +81,9 @@ CloudFilestoreManagerConnection::DeleteInstance(
 }
 
 StreamRange<google::cloud::filestore::v1::Backup>
-    CloudFilestoreManagerConnection::ListBackups(
-        google::cloud::filestore::v1::
-            ListBackupsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudFilestoreManagerConnection::ListBackups(
+    google::cloud::filestore::v1::
+        ListBackupsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::filestore::v1::Backup>>();
 }

--- a/google/cloud/functions/cloud_functions_connection.cc
+++ b/google/cloud/functions/cloud_functions_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudFunctionsServiceConnection::~CloudFunctionsServiceConnection() = default;
 
 StreamRange<google::cloud::functions::v1::CloudFunction>
-    CloudFunctionsServiceConnection::ListFunctions(
-        google::cloud::functions::v1::
-            ListFunctionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudFunctionsServiceConnection::ListFunctions(
+    google::cloud::functions::v1::
+        ListFunctionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::functions::v1::CloudFunction>>();
 }

--- a/google/cloud/gameservices/game_server_clusters_connection.cc
+++ b/google/cloud/gameservices/game_server_clusters_connection.cc
@@ -36,9 +36,9 @@ GameServerClustersServiceConnection::~GameServerClustersServiceConnection() =
     default;
 
 StreamRange<google::cloud::gaming::v1::GameServerCluster>
-    GameServerClustersServiceConnection::ListGameServerClusters(
-        google::cloud::gaming::v1::
-            ListGameServerClustersRequest) {  // NOLINT(performance-unnecessary-value-param)
+GameServerClustersServiceConnection::ListGameServerClusters(
+    google::cloud::gaming::v1::
+        ListGameServerClustersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::gaming::v1::GameServerCluster>>();
 }

--- a/google/cloud/gameservices/game_server_configs_connection.cc
+++ b/google/cloud/gameservices/game_server_configs_connection.cc
@@ -36,9 +36,9 @@ GameServerConfigsServiceConnection::~GameServerConfigsServiceConnection() =
     default;
 
 StreamRange<google::cloud::gaming::v1::GameServerConfig>
-    GameServerConfigsServiceConnection::ListGameServerConfigs(
-        google::cloud::gaming::v1::
-            ListGameServerConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+GameServerConfigsServiceConnection::ListGameServerConfigs(
+    google::cloud::gaming::v1::
+        ListGameServerConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::gaming::v1::GameServerConfig>>();
 }

--- a/google/cloud/gameservices/game_server_deployments_connection.cc
+++ b/google/cloud/gameservices/game_server_deployments_connection.cc
@@ -36,9 +36,9 @@ GameServerDeploymentsServiceConnection::
     ~GameServerDeploymentsServiceConnection() = default;
 
 StreamRange<google::cloud::gaming::v1::GameServerDeployment>
-    GameServerDeploymentsServiceConnection::ListGameServerDeployments(
-        google::cloud::gaming::v1::
-            ListGameServerDeploymentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+GameServerDeploymentsServiceConnection::ListGameServerDeployments(
+    google::cloud::gaming::v1::
+        ListGameServerDeploymentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::gaming::v1::GameServerDeployment>>();
 }

--- a/google/cloud/gameservices/realms_connection.cc
+++ b/google/cloud/gameservices/realms_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 RealmsServiceConnection::~RealmsServiceConnection() = default;
 
 StreamRange<google::cloud::gaming::v1::Realm>
-    RealmsServiceConnection::ListRealms(
-        google::cloud::gaming::v1::
-            ListRealmsRequest) {  // NOLINT(performance-unnecessary-value-param)
+RealmsServiceConnection::ListRealms(
+    google::cloud::gaming::v1::
+        ListRealmsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::gaming::v1::Realm>>();
 }

--- a/google/cloud/gkehub/gke_hub_connection.cc
+++ b/google/cloud/gkehub/gke_hub_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 GkeHubConnection::~GkeHubConnection() = default;
 
 StreamRange<google::cloud::gkehub::v1::Membership>
-    GkeHubConnection::ListMemberships(
-        google::cloud::gkehub::v1::
-            ListMembershipsRequest) {  // NOLINT(performance-unnecessary-value-param)
+GkeHubConnection::ListMemberships(
+    google::cloud::gkehub::v1::
+        ListMembershipsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::gkehub::v1::Membership>>();
 }

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 IAMConnection::~IAMConnection() = default;
 
 StreamRange<google::iam::admin::v1::ServiceAccount>
-    IAMConnection::ListServiceAccounts(
-        google::iam::admin::v1::
-            ListServiceAccountsRequest) {  // NOLINT(performance-unnecessary-value-param)
+IAMConnection::ListServiceAccounts(
+    google::iam::admin::v1::
+        ListServiceAccountsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::iam::admin::v1::ServiceAccount>>();
 }
@@ -166,9 +166,9 @@ StatusOr<google::iam::admin::v1::Role> IAMConnection::UndeleteRole(
 }
 
 StreamRange<google::iam::admin::v1::Permission>
-    IAMConnection::QueryTestablePermissions(
-        google::iam::admin::v1::
-            QueryTestablePermissionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+IAMConnection::QueryTestablePermissions(
+    google::iam::admin::v1::
+        QueryTestablePermissionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::iam::admin::v1::Permission>>();
 }

--- a/google/cloud/iap/identity_aware_proxy_o_auth_connection.cc
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_connection.cc
@@ -60,9 +60,9 @@ IdentityAwareProxyOAuthServiceConnection::CreateIdentityAwareProxyClient(
 }
 
 StreamRange<google::cloud::iap::v1::IdentityAwareProxyClient>
-    IdentityAwareProxyOAuthServiceConnection::ListIdentityAwareProxyClients(
-        google::cloud::iap::v1::
-            ListIdentityAwareProxyClientsRequest) {  // NOLINT(performance-unnecessary-value-param)
+IdentityAwareProxyOAuthServiceConnection::ListIdentityAwareProxyClients(
+    google::cloud::iap::v1::
+        ListIdentityAwareProxyClientsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::iap::v1::IdentityAwareProxyClient>>();
 }

--- a/google/cloud/iot/device_manager_connection.cc
+++ b/google/cloud/iot/device_manager_connection.cc
@@ -58,9 +58,9 @@ Status DeviceManagerConnection::DeleteDeviceRegistry(
 }
 
 StreamRange<google::cloud::iot::v1::DeviceRegistry>
-    DeviceManagerConnection::ListDeviceRegistries(
-        google::cloud::iot::v1::
-            ListDeviceRegistriesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DeviceManagerConnection::ListDeviceRegistries(
+    google::cloud::iot::v1::
+        ListDeviceRegistriesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::iot::v1::DeviceRegistry>>();
 }
@@ -85,7 +85,8 @@ Status DeviceManagerConnection::DeleteDevice(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-StreamRange<google::cloud::iot::v1::Device> DeviceManagerConnection::ListDevices(
+StreamRange<google::cloud::iot::v1::Device>
+DeviceManagerConnection::ListDevices(
     google::cloud::iot::v1::
         ListDevicesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<

--- a/google/cloud/kms/ekm_connection.cc
+++ b/google/cloud/kms/ekm_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EkmServiceConnection::~EkmServiceConnection() = default;
 
 StreamRange<google::cloud::kms::v1::EkmConnection>
-    EkmServiceConnection::ListEkmConnections(
-        google::cloud::kms::v1::
-            ListEkmConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+EkmServiceConnection::ListEkmConnections(
+    google::cloud::kms::v1::
+        ListEkmConnectionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::kms::v1::EkmConnection>>();
 }

--- a/google/cloud/kms/key_management_connection.cc
+++ b/google/cloud/kms/key_management_connection.cc
@@ -35,33 +35,33 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 KeyManagementServiceConnection::~KeyManagementServiceConnection() = default;
 
 StreamRange<google::cloud::kms::v1::KeyRing>
-    KeyManagementServiceConnection::ListKeyRings(
-        google::cloud::kms::v1::
-            ListKeyRingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+KeyManagementServiceConnection::ListKeyRings(
+    google::cloud::kms::v1::
+        ListKeyRingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::kms::v1::KeyRing>>();
 }
 
 StreamRange<google::cloud::kms::v1::CryptoKey>
-    KeyManagementServiceConnection::ListCryptoKeys(
-        google::cloud::kms::v1::
-            ListCryptoKeysRequest) {  // NOLINT(performance-unnecessary-value-param)
+KeyManagementServiceConnection::ListCryptoKeys(
+    google::cloud::kms::v1::
+        ListCryptoKeysRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::kms::v1::CryptoKey>>();
 }
 
 StreamRange<google::cloud::kms::v1::CryptoKeyVersion>
-    KeyManagementServiceConnection::ListCryptoKeyVersions(
-        google::cloud::kms::v1::
-            ListCryptoKeyVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+KeyManagementServiceConnection::ListCryptoKeyVersions(
+    google::cloud::kms::v1::
+        ListCryptoKeyVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::kms::v1::CryptoKeyVersion>>();
 }
 
 StreamRange<google::cloud::kms::v1::ImportJob>
-    KeyManagementServiceConnection::ListImportJobs(
-        google::cloud::kms::v1::
-            ListImportJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+KeyManagementServiceConnection::ListImportJobs(
+    google::cloud::kms::v1::
+        ListImportJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::kms::v1::ImportJob>>();
 }

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -46,17 +46,17 @@ LoggingServiceV2Connection::WriteLogEntries(
 }
 
 StreamRange<google::logging::v2::LogEntry>
-    LoggingServiceV2Connection::ListLogEntries(
-        google::logging::v2::
-            ListLogEntriesRequest) {  // NOLINT(performance-unnecessary-value-param)
+LoggingServiceV2Connection::ListLogEntries(
+    google::logging::v2::
+        ListLogEntriesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::logging::v2::LogEntry>>();
 }
 
 StreamRange<google::api::MonitoredResourceDescriptor>
-    LoggingServiceV2Connection::ListMonitoredResourceDescriptors(
-        google::logging::v2::
-            ListMonitoredResourceDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+LoggingServiceV2Connection::ListMonitoredResourceDescriptors(
+    google::logging::v2::
+        ListMonitoredResourceDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::MonitoredResourceDescriptor>>();
 }

--- a/google/cloud/managedidentities/managed_identities_connection.cc
+++ b/google/cloud/managedidentities/managed_identities_connection.cc
@@ -51,9 +51,9 @@ ManagedIdentitiesServiceConnection::ResetAdminPassword(
 }
 
 StreamRange<google::cloud::managedidentities::v1::Domain>
-    ManagedIdentitiesServiceConnection::ListDomains(
-        google::cloud::managedidentities::v1::
-            ListDomainsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ManagedIdentitiesServiceConnection::ListDomains(
+    google::cloud::managedidentities::v1::
+        ListDomainsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::managedidentities::v1::Domain>>();
 }

--- a/google/cloud/memcache/cloud_memcache_connection.cc
+++ b/google/cloud/memcache/cloud_memcache_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudMemcacheConnection::~CloudMemcacheConnection() = default;
 
 StreamRange<google::cloud::memcache::v1::Instance>
-    CloudMemcacheConnection::ListInstances(
-        google::cloud::memcache::v1::
-            ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudMemcacheConnection::ListInstances(
+    google::cloud::memcache::v1::
+        ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::memcache::v1::Instance>>();
 }

--- a/google/cloud/monitoring/alert_policy_connection.cc
+++ b/google/cloud/monitoring/alert_policy_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AlertPolicyServiceConnection::~AlertPolicyServiceConnection() = default;
 
 StreamRange<google::monitoring::v3::AlertPolicy>
-    AlertPolicyServiceConnection::ListAlertPolicies(
-        google::monitoring::v3::
-            ListAlertPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
+AlertPolicyServiceConnection::ListAlertPolicies(
+    google::monitoring::v3::
+        ListAlertPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::AlertPolicy>>();
 }

--- a/google/cloud/monitoring/dashboards_connection.cc
+++ b/google/cloud/monitoring/dashboards_connection.cc
@@ -41,9 +41,9 @@ DashboardsServiceConnection::CreateDashboard(
 }
 
 StreamRange<google::monitoring::dashboard::v1::Dashboard>
-    DashboardsServiceConnection::ListDashboards(
-        google::monitoring::dashboard::v1::
-            ListDashboardsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DashboardsServiceConnection::ListDashboards(
+    google::monitoring::dashboard::v1::
+        ListDashboardsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::dashboard::v1::Dashboard>>();
 }

--- a/google/cloud/monitoring/group_connection.cc
+++ b/google/cloud/monitoring/group_connection.cc
@@ -62,9 +62,9 @@ Status GroupServiceConnection::DeleteGroup(
 }
 
 StreamRange<google::api::MonitoredResource>
-    GroupServiceConnection::ListGroupMembers(
-        google::monitoring::v3::
-            ListGroupMembersRequest) {  // NOLINT(performance-unnecessary-value-param)
+GroupServiceConnection::ListGroupMembers(
+    google::monitoring::v3::
+        ListGroupMembersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::MonitoredResource>>();
 }

--- a/google/cloud/monitoring/metric_connection.cc
+++ b/google/cloud/monitoring/metric_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 MetricServiceConnection::~MetricServiceConnection() = default;
 
 StreamRange<google::api::MonitoredResourceDescriptor>
-    MetricServiceConnection::ListMonitoredResourceDescriptors(
-        google::monitoring::v3::
-            ListMonitoredResourceDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+MetricServiceConnection::ListMonitoredResourceDescriptors(
+    google::monitoring::v3::
+        ListMonitoredResourceDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::MonitoredResourceDescriptor>>();
 }
@@ -49,9 +49,9 @@ MetricServiceConnection::GetMonitoredResourceDescriptor(
 }
 
 StreamRange<google::api::MetricDescriptor>
-    MetricServiceConnection::ListMetricDescriptors(
-        google::monitoring::v3::
-            ListMetricDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+MetricServiceConnection::ListMetricDescriptors(
+    google::monitoring::v3::
+        ListMetricDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::MetricDescriptor>>();
 }
@@ -74,9 +74,9 @@ Status MetricServiceConnection::DeleteMetricDescriptor(
 }
 
 StreamRange<google::monitoring::v3::TimeSeries>
-    MetricServiceConnection::ListTimeSeries(
-        google::monitoring::v3::
-            ListTimeSeriesRequest) {  // NOLINT(performance-unnecessary-value-param)
+MetricServiceConnection::ListTimeSeries(
+    google::monitoring::v3::
+        ListTimeSeriesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::TimeSeries>>();
 }

--- a/google/cloud/monitoring/notification_channel_connection.cc
+++ b/google/cloud/monitoring/notification_channel_connection.cc
@@ -36,9 +36,9 @@ NotificationChannelServiceConnection::~NotificationChannelServiceConnection() =
     default;
 
 StreamRange<google::monitoring::v3::NotificationChannelDescriptor>
-    NotificationChannelServiceConnection::ListNotificationChannelDescriptors(
-        google::monitoring::v3::
-            ListNotificationChannelDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+NotificationChannelServiceConnection::ListNotificationChannelDescriptors(
+    google::monitoring::v3::
+        ListNotificationChannelDescriptorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::NotificationChannelDescriptor>>();
 }
@@ -50,9 +50,9 @@ NotificationChannelServiceConnection::GetNotificationChannelDescriptor(
 }
 
 StreamRange<google::monitoring::v3::NotificationChannel>
-    NotificationChannelServiceConnection::ListNotificationChannels(
-        google::monitoring::v3::
-            ListNotificationChannelsRequest) {  // NOLINT(performance-unnecessary-value-param)
+NotificationChannelServiceConnection::ListNotificationChannels(
+    google::monitoring::v3::
+        ListNotificationChannelsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::NotificationChannel>>();
 }

--- a/google/cloud/monitoring/query_connection.cc
+++ b/google/cloud/monitoring/query_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 QueryServiceConnection::~QueryServiceConnection() = default;
 
 StreamRange<google::monitoring::v3::TimeSeriesData>
-    QueryServiceConnection::QueryTimeSeries(
-        google::monitoring::v3::
-            QueryTimeSeriesRequest) {  // NOLINT(performance-unnecessary-value-param)
+QueryServiceConnection::QueryTimeSeries(
+    google::monitoring::v3::
+        QueryTimeSeriesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::TimeSeriesData>>();
 }

--- a/google/cloud/monitoring/service_monitoring_connection.cc
+++ b/google/cloud/monitoring/service_monitoring_connection.cc
@@ -48,9 +48,9 @@ ServiceMonitoringServiceConnection::GetService(
 }
 
 StreamRange<google::monitoring::v3::Service>
-    ServiceMonitoringServiceConnection::ListServices(
-        google::monitoring::v3::
-            ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ServiceMonitoringServiceConnection::ListServices(
+    google::monitoring::v3::
+        ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::Service>>();
 }
@@ -79,9 +79,9 @@ ServiceMonitoringServiceConnection::GetServiceLevelObjective(
 }
 
 StreamRange<google::monitoring::v3::ServiceLevelObjective>
-    ServiceMonitoringServiceConnection::ListServiceLevelObjectives(
-        google::monitoring::v3::
-            ListServiceLevelObjectivesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ServiceMonitoringServiceConnection::ListServiceLevelObjectives(
+    google::monitoring::v3::
+        ListServiceLevelObjectivesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::ServiceLevelObjective>>();
 }

--- a/google/cloud/monitoring/uptime_check_connection.cc
+++ b/google/cloud/monitoring/uptime_check_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 UptimeCheckServiceConnection::~UptimeCheckServiceConnection() = default;
 
 StreamRange<google::monitoring::v3::UptimeCheckConfig>
-    UptimeCheckServiceConnection::ListUptimeCheckConfigs(
-        google::monitoring::v3::
-            ListUptimeCheckConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+UptimeCheckServiceConnection::ListUptimeCheckConfigs(
+    google::monitoring::v3::
+        ListUptimeCheckConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::UptimeCheckConfig>>();
 }
@@ -66,9 +66,9 @@ Status UptimeCheckServiceConnection::DeleteUptimeCheckConfig(
 }
 
 StreamRange<google::monitoring::v3::UptimeCheckIp>
-    UptimeCheckServiceConnection::ListUptimeCheckIps(
-        google::monitoring::v3::
-            ListUptimeCheckIpsRequest) {  // NOLINT(performance-unnecessary-value-param)
+UptimeCheckServiceConnection::ListUptimeCheckIps(
+    google::monitoring::v3::
+        ListUptimeCheckIpsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::monitoring::v3::UptimeCheckIp>>();
 }

--- a/google/cloud/networkmanagement/reachability_connection.cc
+++ b/google/cloud/networkmanagement/reachability_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ReachabilityServiceConnection::~ReachabilityServiceConnection() = default;
 
 StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>
-    ReachabilityServiceConnection::ListConnectivityTests(
-        google::cloud::networkmanagement::v1::
-            ListConnectivityTestsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ReachabilityServiceConnection::ListConnectivityTests(
+    google::cloud::networkmanagement::v1::
+        ListConnectivityTestsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>>();
 }

--- a/google/cloud/notebooks/managed_notebook_connection.cc
+++ b/google/cloud/notebooks/managed_notebook_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ManagedNotebookServiceConnection::~ManagedNotebookServiceConnection() = default;
 
 StreamRange<google::cloud::notebooks::v1::Runtime>
-    ManagedNotebookServiceConnection::ListRuntimes(
-        google::cloud::notebooks::v1::
-            ListRuntimesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ManagedNotebookServiceConnection::ListRuntimes(
+    google::cloud::notebooks::v1::
+        ListRuntimesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::notebooks::v1::Runtime>>();
 }

--- a/google/cloud/notebooks/notebook_connection.cc
+++ b/google/cloud/notebooks/notebook_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 NotebookServiceConnection::~NotebookServiceConnection() = default;
 
 StreamRange<google::cloud::notebooks::v1::Instance>
-    NotebookServiceConnection::ListInstances(
-        google::cloud::notebooks::v1::
-            ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
+NotebookServiceConnection::ListInstances(
+    google::cloud::notebooks::v1::
+        ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::notebooks::v1::Instance>>();
 }
@@ -181,9 +181,9 @@ NotebookServiceConnection::UpgradeInstanceInternal(
 }
 
 StreamRange<google::cloud::notebooks::v1::Environment>
-    NotebookServiceConnection::ListEnvironments(
-        google::cloud::notebooks::v1::
-            ListEnvironmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+NotebookServiceConnection::ListEnvironments(
+    google::cloud::notebooks::v1::
+        ListEnvironmentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::notebooks::v1::Environment>>();
 }
@@ -211,9 +211,9 @@ NotebookServiceConnection::DeleteEnvironment(
 }
 
 StreamRange<google::cloud::notebooks::v1::Schedule>
-    NotebookServiceConnection::ListSchedules(
-        google::cloud::notebooks::v1::
-            ListSchedulesRequest) {  // NOLINT(performance-unnecessary-value-param)
+NotebookServiceConnection::ListSchedules(
+    google::cloud::notebooks::v1::
+        ListSchedulesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::notebooks::v1::Schedule>>();
 }
@@ -249,9 +249,9 @@ NotebookServiceConnection::TriggerSchedule(
 }
 
 StreamRange<google::cloud::notebooks::v1::Execution>
-    NotebookServiceConnection::ListExecutions(
-        google::cloud::notebooks::v1::
-            ListExecutionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+NotebookServiceConnection::ListExecutions(
+    google::cloud::notebooks::v1::
+        ListExecutionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::notebooks::v1::Execution>>();
 }

--- a/google/cloud/orgpolicy/org_policy_connection.cc
+++ b/google/cloud/orgpolicy/org_policy_connection.cc
@@ -35,17 +35,17 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 OrgPolicyConnection::~OrgPolicyConnection() = default;
 
 StreamRange<google::cloud::orgpolicy::v2::Constraint>
-    OrgPolicyConnection::ListConstraints(
-        google::cloud::orgpolicy::v2::
-            ListConstraintsRequest) {  // NOLINT(performance-unnecessary-value-param)
+OrgPolicyConnection::ListConstraints(
+    google::cloud::orgpolicy::v2::
+        ListConstraintsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::orgpolicy::v2::Constraint>>();
 }
 
 StreamRange<google::cloud::orgpolicy::v2::Policy>
-    OrgPolicyConnection::ListPolicies(
-        google::cloud::orgpolicy::v2::
-            ListPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
+OrgPolicyConnection::ListPolicies(
+    google::cloud::orgpolicy::v2::
+        ListPoliciesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::orgpolicy::v2::Policy>>();
 }

--- a/google/cloud/osconfig/os_config_connection.cc
+++ b/google/cloud/osconfig/os_config_connection.cc
@@ -53,17 +53,17 @@ OsConfigServiceConnection::CancelPatchJob(
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchJob>
-    OsConfigServiceConnection::ListPatchJobs(
-        google::cloud::osconfig::v1::
-            ListPatchJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+OsConfigServiceConnection::ListPatchJobs(
+    google::cloud::osconfig::v1::
+        ListPatchJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::osconfig::v1::PatchJob>>();
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>
-    OsConfigServiceConnection::ListPatchJobInstanceDetails(
-        google::cloud::osconfig::v1::
-            ListPatchJobInstanceDetailsRequest) {  // NOLINT(performance-unnecessary-value-param)
+OsConfigServiceConnection::ListPatchJobInstanceDetails(
+    google::cloud::osconfig::v1::
+        ListPatchJobInstanceDetailsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::osconfig::v1::PatchJobInstanceDetails>>();
 }
@@ -81,9 +81,9 @@ OsConfigServiceConnection::GetPatchDeployment(
 }
 
 StreamRange<google::cloud::osconfig::v1::PatchDeployment>
-    OsConfigServiceConnection::ListPatchDeployments(
-        google::cloud::osconfig::v1::
-            ListPatchDeploymentsRequest) {  // NOLINT(performance-unnecessary-value-param)
+OsConfigServiceConnection::ListPatchDeployments(
+    google::cloud::osconfig::v1::
+        ListPatchDeploymentsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::osconfig::v1::PatchDeployment>>();
 }

--- a/google/cloud/privateca/certificate_authority_connection.cc
+++ b/google/cloud/privateca/certificate_authority_connection.cc
@@ -48,9 +48,9 @@ CertificateAuthorityServiceConnection::GetCertificate(
 }
 
 StreamRange<google::cloud::security::privateca::v1::Certificate>
-    CertificateAuthorityServiceConnection::ListCertificates(
-        google::cloud::security::privateca::v1::
-            ListCertificatesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CertificateAuthorityServiceConnection::ListCertificates(
+    google::cloud::security::privateca::v1::
+        ListCertificatesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::security::privateca::v1::Certificate>>();
 }
@@ -119,9 +119,9 @@ CertificateAuthorityServiceConnection::GetCertificateAuthority(
 }
 
 StreamRange<google::cloud::security::privateca::v1::CertificateAuthority>
-    CertificateAuthorityServiceConnection::ListCertificateAuthorities(
-        google::cloud::security::privateca::v1::
-            ListCertificateAuthoritiesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CertificateAuthorityServiceConnection::ListCertificateAuthorities(
+    google::cloud::security::privateca::v1::
+        ListCertificateAuthoritiesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::security::privateca::v1::CertificateAuthority>>();
 }
@@ -176,9 +176,9 @@ CertificateAuthorityServiceConnection::GetCaPool(
 }
 
 StreamRange<google::cloud::security::privateca::v1::CaPool>
-    CertificateAuthorityServiceConnection::ListCaPools(
-        google::cloud::security::privateca::v1::
-            ListCaPoolsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CertificateAuthorityServiceConnection::ListCaPools(
+    google::cloud::security::privateca::v1::
+        ListCaPoolsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::security::privateca::v1::CaPool>>();
 }
@@ -205,9 +205,9 @@ CertificateAuthorityServiceConnection::GetCertificateRevocationList(
 }
 
 StreamRange<google::cloud::security::privateca::v1::CertificateRevocationList>
-    CertificateAuthorityServiceConnection::ListCertificateRevocationLists(
-        google::cloud::security::privateca::v1::
-            ListCertificateRevocationListsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CertificateAuthorityServiceConnection::ListCertificateRevocationLists(
+    google::cloud::security::privateca::v1::
+        ListCertificateRevocationListsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::security::privateca::v1::CertificateRevocationList>>();
 }
@@ -248,9 +248,9 @@ CertificateAuthorityServiceConnection::GetCertificateTemplate(
 }
 
 StreamRange<google::cloud::security::privateca::v1::CertificateTemplate>
-    CertificateAuthorityServiceConnection::ListCertificateTemplates(
-        google::cloud::security::privateca::v1::
-            ListCertificateTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CertificateAuthorityServiceConnection::ListCertificateTemplates(
+    google::cloud::security::privateca::v1::
+        ListCertificateTemplatesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<StreamRange<
       google::cloud::security::privateca::v1::CertificateTemplate>>();
 }

--- a/google/cloud/pubsublite/admin_connection.cc
+++ b/google/cloud/pubsublite/admin_connection.cc
@@ -52,9 +52,9 @@ AdminServiceConnection::GetTopicPartitions(
 }
 
 StreamRange<google::cloud::pubsublite::v1::Topic>
-    AdminServiceConnection::ListTopics(
-        google::cloud::pubsublite::v1::
-            ListTopicsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AdminServiceConnection::ListTopics(
+    google::cloud::pubsublite::v1::
+        ListTopicsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::pubsublite::v1::Topic>>();
 }
@@ -90,9 +90,9 @@ AdminServiceConnection::GetSubscription(
 }
 
 StreamRange<google::cloud::pubsublite::v1::Subscription>
-    AdminServiceConnection::ListSubscriptions(
-        google::cloud::pubsublite::v1::
-            ListSubscriptionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AdminServiceConnection::ListSubscriptions(
+    google::cloud::pubsublite::v1::
+        ListSubscriptionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::pubsublite::v1::Subscription>>();
 }
@@ -129,9 +129,9 @@ AdminServiceConnection::GetReservation(
 }
 
 StreamRange<google::cloud::pubsublite::v1::Reservation>
-    AdminServiceConnection::ListReservations(
-        google::cloud::pubsublite::v1::
-            ListReservationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+AdminServiceConnection::ListReservations(
+    google::cloud::pubsublite::v1::
+        ListReservationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::pubsublite::v1::Reservation>>();
 }

--- a/google/cloud/recommender/recommender_connection.cc
+++ b/google/cloud/recommender/recommender_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 RecommenderConnection::~RecommenderConnection() = default;
 
 StreamRange<google::cloud::recommender::v1::Insight>
-    RecommenderConnection::ListInsights(
-        google::cloud::recommender::v1::
-            ListInsightsRequest) {  // NOLINT(performance-unnecessary-value-param)
+RecommenderConnection::ListInsights(
+    google::cloud::recommender::v1::
+        ListInsightsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::recommender::v1::Insight>>();
 }
@@ -55,9 +55,9 @@ RecommenderConnection::MarkInsightAccepted(
 }
 
 StreamRange<google::cloud::recommender::v1::Recommendation>
-    RecommenderConnection::ListRecommendations(
-        google::cloud::recommender::v1::
-            ListRecommendationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+RecommenderConnection::ListRecommendations(
+    google::cloud::recommender::v1::
+        ListRecommendationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::recommender::v1::Recommendation>>();
 }

--- a/google/cloud/redis/cloud_redis_connection.cc
+++ b/google/cloud/redis/cloud_redis_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudRedisConnection::~CloudRedisConnection() = default;
 
 StreamRange<google::cloud::redis::v1::Instance>
-    CloudRedisConnection::ListInstances(
-        google::cloud::redis::v1::
-            ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudRedisConnection::ListInstances(
+    google::cloud::redis::v1::
+        ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::redis::v1::Instance>>();
 }

--- a/google/cloud/resourcemanager/folders_connection.cc
+++ b/google/cloud/resourcemanager/folders_connection.cc
@@ -41,17 +41,17 @@ FoldersConnection::GetFolder(
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Folder>
-    FoldersConnection::ListFolders(
-        google::cloud::resourcemanager::v3::
-            ListFoldersRequest) {  // NOLINT(performance-unnecessary-value-param)
+FoldersConnection::ListFolders(
+    google::cloud::resourcemanager::v3::
+        ListFoldersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::resourcemanager::v3::Folder>>();
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Folder>
-    FoldersConnection::SearchFolders(
-        google::cloud::resourcemanager::v3::
-            SearchFoldersRequest) {  // NOLINT(performance-unnecessary-value-param)
+FoldersConnection::SearchFolders(
+    google::cloud::resourcemanager::v3::
+        SearchFoldersRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::resourcemanager::v3::Folder>>();
 }

--- a/google/cloud/resourcemanager/organizations_connection.cc
+++ b/google/cloud/resourcemanager/organizations_connection.cc
@@ -41,9 +41,9 @@ OrganizationsConnection::GetOrganization(
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Organization>
-    OrganizationsConnection::SearchOrganizations(
-        google::cloud::resourcemanager::v3::
-            SearchOrganizationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+OrganizationsConnection::SearchOrganizations(
+    google::cloud::resourcemanager::v3::
+        SearchOrganizationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::resourcemanager::v3::Organization>>();
 }

--- a/google/cloud/resourcemanager/projects_connection.cc
+++ b/google/cloud/resourcemanager/projects_connection.cc
@@ -41,17 +41,17 @@ ProjectsConnection::GetProject(
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Project>
-    ProjectsConnection::ListProjects(
-        google::cloud::resourcemanager::v3::
-            ListProjectsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProjectsConnection::ListProjects(
+    google::cloud::resourcemanager::v3::
+        ListProjectsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::resourcemanager::v3::Project>>();
 }
 
 StreamRange<google::cloud::resourcemanager::v3::Project>
-    ProjectsConnection::SearchProjects(
-        google::cloud::resourcemanager::v3::
-            SearchProjectsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProjectsConnection::SearchProjects(
+    google::cloud::resourcemanager::v3::
+        SearchProjectsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::resourcemanager::v3::Project>>();
 }

--- a/google/cloud/resourcesettings/resource_settings_connection.cc
+++ b/google/cloud/resourcesettings/resource_settings_connection.cc
@@ -36,9 +36,9 @@ ResourceSettingsServiceConnection::~ResourceSettingsServiceConnection() =
     default;
 
 StreamRange<google::cloud::resourcesettings::v1::Setting>
-    ResourceSettingsServiceConnection::ListSettings(
-        google::cloud::resourcesettings::v1::
-            ListSettingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ResourceSettingsServiceConnection::ListSettings(
+    google::cloud::resourcesettings::v1::
+        ListSettingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::resourcesettings::v1::Setting>>();
 }

--- a/google/cloud/retail/catalog_connection.cc
+++ b/google/cloud/retail/catalog_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CatalogServiceConnection::~CatalogServiceConnection() = default;
 
 StreamRange<google::cloud::retail::v2::Catalog>
-    CatalogServiceConnection::ListCatalogs(
-        google::cloud::retail::v2::
-            ListCatalogsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CatalogServiceConnection::ListCatalogs(
+    google::cloud::retail::v2::
+        ListCatalogsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::retail::v2::Catalog>>();
 }

--- a/google/cloud/retail/product_connection.cc
+++ b/google/cloud/retail/product_connection.cc
@@ -47,9 +47,9 @@ ProductServiceConnection::GetProduct(
 }
 
 StreamRange<google::cloud::retail::v2::Product>
-    ProductServiceConnection::ListProducts(
-        google::cloud::retail::v2::
-            ListProductsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProductServiceConnection::ListProducts(
+    google::cloud::retail::v2::
+        ListProductsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::retail::v2::Product>>();
 }

--- a/google/cloud/retail/search_connection.cc
+++ b/google/cloud/retail/search_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SearchServiceConnection::~SearchServiceConnection() = default;
 
 StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult>
-    SearchServiceConnection::Search(
-        google::cloud::retail::v2::
-            SearchRequest) {  // NOLINT(performance-unnecessary-value-param)
+SearchServiceConnection::Search(
+    google::cloud::retail::v2::
+        SearchRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult>>();
 }

--- a/google/cloud/scheduler/cloud_scheduler_connection.cc
+++ b/google/cloud/scheduler/cloud_scheduler_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudSchedulerConnection::~CloudSchedulerConnection() = default;
 
 StreamRange<google::cloud::scheduler::v1::Job>
-    CloudSchedulerConnection::ListJobs(
-        google::cloud::scheduler::v1::
-            ListJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+CloudSchedulerConnection::ListJobs(
+    google::cloud::scheduler::v1::
+        ListJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::scheduler::v1::Job>>();
 }

--- a/google/cloud/secretmanager/secret_manager_connection.cc
+++ b/google/cloud/secretmanager/secret_manager_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SecretManagerServiceConnection::~SecretManagerServiceConnection() = default;
 
 StreamRange<google::cloud::secretmanager::v1::Secret>
-    SecretManagerServiceConnection::ListSecrets(
-        google::cloud::secretmanager::v1::
-            ListSecretsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecretManagerServiceConnection::ListSecrets(
+    google::cloud::secretmanager::v1::
+        ListSecretsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::secretmanager::v1::Secret>>();
 }
@@ -72,9 +72,9 @@ Status SecretManagerServiceConnection::DeleteSecret(
 }
 
 StreamRange<google::cloud::secretmanager::v1::SecretVersion>
-    SecretManagerServiceConnection::ListSecretVersions(
-        google::cloud::secretmanager::v1::
-            ListSecretVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecretManagerServiceConnection::ListSecretVersions(
+    google::cloud::secretmanager::v1::
+        ListSecretVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::secretmanager::v1::SecretVersion>>();
 }

--- a/google/cloud/securitycenter/security_center_connection.cc
+++ b/google/cloud/securitycenter/security_center_connection.cc
@@ -112,26 +112,26 @@ SecurityCenterConnection::GetSource(
 }
 
 StreamRange<google::cloud::securitycenter::v1::GroupResult>
-    SecurityCenterConnection::GroupAssets(
-        google::cloud::securitycenter::v1::
-            GroupAssetsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::GroupAssets(
+    google::cloud::securitycenter::v1::
+        GroupAssetsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::GroupResult>>();
 }
 
 StreamRange<google::cloud::securitycenter::v1::GroupResult>
-    SecurityCenterConnection::GroupFindings(
-        google::cloud::securitycenter::v1::
-            GroupFindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::GroupFindings(
+    google::cloud::securitycenter::v1::
+        GroupFindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::GroupResult>>();
 }
 
 StreamRange<
     google::cloud::securitycenter::v1::ListAssetsResponse::ListAssetsResult>
-    SecurityCenterConnection::ListAssets(
-        google::cloud::securitycenter::v1::
-            ListAssetsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::ListAssets(
+    google::cloud::securitycenter::v1::
+        ListAssetsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::ListAssetsResponse::
                       ListAssetsResult>>();
@@ -139,34 +139,34 @@ StreamRange<
 
 StreamRange<
     google::cloud::securitycenter::v1::ListFindingsResponse::ListFindingsResult>
-    SecurityCenterConnection::ListFindings(
-        google::cloud::securitycenter::v1::
-            ListFindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::ListFindings(
+    google::cloud::securitycenter::v1::
+        ListFindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::ListFindingsResponse::
                       ListFindingsResult>>();
 }
 
 StreamRange<google::cloud::securitycenter::v1::MuteConfig>
-    SecurityCenterConnection::ListMuteConfigs(
-        google::cloud::securitycenter::v1::
-            ListMuteConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::ListMuteConfigs(
+    google::cloud::securitycenter::v1::
+        ListMuteConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::MuteConfig>>();
 }
 
 StreamRange<google::cloud::securitycenter::v1::NotificationConfig>
-    SecurityCenterConnection::ListNotificationConfigs(
-        google::cloud::securitycenter::v1::
-            ListNotificationConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::ListNotificationConfigs(
+    google::cloud::securitycenter::v1::
+        ListNotificationConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::NotificationConfig>>();
 }
 
 StreamRange<google::cloud::securitycenter::v1::Source>
-    SecurityCenterConnection::ListSources(
-        google::cloud::securitycenter::v1::
-            ListSourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::ListSources(
+    google::cloud::securitycenter::v1::
+        ListSourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::Source>>();
 }
@@ -263,9 +263,9 @@ SecurityCenterConnection::UpdateBigQueryExport(
 }
 
 StreamRange<google::cloud::securitycenter::v1::BigQueryExport>
-    SecurityCenterConnection::ListBigQueryExports(
-        google::cloud::securitycenter::v1::
-            ListBigQueryExportsRequest) {  // NOLINT(performance-unnecessary-value-param)
+SecurityCenterConnection::ListBigQueryExports(
+    google::cloud::securitycenter::v1::
+        ListBigQueryExportsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::securitycenter::v1::BigQueryExport>>();
 }

--- a/google/cloud/servicedirectory/registration_connection.cc
+++ b/google/cloud/servicedirectory/registration_connection.cc
@@ -41,9 +41,9 @@ RegistrationServiceConnection::CreateNamespace(
 }
 
 StreamRange<google::cloud::servicedirectory::v1::Namespace>
-    RegistrationServiceConnection::ListNamespaces(
-        google::cloud::servicedirectory::v1::
-            ListNamespacesRequest) {  // NOLINT(performance-unnecessary-value-param)
+RegistrationServiceConnection::ListNamespaces(
+    google::cloud::servicedirectory::v1::
+        ListNamespacesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::servicedirectory::v1::Namespace>>();
 }
@@ -72,9 +72,9 @@ RegistrationServiceConnection::CreateService(
 }
 
 StreamRange<google::cloud::servicedirectory::v1::Service>
-    RegistrationServiceConnection::ListServices(
-        google::cloud::servicedirectory::v1::
-            ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
+RegistrationServiceConnection::ListServices(
+    google::cloud::servicedirectory::v1::
+        ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::servicedirectory::v1::Service>>();
 }
@@ -103,9 +103,9 @@ RegistrationServiceConnection::CreateEndpoint(
 }
 
 StreamRange<google::cloud::servicedirectory::v1::Endpoint>
-    RegistrationServiceConnection::ListEndpoints(
-        google::cloud::servicedirectory::v1::
-            ListEndpointsRequest) {  // NOLINT(performance-unnecessary-value-param)
+RegistrationServiceConnection::ListEndpoints(
+    google::cloud::servicedirectory::v1::
+        ListEndpointsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::servicedirectory::v1::Endpoint>>();
 }

--- a/google/cloud/servicemanagement/service_manager_connection.cc
+++ b/google/cloud/servicemanagement/service_manager_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ServiceManagerConnection::~ServiceManagerConnection() = default;
 
 StreamRange<google::api::servicemanagement::v1::ManagedService>
-    ServiceManagerConnection::ListServices(
-        google::api::servicemanagement::v1::
-            ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ServiceManagerConnection::ListServices(
+    google::api::servicemanagement::v1::
+        ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::servicemanagement::v1::ManagedService>>();
 }
@@ -98,9 +98,9 @@ ServiceManagerConnection::SubmitConfigSource(
 }
 
 StreamRange<google::api::servicemanagement::v1::Rollout>
-    ServiceManagerConnection::ListServiceRollouts(
-        google::api::servicemanagement::v1::
-            ListServiceRolloutsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ServiceManagerConnection::ListServiceRollouts(
+    google::api::servicemanagement::v1::
+        ListServiceRolloutsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::servicemanagement::v1::Rollout>>();
 }

--- a/google/cloud/serviceusage/service_usage_connection.cc
+++ b/google/cloud/serviceusage/service_usage_connection.cc
@@ -57,9 +57,9 @@ ServiceUsageConnection::GetService(
 }
 
 StreamRange<google::api::serviceusage::v1::Service>
-    ServiceUsageConnection::ListServices(
-        google::api::serviceusage::v1::
-            ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ServiceUsageConnection::ListServices(
+    google::api::serviceusage::v1::
+        ListServicesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::api::serviceusage::v1::Service>>();
 }

--- a/google/cloud/spanner/admin/database_admin_connection.cc
+++ b/google/cloud/spanner/admin/database_admin_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DatabaseAdminConnection::~DatabaseAdminConnection() = default;
 
 StreamRange<google::spanner::admin::database::v1::Database>
-    DatabaseAdminConnection::ListDatabases(
-        google::spanner::admin::database::v1::
-            ListDatabasesRequest) {  // NOLINT(performance-unnecessary-value-param)
+DatabaseAdminConnection::ListDatabases(
+    google::spanner::admin::database::v1::
+        ListDatabasesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::spanner::admin::database::v1::Database>>();
 }
@@ -126,9 +126,9 @@ Status DatabaseAdminConnection::DeleteBackup(
 }
 
 StreamRange<google::spanner::admin::database::v1::Backup>
-    DatabaseAdminConnection::ListBackups(
-        google::spanner::admin::database::v1::
-            ListBackupsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DatabaseAdminConnection::ListBackups(
+    google::spanner::admin::database::v1::
+        ListBackupsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::spanner::admin::database::v1::Backup>>();
 }
@@ -142,17 +142,17 @@ DatabaseAdminConnection::RestoreDatabase(
 }
 
 StreamRange<google::longrunning::Operation>
-    DatabaseAdminConnection::ListDatabaseOperations(
-        google::spanner::admin::database::v1::
-            ListDatabaseOperationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DatabaseAdminConnection::ListDatabaseOperations(
+    google::spanner::admin::database::v1::
+        ListDatabaseOperationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::longrunning::Operation>>();
 }
 
 StreamRange<google::longrunning::Operation>
-    DatabaseAdminConnection::ListBackupOperations(
-        google::spanner::admin::database::v1::
-            ListBackupOperationsRequest) {  // NOLINT(performance-unnecessary-value-param)
+DatabaseAdminConnection::ListBackupOperations(
+    google::spanner::admin::database::v1::
+        ListBackupOperationsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::longrunning::Operation>>();
 }

--- a/google/cloud/spanner/admin/instance_admin_connection.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 InstanceAdminConnection::~InstanceAdminConnection() = default;
 
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
-    InstanceAdminConnection::ListInstanceConfigs(
-        google::spanner::admin::instance::v1::
-            ListInstanceConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+InstanceAdminConnection::ListInstanceConfigs(
+    google::spanner::admin::instance::v1::
+        ListInstanceConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::spanner::admin::instance::v1::InstanceConfig>>();
 }
@@ -49,9 +49,9 @@ InstanceAdminConnection::GetInstanceConfig(
 }
 
 StreamRange<google::spanner::admin::instance::v1::Instance>
-    InstanceAdminConnection::ListInstances(
-        google::spanner::admin::instance::v1::
-            ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
+InstanceAdminConnection::ListInstances(
+    google::spanner::admin::instance::v1::
+        ListInstancesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::spanner::admin::instance::v1::Instance>>();
 }

--- a/google/cloud/storagetransfer/storage_transfer_connection.cc
+++ b/google/cloud/storagetransfer/storage_transfer_connection.cc
@@ -59,9 +59,9 @@ StorageTransferServiceConnection::GetTransferJob(
 }
 
 StreamRange<google::storagetransfer::v1::TransferJob>
-    StorageTransferServiceConnection::ListTransferJobs(
-        google::storagetransfer::v1::
-            ListTransferJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+StorageTransferServiceConnection::ListTransferJobs(
+    google::storagetransfer::v1::
+        ListTransferJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::storagetransfer::v1::TransferJob>>();
 }

--- a/google/cloud/talent/company_connection.cc
+++ b/google/cloud/talent/company_connection.cc
@@ -58,9 +58,9 @@ Status CompanyServiceConnection::DeleteCompany(
 }
 
 StreamRange<google::cloud::talent::v4::Company>
-    CompanyServiceConnection::ListCompanies(
-        google::cloud::talent::v4::
-            ListCompaniesRequest) {  // NOLINT(performance-unnecessary-value-param)
+CompanyServiceConnection::ListCompanies(
+    google::cloud::talent::v4::
+        ListCompaniesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::talent::v4::Company>>();
 }

--- a/google/cloud/talent/tenant_connection.cc
+++ b/google/cloud/talent/tenant_connection.cc
@@ -57,9 +57,9 @@ Status TenantServiceConnection::DeleteTenant(
 }
 
 StreamRange<google::cloud::talent::v4::Tenant>
-    TenantServiceConnection::ListTenants(
-        google::cloud::talent::v4::
-            ListTenantsRequest) {  // NOLINT(performance-unnecessary-value-param)
+TenantServiceConnection::ListTenants(
+    google::cloud::talent::v4::
+        ListTenantsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::talent::v4::Tenant>>();
 }

--- a/google/cloud/tpu/tpu_connection.cc
+++ b/google/cloud/tpu/tpu_connection.cc
@@ -82,9 +82,9 @@ future<StatusOr<google::cloud::tpu::v1::Node>> TpuConnection::StartNode(
 }
 
 StreamRange<google::cloud::tpu::v1::TensorFlowVersion>
-    TpuConnection::ListTensorFlowVersions(
-        google::cloud::tpu::v1::
-            ListTensorFlowVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+TpuConnection::ListTensorFlowVersions(
+    google::cloud::tpu::v1::
+        ListTensorFlowVersionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::tpu::v1::TensorFlowVersion>>();
 }
@@ -96,9 +96,9 @@ TpuConnection::GetTensorFlowVersion(
 }
 
 StreamRange<google::cloud::tpu::v1::AcceleratorType>
-    TpuConnection::ListAcceleratorTypes(
-        google::cloud::tpu::v1::
-            ListAcceleratorTypesRequest) {  // NOLINT(performance-unnecessary-value-param)
+TpuConnection::ListAcceleratorTypes(
+    google::cloud::tpu::v1::
+        ListAcceleratorTypesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::tpu::v1::AcceleratorType>>();
 }

--- a/google/cloud/translate/translation_connection.cc
+++ b/google/cloud/translate/translation_connection.cc
@@ -83,9 +83,9 @@ TranslationServiceConnection::CreateGlossary(
 }
 
 StreamRange<google::cloud::translation::v3::Glossary>
-    TranslationServiceConnection::ListGlossaries(
-        google::cloud::translation::v3::
-            ListGlossariesRequest) {  // NOLINT(performance-unnecessary-value-param)
+TranslationServiceConnection::ListGlossaries(
+    google::cloud::translation::v3::
+        ListGlossariesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::translation::v3::Glossary>>();
 }

--- a/google/cloud/vision/product_search_connection.cc
+++ b/google/cloud/vision/product_search_connection.cc
@@ -41,9 +41,9 @@ ProductSearchConnection::CreateProductSet(
 }
 
 StreamRange<google::cloud::vision::v1::ProductSet>
-    ProductSearchConnection::ListProductSets(
-        google::cloud::vision::v1::
-            ListProductSetsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProductSearchConnection::ListProductSets(
+    google::cloud::vision::v1::
+        ListProductSetsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vision::v1::ProductSet>>();
 }
@@ -72,9 +72,9 @@ ProductSearchConnection::CreateProduct(
 }
 
 StreamRange<google::cloud::vision::v1::Product>
-    ProductSearchConnection::ListProducts(
-        google::cloud::vision::v1::
-            ListProductsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProductSearchConnection::ListProducts(
+    google::cloud::vision::v1::
+        ListProductsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vision::v1::Product>>();
 }
@@ -108,9 +108,9 @@ Status ProductSearchConnection::DeleteReferenceImage(
 }
 
 StreamRange<google::cloud::vision::v1::ReferenceImage>
-    ProductSearchConnection::ListReferenceImages(
-        google::cloud::vision::v1::
-            ListReferenceImagesRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProductSearchConnection::ListReferenceImages(
+    google::cloud::vision::v1::
+        ListReferenceImagesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vision::v1::ReferenceImage>>();
 }
@@ -132,9 +132,9 @@ Status ProductSearchConnection::RemoveProductFromProductSet(
 }
 
 StreamRange<google::cloud::vision::v1::Product>
-    ProductSearchConnection::ListProductsInProductSet(
-        google::cloud::vision::v1::
-            ListProductsInProductSetRequest) {  // NOLINT(performance-unnecessary-value-param)
+ProductSearchConnection::ListProductsInProductSet(
+    google::cloud::vision::v1::
+        ListProductsInProductSetRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vision::v1::Product>>();
 }

--- a/google/cloud/vmmigration/vm_migration_connection.cc
+++ b/google/cloud/vmmigration/vm_migration_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VmMigrationConnection::~VmMigrationConnection() = default;
 
 StreamRange<google::cloud::vmmigration::v1::Source>
-    VmMigrationConnection::ListSources(
-        google::cloud::vmmigration::v1::
-            ListSourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListSources(
+    google::cloud::vmmigration::v1::
+        ListSourcesRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::Source>>();
 }
@@ -79,9 +79,9 @@ VmMigrationConnection::FetchInventory(
 }
 
 StreamRange<google::cloud::vmmigration::v1::UtilizationReport>
-    VmMigrationConnection::ListUtilizationReports(
-        google::cloud::vmmigration::v1::
-            ListUtilizationReportsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListUtilizationReports(
+    google::cloud::vmmigration::v1::
+        ListUtilizationReportsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::UtilizationReport>>();
 }
@@ -109,9 +109,9 @@ VmMigrationConnection::DeleteUtilizationReport(
 }
 
 StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>
-    VmMigrationConnection::ListDatacenterConnectors(
-        google::cloud::vmmigration::v1::
-            ListDatacenterConnectorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListDatacenterConnectors(
+    google::cloud::vmmigration::v1::
+        ListDatacenterConnectorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::DatacenterConnector>>();
 }
@@ -147,9 +147,9 @@ VmMigrationConnection::CreateMigratingVm(
 }
 
 StreamRange<google::cloud::vmmigration::v1::MigratingVm>
-    VmMigrationConnection::ListMigratingVms(
-        google::cloud::vmmigration::v1::
-            ListMigratingVmsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListMigratingVms(
+    google::cloud::vmmigration::v1::
+        ListMigratingVmsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::MigratingVm>>();
 }
@@ -225,9 +225,9 @@ VmMigrationConnection::CancelCloneJob(
 }
 
 StreamRange<google::cloud::vmmigration::v1::CloneJob>
-    VmMigrationConnection::ListCloneJobs(
-        google::cloud::vmmigration::v1::
-            ListCloneJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListCloneJobs(
+    google::cloud::vmmigration::v1::
+        ListCloneJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::CloneJob>>();
 }
@@ -255,9 +255,9 @@ VmMigrationConnection::CancelCutoverJob(
 }
 
 StreamRange<google::cloud::vmmigration::v1::CutoverJob>
-    VmMigrationConnection::ListCutoverJobs(
-        google::cloud::vmmigration::v1::
-            ListCutoverJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListCutoverJobs(
+    google::cloud::vmmigration::v1::
+        ListCutoverJobsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::CutoverJob>>();
 }
@@ -269,9 +269,9 @@ VmMigrationConnection::GetCutoverJob(
 }
 
 StreamRange<google::cloud::vmmigration::v1::Group>
-    VmMigrationConnection::ListGroups(
-        google::cloud::vmmigration::v1::
-            ListGroupsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListGroups(
+    google::cloud::vmmigration::v1::
+        ListGroupsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::Group>>();
 }
@@ -322,9 +322,9 @@ VmMigrationConnection::RemoveGroupMigration(
 }
 
 StreamRange<google::cloud::vmmigration::v1::TargetProject>
-    VmMigrationConnection::ListTargetProjects(
-        google::cloud::vmmigration::v1::
-            ListTargetProjectsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VmMigrationConnection::ListTargetProjects(
+    google::cloud::vmmigration::v1::
+        ListTargetProjectsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vmmigration::v1::TargetProject>>();
 }

--- a/google/cloud/vpcaccess/vpc_access_connection.cc
+++ b/google/cloud/vpcaccess/vpc_access_connection.cc
@@ -49,9 +49,9 @@ VpcAccessServiceConnection::GetConnector(
 }
 
 StreamRange<google::cloud::vpcaccess::v1::Connector>
-    VpcAccessServiceConnection::ListConnectors(
-        google::cloud::vpcaccess::v1::
-            ListConnectorsRequest) {  // NOLINT(performance-unnecessary-value-param)
+VpcAccessServiceConnection::ListConnectors(
+    google::cloud::vpcaccess::v1::
+        ListConnectorsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::vpcaccess::v1::Connector>>();
 }

--- a/google/cloud/websecurityscanner/web_security_scanner_connection.cc
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection.cc
@@ -52,9 +52,9 @@ WebSecurityScannerConnection::GetScanConfig(
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::ScanConfig>
-    WebSecurityScannerConnection::ListScanConfigs(
-        google::cloud::websecurityscanner::v1::
-            ListScanConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
+WebSecurityScannerConnection::ListScanConfigs(
+    google::cloud::websecurityscanner::v1::
+        ListScanConfigsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::websecurityscanner::v1::ScanConfig>>();
 }
@@ -78,9 +78,9 @@ WebSecurityScannerConnection::GetScanRun(
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::ScanRun>
-    WebSecurityScannerConnection::ListScanRuns(
-        google::cloud::websecurityscanner::v1::
-            ListScanRunsRequest) {  // NOLINT(performance-unnecessary-value-param)
+WebSecurityScannerConnection::ListScanRuns(
+    google::cloud::websecurityscanner::v1::
+        ListScanRunsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::websecurityscanner::v1::ScanRun>>();
 }
@@ -92,9 +92,9 @@ WebSecurityScannerConnection::StopScanRun(
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::CrawledUrl>
-    WebSecurityScannerConnection::ListCrawledUrls(
-        google::cloud::websecurityscanner::v1::
-            ListCrawledUrlsRequest) {  // NOLINT(performance-unnecessary-value-param)
+WebSecurityScannerConnection::ListCrawledUrls(
+    google::cloud::websecurityscanner::v1::
+        ListCrawledUrlsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::websecurityscanner::v1::CrawledUrl>>();
 }
@@ -106,9 +106,9 @@ WebSecurityScannerConnection::GetFinding(
 }
 
 StreamRange<google::cloud::websecurityscanner::v1::Finding>
-    WebSecurityScannerConnection::ListFindings(
-        google::cloud::websecurityscanner::v1::
-            ListFindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
+WebSecurityScannerConnection::ListFindings(
+    google::cloud::websecurityscanner::v1::
+        ListFindingsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::websecurityscanner::v1::Finding>>();
 }

--- a/google/cloud/workflows/executions_connection.cc
+++ b/google/cloud/workflows/executions_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ExecutionsConnection::~ExecutionsConnection() = default;
 
 StreamRange<google::cloud::workflows::executions::v1::Execution>
-    ExecutionsConnection::ListExecutions(
-        google::cloud::workflows::executions::v1::
-            ListExecutionsRequest) {  // NOLINT(performance-unnecessary-value-param)
+ExecutionsConnection::ListExecutions(
+    google::cloud::workflows::executions::v1::
+        ListExecutionsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::workflows::executions::v1::Execution>>();
 }

--- a/google/cloud/workflows/workflows_connection.cc
+++ b/google/cloud/workflows/workflows_connection.cc
@@ -35,9 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 WorkflowsConnection::~WorkflowsConnection() = default;
 
 StreamRange<google::cloud::workflows::v1::Workflow>
-    WorkflowsConnection::ListWorkflows(
-        google::cloud::workflows::v1::
-            ListWorkflowsRequest) {  // NOLINT(performance-unnecessary-value-param)
+WorkflowsConnection::ListWorkflows(
+    google::cloud::workflows::v1::
+        ListWorkflowsRequest) {  // NOLINT(performance-unnecessary-value-param)
   return google::cloud::internal::MakeUnimplementedPaginationRange<
       StreamRange<google::cloud::workflows::v1::Workflow>>();
 }


### PR DESCRIPTION
This time the `checkers` and the `generate-libraries` builds move.

Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8641)
<!-- Reviewable:end -->
