### PR TITLE
cleanup(pubsublite): prevent alarm from executing when Start not called

### DIFF
--- a/google/cloud/pubsublite/internal/partition_publisher.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher.cc
@@ -45,9 +45,6 @@ PartitionPublisher::PartitionPublisher(
           std::bind(&PartitionPublisher::Flush, this))} {}
 
 PartitionPublisher::~PartitionPublisher() {
-  // set to nullptr in case `Shutdown` wasn't called so that alarm function
-  // doesn't still execute
-  if (cancel_token_ != nullptr) cancel_token_ = nullptr;
   future<void> shutdown = Shutdown();
   if (!shutdown.is_ready()) {
     GCP_LOG(WARNING) << "`Shutdown` must be called and finished before object "

--- a/google/cloud/pubsublite/internal/partition_publisher.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher.cc
@@ -45,6 +45,9 @@ PartitionPublisher::PartitionPublisher(
           std::bind(&PartitionPublisher::Flush, this))} {}
 
 PartitionPublisher::~PartitionPublisher() {
+  // set to nullptr in case `Shutdown` wasn't called so that alarm function
+  // doesn't still execute
+  if (cancel_token_ != nullptr) cancel_token_ = nullptr;
   future<void> shutdown = Shutdown();
   if (!shutdown.is_ready()) {
     GCP_LOG(WARNING) << "`Shutdown` must be called and finished before object "

--- a/google/cloud/pubsublite/internal/partition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher_test.cc
@@ -375,6 +375,10 @@ class PartitionPublisherTest : public ::testing::Test {
   std::unique_ptr<Publisher<Cursor>> publisher_;
 };
 
+TEST_F(PartitionPublisherTest, StartNotCalled) {
+  EXPECT_CALL(alarm_token_ref_, Destroy);
+}
+
 TEST_F(PartitionPublisherTest, SatisfyOutstandingMessages) {
   InSequence seq;
 


### PR DESCRIPTION
In the case that a `PartitionPublisher` is instantiated, but `Start` and `Shutdown` are not called on it, then the alarm that is created still must terminate. This PR adds a test for that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8643)
<!-- Reviewable:end -->
