### PR TITLE
ci(spanner): temporarily tolerate another failure in CreateBackup()

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -447,6 +447,17 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
       GTEST_SKIP();
     }
   }
+  {
+    // TODO(#8616): Remove this when we know how to deal with the issue.
+    auto matcher = testing_util::StatusIs(
+        StatusCode::kDeadlineExceeded,
+        testing::HasSubstr("terminated by polling policy"));
+    testing::StringMatchResultListener listener;
+    if (matcher.impl().MatchAndExplain(backup, &listener)) {
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
+      GTEST_SKIP();
+    }
+  }
   ASSERT_STATUS_OK(backup);
   EXPECT_TRUE(backup->has_encryption_info());
   if (backup->has_encryption_info()) {

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -176,6 +176,17 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
       GTEST_SKIP();
     }
   }
+  {
+    // TODO(#8616): Remove this when we know how to deal with the issue.
+    auto matcher = testing_util::StatusIs(
+        StatusCode::kDeadlineExceeded,
+        testing::HasSubstr("terminated by polling policy"));
+    testing::StringMatchResultListener listener;
+    if (matcher.impl().MatchAndExplain(backup, &listener)) {
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
+      GTEST_SKIP();
+    }
+  }
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(MakeTimestamp(backup->expire_time()).value(), expire_time);
   // Verify that the version_time is the same as the creation_time.

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -367,6 +367,17 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
       GTEST_SKIP();
     }
   }
+  {
+    // TODO(#8616): Remove this when we know how to deal with the issue.
+    auto matcher = testing_util::StatusIs(
+        StatusCode::kDeadlineExceeded,
+        testing::HasSubstr("terminated by polling policy"));
+    testing::StringMatchResultListener listener;
+    if (matcher.impl().MatchAndExplain(backup, &listener)) {
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
+      GTEST_SKIP();
+    }
+  }
   ASSERT_STATUS_OK(backup);
   EXPECT_TRUE(backup->has_encryption_info());
   if (backup->has_encryption_info()) {

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -143,6 +143,17 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
       GTEST_SKIP();
     }
   }
+  {
+    // TODO(#8616): Remove this when we know how to deal with the issue.
+    auto matcher = testing_util::StatusIs(
+        StatusCode::kDeadlineExceeded,
+        testing::HasSubstr("terminated by polling policy"));
+    testing::StringMatchResultListener listener;
+    if (matcher.impl().MatchAndExplain(backup, &listener)) {
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
+      GTEST_SKIP();
+    }
+  }
   ASSERT_STATUS_OK(backup);
   EXPECT_EQ(MakeTimestamp(backup->expire_time()).value(), expire_time);
   // Verify that the version_time is the same as the creation_time.


### PR DESCRIPTION
Tolerate (cleanup and skip) `CreateBackup()` integration tests that fail
with "terminated by polling policy" deadline-exceeded errors, until #8616
can be resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8644)
<!-- Reviewable:end -->
