### PR TITLE
ci: move `demo-fedora` build to Fedora:35

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:34
+FROM fedora:35
 ARG NCPU=4
 
 ## [BEGIN packaging.md]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8647)
<!-- Reviewable:end -->
