### PR TITLE
ci: set up git for integration tests

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -24,6 +24,7 @@ fi # include guard
 
 source module ci/etc/integration-tests-config.sh
 source module ci/lib/io.sh
+source module ci/cloudbuild/builds/lib/git.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"


### PR DESCRIPTION
The integration tests may need git to compare the generator golden
files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8651)
<!-- Reviewable:end -->
