### PR TITLE
cleanup(bigtable)!: remove deprecated InstanceAdmin IAM functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,15 @@ https://github.com/googleapis/google-cloud-cpp/issues/8234.
   * This only changes the default C++ version, we continue to test and support C++11.
   * For more details, see [#6767](https://github.com/googleapis/google-cloud-cpp/issues/6767).
 
+### [Bigtable](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/bigtable/README.md)
+
+**BREAKING CHANGES**
+
+* `InstanceAdmin::GetIamPolicy` and `InstanceAdmin::SetIamPolicy` have been
+  retired. If you are affected by this removal, please use
+  `InstanceAdmin::GetNativeIamPolicy` and `InstanceAdmin::SetNativeIamPolicy`
+  instead. See [#5929] for more details.
+
 ### [KMS](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/kms/README.md)
 
 The library has been expanded to include the following services:

--- a/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
@@ -32,8 +32,6 @@
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
-// TODO(#5929) - remove once deprecated functions are removed
-#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/instance_admin.h
+++ b/google/cloud/bigtable/instance_admin.h
@@ -615,31 +615,6 @@ class InstanceAdmin {
                           bool ignore_warnings = true);
 
   /**
-   * Gets the policy for @p instance_id.
-   *
-   * @param instance_id the instance to query.
-   * @return Policy the full IAM policy for the instance.
-   *
-   * @deprecated this function is deprecated; it doesn't support conditional
-   *     bindings and will not support any other features to come; please use
-   *     `GetNativeIamPolicy` instead.
-   *
-   * @par Idempotency
-   * This operation is read-only and therefore it is always idempotent.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread.
-   *
-   * @par Example
-   * Use #GetNativeIamPolicy() instead.
-   */
-  GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED("GetNativeIamPolicy")
-  StatusOr<google::cloud::IamPolicy> GetIamPolicy(
-      std::string const& instance_id);
-
-  /**
    * Gets the native policy for @p instance_id.
    *
    * This is the preferred way to `GetIamPolicy()`. This is more closely coupled
@@ -662,43 +637,6 @@ class InstanceAdmin {
    */
   StatusOr<google::iam::v1::Policy> GetNativeIamPolicy(
       std::string const& instance_id);
-
-  /**
-   * Sets the IAM policy for an instance.
-   *
-   * Applications can provide the @p etag to implement optimistic concurrency
-   * control. If @p etag is not empty, the server will reject calls where the
-   * provided ETag does not match the ETag value stored in the server.
-   *
-   * @param instance_id which instance to set the IAM policy for.
-   * @param iam_bindings IamBindings object containing role and members.
-   * @param etag the expected ETag value for the current policy.
-   * @return Policy the current IAM bindings for the instance.
-   *
-   * @deprecated this function is deprecated; it doesn't support conditional
-   *     bindings and will not support any other features to come; please use
-   *     the overload for `google::iam::v1::Policy` instead.
-   *
-   * @warning ETags are currently not used by Cloud Bigtable.
-   *
-   * @par Idempotency
-   * This operation is always treated as non-idempotent.
-   *
-   * @par Thread-safety
-   * Two threads concurrently calling this member function on the same instance
-   * of this class are **not** guaranteed to work. Consider copying the object
-   * and using different copies in each thread.
-   *
-   * @par Example
-   * Use #SetIamPolicy(std::string const&, google::iam::v1::Policy const&)
-   * instead.
-   */
-  GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(
-      "SetIamPolicy(std::string const&, google::iam::v1::Policy const&)")
-  StatusOr<google::cloud::IamPolicy> SetIamPolicy(
-      std::string const& instance_id,
-      google::cloud::IamBindings const& iam_bindings,
-      std::string const& etag = std::string{});
 
   /**
    * Sets the IAM policy for an instance.

--- a/google/cloud/bigtable/tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/instance_admin_integration_test.cc
@@ -26,8 +26,6 @@
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
-// TODO(#5929) - remove once deprecated functions are removed
-#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {
@@ -340,38 +338,6 @@ TEST_F(InstanceAdminIntegrationTest, CreateListGetDeleteClusterTest) {
 
   // Delete instance
   ASSERT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
-}
-
-/// @test Verify that IAM Policy APIs work as expected.
-TEST_F(InstanceAdminIntegrationTest, SetGetTestIamAPIsTest) {
-  auto const instance_id =
-      "it-" + google::cloud::internal::Sample(
-                  generator_, 8, "abcdefghijklmnopqrstuvwxyz0123456789");
-
-  // Create instance prerequisites for cluster operations
-  auto config = IntegrationTestConfig(instance_id, zone_a_,
-                                      bigtable::InstanceConfig::PRODUCTION, 3);
-  ASSERT_STATUS_OK(instance_admin_->CreateInstance(config).get());
-
-  auto iam_bindings = google::cloud::IamBindings(
-      "roles/bigtable.reader", {"serviceAccount:" + service_account_});
-
-  auto initial_policy =
-      instance_admin_->SetIamPolicy(instance_id, iam_bindings);
-  ASSERT_STATUS_OK(initial_policy);
-
-  auto fetched_policy = instance_admin_->GetIamPolicy(instance_id);
-  ASSERT_STATUS_OK(fetched_policy);
-
-  EXPECT_EQ(initial_policy->version, fetched_policy->version);
-  EXPECT_EQ(initial_policy->etag, fetched_policy->etag);
-
-  auto permission_set = instance_admin_->TestIamPermissions(
-      instance_id, {"bigtable.tables.list", "bigtable.tables.delete"});
-  ASSERT_STATUS_OK(permission_set);
-
-  EXPECT_EQ(2, permission_set->size());
-  EXPECT_STATUS_OK(instance_admin_->DeleteInstance(instance_id));
 }
 
 /// @test Verify that IAM Policy Native APIs work as expected.

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -20,13 +20,6 @@
 #include "google/cloud/version.h"
 #include <string>
 
-#define GOOGLE_CLOUD_CPP_BIGTABLE_IAM_DEPRECATED(alternative)                  \
-  GOOGLE_CLOUD_CPP_DEPRECATED(                                                 \
-      "this function predates IAM conditions and does not work with policies " \
-      "that include IAM conditions. Please use " alternative                   \
-      " instead. The function will be removed on 2022-04-01 or shortly "       \
-      "after. See GitHub issue #5929 for more information.")
-
 // This preprocessor symbol is deprecated and should never be used anywhere. It
 // exists solely for backward compatibility to avoid breaking anyone who may
 // have been using it.


### PR DESCRIPTION
The bigtable part of #5929 

I think the storage part will require some minor test updates, so I am going to break the task up into three PRs.
1. Bigtable
2. Storage
3. Common

I will not remove the future breaking change note in the CHANGELOG until step 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8652)
<!-- Reviewable:end -->
