### PR TITLE
ci: update *san trigger files to use Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: asan-ci
 substitutions:
   _BUILD_NAME: asan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: asan-pr
 substitutions:
   _BUILD_NAME: asan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: tsan-pr
 substitutions:
   _BUILD_NAME: tsan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: ubsan-pr
 substitutions:
   _BUILD_NAME: ubsan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: xsan-pr
 substitutions:
   _BUILD_NAME: xsan
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
The builds are already moved, this just updates the trigger files.

Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8653)
<!-- Reviewable:end -->
