### PR TITLE
ci: move `noex` build to Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/noex-ci.yaml
+++ b/ci/cloudbuild/triggers/noex-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: noex-ci
 substitutions:
   _BUILD_NAME: noex
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/noex-pr.yaml
+++ b/ci/cloudbuild/triggers/noex-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: noex-pr
 substitutions:
   _BUILD_NAME: noex
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8660)
<!-- Reviewable:end -->
