### PR TITLE
ci: move `coverage` build to Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/coverage-ci.yaml
+++ b/ci/cloudbuild/triggers/coverage-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: coverage-ci
 substitutions:
   _BUILD_NAME: coverage
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/coverage-pr.yaml
+++ b/ci/cloudbuild/triggers/coverage-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: coverage-pr
 substitutions:
   _BUILD_NAME: coverage
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8663)
<!-- Reviewable:end -->
