### PR TITLE
ci: move `cmake-install` build to Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: cmake-install-pr
 substitutions:
   _BUILD_NAME: cmake-install
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8670)
<!-- Reviewable:end -->
