### PR TITLE
ci: move `bazel-targets` build to Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/bazel-targets-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: bazel-targets-ci
 substitutions:
   _BUILD_NAME: bazel-targets
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/bazel-targets-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: bazel-targets-pr
 substitutions:
   _BUILD_NAME: bazel-targets
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8672)
<!-- Reviewable:end -->
