### PR TITLE
ci: move GCS+gRPC builds to Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: gcs-grpc-ci
 substitutions:
   _BUILD_NAME: gcs-grpc
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: gcs-grpc-pr
 substitutions:
   _BUILD_NAME: gcs-grpc
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/install-gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/install-gcs-grpc-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: install-gcs-grpc-ci
 substitutions:
   _BUILD_NAME: install-gcs-grpc
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/install-gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/install-gcs-grpc-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: install-gcs-grpc-pr
 substitutions:
   _BUILD_NAME: install-gcs-grpc
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8673)
<!-- Reviewable:end -->
