### PR TITLE
ci(spanner): tweak response to polling timeout in CreateBackup() test

### DIFF
--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -30,7 +30,7 @@ $env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
 
 # A number of options to improve logging during the CI builds. They are useful
 # when troubleshooting problems.
-$env:GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,256,WARNING"
+$env:GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,1024,WARNING"
 $env:GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 $env:GOOGLE_CLOUD_CPP_TRACING_OPTIONS="single_line_mode=off,truncate_string_field_longer_than=512"
 $env:CLOUD_STORAGE_ENABLE_TRACING="raw-client"

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -38,7 +38,7 @@ export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
 
 # A number of options to improve logging during the CI builds. They are useful
 # when troubleshooting problems.
-export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,256,WARNING"
+export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,1024,WARNING"
 export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="single_line_mode=off,truncate_string_field_longer_than=512"
 export CLOUD_STORAGE_ENABLE_TRACING="raw-client"

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -137,6 +137,10 @@ class AsyncPollingLoopImpl
     // after too many polling attempts.
     if (!polling_policy_->OnFailure(op.status())) {
       if (op) {
+        // We should not be fabricating a `Status` value here. Rather, we
+        // should cancel the operation and wait for the next poll to return
+        // an accurate status to the user, otherwise they will have no idea
+        // how to react.
         return promise_.set_value(Status(
             StatusCode::kDeadlineExceeded,
             location_ + "() - polling loop terminated by polling policy"));

--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -454,7 +454,9 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
         testing::HasSubstr("terminated by polling policy"));
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
+      // The backup is still in progress (and may eventually complete),
+      // and we can't drop the database while it has pending backups, so
+      // we simply abandon them, to be cleaned up offline.
       GTEST_SKIP();
     }
   }

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -183,7 +183,9 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
         testing::HasSubstr("terminated by polling policy"));
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
+      // The backup is still in progress (and may eventually complete),
+      // and we can't drop the database while it has pending backups, so
+      // we simply abandon them, to be cleaned up offline.
       GTEST_SKIP();
     }
   }

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -374,7 +374,9 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
         testing::HasSubstr("terminated by polling policy"));
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
+      // The backup is still in progress (and may eventually complete),
+      // and we can't drop the database while it has pending backups, so
+      // we simply abandon them, to be cleaned up offline.
       GTEST_SKIP();
     }
   }

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -150,7 +150,9 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
         testing::HasSubstr("terminated by polling policy"));
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
+      // The backup is still in progress (and may eventually complete),
+      // and we can't drop the database while it has pending backups, so
+      // we simply abandon them, to be cleaned up offline.
       GTEST_SKIP();
     }
   }


### PR DESCRIPTION
Reacting to a "terminated by polling policy" error is difficult at
best as the caller won't know the actual state of the operation, and
will have little they can do to regain state.  In the case at hand,
we stop waiting for the CreateBackup(), but it continues none the
less, and we no longer have a handle by which the operation can be
canceled.  Attempting to drop the database while a backup operation
is pending will fail, so don't even try.  Instead, we rely upon the
short expiration time of test backups, and the eventual cleanup of
test databases (2 days) to reclaim the lost resources.

In general, the client library probably shouldn't be synthesizing
a return status for an operation.  Rather, it should be accurately
reflecting the state of the service. Leave a comment to that effect,
which we can discuss and follow up on later.

Also, the previous increase in the "lastN" tracing to 256 was not
adequate to capture a ~100x polling loop, so bump it to 1024. There
are 6 trace events per loop, so that should be sufficient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8674)
<!-- Reviewable:end -->
