### PR TITLE
ci: move builds using production to Fedora:35

### DIFF
--- a/ci/cloudbuild/triggers/integration-production-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: integration-production-ci
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/integration-production-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: integration-production-pr
 substitutions:
   _BUILD_NAME: integration-production
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr

--- a/ci/cloudbuild/triggers/quickstart-production-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-ci.yaml
@@ -7,7 +7,7 @@ github:
 name: quickstart-production-ci
 substitutions:
   _BUILD_NAME: quickstart-production
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: ci
 tags:
 - ci

--- a/ci/cloudbuild/triggers/quickstart-production-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-pr.yaml
@@ -8,7 +8,7 @@ github:
 name: quickstart-production-pr
 substitutions:
   _BUILD_NAME: quickstart-production
-  _DISTRO: fedora-34
+  _DISTRO: fedora-35
   _TRIGGER_TYPE: pr
 tags:
 - pr


### PR DESCRIPTION
Part of the work for #7555

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8676)
<!-- Reviewable:end -->
