### PR TITLE
fix(pubsublite): internal namespaces

### DIFF
--- a/google/cloud/pubsublite/internal/alarm_registry.h
+++ b/google/cloud/pubsublite/internal/alarm_registry.h
@@ -22,8 +22,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * An `AlarmRegistry` allows the user to run a function at their own defined
@@ -59,8 +59,8 @@ class AlarmRegistry {
       std::chrono::milliseconds period, std::function<void()> on_alarm) = 0;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/alarm_registry_impl.cc
+++ b/google/cloud/pubsublite/internal/alarm_registry_impl.cc
@@ -20,8 +20,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 AlarmRegistryImpl::AlarmRegistryImpl(google::cloud::CompletionQueue cq)
     : cq_{std::move(cq)} {}
@@ -74,7 +74,7 @@ std::unique_ptr<AlarmRegistry::CancelToken> AlarmRegistryImpl::RegisterAlarm(
   return absl::make_unique<CancelTokenImpl>(state);
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/alarm_registry_impl.h
+++ b/google/cloud/pubsublite/internal/alarm_registry_impl.h
@@ -23,8 +23,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Default implementation of `AlarmRegistry`.
@@ -77,8 +77,8 @@ class AlarmRegistryImpl : public AlarmRegistry {
   google::cloud::CompletionQueue const cq_;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/alarm_registry_impl_test.cc
+++ b/google/cloud/pubsublite/internal/alarm_registry_impl_test.cc
@@ -25,8 +25,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using google::cloud::CompletionQueue;
@@ -146,7 +146,7 @@ TEST_F(AlarmRegistryImplTest, TokenDestroyedDuringSecondRun) {
 }
 
 }  // namespace
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/batching_options.h
+++ b/google/cloud/pubsublite/internal/batching_options.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Batching options for a `Publisher`.
@@ -73,8 +73,8 @@ class BatchingOptions {
   std::chrono::milliseconds alarm_period_{50};
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/cloud_region.cc
+++ b/google/cloud/pubsublite/internal/cloud_region.cc
@@ -16,8 +16,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<CloudRegion> MakeCloudRegion(std::string const& region) {
   std::vector<std::string> splits = absl::StrSplit(region, '-');
@@ -27,7 +27,7 @@ StatusOr<CloudRegion> MakeCloudRegion(std::string const& region) {
   return CloudRegion{region};
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/cloud_region.h
+++ b/google/cloud/pubsublite/internal/cloud_region.h
@@ -23,8 +23,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * A wrapped string representing a Google Cloud region.
@@ -49,8 +49,8 @@ inline bool operator!=(CloudRegion const& a, CloudRegion const& b) {
   return !(a == b);
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/cloud_zone.cc
+++ b/google/cloud/pubsublite/internal/cloud_zone.cc
@@ -16,8 +16,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<CloudZone> MakeCloudZone(std::string const& zone) {
   std::vector<std::string> splits = absl::StrSplit(zone, '-');
@@ -28,7 +28,7 @@ StatusOr<CloudZone> MakeCloudZone(std::string const& zone) {
                    splits[2][0]};
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/cloud_zone.h
+++ b/google/cloud/pubsublite/internal/cloud_zone.h
@@ -24,8 +24,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * A representation of a Google Cloud zone.
@@ -53,8 +53,8 @@ inline bool operator!=(CloudZone const& a, CloudZone const& b) {
   return !(a == b);
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/default_routing_policy.cc
+++ b/google/cloud/pubsublite/internal/default_routing_policy.cc
@@ -18,8 +18,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 // Uses the identity that `(a*b) % m == ((a % m) * (b % m)) % m`
 std::uint64_t ModPow(std::uint64_t val, std::uint64_t pow, std::uint32_t mod) {
@@ -60,7 +60,7 @@ std::uint64_t DefaultRoutingPolicy::Route(std::string const& message_key,
                 num_partitions);
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/default_routing_policy.h
+++ b/google/cloud/pubsublite/internal/default_routing_policy.h
@@ -24,8 +24,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 // Calculates the val^pow % mod while accounting for overflow.
 // Needed because after calculating `big_endian[i]` % `mod` in `GetMod`, we need
@@ -57,8 +57,8 @@ class DefaultRoutingPolicy : public RoutingPolicy {
   std::atomic<std::int64_t> counter_{0};
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/default_routing_policy_test.cc
+++ b/google/cloud/pubsublite/internal/default_routing_policy_test.cc
@@ -18,8 +18,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using google::cloud::pubsublite_internal::DefaultRoutingPolicy;
 
@@ -117,7 +117,7 @@ TEST(TestGetMod, ArbitraryValue1) {
   EXPECT_EQ(GetMod(arr, UINT8_MAX), 37);
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/futures.h
+++ b/google/cloud/pubsublite/internal/futures.h
@@ -19,8 +19,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 template <typename T>
 struct ChainFutureImpl {
@@ -70,8 +70,8 @@ class AsyncRoot {
   promise<void> root_;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/location.cc
+++ b/google/cloud/pubsublite/internal/location.cc
@@ -16,8 +16,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<Location> MakeLocation(std::string const& location) {
   auto possible_zone = MakeCloudZone(location);
@@ -27,7 +27,7 @@ StatusOr<Location> MakeLocation(std::string const& location) {
   return Status{StatusCode::kInvalidArgument, "Invalid location"};
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/location.h
+++ b/google/cloud/pubsublite/internal/location.h
@@ -25,8 +25,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * A wrapper around a Google Cloud Location which can be either a `CloudRegion`
@@ -69,8 +69,8 @@ inline bool operator!=(Location const& a, Location const& b) {
   return !(a == b);
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/location_test.cc
+++ b/google/cloud/pubsublite/internal/location_test.cc
@@ -19,8 +19,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using google::cloud::pubsublite_internal::MakeCloudRegion;
@@ -121,7 +121,7 @@ TEST(Location, InvalidCloudZone) {
 }
 
 }  // namespace
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/partition_publisher.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher.cc
@@ -19,8 +19,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using google::cloud::pubsublite::v1::Cursor;
 using google::cloud::pubsublite::v1::InitialPublishRequest;
@@ -258,7 +258,7 @@ PartitionPublisher::Initializer(ResumableStreamImpl::UnderlyingStream stream) {
       });
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/partition_publisher.h
+++ b/google/cloud/pubsublite/internal/partition_publisher.h
@@ -27,8 +27,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class PartitionPublisher
     : public Publisher<google::cloud::pubsublite::v1::Cursor> {
@@ -105,8 +105,8 @@ class PartitionPublisher
   friend class PartitionPublisherBatchingTest;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/partition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher_test.cc
@@ -29,8 +29,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::testing::_;
@@ -1233,7 +1233,7 @@ TEST_F(InitializedPartitionPublisherTest, RetryAfterSuccessfulWriteAfterRead) {
   }
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/publisher.h
+++ b/google/cloud/pubsublite/internal/publisher.h
@@ -22,8 +22,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * A generic publisher interface. Example implementations include single
@@ -49,8 +49,8 @@ class Publisher : public Service {
   virtual void Flush() = 0;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h
+++ b/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h
@@ -29,8 +29,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using google::cloud::internal::BackoffPolicy;
 using google::cloud::internal::RetryPolicy;
@@ -593,8 +593,8 @@ MakeResumableAsyncStreamingReadWriteRpcImpl(
       std::move(stream_factory), std::move(initializer));
 }
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc_test.cc
+++ b/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc_test.cc
@@ -27,8 +27,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
@@ -1194,7 +1194,7 @@ TEST_F(InitializedResumableAsyncReadWriteStreamingRpcTest,
 }
 
 }  // namespace
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/internal/routing_policy.h
+++ b/google/cloud/pubsublite/internal/routing_policy.h
@@ -19,8 +19,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * Interface for a Pub/Sub Lite routing policy that determines the partition
@@ -35,8 +35,8 @@ class RoutingPolicy {
                               std::uint32_t num_partitions) = 0;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/service.h
+++ b/google/cloud/pubsublite/internal/service.h
@@ -20,8 +20,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
  * A `Service` is anything that can start, run for a while, possibly have other
@@ -73,8 +73,8 @@ class Service {
   virtual future<void> Shutdown() = 0;
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/service_composite.h
+++ b/google/cloud/pubsublite/internal/service_composite.h
@@ -23,8 +23,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class ServiceComposite : public Service {
  public:
@@ -155,8 +155,8 @@ class ServiceComposite : public Service {
                           "`Start` not called"};  // ABSL_GUARDED_BY(mu_)
 };
 
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/internal/service_composite_test.cc
+++ b/google/cloud/pubsublite/internal/service_composite_test.cc
@@ -20,8 +20,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::testing::ByMove;
@@ -347,7 +347,7 @@ TEST(ServiceTest, AddDependencyAfterStartFailedBeforeShutdown) {
 }
 
 }  // namespace
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/message_metadata_test.cc
+++ b/google/cloud/pubsublite/message_metadata_test.cc
@@ -25,8 +25,8 @@ using ::google::cloud::testing_util::IsProtoEqual;
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 TEST(MessageMetadata, ValidParse) {
@@ -78,7 +78,7 @@ TEST(MessageMetadata, RoundTrip) {
 }
 
 }  // namespace
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/message_metadata_test.cc
+++ b/google/cloud/pubsublite/message_metadata_test.cc
@@ -25,7 +25,7 @@ using ::google::cloud::testing_util::IsProtoEqual;
 
 namespace google {
 namespace cloud {
-namespace pubsublite_internal {
+namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
@@ -79,6 +79,6 @@ TEST(MessageMetadata, RoundTrip) {
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace pubsublite_internal
+}  // namespace pubsublite
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/testing/mock_alarm_registry.h
+++ b/google/cloud/pubsublite/testing/mock_alarm_registry.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class MockAlarmRegistry
     : public google::cloud::pubsublite_internal::AlarmRegistry {
@@ -38,8 +38,8 @@ class MockAlarmRegistryCancelToken
   MOCK_METHOD(void, Destroy, (), ());
 };
 
-}  // namespace pubsublite_testing
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/testing/mock_async_reader_writer.h
+++ b/google/cloud/pubsublite/testing/mock_async_reader_writer.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 template <typename RequestType, typename ResponseType>
 class MockAsyncReaderWriter
@@ -38,8 +38,8 @@ class MockAsyncReaderWriter
   MOCK_METHOD(future<bool>, Start, (), (override));
 };
 
-}  // namespace pubsublite_testing
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/testing/mock_backoff_policy.h
+++ b/google/cloud/pubsublite/testing/mock_backoff_policy.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class MockBackoffPolicy : public google::cloud::internal::BackoffPolicy {
  public:
@@ -30,8 +30,8 @@ class MockBackoffPolicy : public google::cloud::internal::BackoffPolicy {
   MOCK_METHOD(std::chrono::milliseconds, OnCompletion, (), (override));
 };
 
-}  // namespace pubsublite_testing
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/testing/mock_resumable_async_reader_writer_stream.h
+++ b/google/cloud/pubsublite/testing/mock_resumable_async_reader_writer_stream.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 template <typename RequestType, typename ResponseType>
 class MockResumableAsyncReaderWriter
@@ -35,8 +35,8 @@ class MockResumableAsyncReaderWriter
   MOCK_METHOD(future<void>, Shutdown, (), (override));
 };
 
-}  // namespace pubsublite_testing
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/testing/mock_retry_policy.h
+++ b/google/cloud/pubsublite/testing/mock_retry_policy.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class MockRetryPolicy : public google::cloud::internal::RetryPolicy {
  public:
@@ -31,8 +31,8 @@ class MockRetryPolicy : public google::cloud::internal::RetryPolicy {
   MOCK_METHOD(bool, IsPermanentFailure, (Status const&), (const, override));
 };
 
-}  // namespace pubsublite_testing
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/testing/mock_service.h
+++ b/google/cloud/pubsublite/testing/mock_service.h
@@ -21,8 +21,8 @@
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 class MockService : public google::cloud::pubsublite_internal::Service {
  public:
@@ -30,8 +30,8 @@ class MockService : public google::cloud::pubsublite_internal::Service {
   MOCK_METHOD(future<void>, Shutdown, (), (override));
 };
 
-}  // namespace pubsublite_testing
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_testing
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/pubsublite/topic_test.cc
+++ b/google/cloud/pubsublite/topic_test.cc
@@ -22,8 +22,8 @@ using google::cloud::pubsublite::Topic;
 
 namespace google {
 namespace cloud {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace pubsublite_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 TEST(Topic, BasicTopic) {
@@ -40,7 +40,7 @@ TEST(Topic, BasicTopic) {
 }
 
 }  // namespace
-}  // namespace pubsublite_internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsublite_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/pubsublite/topic_test.cc
+++ b/google/cloud/pubsublite/topic_test.cc
@@ -22,7 +22,7 @@ using google::cloud::pubsublite::Topic;
 
 namespace google {
 namespace cloud {
-namespace pubsublite_internal {
+namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
@@ -41,6 +41,6 @@ TEST(Topic, BasicTopic) {
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace pubsublite_internal
+}  // namespace pubsublite
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
the latest PRs for pubsublite have written internal namespaces as
```
namespace google {
namespace cloud {
GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
namespace pubsublite_internal {
```
while previous code and generated code write namespaces as 
```
namespace google {
namespace cloud {
namespace pubsublite {
GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
```
.
This PR changes the namespaces to be consistent with the latter to avoid namespace conflicts down the line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8680)
<!-- Reviewable:end -->
