### PR TITLE
test(spanner): revert to using hyphen separators in database names

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -397,7 +397,8 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
   Database db(in, spanner_testing::RandomDatabaseName(generator_));
   google::spanner::admin::database::v1::CreateDatabaseRequest creq;
   creq.set_parent(db.instance().FullName());
-  creq.set_create_statement(absl::StrCat("CREATE DATABASE ", db.database_id()));
+  creq.set_create_statement(
+      absl::StrCat("CREATE DATABASE \"", db.database_id(), "\""));
   creq.mutable_encryption_config()->set_kms_key_name(encryption_key.FullName());
   creq.set_database_dialect(
       google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);

--- a/google/cloud/spanner/samples/postgresql_samples.cc
+++ b/google/cloud/spanner/samples/postgresql_samples.cc
@@ -51,7 +51,8 @@ void CreateDatabase(google::cloud::spanner_admin::DatabaseAdminClient client,
                     google::cloud::spanner::Database const& database) {
   google::spanner::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(database.instance().FullName());
-  request.set_create_statement("CREATE DATABASE " + database.database_id());
+  request.set_create_statement("CREATE DATABASE \"" + database.database_id() +
+                               "\"");
   request.set_database_dialect(
       google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
   auto db = client.CreateDatabase(request).get();

--- a/google/cloud/spanner/testing/cleanup_stale_databases.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.cc
@@ -38,7 +38,7 @@ Status CleanupStaleDatabases(
     if (!db) return std::move(db).status();
     auto id = spanner::MakeDatabase(db->name())->database_id();
     // Skip databases that do not look like a randomly created DB.
-    if (!std::regex_match(id, re)) continue;
+    if (!std::regex_search(id, re)) continue;
     // Skip databases that are relatively recent
     if (id > expired) continue;
     // Drop the database and ignore errors.

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -21,29 +21,24 @@ namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string RandomDatabasePrefixRegex() {
-  // Temporarily, we also match the old '-' separators.
-  return R"re(^db[-_]\d{4}[-_]\d{2}[-_]\d{2}[-_].*$)re";
+  // Temporarily, we match both styles of separators.
+  return R"re(^db[-_]\d{4}[-_]\d{2}[-_]\d{2}[-_])re";
 }
 
 std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {
-  std::string prefix = "db_";
-  for (auto const& c : google::cloud::internal::FormatUtcDate(tp)) {
-    prefix.push_back(c == '-' ? '_' : c);
-  }
-  prefix.push_back('_');
-  return prefix;
+  return "db-" + google::cloud::internal::FormatUtcDate(tp) + "-";
 }
 
 std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator,
                                std::chrono::system_clock::time_point tp) {
   // A database ID must be between 2 and 30 characters, fitting the regular
-  // expression `[a-z][a-z0-9_]*[a-z0-9]`
+  // expression `[a-z][a-z0-9_-]*[a-z0-9]`
   std::size_t const max_size = 30;
   auto const prefix = RandomDatabasePrefix(tp);
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
          google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789_") +
+             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789_-") +
          google::cloud::internal::Sample(
              generator, 1, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }

--- a/google/cloud/spanner/testing/random_database_name.h
+++ b/google/cloud/spanner/testing/random_database_name.h
@@ -31,7 +31,7 @@ std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator,
                                    std::chrono::system_clock::now());
 
 /// Return a regular expression (as a string) suitable to match the random
-/// database IDs
+/// database IDs using std::regex_search().
 std::string RandomDatabasePrefixRegex();
 
 // The prefix for databases created on the (UTC) day at @p tp.

--- a/google/cloud/spanner/testing/random_database_name_test.cc
+++ b/google/cloud/spanner/testing/random_database_name_test.cc
@@ -29,7 +29,7 @@ TEST(RandomDatabaseNameTest, PrefixMatchesRegexp) {
   auto const prefix = RandomDatabasePrefix(std::chrono::system_clock::now());
   auto const re = RandomDatabasePrefixRegex();
 
-  EXPECT_TRUE(std::regex_match(prefix, std::regex(re)));
+  EXPECT_TRUE(std::regex_search(prefix, std::regex(re)));
 }
 
 TEST(RandomDatabaseNameTest, NameMatchesRegexp) {
@@ -37,7 +37,7 @@ TEST(RandomDatabaseNameTest, NameMatchesRegexp) {
   auto const name = RandomDatabaseName(generator);
   auto const re = RandomDatabasePrefixRegex();
 
-  EXPECT_TRUE(std::regex_match(name, std::regex(re)));
+  EXPECT_TRUE(std::regex_search(name, std::regex(re)));
 }
 
 TEST(RandomDatabaseNameTest, RandomNameHasPrefix) {


### PR DESCRIPTION
Now that I have abandoned trying to parameterize tests/samples on
database dialect, it is straightforward to choose the right quoting
convention needed to include hyphens in database names in the CREATE
DDL statement.  So, resume using "db-YYYY-MM-DD-" prefixes for random
database names---they are easier to produce and read.  This reverts
most of #8547.

Also change `RandomDatabasePrefixRegex()` to return a regex that
indeed only matches the random-database prefix, and which therefore
should be passed to `std::regex_search()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8685)
<!-- Reviewable:end -->
