### PR TITLE
test(spanner): re-enable DataTypeIntegrationTest.JsonMaxNesting

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -471,7 +471,7 @@ TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
   std::vector<Json> const bad_data = {Json(bad_json)};
   result = WriteReadData(*client_, bad_data, "JsonValue");
   // NOTE: The backend is currently dropping a more specific "Max nesting
-  // of 100 had been exceeded [INVALID_ARGUMENT]" error, so expect this
+  // of 90 had been exceeded [INVALID_ARGUMENT]" error, so expect this
   // expectation to change when that problem is fixed.
   EXPECT_THAT(result, StatusIs(StatusCode::kFailedPrecondition,
                                HasSubstr("Expected JSON")));

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -445,12 +445,12 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 }
 
 // Verify maximum JSON nesting.
-TEST_F(DataTypeIntegrationTest, DISABLED_JsonMaxNesting) {
+TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
   // TODO(#6873): Remove this check when the emulator supports JSON.
   if (UsingEmulator()) GTEST_SKIP();
 
   // The default value of the backend max-nesting-level flag.
-  int const k_spanner_json_max_nesting_level = 100;
+  int const k_spanner_json_max_nesting_level = 90;
 
   // Nested arrays that exceed `k_spanner_json_max_nesting_level` by one.
   std::string bad_json;


### PR DESCRIPTION
Restore verification of the (newly-lowered) JSON nesting limit.
See #8327.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8689)
<!-- Reviewable:end -->
