### PR TITLE
fix(storage)!: restore committed size for uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ https://github.com/googleapis/google-cloud-cpp/issues/8234.
 
 ## v1.40.0 - TBD
 
+### [Storage](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storage/README.md)
+
+**BREAKING CHANGES**
+
+* While the interface and behavior for `storage::Client::WriteObject()` remains
+  stable, its implementation has changed. Normally implementation details are
+  not breaking changes, but any application mocking the storage library
+  necessarily depends on these implementation details. We updated the
+  [mocking examples][storage-mocking-link] to guide you in changing any tests.
+
 ## v1.39.0 - 2022-04
 
 **BREAKING CHANGES**

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -58,8 +58,6 @@ TEST_F(WriteObjectTest, WriteObject) {
 
         auto mock = absl::make_unique<testing::MockResumableUploadSession>();
         using internal::ResumableUploadResponse;
-        EXPECT_CALL(*mock, done()).WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly(Return(0));
         EXPECT_CALL(*mock, UploadChunk)
             .WillRepeatedly(Return(make_status_or(ResumableUploadResponse{
                 "fake-url", ResumableUploadResponse::kInProgress, 0, {}, {}})));
@@ -128,8 +126,6 @@ TEST_F(WriteObjectTest, WriteObjectErrorInChunk) {
 
         auto mock = absl::make_unique<testing::MockResumableUploadSession>();
         using internal::ResumableUploadResponse;
-        EXPECT_CALL(*mock, done()).WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly(Return(0));
         EXPECT_CALL(*mock, UploadChunk)
             .WillOnce(Return(Status(StatusCode::kDataLoss, "ooops")));
         EXPECT_CALL(*mock, session_id()).WillRepeatedly(ReturnRef(session_id));
@@ -171,8 +167,6 @@ TEST_F(WriteObjectTest, WriteObjectPermanentSessionFailurePropagates) {
   auto create_mock = [&](internal::ResumableUploadRequest const&) {
     auto mock = absl::make_unique<testing::MockResumableUploadSession>();
     EXPECT_CALL(*mock, UploadChunk).WillRepeatedly(Return(PermanentError()));
-    EXPECT_CALL(*mock, next_expected_byte()).WillRepeatedly(Return(0));
-    EXPECT_CALL(*mock, done()).WillRepeatedly(Return(false));
     EXPECT_CALL(*mock, session_id()).WillRepeatedly(ReturnRef(empty));
 
     return make_status_or(internal::CreateResumableSessionResponse{
@@ -229,9 +223,6 @@ TEST_F(WriteObjectTest, UploadStreamResumable) {
 
         auto mock = absl::make_unique<testing::MockResumableUploadSession>();
         using internal::ResumableUploadResponse;
-        EXPECT_CALL(*mock, done()).WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock, next_expected_byte())
-            .WillRepeatedly([&bytes_written]() { return bytes_written; });
 
         EXPECT_CALL(*mock, UploadFinalChunk)
             .WillOnce([expected, &bytes_written](
@@ -297,9 +288,6 @@ TEST_F(WriteObjectTest, UploadFile) {
 
         auto mock = absl::make_unique<testing::MockResumableUploadSession>();
         using internal::ResumableUploadResponse;
-        EXPECT_CALL(*mock, done()).WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock, next_expected_byte())
-            .WillRepeatedly([&bytes_written]() { return bytes_written; });
         EXPECT_CALL(*mock, UploadFinalChunk)
             .WillOnce([&](internal::ConstBufferSequence const& data,
                           std::uint64_t size, internal::HashValues const&) {

--- a/google/cloud/storage/examples/storage_client_mock_samples.cc
+++ b/google/cloud/storage/examples/storage_client_mock_samples.cc
@@ -84,9 +84,6 @@ TEST(StorageMockingSamples, MockWriteObject) {
         auto mock_result =
             absl::make_unique<gcs::testing::MockResumableUploadSession>();
         using gcs::internal::ResumableUploadResponse;
-        EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock_result, next_expected_byte())
-            .WillRepeatedly(Return(0));
         EXPECT_CALL(*mock_result, UploadChunk)
             .WillRepeatedly(Return(google::cloud::make_status_or(
                 ResumableUploadResponse{"fake-url",
@@ -165,9 +162,6 @@ TEST(StorageMockingSamples, MockWriteObjectFailure) {
         auto mock_result =
             absl::make_unique<gcs::testing::MockResumableUploadSession>();
         using gcs::internal::ResumableUploadResponse;
-        EXPECT_CALL(*mock_result, done()).WillRepeatedly(Return(false));
-        EXPECT_CALL(*mock_result, next_expected_byte())
-            .WillRepeatedly(Return(0));
         EXPECT_CALL(*mock_result, UploadChunk)
             .WillRepeatedly(Return(google::cloud::Status(
                 google::cloud::StatusCode::kInvalidArgument,

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -56,18 +56,12 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::ResetSession() {
   return result;
 }
 
-std::uint64_t CurlResumableUploadSession::next_expected_byte() const {
-  return next_expected_;
-}
-
 void CurlResumableUploadSession::Update(
     StatusOr<ResumableUploadResponse> const& result, std::size_t chunk_size) {
-  last_response_ = result;
   if (!result.ok()) {
     return;
   }
-  done_ = result->upload_state == ResumableUploadResponse::kDone;
-  if (done_) {
+  if (result->upload_state == ResumableUploadResponse::kDone) {
     // Sometimes (e.g. when the user sets the X-Upload-Content-Length header)
     // the upload completes but does *not* include a `last_committed_byte`
     // value. In this case we update the next expected byte using the chunk

--- a/google/cloud/storage/internal/curl_resumable_upload_session.h
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.h
@@ -46,15 +46,7 @@ class CurlResumableUploadSession : public ResumableUploadSession {
 
   StatusOr<ResumableUploadResponse> ResetSession() override;
 
-  std::uint64_t next_expected_byte() const override;
-
   std::string const& session_id() const override { return session_id_; }
-
-  bool done() const override { return done_; }
-
-  StatusOr<ResumableUploadResponse> const& last_response() const override {
-    return last_response_;
-  }
 
  private:
   void Update(StatusOr<ResumableUploadResponse> const& result,
@@ -64,8 +56,6 @@ class CurlResumableUploadSession : public ResumableUploadSession {
   ResumableUploadRequest request_;
   std::string session_id_;
   std::uint64_t next_expected_ = 0;
-  bool done_ = false;
-  StatusOr<ResumableUploadResponse> last_response_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -42,13 +42,7 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
 
   StatusOr<ResumableUploadResponse> ResetSession() override;
 
-  std::uint64_t next_expected_byte() const override;
-
   std::string const& session_id() const override;
-
-  bool done() const override;
-
-  StatusOr<ResumableUploadResponse> const& last_response() const override;
 
  private:
   /**
@@ -65,10 +59,9 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
   ResumableUploadSessionGrpcParams session_id_params_;
   std::string session_url_;
 
-  std::uint64_t next_expected_ = 0;
-  bool done_ = false;
-  StatusOr<ResumableUploadResponse> last_response_;
+  std::uint64_t committed_size_ = 0;
 };
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/logging_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.cc
@@ -65,33 +65,12 @@ LoggingResumableUploadSession::ResetSession() {
   return response;
 }
 
-std::uint64_t LoggingResumableUploadSession::next_expected_byte() const {
-  GCP_LOG(INFO) << __func__ << "() << {}";
-  auto response = session_->next_expected_byte();
-  GCP_LOG(INFO) << __func__ << "() >> " << response;
-  return response;
-}
-
 std::string const& LoggingResumableUploadSession::session_id() const {
   GCP_LOG(INFO) << __func__ << "() << {}";
   auto const& response = session_->session_id();
   GCP_LOG(INFO) << __func__ << "() >> " << response;
   return response;
 }
-
-StatusOr<ResumableUploadResponse> const&
-LoggingResumableUploadSession::last_response() const {
-  GCP_LOG(INFO) << __func__ << "() << {}";
-  auto const& response = session_->last_response();
-  if (response.ok()) {
-    GCP_LOG(INFO) << __func__ << "() >> payload={" << response.value() << "}";
-  } else {
-    GCP_LOG(INFO) << __func__ << "() >> status={" << response.status() << "}";
-  }
-  return response;
-}
-
-bool LoggingResumableUploadSession::done() const { return session_->done(); }
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/logging_resumable_upload_session.h
+++ b/google/cloud/storage/internal/logging_resumable_upload_session.h
@@ -40,10 +40,7 @@ class LoggingResumableUploadSession : public ResumableUploadSession {
       ConstBufferSequence const& buffers, std::uint64_t upload_size,
       HashValues const& full_object_hashes) override;
   StatusOr<ResumableUploadResponse> ResetSession() override;
-  std::uint64_t next_expected_byte() const override;
   std::string const& session_id() const override;
-  StatusOr<ResumableUploadResponse> const& last_response() const override;
-  bool done() const override;
 
  private:
   std::unique_ptr<ResumableUploadSession> session_;

--- a/google/cloud/storage/internal/object_write_streambuf.h
+++ b/google/cloud/storage/internal/object_write_streambuf.h
@@ -42,6 +42,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   ObjectWriteStreambuf() = default;
 
   ObjectWriteStreambuf(std::unique_ptr<ResumableUploadSession> upload_session,
+                       StatusOr<ResumableUploadResponse> last_response,
                        std::size_t max_buffer_size,
                        std::unique_ptr<HashFunction> hash_function,
                        HashValues known_hashes,
@@ -68,9 +69,7 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   }
 
   /// The next expected byte, if applicable, always 0 for non-resumable uploads.
-  virtual std::uint64_t next_expected_byte() const {
-    return upload_session_->next_expected_byte();
-  }
+  virtual std::uint64_t next_expected_byte() const { return committed_size_; }
 
   virtual Status last_status() const { return last_response_.status(); }
 
@@ -119,7 +118,9 @@ class ObjectWriteStreambuf : public std::basic_streambuf<char> {
   std::string computed_hash_;
   std::string received_hash_;
 
+  // TODO(coryan) - this may need to be refactored
   StatusOr<ResumableUploadResponse> last_response_;
+  std::uint64_t committed_size_ = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.cc
@@ -53,9 +53,9 @@ RetryResumableUploadSession::RetryResumableUploadSession(
     std::unique_ptr<BackoffPolicy> backoff_policy,
     ResumableUploadResponse const& last_response)
     : session_(std::move(session)),
-      committed_size_(last_response.committed_size.value_or(0)),
       retry_policy_prototype_(std::move(retry_policy)),
-      backoff_policy_prototype_(std::move(backoff_policy)) {}
+      backoff_policy_prototype_(std::move(backoff_policy)),
+      committed_size_(last_response.committed_size.value_or(0)) {}
 
 StatusOr<ResumableUploadResponse> RetryResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
@@ -246,19 +246,8 @@ StatusOr<ResumableUploadResponse> RetryResumableUploadSession::ResetSession() {
   return Status(last_status.code(), std::move(os).str());
 }
 
-std::uint64_t RetryResumableUploadSession::next_expected_byte() const {
-  return session_->next_expected_byte();
-}
-
 std::string const& RetryResumableUploadSession::session_id() const {
   return session_->session_id();
-}
-
-bool RetryResumableUploadSession::done() const { return session_->done(); }
-
-StatusOr<ResumableUploadResponse> const&
-RetryResumableUploadSession::last_response() const {
-  return session_->last_response();
 }
 
 void RetryResumableUploadSession::AppendDebug(char const* action,

--- a/google/cloud/storage/internal/retry_resumable_upload_session.h
+++ b/google/cloud/storage/internal/retry_resumable_upload_session.h
@@ -56,10 +56,7 @@ class RetryResumableUploadSession : public ResumableUploadSession {
       ConstBufferSequence const& buffers, std::uint64_t upload_size,
       HashValues const& full_object_hashes) override;
   StatusOr<ResumableUploadResponse> ResetSession() override;
-  std::uint64_t next_expected_byte() const override;
   std::string const& session_id() const override;
-  bool done() const override;
-  StatusOr<ResumableUploadResponse> const& last_response() const override;
 
  private:
   using UploadChunkFunction =
@@ -84,9 +81,9 @@ class RetryResumableUploadSession : public ResumableUploadSession {
   };
 
   std::unique_ptr<ResumableUploadSession> session_;
-  std::uint64_t committed_size_ = 0;
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
+  std::uint64_t committed_size_ = 0;
   std::mutex mu_;
   std::deque<DebugEntry> debug_;
 };

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -496,7 +496,7 @@ TEST(RetryResumableUploadSessionTest, TooManyTransientOnUploadFinalChunk) {
   EXPECT_THAT(response, Not(IsOk()));
 }
 
-TEST(RetryResumableUploadSession, UploadChunkPolicyExhaustedOnStart) {
+TEST(RetryResumableUploadSessionTest, UploadChunkPolicyExhaustedOnStart) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
   RetryResumableUploadSession session(
       std::move(mock), LimitedTimeRetryPolicy(std::chrono::seconds(0)).clone(),
@@ -509,7 +509,7 @@ TEST(RetryResumableUploadSession, UploadChunkPolicyExhaustedOnStart) {
                     HasSubstr("Retry policy exhausted before first attempt")));
 }
 
-TEST(RetryResumableUploadSession, UploadFinalChunkPolicyExhaustedOnStart) {
+TEST(RetryResumableUploadSessionTest, UploadFinalChunkPolicyExhaustedOnStart) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
   RetryResumableUploadSession session(
       std::move(mock), LimitedTimeRetryPolicy(std::chrono::seconds(0)).clone(),
@@ -522,7 +522,7 @@ TEST(RetryResumableUploadSession, UploadFinalChunkPolicyExhaustedOnStart) {
                     HasSubstr("Retry policy exhausted before first attempt")));
 }
 
-TEST(RetryResumableUploadSession, ResetSessionPolicyExhaustedOnStart) {
+TEST(RetryResumableUploadSessionTest, ResetSessionPolicyExhaustedOnStart) {
   auto mock = absl::make_unique<testing::MockResumableUploadSession>();
   RetryResumableUploadSession session(
       std::move(mock), LimitedTimeRetryPolicy(std::chrono::seconds(0)).clone(),

--- a/google/cloud/storage/object_write_stream.cc
+++ b/google/cloud/storage/object_write_stream.cc
@@ -26,6 +26,7 @@ std::unique_ptr<internal::ObjectWriteStreambuf> MakeErrorStreambuf() {
   return absl::make_unique<internal::ObjectWriteStreambuf>(
       absl::make_unique<internal::ResumableUploadSessionError>(
           Status(StatusCode::kUnimplemented, "null stream")),
+      Status(StatusCode::kUnimplemented, "null stream"),
       /*max_buffer_size=*/0, internal::CreateNullHashFunction(),
       internal::HashValues{}, internal::CreateNullHashValidator(),
       AutoFinalizeConfig::kDisabled);

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -28,9 +28,10 @@ class ParallelObjectWriteStreambuf : public ObjectWriteStreambuf {
   ParallelObjectWriteStreambuf(
       std::shared_ptr<ParallelUploadStateImpl> state, std::size_t stream_idx,
       std::unique_ptr<ResumableUploadSession> upload_session,
-      std::size_t max_buffer_size, ResumableUploadRequest const& request)
+      ResumableUploadResponse response, std::size_t max_buffer_size,
+      ResumableUploadRequest const& request)
       : ObjectWriteStreambuf(
-            std::move(upload_session), max_buffer_size,
+            std::move(upload_session), std::move(response), max_buffer_size,
             CreateHashFunction(request),
             internal::HashValues{
                 request.GetOption<Crc32cChecksumValue>().value_or(""),
@@ -92,7 +93,7 @@ StatusOr<ObjectWriteStream> ParallelUploadStateImpl::CreateStream(
   assert(idx < streams_.size());
   lk.unlock();
   return ObjectWriteStream(absl::make_unique<ParallelObjectWriteStreambuf>(
-      shared_from_this(), idx, std::move(session),
+      shared_from_this(), idx, std::move(session), std::move(create->state),
       raw_client.client_options().upload_buffer_size(), request));
 }
 

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -168,11 +168,7 @@ class MockResumableUploadSession
               (override));
   MOCK_METHOD(StatusOr<internal::ResumableUploadResponse>, ResetSession, (),
               (override));
-  MOCK_METHOD(std::uint64_t, next_expected_byte, (), (const, override));
   MOCK_METHOD(std::string const&, session_id, (), (const, override));
-  MOCK_METHOD(bool, done, (), (const, override));
-  MOCK_METHOD(StatusOr<internal::ResumableUploadResponse> const&, last_response,
-              (), (const, override));
 };
 
 class MockObjectReadSource : public internal::ObjectReadSource {
@@ -200,6 +196,20 @@ Client ClientFromMock(std::shared_ptr<MockClient> const& mock,
                       Policies&&... p) {
   return internal::ClientImplDetails::CreateClient(
       mock, std::forward<Policies>(p)...);
+}
+
+/// Simulate an initial resumable upload session response.
+inline internal::ResumableUploadResponse MockResumableUploadSessionInit() {
+  return internal::ResumableUploadResponse{
+      "", internal::ResumableUploadResponse::kInProgress, absl::nullopt,
+      absl::nullopt, std::string{}};
+}
+
+/// Simulate the final resumable upload session response.
+inline internal::ResumableUploadResponse MockResumableUploadSessionFinal() {
+  return internal::ResumableUploadResponse{
+      "", internal::ResumableUploadResponse::kDone, absl::nullopt,
+      ObjectMetadata(), std::string{}};
 }
 
 }  // namespace testing

--- a/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
+++ b/google/cloud/storage/tests/object_write_streambuf_integration_test.cc
@@ -51,7 +51,7 @@ class ObjectWriteStreambufIntegrationTest
     ASSERT_STATUS_OK(create);
 
     ObjectWriteStream writer(absl::make_unique<ObjectWriteStreambuf>(
-        std::move(create->session),
+        std::move(create->session), std::move(create->state),
         internal::ClientImplDetails::GetRawClient(*client)
             ->client_options()
             .upload_buffer_size(),


### PR DESCRIPTION
When restoring a resumable upload the `ObjectWriteStreambuf`, and any
`ResumableUploadSession` objects should reset their state based on the
latest available state from the service. This changes the client library
to update the stack of objects when the upload is resumed.

Fixes #8559. Note that other changes are needed to make this error less likely, and to make things easier to reason about.