### PR TITLE
chore(rest): correct cmake config and disambiguate C names

### DIFF
--- a/google/cloud/CMakeLists.txt
+++ b/google/cloud/CMakeLists.txt
@@ -804,26 +804,18 @@ if (GOOGLE_CLOUD_CPP_ENABLE_REST)
         endforeach ()
     endif ()
 
-    # Install the libraries and headers in the locations determined by
-    # GNUInstallDirs
-    install(
-        TARGETS
-        EXPORT rest-internal-targets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                COMPONENT google_cloud_cpp_development)
-
     # Export the CMake targets to make it easy to create configuration files.
     install(
-        EXPORT rest-internal-targets
+        EXPORT google_cloud_cpp_rest_internal-targets
         DESTINATION
             "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_rest_internal"
         COMPONENT google_cloud_cpp_development)
 
+    # Install the libraries and headers in the locations determined by
+    # GNUInstallDirs
     install(
         TARGETS google_cloud_cpp_rest_internal
-        EXPORT rest-internal-targets
+        EXPORT google_cloud_cpp_rest_internal-targets
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
                 COMPONENT google_cloud_cpp_runtime
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -861,7 +853,8 @@ if (GOOGLE_CLOUD_CPP_ENABLE_REST)
         COMPONENT google_cloud_cpp_development)
 
     # Create and install the CMake configuration files.
-    configure_file("grpc_utils/config.cmake.in"
+    include(CMakePackageConfigHelpers)
+    configure_file("config-rest.cmake.in"
                    "google_cloud_cpp_rest_internal-config.cmake" @ONLY)
     write_basic_package_version_file(
         "google_cloud_cpp_rest_internal-config-version.cmake"

--- a/google/cloud/config-rest.cmake.in
+++ b/google/cloud/config-rest.cmake.in
@@ -1,0 +1,19 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeFindDependencyMacro)
+find_dependency(google_cloud_cpp_common)
+find_dependency(absl)
+
+include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_rest_internal-targets.cmake")

--- a/google/cloud/config-rest.cmake.in
+++ b/google/cloud/config-rest.cmake.in
@@ -15,5 +15,9 @@
 include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
+find_dependency(CURL)
+find_dependency(Crc32c)
+find_dependency(nlohmann_json)
+find_dependency(OpenSSL)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_rest_internal-targets.cmake")

--- a/google/cloud/config-rest.cmake.in
+++ b/google/cloud/config-rest.cmake.in
@@ -16,7 +16,6 @@ include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
 find_dependency(CURL)
-find_dependency(Crc32c)
 find_dependency(nlohmann_json)
 find_dependency(OpenSSL)
 

--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -32,8 +32,9 @@ using ::google::cloud::rest_internal::BinaryDataAsDebugString;
 
 std::size_t const kMaxDataDebugSize = 48;
 
-extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
-                                       std::size_t size, void* userptr) {
+extern "C" int RestCurlHandleDebugCallback(CURL*, curl_infotype type,
+                                           char* data, std::size_t size,
+                                           void* userptr) {
   auto* debug_info = reinterpret_cast<CurlHandle::DebugInfo*>(userptr);
   switch (type) {
     case CURLINFO_TEXT:
@@ -76,8 +77,8 @@ extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
   return 0;
 }
 
-extern "C" int CurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
-                                    curlsocktype purpose) {
+extern "C" int RestCurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
+                                        curlsocktype purpose) {
   auto errno_msg = [] { return google::cloud::internal::strerror(errno); };
   auto* options = reinterpret_cast<CurlHandle::SocketOptions*>(userdata);
   switch (purpose) {
@@ -146,7 +147,7 @@ CurlHandle::~CurlHandle() { FlushDebug(__func__); }
 void CurlHandle::SetSocketCallback(SocketOptions const& options) {
   socket_options_ = options;
   SetOption(CURLOPT_SOCKOPTDATA, &socket_options_);
-  SetOption(CURLOPT_SOCKOPTFUNCTION, &CurlSetSocketOptions);
+  SetOption(CURLOPT_SOCKOPTFUNCTION, &RestCurlSetSocketOptions);
 }
 
 std::int32_t CurlHandle::GetResponseCode() {
@@ -176,7 +177,7 @@ void CurlHandle::EnableLogging(bool enabled) {
   if (enabled) {
     debug_info_ = std::make_shared<DebugInfo>();
     SetOption(CURLOPT_DEBUGDATA, debug_info_.get());
-    SetOption(CURLOPT_DEBUGFUNCTION, &CurlHandleDebugCallback);
+    SetOption(CURLOPT_DEBUGFUNCTION, &RestCurlHandleDebugCallback);
     SetOption(CURLOPT_VERBOSE, 1L);
   } else {
     SetOption(CURLOPT_DEBUGDATA, nullptr);

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -134,21 +134,22 @@ absl::Span<T> WriteToBuffer(absl::Span<T> destination,
 
 }  // namespace
 
-extern "C" std::size_t CurlRequestWrite(char* ptr, size_t size, size_t nmemb,
-                                        void* userdata) {
+extern "C" std::size_t RestCurlRequestWrite(char* ptr, size_t size,
+                                            size_t nmemb, void* userdata) {
   auto* request = reinterpret_cast<CurlImpl*>(userdata);
   return request->WriteCallback(ptr, size, nmemb);
 }
 
-extern "C" std::size_t CurlRequestHeader(char* contents, std::size_t size,
-                                         std::size_t nitems, void* userdata) {
+extern "C" std::size_t RestCurlRequestHeader(char* contents, std::size_t size,
+                                             std::size_t nitems,
+                                             void* userdata) {
   auto* request = reinterpret_cast<CurlImpl*>(userdata);
   return request->HeaderCallback(contents, size, nitems);
 }
 
-extern "C" std::size_t CurlRequestOnReadData(char* ptr, std::size_t size,
-                                             std::size_t nitems,
-                                             void* userdata) {
+extern "C" std::size_t RestCurlRequestOnReadData(char* ptr, std::size_t size,
+                                                 std::size_t nitems,
+                                                 void* userdata) {
   auto* v = reinterpret_cast<WriteVector*>(userdata);
   return v->OnRead(ptr, size, nitems);
 }
@@ -573,9 +574,9 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
   auto bytes_read = DrainSpillBuffer();
   if (curl_closed_) return bytes_read;
 
-  handle_.SetOption(CURLOPT_WRITEFUNCTION, &CurlRequestWrite);
+  handle_.SetOption(CURLOPT_WRITEFUNCTION, &RestCurlRequestWrite);
   handle_.SetOption(CURLOPT_WRITEDATA, this);
-  handle_.SetOption(CURLOPT_HEADERFUNCTION, &CurlRequestHeader);
+  handle_.SetOption(CURLOPT_HEADERFUNCTION, &RestCurlRequestHeader);
   handle_.SetOption(CURLOPT_HEADERDATA, this);
   handle_.FlushDebug(__func__);
 
@@ -699,7 +700,7 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
 
   if (method == HttpMethod::kPut || method == HttpMethod::kPatch) {
     WriteVector writev{std::move(payload)};
-    handle_.SetOption(CURLOPT_READFUNCTION, &CurlRequestOnReadData);
+    handle_.SetOption(CURLOPT_READFUNCTION, &RestCurlRequestOnReadData);
     handle_.SetOption(CURLOPT_READDATA, &writev);
     handle_.SetOption(CURLOPT_UPLOAD, 1L);
     return MakeRequestImpl();

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -32,10 +32,11 @@ namespace cloud {
 namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-extern "C" std::size_t CurlRequestWrite(char* ptr, size_t size, size_t nmemb,
-                                        void* userdata);
-extern "C" std::size_t CurlRequestHeader(char* contents, std::size_t size,
-                                         std::size_t nitems, void* userdata);
+extern "C" std::size_t RestCurlRequestWrite(char* ptr, size_t size,
+                                            size_t nmemb, void* userdata);
+extern "C" std::size_t RestCurlRequestHeader(char* contents, std::size_t size,
+                                             std::size_t nitems,
+                                             void* userdata);
 
 // This class encapsulates use of libcurl and manages all the necessary state
 // of a request and its associated response.
@@ -76,10 +77,10 @@ class CurlImpl {
   StatusOr<std::size_t> Read(absl::Span<char> output);
 
  private:
-  friend std::size_t CurlRequestWrite(char* ptr, size_t size, size_t nmemb,
-                                      void* userdata);
-  friend std::size_t CurlRequestHeader(char* contents, std::size_t size,
-                                       std::size_t nitems, void* userdata);
+  friend std::size_t RestCurlRequestWrite(char* ptr, size_t size, size_t nmemb,
+                                          void* userdata);
+  friend std::size_t RestCurlRequestHeader(char* contents, std::size_t size,
+                                           std::size_t nitems, void* userdata);
 
   // Called by libcurl to show that more data is available in the request.
   std::size_t WriteCallback(void* ptr, std::size_t size, std::size_t nmemb);

--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -47,7 +47,7 @@ namespace {
 std::vector<std::mutex> ssl_locks;
 
 // A callback to lock and unlock the mutexes needed by the SSL library.
-extern "C" void SslLockingCb(int mode, int type, char const*, int) {
+extern "C" void RestSslLockingCb(int mode, int type, char const*, int) {
   if ((mode & CRYPTO_LOCK) != 0) {
     ssl_locks[type].lock();
   } else {
@@ -123,7 +123,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   GCP_LOG(INFO) << "Installing SSL locking callbacks.";
   ssl_locks =
       std::vector<std::mutex>(static_cast<std::size_t>(CRYPTO_num_locks()));
-  CRYPTO_set_locking_callback(SslLockingCb);
+  CRYPTO_set_locking_callback(RestSslLockingCb);
 
   // The documentation also recommends calling CRYPTO_THREADID_set_callback() to
   // setup a function to return thread ids as integers (or pointers). Writing a


### PR DESCRIPTION
As part of the REST refactor effort, the extern "C" symbols names in the REST library needed to be different than the existing names in GCS.

Also fixes some of the REST libraries cmake configuration to follow existing conventions.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8693)
<!-- Reviewable:end -->
