### PR TITLE
test(spanner): enable JSON testing for Spanner emulator

### DIFF
--- a/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/database_admin_integration_test.cc
@@ -207,16 +207,11 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
   }
   statements.emplace_back(R"""(
         CREATE TABLE Singers (
-          SingerId   INT64 NOT NULL,
-          FirstName  STRING(1024),
-          LastName   STRING(1024),
-          SingerInfo BYTES(MAX)
-      )""");
-  if (!emulator_) {
-    // TODO(#6873): Remove this check when the emulator supports JSON.
-    statements.back().append(R"""(,SingerDetails JSON)""");
-  }
-  statements.back().append(R"""(
+          SingerId      INT64 NOT NULL,
+          FirstName     STRING(1024),
+          LastName      STRING(1024),
+          SingerInfo    BYTES(MAX),
+          SingerDetails JSON
         ) PRIMARY KEY (SingerId)
       )""");
   auto metadata = client_.UpdateDatabase(database_, statements).get();
@@ -239,20 +234,8 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
           ON Singers(SingerDetails)
       )""");
   metadata = client_.UpdateDatabase(database_, statements).get();
-  if (!emulator_) {
-    // TODO(#6873): Remove this check when the emulator supports JSON.
-    EXPECT_THAT(metadata,
-                StatusIs(StatusCode::kFailedPrecondition,
-                         AllOf(HasSubstr("Index SingersByDetail"),
-                               HasSubstr("column of unsupported type JSON"))));
-  } else {
-    EXPECT_THAT(
-        metadata,
-        StatusIs(
-            StatusCode::kInvalidArgument,
-            AllOf(HasSubstr("Index SingersByDetail"),
-                  HasSubstr("column SingerDetails which does not exist"))));
-  }
+  EXPECT_THAT(metadata, StatusIs(StatusCode::kFailedPrecondition,
+                                 HasSubstr("SingersByDetail")));
 
   // Verify that a JSON column cannot be used as a primary key.
   statements.clear();
@@ -262,15 +245,9 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
         ) PRIMARY KEY (Key)
       )""");
   metadata = client_.UpdateDatabase(database_, statements).get();
-  if (!emulator_) {
-    // TODO(#6873): Remove this check when the emulator supports JSON.
-    EXPECT_THAT(metadata,
-                StatusIs(StatusCode::kInvalidArgument,
-                         AllOf(HasSubstr("Key has type JSON"),
-                               HasSubstr("part of the primary key"))));
-  } else {
-    EXPECT_THAT(metadata, Not(IsOk()));
-  }
+  EXPECT_THAT(metadata, StatusIs(StatusCode::kInvalidArgument,
+                                 AllOf(HasSubstr("Key has type JSON"),
+                                       HasSubstr("part of the primary key"))));
 
   EXPECT_TRUE(DatabaseExists()) << "Database " << database_;
   auto drop_status = client_.DropDatabase(database_);

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -4126,17 +4126,14 @@ void RunAll(bool emulator) {
   SampleBanner("spanner_query_data_with_timestamp_column");
   QueryDataWithTimestamp(client);
 
-  // TODO(#6873): Remove this check when the emulator supports JSON.
-  if (!emulator) {
-    SampleBanner("spanner_add_json_column");
-    AddJsonColumn(database_admin_client, project_id, instance_id, database_id);
+  SampleBanner("spanner_add_json_column");
+  AddJsonColumn(database_admin_client, project_id, instance_id, database_id);
 
-    SampleBanner("spanner_update_data_with_json_column");
-    UpdateDataWithJson(client);
+  SampleBanner("spanner_update_data_with_json_column");
+  UpdateDataWithJson(client);
 
-    SampleBanner("spanner_query_with_json_parameter");
-    QueryWithJsonParameter(client);
-  }
+  SampleBanner("spanner_query_with_json_parameter");
+  QueryWithJsonParameter(client);
 
   // TODO(#5024): Remove this check when the emulator supports NUMERIC.
   if (!emulator) {

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -79,11 +79,8 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
           BytesValue BYTES(1024),
           TimestampValue TIMESTAMP,
           DateValue DATE,
+          JsonValue JSON,
       )sql";
-  if (!emulator) {
-    // TODO(#6873): Remove this check when the emulator supports JSON.
-    create_datatypes.append(R"sql(JsonValue JSON,)sql");
-  }
   if (!emulator) {
     // TODO(#5024): Remove this check when the emulator supports NUMERIC.
     create_datatypes.append(R"sql(NumericValue NUMERIC,)sql");
@@ -95,12 +92,9 @@ void DatabaseIntegrationTest::SetUpTestSuite() {
           ArrayStringValue ARRAY<STRING(1024)>,
           ArrayBytesValue ARRAY<BYTES(1024)>,
           ArrayTimestampValue ARRAY<TIMESTAMP>,
-          ArrayDateValue ARRAY<DATE>
+          ArrayDateValue ARRAY<DATE>,
+          ArrayJsonValue ARRAY<JSON>
       )sql");
-  if (!emulator) {
-    // TODO(#6873): Remove this check when the emulator supports JSON.
-    create_datatypes.append(R"sql(,ArrayJsonValue ARRAY<JSON>)sql");
-  }
   if (!emulator) {
     // TODO(#5024): Remove this check when the emulator supports NUMERIC.
     create_datatypes.append(R"sql(,ArrayNumericValue ARRAY<NUMERIC>)sql");


### PR DESCRIPTION
The Cloud Spanner emulator now supports the JSON data type.

Fixes #6873.