### PR TITLE
fix(common): revamp the async polling loop part deux

### DIFF
--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -137,6 +137,7 @@ class AsyncPollingLoopImpl
     // cancel the operation after too many polling attempts.
     if (!polling_policy_->OnFailure(op.status())) {
       if (!op) {
+        // This could be a transient error if the policy is exhausted.
         return promise_.set_value(std::move(op).status());
       }
       // Consider trying to reset the backoff wait period.

--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -450,14 +450,10 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
   }
   {
     // TODO(#8616): Remove this when we know how to deal with the issue.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kDeadlineExceeded,
-        testing::HasSubstr("terminated by polling policy"));
+    auto matcher = testing_util::StatusIs(StatusCode::kCancelled);
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      // The backup is still in progress (and may eventually complete),
-      // and we can't drop the database while it has pending backups, so
-      // we simply abandon them, to be cleaned up offline.
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
       GTEST_SKIP();
     }
   }

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -178,14 +178,10 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
   }
   {
     // TODO(#8616): Remove this when we know how to deal with the issue.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kDeadlineExceeded,
-        testing::HasSubstr("terminated by polling policy"));
+    auto matcher = testing_util::StatusIs(StatusCode::kCancelled);
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      // The backup is still in progress (and may eventually complete),
-      // and we can't drop the database while it has pending backups, so
-      // we simply abandon them, to be cleaned up offline.
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
       GTEST_SKIP();
     }
   }

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -369,14 +369,10 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
   }
   {
     // TODO(#8616): Remove this when we know how to deal with the issue.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kDeadlineExceeded,
-        testing::HasSubstr("terminated by polling policy"));
+    auto matcher = testing_util::StatusIs(StatusCode::kCancelled);
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      // The backup is still in progress (and may eventually complete),
-      // and we can't drop the database while it has pending backups, so
-      // we simply abandon them, to be cleaned up offline.
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
       GTEST_SKIP();
     }
   }

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -145,14 +145,10 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
   }
   {
     // TODO(#8616): Remove this when we know how to deal with the issue.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kDeadlineExceeded,
-        testing::HasSubstr("terminated by polling policy"));
+    auto matcher = testing_util::StatusIs(StatusCode::kCancelled);
     testing::StringMatchResultListener listener;
     if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      // The backup is still in progress (and may eventually complete),
-      // and we can't drop the database while it has pending backups, so
-      // we simply abandon them, to be cleaned up offline.
+      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
       GTEST_SKIP();
     }
   }


### PR DESCRIPTION
Do not fabricate a deadline-exceeded `Status` when the polling policy
says enough is enough.  That left the operation in an unknowable state.
Rather, cancel the operation and wait for the next poll to yield us an
accurate status (which may end up being OK).

That is, a polling limit is really a request for auto-cancellation.

(See #7762 for the part-un work on ensuring an explicit cancel yielded an
accurate status.)

In the case of the Spanner backup tests, for example, this means we can do
something meaningful after hitting the poll limit of a `CreateBackup()`
call, as we'll know that the backup is no longer pending.

Update the poll-loop mocking tests to account for the new sequence of RPCs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8695)
<!-- Reviewable:end -->
