### PR TITLE
feat(generator): scaffold improvements

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -363,8 +363,8 @@ cc_library(
     ),
     visibility = ["//:__pkg__"],
     deps = [
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
         "@com_google_googleapis//$directory$:$library$_cc_grpc",
     ],
 )
@@ -380,8 +380,8 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_$library$",
-        "//google/cloud:google_cloud_cpp_common",
-        "//google/cloud:google_cloud_cpp_grpc_utils",
+        "//:common",
+        "//:grpc_utils",
     ],
 )
 )""";
@@ -429,14 +429,15 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(proto_list "protolists/$library$.list")
+google_cloud_cpp_load_protodeps(proto_deps "protodeps/$library$.deps")
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_$library$_protos # cmake-format: sort
-    $proto_files$
+    $${proto_list}
     PROTO_PATH_DIRECTORIES
     "$${EXTERNAL_GOOGLEAPIS_SOURCE}" "$${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias($library$_protos)
-target_link_libraries(google_cloud_cpp_$library$_protos PUBLIC #
-    $proto_deps$)
+target_link_libraries(google_cloud_cpp_$library$_protos PUBLIC $${proto_deps})
 
 file(GLOB source_files
      RELATIVE "$${CMAKE_CURRENT_SOURCE_DIR}"

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -185,21 +185,15 @@ TEST_F(ScaffoldGenerator, CMakeLists) {
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
   EXPECT_THAT(actual, HasSubstr(R"""(include(CompileProtos)
+google_cloud_cpp_load_protolist(proto_list "protolists/test.list")
+google_cloud_cpp_load_protodeps(proto_deps "protodeps/test.deps")
 google_cloud_cpp_grpcpp_library(
     google_cloud_cpp_test_protos # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/test/v1/foo.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/test/v1/admin.proto
+    ${proto_list}
     PROTO_PATH_DIRECTORIES
     "${EXTERNAL_GOOGLEAPIS_SOURCE}" "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(test_protos)
-target_link_libraries(google_cloud_cpp_test_protos PUBLIC #
-    google-cloud-cpp::longrunning_operations_protos
-    google-cloud-cpp::rpc_status_protos
-    google-cloud-cpp::api_resource_protos
-    google-cloud-cpp::api_field_behavior_protos
-    google-cloud-cpp::api_client_protos
-    google-cloud-cpp::api_annotations_protos
-    google-cloud-cpp::api_http_protos)
+target_link_libraries(google_cloud_cpp_test_protos PUBLIC ${proto_deps})
 )"""));
 
   EXPECT_THAT(actual, HasSubstr(R"""(add_executable(test_quickstart)"""));


### PR DESCRIPTION
Using the `protolists/*.list` and `protodeps/*.deps` files to requires
fewer manual updates when updating the googleapis SHA.

Avoid deprecation warnings, use the `//:common` and `//:grpc_utils`
targets.