### PR TITLE
cleanup(pubsublite): wrap partition publisher test mocks with `StrictMock`

### DIFF
--- a/google/cloud/pubsublite/internal/partition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/partition_publisher_test.cc
@@ -365,12 +365,12 @@ class PartitionPublisherTest : public ::testing::Test {
   // function that's only called in its destructor which is only called in
   // `Shutdown`
   StrictMock<MockAlarmRegistryCancelToken>& alarm_token_ref_;
-  MockAlarmRegistry alarm_registry_;
+  StrictMock<MockAlarmRegistry> alarm_registry_;
   std::function<void()> on_alarm_;
   // the reference remains valid because the resumable stream object is
   // never destroyed before the publisher goes out of scope at the end of
   // the test case
-  MockResumableAsyncReaderWriter<PublishRequest, PublishResponse>&
+  StrictMock<MockResumableAsyncReaderWriter<PublishRequest, PublishResponse>>&
       resumable_stream_ref_;
   std::unique_ptr<Publisher<Cursor>> publisher_;
 };


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8710)
<!-- Reviewable:end -->
