### PR TITLE
ci: use release version of Kaniko

### DIFF
--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -62,7 +62,7 @@ logsBucket: 'gs://${_LOGS_BUCKET}/logs/google-cloud-cpp/${_TRIGGER_SOURCE}/${COM
 
 steps:
   # Builds the docker image that will be used by the main build step.
-- name: 'gcr.io/kaniko-project/executor:v1.8.1-debug'
+- name: 'gcr.io/kaniko-project/executor:v1.8.1'
   args: [
     '--log-format=text',
     '--context=dir:///workspace/ci',


### PR DESCRIPTION
We use `kaniko:v1.6.y-debug` instead of `kaniko:v1.6.y` to workaround
problems I think do not exist in the v1.8.x series (and higher).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8711)
<!-- Reviewable:end -->
