### PR TITLE
cleanup(storage)!: scaffold session-less RU

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -180,7 +180,7 @@ CurlClient::CurlClient(google::cloud::Options options)
   CurlInitializeOnce(opts_);
 }
 
-StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
+StatusOr<ResumableUploadResponse> CurlClient::UploadSessionChunk(
     UploadChunkRequest const& request) {
   CurlRequestBuilder builder(request.upload_session_url(), upload_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
@@ -207,7 +207,7 @@ StatusOr<ResumableUploadResponse> CurlClient::UploadChunk(
   return AsStatus(*response);
 }
 
-StatusOr<ResumableUploadResponse> CurlClient::QueryResumableUpload(
+StatusOr<ResumableUploadResponse> CurlClient::QueryResumableSession(
     QueryResumableUploadRequest const& request) {
   CurlRequestBuilder builder(request.upload_session_url(), upload_factory_);
   auto status = SetupBuilder(builder, request, "PUT");
@@ -670,6 +670,16 @@ StatusOr<CreateResumableSessionResponse> CurlClient::CreateResumableSession(
                               /*.annotations=*/{}}};
 }
 
+StatusOr<CreateResumableUploadResponse> CurlClient::CreateResumableUpload(
+    ResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
+StatusOr<QueryResumableUploadResponse> CurlClient::QueryResumableUpload(
+    QueryResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
 StatusOr<EmptyResponse> CurlClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   CurlRequestBuilder builder(request.upload_session_url(), upload_factory_);
@@ -686,6 +696,11 @@ StatusOr<EmptyResponse> CurlClient::DeleteResumableUpload(
     return AsStatus(*response);
   }
   return EmptyResponse{};
+}
+
+StatusOr<QueryResumableUploadResponse> CurlClient::UploadChunk(
+    UploadChunkRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
 }
 
 StatusOr<ListBucketAclResponse> CurlClient::ListBucketAcl(

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -75,9 +75,9 @@ class CurlClient : public RawClient,
   // them is very different from the standard retry loop. Also note that some of
   // these member functions are virtual, but only because we need to override
   // them in the *library* unit tests.
-  virtual StatusOr<ResumableUploadResponse> UploadChunk(
+  virtual StatusOr<ResumableUploadResponse> UploadSessionChunk(
       UploadChunkRequest const&);
-  virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
+  virtual StatusOr<ResumableUploadResponse> QueryResumableSession(
       QueryResumableUploadRequest const&);
   StatusOr<CreateResumableSessionResponse> FullyRestoreResumableSession(
       ResumableUploadRequest const& request, std::string const& session_id);
@@ -125,8 +125,15 @@ class CurlClient : public RawClient,
       ComposeObjectRequest const& request) override;
   StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
+
+  StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
+      ResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
+      QueryResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> UploadChunk(
+      UploadChunkRequest const& request) override;
 
   StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -144,7 +144,7 @@ TEST(CurlClientStandaloneFunctions, HostHeader) {
 TEST_P(CurlClientTest, UploadChunk) {
   // Use an invalid port (0) to force a libcurl failure
   auto actual = client_
-                    ->UploadChunk(UploadChunkRequest(
+                    ->UploadSessionChunk(UploadChunkRequest(
                         "http://localhost:1/invalid-session-id", 0,
                         {ConstBuffer{std::string{}}}, 0))
                     .status();
@@ -154,7 +154,7 @@ TEST_P(CurlClientTest, UploadChunk) {
 TEST_P(CurlClientTest, QueryResumableUpload) {
   // Use http://localhost:1 to force a libcurl failure
   auto actual = client_
-                    ->QueryResumableUpload(QueryResumableUploadRequest(
+                    ->QueryResumableSession(QueryResumableUploadRequest(
                         "http://localhost:9/invalid-session-id"))
                     .status();
   CheckStatus(actual);

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -27,7 +27,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
       request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
       request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
       request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
-  auto result = client_->UploadChunk(request);
+  auto result = client_->UploadSessionChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
 }
@@ -40,7 +40,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
       request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
       request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
       request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
-  auto result = client_->UploadChunk(request);
+  auto result = client_->UploadSessionChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
 }
@@ -51,7 +51,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::ResetSession() {
       request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
       request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
       request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
-  auto result = client_->QueryResumableUpload(request);
+  auto result = client_->QueryResumableSession(request);
   Update(result, 0);
   return result;
 }

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -38,9 +38,9 @@ class MockCurlClient : public CurlClient {
       : CurlClient(internal::DefaultOptions(
             oauth2::CreateAnonymousCredentials(), {})) {}
 
-  MOCK_METHOD(StatusOr<ResumableUploadResponse>, UploadChunk,
+  MOCK_METHOD(StatusOr<ResumableUploadResponse>, UploadSessionChunk,
               (UploadChunkRequest const&), (override));
-  MOCK_METHOD(StatusOr<ResumableUploadResponse>, QueryResumableUpload,
+  MOCK_METHOD(StatusOr<ResumableUploadResponse>, QueryResumableSession,
               (QueryResumableUploadRequest const&), (override));
 };
 
@@ -66,7 +66,7 @@ TEST(CurlResumableUploadSessionTest, Simple) {
   std::string const payload = "test payload";
   auto const size = payload.size();
 
-  EXPECT_CALL(*mock, UploadChunk)
+  EXPECT_CALL(*mock, UploadSessionChunk)
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(request.GetOption<CustomHeader>().value_or(""),
                   "custom-value");
@@ -115,7 +115,7 @@ TEST(CurlResumableUploadSessionTest, Reset) {
   std::string const payload = "test payload";
   auto const size = payload.size();
 
-  EXPECT_CALL(*mock, UploadChunk)
+  EXPECT_CALL(*mock, UploadSessionChunk)
       .WillOnce([&](UploadChunkRequest const&) {
         return make_status_or(ResumableUploadResponse{
             "", ResumableUploadResponse::kInProgress, size, {}, {}});
@@ -126,7 +126,7 @@ TEST(CurlResumableUploadSessionTest, Reset) {
       });
   const ResumableUploadResponse resume_response{
       url2, ResumableUploadResponse::kInProgress, 2 * size, {}, {}};
-  EXPECT_CALL(*mock, QueryResumableUpload)
+  EXPECT_CALL(*mock, QueryResumableSession)
       .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ(request.GetOption<CustomHeader>().value_or(""),
                   "custom-value");
@@ -164,7 +164,7 @@ TEST(CurlResumableUploadSessionTest, Empty) {
   std::string const payload{};
   auto const size = payload.size();
 
-  EXPECT_CALL(*mock, UploadChunk)
+  EXPECT_CALL(*mock, UploadSessionChunk)
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -117,7 +117,7 @@ std::unique_ptr<GrpcClient::WriteObjectStream> GrpcClient::CreateUploadWriter(
   return stub_->WriteObject(std::move(context));
 }
 
-StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableUpload(
+StatusOr<ResumableUploadResponse> GrpcClient::QueryResumableSession(
     QueryResumableUploadRequest const& request) {
   OptionsSpan span(options_);
   grpc::ClientContext context;
@@ -469,9 +469,24 @@ StatusOr<CreateResumableSessionResponse> GrpcClient::CreateResumableSession(
                               /*.annotations=*/std::string{}}};
 }
 
+StatusOr<CreateResumableUploadResponse> GrpcClient::CreateResumableUpload(
+    ResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
+StatusOr<QueryResumableUploadResponse> GrpcClient::QueryResumableUpload(
+    QueryResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
 StatusOr<EmptyResponse> GrpcClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const&) {
   return Status(StatusCode::kUnimplemented, __func__);
+}
+
+StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
+    UploadChunkRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
 }
 
 StatusOr<ListBucketAclResponse> GrpcClient::ListBucketAcl(

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -67,7 +67,7 @@ class GrpcClient : public RawClient,
       google::storage::v2::WriteObjectResponse>;
   virtual std::unique_ptr<WriteObjectStream> CreateUploadWriter(
       std::unique_ptr<grpc::ClientContext> context);
-  virtual StatusOr<ResumableUploadResponse> QueryResumableUpload(
+  virtual StatusOr<ResumableUploadResponse> QueryResumableSession(
       QueryResumableUploadRequest const&);
   StatusOr<CreateResumableSessionResponse> FullyRestoreResumableSession(
       ResumableUploadRequest const& request, std::string const& upload_url);
@@ -119,8 +119,15 @@ class GrpcClient : public RawClient,
       RewriteObjectRequest const&) override;
   StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
+
+  StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
+      ResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
+      QueryResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> UploadChunk(
+      UploadChunkRequest const& request) override;
 
   StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -97,7 +97,7 @@ TEST_F(GrpcClientTest, QueryResumableUpload) {
         return PermanentError();
       });
   auto client = CreateTestClient(mock);
-  auto response = client->QueryResumableUpload(
+  auto response = client->QueryResumableSession(
       QueryResumableUploadRequest("test-only-upload-id")
           .set_multiple_options(Fields("field1,field2"),
                                 QuotaUser("test-quota-user")));

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -56,7 +56,7 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadFinalChunk(
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_params_.upload_id);
-  auto result = client_->QueryResumableUpload(request);
+  auto result = client_->QueryResumableSession(request);
   if (!result) return result;
 
   committed_size_ = result->committed_size.value_or(0);

--- a/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session_test.cc
@@ -57,7 +57,7 @@ class MockGrpcClient : public GrpcClient {
   MOCK_METHOD(std::unique_ptr<GrpcClient::WriteObjectStream>,
               CreateUploadWriter, (std::unique_ptr<grpc::ClientContext>),
               (override));
-  MOCK_METHOD(StatusOr<ResumableUploadResponse>, QueryResumableUpload,
+  MOCK_METHOD(StatusOr<ResumableUploadResponse>, QueryResumableSession,
               (QueryResumableUploadRequest const&), (override));
 };
 
@@ -219,7 +219,7 @@ TEST(GrpcResumableUploadSessionTest, Reset) {
         return std::unique_ptr<GrpcClient::WriteObjectStream>(writer.release());
       });
 
-  EXPECT_CALL(*mock, QueryResumableUpload)
+  EXPECT_CALL(*mock, QueryResumableSession)
       .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ("test-upload-id", request.upload_session_url());
         return make_status_or(ResumableUploadResponse{
@@ -292,7 +292,7 @@ TEST(GrpcResumableUploadSessionTest, ResumeFromEmpty) {
 
   ResumableUploadResponse const resume_response{
       {}, ResumableUploadResponse::kInProgress, 0, {}, {}};
-  EXPECT_CALL(*mock, QueryResumableUpload)
+  EXPECT_CALL(*mock, QueryResumableSession)
       .WillOnce([&](QueryResumableUploadRequest const& request) {
         EXPECT_EQ("test-upload-id", request.upload_session_url());
         return make_status_or(resume_response);

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -138,12 +138,27 @@ StatusOr<CreateResumableSessionResponse> HybridClient::CreateResumableSession(
   return grpc_->CreateResumableSession(request);
 }
 
+StatusOr<CreateResumableUploadResponse> HybridClient::CreateResumableUpload(
+    ResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
+StatusOr<QueryResumableUploadResponse> HybridClient::QueryResumableUpload(
+    QueryResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
 StatusOr<EmptyResponse> HybridClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   if (internal::IsGrpcResumableSessionUrl(request.upload_session_url())) {
     return grpc_->DeleteResumableUpload(request);
   }
   return curl_->DeleteResumableUpload(request);
+}
+
+StatusOr<QueryResumableUploadResponse> HybridClient::UploadChunk(
+    UploadChunkRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
 }
 
 StatusOr<ListBucketAclResponse> HybridClient::ListBucketAcl(

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -76,8 +76,15 @@ class HybridClient : public RawClient {
       RewriteObjectRequest const&) override;
   StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
+
+  StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
+      ResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
+      QueryResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> UploadChunk(
+      UploadChunkRequest const& request) override;
 
   StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -203,10 +203,25 @@ StatusOr<CreateResumableSessionResponse> LoggingClient::CreateResumableSession(
   return result;
 }
 
+StatusOr<CreateResumableUploadResponse> LoggingClient::CreateResumableUpload(
+    ResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
+StatusOr<QueryResumableUploadResponse> LoggingClient::QueryResumableUpload(
+    QueryResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
 StatusOr<EmptyResponse> LoggingClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   return MakeCall(*client_, &RawClient::DeleteResumableUpload, request,
                   __func__);
+}
+
+StatusOr<QueryResumableUploadResponse> LoggingClient::UploadChunk(
+    UploadChunkRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
 }
 
 StatusOr<ListBucketAclResponse> LoggingClient::ListBucketAcl(

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -74,8 +74,15 @@ class LoggingClient : public RawClient {
       RewriteObjectRequest const&) override;
   StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
+
+  StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
+      ResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
+      QueryResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> UploadChunk(
+      UploadChunkRequest const& request) override;
 
   StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -102,8 +102,15 @@ class RawClient {
   GOOGLE_CLOUD_CPP_STORAGE_RESTORE_UPLOAD_DEPRECATED()
   virtual StatusOr<std::unique_ptr<ResumableUploadSession>>
   RestoreResumableSession(std::string const& session_id);
+
+  virtual StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
+      ResumableUploadRequest const& request) = 0;
+  virtual StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
+      QueryResumableUploadRequest const& request) = 0;
   virtual StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) = 0;
+  virtual StatusOr<QueryResumableUploadResponse> UploadChunk(
+      UploadChunkRequest const& request) = 0;
   //@}
 
   //@{

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -363,6 +363,16 @@ StatusOr<CreateResumableSessionResponse> RetryClient::CreateResumableSession(
   return result;
 }
 
+StatusOr<CreateResumableUploadResponse> RetryClient::CreateResumableUpload(
+    ResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
+StatusOr<QueryResumableUploadResponse> RetryClient::QueryResumableUpload(
+    QueryResumableUploadRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+}
+
 StatusOr<EmptyResponse> RetryClient::DeleteResumableUpload(
     DeleteResumableUploadRequest const& request) {
   auto retry_policy = retry_policy_prototype_->clone();
@@ -370,6 +380,11 @@ StatusOr<EmptyResponse> RetryClient::DeleteResumableUpload(
   return MakeCall(*retry_policy, *backoff_policy, Idempotency::kIdempotent,
                   *client_, &RawClient::DeleteResumableUpload, request,
                   __func__);
+}
+
+StatusOr<QueryResumableUploadResponse> RetryClient::UploadChunk(
+    UploadChunkRequest const&) {
+  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
 }
 
 StatusOr<ListBucketAclResponse> RetryClient::ListBucketAcl(

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -85,8 +85,15 @@ class RetryClient : public RawClient,
       RewriteObjectRequest const&) override;
   StatusOr<CreateResumableSessionResponse> CreateResumableSession(
       ResumableUploadRequest const& request) override;
+
+  StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
+      ResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
+      QueryResumableUploadRequest const& request) override;
   StatusOr<EmptyResponse> DeleteResumableUpload(
       DeleteResumableUploadRequest const& request) override;
+  StatusOr<QueryResumableUploadResponse> UploadChunk(
+      UploadChunkRequest const& request) override;
 
   StatusOr<ListBucketAclResponse> ListBucketAcl(
       ListBucketAclRequest const& request) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -83,8 +83,17 @@ class MockClient : public google::cloud::storage::internal::RawClient {
               (override));
   MOCK_METHOD(StatusOr<std::unique_ptr<internal::ResumableUploadSession>>,
               RestoreResumableSession, (std::string const&), (override));
+
+  MOCK_METHOD(StatusOr<internal::CreateResumableUploadResponse>,
+              CreateResumableUpload, (internal::ResumableUploadRequest const&),
+              (override));
+  MOCK_METHOD(StatusOr<internal::QueryResumableUploadResponse>,
+              QueryResumableUpload,
+              (internal::QueryResumableUploadRequest const&), (override));
   MOCK_METHOD(StatusOr<internal::EmptyResponse>, DeleteResumableUpload,
               (internal::DeleteResumableUploadRequest const&), (override));
+  MOCK_METHOD(StatusOr<internal::QueryResumableUploadResponse>, UploadChunk,
+              (internal::UploadChunkRequest const&), (override));
 
   MOCK_METHOD(StatusOr<internal::ListBucketAclResponse>, ListBucketAcl,
               (internal::ListBucketAclRequest const&), (override));


### PR DESCRIPTION
The plan is to remove the "sessions" used for resumable uploads. To that
end this PR introduces the new functions that implement resumable
uploads, albeit they are unused and unimplemented.

Part of the work for #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8712)
<!-- Reviewable:end -->
