### PR TITLE
cleanup(common): fix clang-tidy 14 warnings

### DIFF
--- a/google/cloud/connection_options_test.cc
+++ b/google/cloud/connection_options_test.cc
@@ -28,6 +28,7 @@ namespace {
 
 using ::testing::ElementsAre;
 using ::testing::StartsWith;
+using ::testing::UnorderedElementsAre;
 
 /// Use these traits to test ConnectionOptions.
 struct TestTraits {
@@ -118,7 +119,7 @@ TEST(ConnectionOptionsTest, DefaultTracingSet) {
   EXPECT_TRUE(conn_opts.tracing_enabled("bar"));
   EXPECT_TRUE(conn_opts.tracing_enabled("baz"));
   EXPECT_THAT(internal::MakeOptions(conn_opts).get<TracingComponentsOption>(),
-              testing::UnorderedElementsAre("foo", "bar", "baz"));
+              UnorderedElementsAre("foo", "bar", "baz"));
 }
 
 TEST(ConnectionOptionsTest, TracingOptions) {
@@ -152,13 +153,13 @@ TEST(ConnectionOptionsTest, UserAgentProducts) {
   TestConnectionOptions conn_opts(grpc::InsecureChannelCredentials());
   EXPECT_EQ(TestTraits::user_agent_prefix(), conn_opts.user_agent_prefix());
   EXPECT_THAT(internal::MakeOptions(conn_opts).get<UserAgentProductsOption>(),
-              testing::ElementsAre(conn_opts.user_agent_prefix()));
+              ElementsAre(conn_opts.user_agent_prefix()));
 
   conn_opts.add_user_agent_prefix("test-prefix/1.2.3");
   EXPECT_EQ("test-prefix/1.2.3 " + TestTraits::user_agent_prefix(),
             conn_opts.user_agent_prefix());
   EXPECT_THAT(internal::MakeOptions(conn_opts).get<UserAgentProductsOption>(),
-              testing::ElementsAre(conn_opts.user_agent_prefix()));
+              ElementsAre(conn_opts.user_agent_prefix()));
 }
 
 TEST(ConnectionOptionsTest, CreateChannelArgumentsDefault) {

--- a/google/cloud/future_generic_test.cc
+++ b/google/cloud/future_generic_test.cc
@@ -23,7 +23,7 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator"" _ms;
+using testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using testing_util::ExpectFutureError;
 using testing_util::ScopedThread;
 

--- a/google/cloud/future_generic_then_test.cc
+++ b/google/cloud/future_generic_then_test.cc
@@ -24,8 +24,8 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator"" _ms;
-using testing_util::ExpectFutureError;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
+using ::google::cloud::testing_util::ExpectFutureError;
 
 TEST(FutureTestInt, ThenSimple) {
   promise<int> p;

--- a/google/cloud/future_void_test.cc
+++ b/google/cloud/future_void_test.cc
@@ -23,7 +23,7 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator"" _ms;
+using testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using testing_util::ExpectFutureError;
 using testing_util::ScopedThread;
 

--- a/google/cloud/future_void_then_test.cc
+++ b/google/cloud/future_void_then_test.cc
@@ -24,7 +24,7 @@ namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator"" _ms;
+using testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using testing_util::ExpectFutureError;
 
 TEST(FutureTestVoid, ThenSimple) {

--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -39,8 +39,7 @@ class AsyncPollingLoopImpl
         cancel_(std::move(cancel)),
         polling_policy_(std::move(polling_policy)),
         location_(std::move(location)),
-        promise_(null_promise_t{}),
-        delayed_cancel_(false) {}
+        promise_(null_promise_t{}) {}
 
   future<StatusOr<Operation>> Start(future<StatusOr<Operation>> op) {
     auto self = shared_from_this();
@@ -167,8 +166,8 @@ class AsyncPollingLoopImpl
   // `delayed_cancel_` and `op_name_`, in contrast, are also used from
   // `DoCancel()`, which is called asynchronously, so they need locking.
   std::mutex mu_;
-  bool delayed_cancel_;  // GUARDED_BY(mu_)
-  std::string op_name_;  // GUARDED_BY(mu_)
+  bool delayed_cancel_ = false;  // GUARDED_BY(mu_)
+  std::string op_name_;          // GUARDED_BY(mu_)
 };
 
 future<StatusOr<Operation>> AsyncPollingLoop(

--- a/google/cloud/internal/async_retry_loop.h
+++ b/google/cloud/internal/async_retry_loop.h
@@ -310,7 +310,7 @@ class AsyncRetryLoopImpl
     return State{true, 0};
   }
 
-  void Cancel() { return Cancel(std::unique_lock<std::mutex>(mu_)); }
+  void Cancel() { return Cancel(std::unique_lock<std::mutex>{mu_}); }
 
   void Cancel(std::unique_lock<std::mutex> lk) {
     cancelled_ = true;

--- a/google/cloud/internal/async_retry_unary_rpc_test.cc
+++ b/google/cloud/internal/async_retry_unary_rpc_test.cc
@@ -33,7 +33,7 @@ namespace btadmin = ::google::bigtable::admin::v2;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::MockAsyncResponseReader;
 using ::google::cloud::testing_util::StatusIs;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::testing::HasSubstr;
 using ::testing::Return;
 

--- a/google/cloud/internal/base64_transforms.h
+++ b/google/cloud/internal/base64_transforms.h
@@ -56,7 +56,7 @@ struct Base64Decoder {
     using reference = value_type&;
 
     Iterator(std::string::const_iterator begin, std::string::const_iterator end)
-        : pos_(begin), end_(end), len_(0) {
+        : pos_(begin), end_(end) {
       Fill();
     }
 
@@ -85,7 +85,7 @@ struct Base64Decoder {
    private:
     std::string::const_iterator pos_;  // [pos_ .. end_) pending decode
     std::string::const_iterator end_;
-    std::size_t len_;  // buf_[len_ .. 1] decoded
+    std::size_t len_ = 0;  // buf_[len_ .. 1] decoded
     std::array<value_type, 1 + 3> buf_;
   };
 

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -172,18 +172,11 @@ CurlImpl::CurlImpl(CurlHandle handle,
                    std::shared_ptr<CurlHandleFactory> factory, Options options)
     : factory_(std::move(factory)),
       request_headers_(nullptr, &curl_slist_free_all),
-      logging_enabled_(false),
       transfer_stall_timeout_(0),
       download_stall_timeout_(0),
-      closing_(false),
-      curl_closed_(false),
       handle_(std::move(handle)),
       multi_(factory_->CreateMultiHandle()),
-      in_multi_(false),
-      paused_(false),
-      all_headers_received_(false),
       buffer_({nullptr, 0}),
-      spill_offset_(0),
       options_(std::move(options)) {
   CurlInitializeOnce(options_);
   ApplyOptions(options_);

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -114,7 +114,7 @@ class CurlImpl {
   CurlReceivedHeaders received_headers_;
   std::string url_;
   std::string user_agent_;
-  bool logging_enabled_;
+  bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds transfer_stall_timeout_;
   std::chrono::seconds download_stall_timeout_;
@@ -132,21 +132,21 @@ class CurlImpl {
   // PerformWork() sets the curl_closed_ flags to true.
   //
   // The closing_ flag is set when we enter step 1.
-  bool closing_;
+  bool closing_ = false;
   // The curl_closed_ flag is set when we enter step 2, or when the transfer
   // completes.
-  bool curl_closed_;
+  bool curl_closed_ = false;
 
   CurlHandle handle_;
   CurlMulti multi_;
   // Track whether `handle_` has been added to `multi_` or not. The exact
   // lifecycle for the handle depends on the libcurl version, and using this
   // flag makes the code less elegant, but less prone to bugs.
-  bool in_multi_;
-  bool paused_;
+  bool in_multi_ = false;
+  bool paused_ = false;
 
   // Track when status and headers from the response are received.
-  bool all_headers_received_;
+  bool all_headers_received_ = false;
 
   // Track the usage of the buffer provided to Read.
   absl::Span<char> buffer_;
@@ -158,7 +158,7 @@ class CurlImpl {
   // additional bytes. We get better performance using a slightly larger buffer
   // (128KiB) than the default buffer size set by libcurl (16KiB).
   std::array<char, 128 * 1024L> spill_;
-  std::size_t spill_offset_;
+  std::size_t spill_offset_ = 0;
 
   Options options_;
 };

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -28,7 +28,6 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::HasSubstr;
@@ -71,8 +70,8 @@ class RestClientIntegrationTest : public ::testing::Test {
     ASSERT_TRUE(content_length != headers.end());
     EXPECT_GT(std::stoi(content_length->second), 0);
 
-    EXPECT_THAT(headers, testing::Contains(std::make_pair("content-type",
-                                                          "application/json")));
+    EXPECT_THAT(headers,
+                Contains(std::make_pair("content-type", "application/json")));
     std::unique_ptr<HttpPayload> payload =
         std::move(*response).ExtractPayload();
     auto body = ReadAll(std::move(payload));

--- a/google/cloud/internal/extract_long_running_result_test.cc
+++ b/google/cloud/internal/extract_long_running_result_test.cc
@@ -29,7 +29,6 @@ using ::google::bigtable::admin::v2::Instance;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
-using ::google::longrunning::Operation;
 using ::testing::HasSubstr;
 
 TEST(ExtractLongRunningResultTest, MetadataDoneWithSuccess) {

--- a/google/cloud/internal/future_impl_test.cc
+++ b/google/cloud/internal/future_impl_test.cc
@@ -26,7 +26,7 @@ namespace internal {
 namespace {
 
 using ::testing::HasSubstr;
-using testing_util::chrono_literals::operator"" _us;
+using testing_util::chrono_literals::operator"" _us;  // NOLINT
 using testing_util::ExpectFutureError;
 using testing_util::NoDefaultConstructor;
 using testing_util::Observable;

--- a/google/cloud/internal/log_impl.h
+++ b/google/cloud/internal/log_impl.h
@@ -46,8 +46,6 @@ class CircularBufferBackend : public LogBackend {
   CircularBufferBackend(std::size_t size, Severity min_flush_severity,
                         std::shared_ptr<LogBackend> backend)
       : buffer_(size),
-        begin_(0),
-        end_(0),
         min_flush_severity_(min_flush_severity),
         backend_(std::move(backend)) {}
 
@@ -66,8 +64,8 @@ class CircularBufferBackend : public LogBackend {
 
   std::mutex mu_;
   std::vector<LogRecord> buffer_;
-  std::size_t begin_;
-  std::size_t end_;
+  std::size_t begin_ = 0;
+  std::size_t end_ = 0;
   Severity min_flush_severity_;
   std::shared_ptr<LogBackend> backend_;
 };

--- a/google/cloud/internal/oauth2_authorized_user_credentials.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.cc
@@ -79,8 +79,7 @@ ParseAuthorizedUserRefreshResponse(rest_internal::RestResponse& response,
   std::string header_value = access_token.value("token_type", "");
   header_value += ' ';
   header_value += access_token.value("access_token", "");
-  auto expires_in =
-      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
   return RefreshingCredentialsWrapper::TemporaryToken{
       std::make_pair("Authorization", std::move(header_value)), new_expiration};

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -72,8 +72,7 @@ ParseComputeEngineRefreshResponse(rest_internal::RestResponse& response,
   std::string header_value = access_token.value("token_type", "");
   header_value += ' ';
   header_value += access_token.value("access_token", "");
-  auto expires_in =
-      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
 
   return RefreshingCredentialsWrapper::TemporaryToken{

--- a/google/cloud/internal/oauth2_google_credentials_test.cc
+++ b/google/cloud/internal/oauth2_google_credentials_test.cc
@@ -32,7 +32,6 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AllOf;

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest_test.cc
@@ -91,7 +91,7 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenSuccess) {
 
   EXPECT_CALL(*mock_rest_client_,
               Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](rest_internal::RestRequest const& request,
+      .WillOnce([&](RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(),
                     Eq(absl::StrCat("projects/-/serviceAccounts/",
@@ -149,7 +149,7 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenNonRfc3339Time) {
 
   EXPECT_CALL(*mock_rest_client_,
               Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](rest_internal::RestRequest const& request,
+      .WillOnce([&](RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(),
                     Eq(absl::StrCat("projects/-/serviceAccounts/",
@@ -205,7 +205,7 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenInvalidResponse) {
 
   EXPECT_CALL(*mock_rest_client_,
               Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](rest_internal::RestRequest const& request,
+      .WillOnce([&](RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(),
                     Eq(absl::StrCat("projects/-/serviceAccounts/",
@@ -254,7 +254,7 @@ TEST_F(MinimalIamCredentialsRestTest, GenerateAccessTokenPostFailure) {
 
   EXPECT_CALL(*mock_rest_client_,
               Post(_, A<std::vector<absl::Span<char const>> const&>()))
-      .WillOnce([&](rest_internal::RestRequest const& request,
+      .WillOnce([&](RestRequest const& request,
                     std::vector<absl::Span<char const>> const& payload) {
         EXPECT_THAT(request.path(),
                     Eq(absl::StrCat("projects/-/serviceAccounts/",

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -156,8 +156,7 @@ ParseServiceAccountRefreshResponse(rest_internal::RestResponse& response,
   std::string header_value = access_token.value("token_type", "");
   header_value += ' ';
   header_value += access_token.value("access_token", "");
-  auto expires_in =
-      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
   return RefreshingCredentialsWrapper::TemporaryToken{
       std::make_pair("Authorization", header_value), new_expiration};

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -35,10 +35,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::rest_internal::HttpPayload;
-using ::google::cloud::rest_internal::RestRequest;
-using ::google::cloud::rest_internal::RestResponse;
 using ::google::cloud::testing_util::FakeClock;
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::MockHttpPayload;
 using ::google::cloud::testing_util::MockRestClient;
 using ::google::cloud::testing_util::MockRestResponse;

--- a/google/cloud/internal/pagination_range.h
+++ b/google/cloud/internal/pagination_range.h
@@ -80,8 +80,7 @@ class PagedStreamReader {
                     std::function<std::vector<T>(Response)> extractor)
       : request_(std::move(request)),
         loader_(std::move(loader)),
-        extractor_(std::move(extractor)),
-        last_page_(false) {
+        extractor_(std::move(extractor)) {
     current_ = page_.begin();
   }
 
@@ -132,7 +131,7 @@ class PagedStreamReader {
   std::vector<T> page_;
   typename std::vector<T>::iterator current_;
   std::string token_;
-  bool last_page_;
+  bool last_page_ = false;
 };
 
 /**

--- a/google/cloud/internal/random.cc
+++ b/google/cloud/internal/random.cc
@@ -83,7 +83,7 @@ std::vector<unsigned int> FetchEntropy(std::size_t desired_bits) {
 std::string Sample(DefaultPRNG& gen, int n, std::string const& population) {
   std::uniform_int_distribution<std::size_t> rd(0, population.size() - 1);
 
-  std::string result(std::size_t(n), '0');
+  std::string result(n, '0');
   std::generate(result.begin(), result.end(),
                 [&rd, &gen, &population]() { return population[rd(gen)]; });
   return result;

--- a/google/cloud/internal/retry_policy.h
+++ b/google/cloud/internal/retry_policy.h
@@ -121,7 +121,7 @@ class LimitedErrorCountRetryPolicy
   using BaseType = TraitBasedRetryPolicy<RetryablePolicy>;
 
   explicit LimitedErrorCountRetryPolicy(int maximum_failures)
-      : failure_count_(0), maximum_failures_(maximum_failures) {}
+      : maximum_failures_(maximum_failures) {}
 
   LimitedErrorCountRetryPolicy(LimitedErrorCountRetryPolicy&& rhs) noexcept
       : LimitedErrorCountRetryPolicy(rhs.maximum_failures_) {}
@@ -141,7 +141,7 @@ class LimitedErrorCountRetryPolicy
   void OnFailureImpl() override { ++failure_count_; }
 
  private:
-  int failure_count_;
+  int failure_count_ = 0;
   int maximum_failures_;
 };
 

--- a/google/cloud/log.h
+++ b/google/cloud/log.h
@@ -202,12 +202,12 @@ enum class Severity : int {
   /// The system is unusable.  GCP_LOG(FATAL) will call std::abort().
   GCP_LS_FATAL,  // NOLINT(readability-identifier-naming)
   /// The highest possible severity level.
-  GCP_LS_HIGHEST = int(GCP_LS_FATAL),  // NOLINT(readability-identifier-naming)
+  GCP_LS_HIGHEST = GCP_LS_FATAL,  // NOLINT(readability-identifier-naming)
   /// The lowest possible severity level.
-  GCP_LS_LOWEST = int(GCP_LS_TRACE),  // NOLINT(readability-identifier-naming)
+  GCP_LS_LOWEST = GCP_LS_TRACE,  // NOLINT(readability-identifier-naming)
   /// The lowest level that is enabled at compile-time.
   // NOLINTNEXTLINE(readability-identifier-naming)
-  GCP_LS_LOWEST_ENABLED = int(GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED),
+  GCP_LS_LOWEST_ENABLED = GOOGLE_CLOUD_CPP_LOGGING_MIN_SEVERITY_ENABLED,
 };
 
 /// Streaming operator, writes a human readable representation.


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by #8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8715)
<!-- Reviewable:end -->
