### PR TITLE
cleanup(bigtable): fix clang-tidy 14 warnings

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/instance_admin_integration_test.cc
@@ -41,7 +41,6 @@ namespace {
 
 using ::google::cloud::internal::GetEnv;
 using ::google::cloud::testing_util::ContainsOnce;
-using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 using ::testing::IsEmpty;

--- a/google/cloud/bigtable/async_row_reader.h
+++ b/google/cloud/bigtable/async_row_reader.h
@@ -104,10 +104,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
         rpc_retry_policy_(std::move(rpc_retry_policy)),
         rpc_backoff_policy_(std::move(rpc_backoff_policy)),
         metadata_update_policy_(std::move(metadata_update_policy)),
-        parser_factory_(std::move(parser_factory)),
-        rows_count_(0),
-        whole_op_finished_(),
-        recursion_level_() {}
+        parser_factory_(std::move(parser_factory)) {}
 
   void MakeRequest() {
     status_ = Status();
@@ -398,7 +395,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
   std::unique_ptr<internal::ReadRowsParserFactory> parser_factory_;
   std::unique_ptr<internal::ReadRowsParser> parser_;
   /// Number of rows read so far, used to set row_limit in retries.
-  std::int64_t rows_count_;
+  std::int64_t rows_count_ = 0;
   /// Holds the last read row key, for retries.
   RowKeyType last_read_row_key_;
   /// The queue of rows which we already received but no one has asked for them.
@@ -414,7 +411,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
    */
   absl::optional<promise<bool>> continue_reading_;
   /// The final status of the operation.
-  bool whole_op_finished_;
+  bool whole_op_finished_ = false;
   /**
    * The status of the last retry attempt_.
    *
@@ -424,7 +421,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
    */
   Status status_;
   /// Tracks the level of recursion of TryGiveRowToUser
-  int recursion_level_;
+  int recursion_level_ = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/async_row_reader_test.cc
+++ b/google/cloud/bigtable/async_row_reader_test.cc
@@ -36,7 +36,7 @@ namespace btproto = ::google::bigtable::v2;
 
 using ::google::cloud::bigtable::testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::HasSubstr;
 using ::testing::Values;

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -68,7 +68,7 @@ google::cloud::StatusOr<long> RunBenchmark(  // NOLINT(google-runtime-int)
 }  // anonymous namespace
 
 int main(int argc, char* argv[]) {
-  auto options = bigtable::benchmarks::ParseArgs(argc, argv, kDescription);
+  auto options = ParseArgs(argc, argv, kDescription);
   if (!options) {
     std::cerr << options.status() << "\n";
     return -1;

--- a/google/cloud/bigtable/client_options.cc
+++ b/google/cloud/bigtable/client_options.cc
@@ -52,8 +52,9 @@ ClientOptions::ClientOptions(std::shared_ptr<grpc::ChannelCredentials> creds)
 
 // NOLINTNEXTLINE(readability-identifier-naming)
 ClientOptions& ClientOptions::set_connection_pool_size(std::size_t size) {
-  opts_.set<GrpcNumChannelsOption>(
-      size == 0 ? internal::DefaultConnectionPoolSize() : int(size));
+  opts_.set<GrpcNumChannelsOption>(size == 0
+                                       ? internal::DefaultConnectionPoolSize()
+                                       : static_cast<int>(size));
   return *this;
 }
 

--- a/google/cloud/bigtable/column_family_test.cc
+++ b/google/cloud/bigtable/column_family_test.cc
@@ -22,11 +22,12 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _h;
+// NOLINTNEXTLINE
 using ::google::cloud::testing_util::chrono_literals::operator"" _min;
-using ::google::cloud::testing_util::chrono_literals::operator"" _s;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ns;
+using ::google::cloud::testing_util::chrono_literals::operator"" _h;   // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _s;   // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _ns;  // NOLINT
 
 TEST(GcRule, MaxNumVersions) {
   auto proto = GcRule::MaxNumVersions(3).as_proto();

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -37,10 +37,10 @@ void HelloWorldAppProfile(std::vector<std::string> const& argv) {
         "hello-world-app-profile <project-id> <instance-id>"
         " <table-id> <profile-id>"};
   }
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const table_id = argv[2];
-  std::string const profile_id = argv[3];
+  std::string const& project_id = argv[0];
+  std::string const& instance_id = argv[1];
+  std::string const& table_id = argv[2];
+  std::string const& profile_id = argv[3];
 
   // Create an object to access the Cloud Bigtable Data API.
   auto data_client = cbt::MakeDataClient(project_id, instance_id);

--- a/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_instance_admin.cc
@@ -39,10 +39,10 @@ void BigtableHelloInstance(std::vector<std::string> const& argv) {
         "<zone>"};
   }
 
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const cluster_id = argv[2];
-  std::string const zone = argv[3];
+  std::string const& project_id = argv[0];
+  std::string const& instance_id = argv[1];
+  std::string const& cluster_id = argv[2];
+  std::string const& zone = argv[3];
 
   //! [aliases]
   namespace cbt = ::google::cloud::bigtable;

--- a/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_table_admin.cc
@@ -37,9 +37,9 @@ void HelloWorldTableAdmin(std::vector<std::string> const& argv) {
         "hello-world-table-admin <project-id> <instance-id> "
         "<table-id>"};
   }
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const table_id = argv[2];
+  std::string const& project_id = argv[0];
+  std::string const& instance_id = argv[1];
+  std::string const& table_id = argv[2];
 
   //! [aliases]
   namespace cbt = ::google::cloud::bigtable;

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -34,9 +34,9 @@ void BigtableHelloWorld(std::vector<std::string> const& argv) {
   if (argv.size() != 3) {
     throw Usage{"hello-world <project-id> <instance-id> <table-id>"};
   }
-  std::string const project_id = argv[0];
-  std::string const instance_id = argv[1];
-  std::string const table_id = argv[2];
+  std::string const& project_id = argv[0];
+  std::string const& instance_id = argv[1];
+  std::string const& table_id = argv[2];
 
   // Create a namespace alias to make the code easier to read.
   //! [aliases]

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -658,7 +658,7 @@ void DeleteAppProfile(std::vector<std::string> const& argv) {
 
   bool ignore_warnings = true;
   if (argv.size() == 4) {
-    std::string arg = argv[3];
+    std::string const& arg = argv[3];
     if (arg == "true") {
       ignore_warnings = true;
     } else if (arg == "false") {

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -26,8 +26,8 @@ namespace {
 namespace btproto = ::google::bigtable::v2;
 
 using ::google::cloud::testing_util::IsProtoEqual;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 
 TEST(FiltersTest, PassAllFilter) {
   auto proto = Filter::PassAllFilter().as_proto();

--- a/google/cloud/bigtable/idempotent_mutation_policy_test.cc
+++ b/google/cloud/bigtable/idempotent_mutation_policy_test.cc
@@ -22,8 +22,8 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 
 /// @test Verify that the default policy works as expected.
 TEST(IdempotentMutationPolicyTest, Simple) {

--- a/google/cloud/bigtable/instance_admin_test.cc
+++ b/google/cloud/bigtable/instance_admin_test.cc
@@ -49,7 +49,6 @@ using ::google::cloud::bigtable::testing::MockBackoffPolicy;
 using ::google::cloud::bigtable::testing::MockPollingPolicy;
 using ::google::cloud::bigtable::testing::MockRetryPolicy;
 using ::google::cloud::bigtable_internal::InstanceAdminTester;
-using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::An;
 using ::testing::Contains;

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -36,7 +36,7 @@ namespace btproto = ::google::bigtable::v2;
 
 using ::google::cloud::bigtable::testing::MockBackoffPolicy;
 using ::google::cloud::bigtable::testing::MockClientAsyncReaderInterface;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::google::cloud::testing_util::StatusIs;
 

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -54,8 +54,7 @@ AsyncRowSampler::AsyncRowSampler(
       metadata_update_policy_(std::move(metadata_update_policy)),
       app_profile_id_(std::move(app_profile_id)),
       table_name_(std::move(table_name)),
-      stream_cancelled_(false),
-      promise_([&] { stream_cancelled_ = true; }) {}
+      promise_([this] { stream_cancelled_ = true; }) {}
 
 void AsyncRowSampler::StartIteration() {
   btproto::SampleRowKeysRequest request;

--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -67,7 +67,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::string app_profile_id_;
   std::string table_name_;
 
-  bool stream_cancelled_;
+  bool stream_cancelled_ = false;
   std::vector<RowKeySample> samples_;
   promise<StatusOr<std::vector<RowKeySample>>> promise_;
 };

--- a/google/cloud/bigtable/internal/bulk_mutator_test.cc
+++ b/google/cloud/bigtable/internal/bulk_mutator_test.cc
@@ -28,7 +28,7 @@ namespace {
 
 namespace btproto = ::google::bigtable::v2;
 using ::testing::Return;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::bigtable::testing::MockMutateRowsReader;
 
 std::unique_ptr<grpc::ClientContext> TestContext() {

--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -123,7 +123,6 @@ class CommonClient {
 
   explicit CommonClient(Options opts)
       : opts_(std::move(opts)),
-        current_index_(0),
         background_threads_(
             google::cloud::internal::DefaultBackgroundThreads(1)),
         refresh_cq_(
@@ -241,11 +240,11 @@ class CommonClient {
   }
 
   std::mutex mu_;
-  std::size_t num_pending_refreshes_{};
+  std::size_t num_pending_refreshes_ = 0;
   google::cloud::Options opts_;
   std::vector<ChannelPtr> channels_;
   std::vector<StubPtr> stubs_;
-  std::size_t current_index_;
+  std::size_t current_index_ = 0;
   std::unique_ptr<BackgroundThreads> background_threads_;
   // Timers, which we schedule for refreshes, need to reference the completion
   // queue. We cannot make the completion queue's underlying implementation

--- a/google/cloud/bigtable/mutation_batcher.h
+++ b/google/cloud/bigtable/mutation_batcher.h
@@ -94,10 +94,6 @@ class MutationBatcher {
   explicit MutationBatcher(Table table, Options options = Options())
       : table_(std::move(table)),
         options_(options),
-        num_outstanding_batches_(),
-        outstanding_size_(),
-        outstanding_mutations_(),
-        num_requests_pending_(),
         cur_batch_(std::make_shared<Batch>()) {}
 
   virtual ~MutationBatcher() = default;
@@ -200,10 +196,9 @@ class MutationBatcher {
    */
   struct MutationData {
     explicit MutationData(PendingSingleRowMutation pending)
-        : completion_promise(std::move(pending.completion_promise)),
-          done(false) {}
+        : completion_promise(std::move(pending.completion_promise)) {}
     CompletionPromise completion_promise;
-    bool done;
+    bool done = false;
   };
 
   /**
@@ -225,8 +220,8 @@ class MutationBatcher {
   struct Batch {
     Batch() = default;
 
-    size_t num_mutations{};
-    size_t requests_size{};
+    std::size_t num_mutations = 0;
+    std::size_t requests_size = 0;
     BulkMutation requests;
     std::vector<MutationData> mutation_data;
   };
@@ -287,13 +282,13 @@ class MutationBatcher {
   Options options_;
 
   /// Num batches sent but not completed.
-  size_t num_outstanding_batches_;
+  std::size_t num_outstanding_batches_ = 0;
   /// Size of admitted but uncompleted mutations.
-  size_t outstanding_size_;
+  std::size_t outstanding_size_ = 0;
   /// Number of admitted but uncompleted mutations.
-  size_t outstanding_mutations_;
+  std::size_t outstanding_mutations_ = 0;
   // Number of uncompleted SingleRowMutations (including not admitted).
-  size_t num_requests_pending_;
+  std::size_t num_requests_pending_ = 0;
 
   /// Currently constructed batch of mutations.
   std::shared_ptr<Batch> cur_batch_;

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -36,7 +36,7 @@ namespace bt = ::google::cloud::bigtable;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using bigtable::testing::MockClientAsyncReaderInterface;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
 using ::testing::Not;

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -27,8 +27,8 @@ namespace {
 
 namespace btproto = ::google::bigtable::v2;
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 
 /// @test Verify that SetCell() works as expected.
 TEST(MutationsTest, SetCell) {

--- a/google/cloud/bigtable/polling_policy_test.cc
+++ b/google/cloud/bigtable/polling_policy_test.cc
@@ -43,7 +43,7 @@ grpc::Status GrpcTransientError() {
   return grpc::Status(grpc::StatusCode::UNAVAILABLE, "try again");
 }
 
-using testing_util::chrono_literals::operator"" _ms;
+using testing_util::chrono_literals::operator"" _ms;  // NOLINT
 auto const kLimitedTimeTestPeriod = 100_ms;
 auto const kLimitedTimeTolerance = 20_ms;
 

--- a/google/cloud/bigtable/rpc_backoff_policy_test.cc
+++ b/google/cloud/bigtable/rpc_backoff_policy_test.cc
@@ -24,7 +24,7 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 
 /// Create a grpc::Status with a status code for transient errors.
 grpc::Status GrpcTransientError() {

--- a/google/cloud/bigtable/rpc_retry_policy_test.cc
+++ b/google/cloud/bigtable/rpc_retry_policy_test.cc
@@ -46,7 +46,7 @@ Status PermanentError() {
   return Status(StatusCode::kFailedPrecondition, "failed");
 }
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 
 auto const kLimitedTimeTestPeriod = 100_ms;
 auto const kLimitedTimeTolerance = 20_ms;

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -28,7 +28,7 @@ namespace {
 namespace bigtable = ::google::cloud::bigtable;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 
 class TableApplyTest : public bigtable::testing::TableTestFixture {
  protected:

--- a/google/cloud/bigtable/table_bulk_apply_test.cc
+++ b/google/cloud/bigtable/table_bulk_apply_test.cc
@@ -28,8 +28,8 @@ namespace {
 namespace btproto = ::google::bigtable::v2;
 
 using ::google::cloud::testing_util::IsOk;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::testing::Not;
 using ::testing::Return;
 

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -26,7 +26,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::ValidateMetadataFixture;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 
 class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
  protected:

--- a/google/cloud/bigtable/table_sample_row_keys_test.cc
+++ b/google/cloud/bigtable/table_sample_row_keys_test.cc
@@ -25,7 +25,7 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::google::cloud::bigtable::testing::MockSampleRowKeysReader;
 using ::testing::Return;
 using ::testing::Unused;

--- a/google/cloud/bigtable/testing/cleanup_stale_resources.cc
+++ b/google/cloud/bigtable/testing/cleanup_stale_resources.cc
@@ -41,7 +41,7 @@ Status CleanupStaleTables(
     if (!t) return std::move(t).status();
     std::vector<std::string> const components = absl::StrSplit(t->name(), '/');
     if (components.empty()) continue;
-    auto const id = components.back();
+    auto const& id = components.back();
     if (!std::regex_match(id, re)) continue;
     if (id >= max_table_id) continue;
     // Failure to cleanup is not an error.
@@ -65,7 +65,7 @@ Status CleanupStaleBackups(
     if (!b) return std::move(b).status();
     std::vector<std::string> const components = absl::StrSplit(b->name(), '/');
     if (components.empty()) continue;
-    auto const id = components.back();
+    auto const& id = components.back();
     if (!std::regex_match(id, re)) continue;
     if (id >= max_backup_id) continue;
     // Failure to cleanup is not an error.
@@ -89,7 +89,7 @@ Status CleanupStaleInstances(
   for (auto const& i : instances->instances()) {
     std::vector<std::string> const components = absl::StrSplit(i.name(), '/');
     if (components.empty()) continue;
-    auto const id = components.back();
+    auto const& id = components.back();
     if (!std::regex_match(id, re)) continue;
     if (id >= max_instance_id) continue;
     // Failure to cleanup is not an error.

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -21,7 +21,7 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using DataAsyncFutureIntegrationTest = bigtable::testing::TableIntegrationTest;
 
 std::string const kFamily = "family1";

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -27,7 +27,7 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::std::chrono::duration_cast;
 using ::std::chrono::microseconds;
 using ::std::chrono::milliseconds;

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -22,6 +22,7 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::testing::ContainerEq;
 
 using FilterIntegrationTest =
@@ -58,7 +59,6 @@ using FilterIntegrationTest =
  */
 void CreateComplexRows(Table& table, std::string const& prefix) {
   namespace bt = bigtable;
-  using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
 
   bt::BulkMutation mutation;
   // Prepare a set of rows, with different numbers of cells, columns, and
@@ -353,8 +353,6 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
 }
 
 TEST_F(FilterIntegrationTest, RowSample) {
-  using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
-
   auto table = GetTable();
   std::string const prefix = "row-sample-prefix";
 

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -23,7 +23,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::IsOk;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::testing::Not;
 
 using MutationIntegrationTest =


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by #8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8716)
<!-- Reviewable:end -->
