### PR TITLE
cleanup(generator): fix clang-tidy 14 warnings

### DIFF
--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_client_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_client_test.cc
@@ -170,8 +170,7 @@ TEST(GoldenKitchenSinkClientTest, WriteLogEntries) {
         EXPECT_EQ(request.log_name(), expected_log_name);
         std::map<std::string, std::string> labels = {request.labels().begin(),
                                                      request.labels().end()};
-        EXPECT_THAT(labels,
-                    testing::UnorderedElementsAreArray(expected_labels));
+        EXPECT_THAT(labels, UnorderedElementsAreArray(expected_labels));
         ::google::test::admin::database::v1::WriteLogEntriesResponse response;
         return response;
       });

--- a/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_connection_test.cc
@@ -127,7 +127,7 @@ TEST(GoldenThingAdminConnectionTest, ListDatabases) {
     actual_names.push_back(database->name());
   }
   EXPECT_THAT(actual_names,
-              ::testing::ElementsAre("db-1", "db-2", "db-3", "db-4", "db-5"));
+              ElementsAre("db-1", "db-2", "db-3", "db-4", "db-5"));
 }
 
 TEST(GoldenThingAdminConnectionTest, ListDatabasesPermanentFailure) {
@@ -904,9 +904,8 @@ TEST(GoldenThingAdminConnectionTest, ListBackups) {
     ASSERT_STATUS_OK(backup);
     actual_names.push_back(backup->name());
   }
-  EXPECT_THAT(actual_names,
-              ::testing::ElementsAre("backup-1", "backup-2", "backup-3",
-                                     "backup-4", "backup-5"));
+  EXPECT_THAT(actual_names, ElementsAre("backup-1", "backup-2", "backup-3",
+                                        "backup-4", "backup-5"));
 }
 
 TEST(GoldenThingAdminConnectionTest, ListBackupsPermanentFailure) {
@@ -1067,7 +1066,7 @@ TEST(GoldenThingAdminConnectionTest, ListDatabaseOperations) {
     actual_names.push_back(operation->name());
   }
   EXPECT_THAT(actual_names,
-              ::testing::ElementsAre("op-1", "op-2", "op-3", "op-4", "op-5"));
+              ElementsAre("op-1", "op-2", "op-3", "op-4", "op-5"));
 }
 
 TEST(GoldenThingAdminConnectionTest, ListDatabaseOperationsPermanentFailure) {
@@ -1149,7 +1148,7 @@ TEST(GoldenThingAdminConnectionTest, ListBackupOperations) {
     actual_names.push_back(operation->name());
   }
   EXPECT_THAT(actual_names,
-              ::testing::ElementsAre("op-1", "op-2", "op-3", "op-4", "op-5"));
+              ElementsAre("op-1", "op-2", "op-3", "op-4", "op-5"));
 }
 
 TEST(GoldenThingAdminConnectionTest, ListBackupOperationsPermanentFailure) {

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -41,8 +41,6 @@
 #include <string>
 
 using ::google::protobuf::FieldDescriptor;
-using ::google::protobuf::MethodDescriptor;
-using ::google::protobuf::ServiceDescriptor;
 using ::google::protobuf::compiler::cpp::FieldName;
 
 namespace google {

--- a/generator/internal/predicate_utils.cc
+++ b/generator/internal/predicate_utils.cc
@@ -28,9 +28,8 @@ using ::google::protobuf::FieldDescriptor;
 using ::google::protobuf::MethodDescriptor;
 
 // https://google.aip.dev/client-libraries/4233
-google::cloud::optional<
-    std::pair<std::string, google::protobuf::Descriptor const*>>
-DeterminePagination(google::protobuf::MethodDescriptor const& method) {
+google::cloud::optional<std::pair<std::string, Descriptor const*>>
+DeterminePagination(MethodDescriptor const& method) {
   std::string paginated_type;
   Descriptor const* request_message = method.input_type();
   FieldDescriptor const* page_size =
@@ -89,36 +88,35 @@ DeterminePagination(google::protobuf::MethodDescriptor const& method) {
                         std::get<1>(repeated_message_fields[0]));
 }
 
-bool IsPaginated(google::protobuf::MethodDescriptor const& method) {
+bool IsPaginated(MethodDescriptor const& method) {
   return DeterminePagination(method).has_value();
 }
 
-bool IsNonStreaming(google::protobuf::MethodDescriptor const& method) {
+bool IsNonStreaming(MethodDescriptor const& method) {
   return !method.client_streaming() && !method.server_streaming();
 }
 
-bool IsStreamingRead(google::protobuf::MethodDescriptor const& method) {
+bool IsStreamingRead(MethodDescriptor const& method) {
   return !method.client_streaming() && method.server_streaming();
 }
 
-bool IsStreamingWrite(google::protobuf::MethodDescriptor const& method) {
+bool IsStreamingWrite(MethodDescriptor const& method) {
   return method.client_streaming() && !method.server_streaming();
 }
 
-bool IsBidirStreaming(google::protobuf::MethodDescriptor const& method) {
+bool IsBidirStreaming(MethodDescriptor const& method) {
   return method.client_streaming() && method.server_streaming();
 }
 
-bool IsLongrunningOperation(google::protobuf::MethodDescriptor const& method) {
+bool IsLongrunningOperation(MethodDescriptor const& method) {
   return method.output_type()->full_name() == "google.longrunning.Operation";
 }
 
-bool IsResponseTypeEmpty(google::protobuf::MethodDescriptor const& method) {
+bool IsResponseTypeEmpty(MethodDescriptor const& method) {
   return method.output_type()->full_name() == "google.protobuf.Empty";
 }
 
-bool IsLongrunningMetadataTypeUsedAsResponse(
-    google::protobuf::MethodDescriptor const& method) {
+bool IsLongrunningMetadataTypeUsedAsResponse(MethodDescriptor const& method) {
   if (method.output_type()->full_name() == "google.longrunning.Operation") {
     auto operation_info =
         method.options().GetExtension(google::longrunning::operation_info);
@@ -127,7 +125,7 @@ bool IsLongrunningMetadataTypeUsedAsResponse(
   return false;
 }
 
-bool HasRoutingHeader(google::protobuf::MethodDescriptor const& method) {
+bool HasRoutingHeader(MethodDescriptor const& method) {
   auto result = ParseResourceRoutingHeader(method);
   return result.has_value();
 }


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by #8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8717)
<!-- Reviewable:end -->
