### PR TITLE
cleanup: miscellanous clang-tidy 14 fixes

### DIFF
--- a/google/cloud/examples/grpc_credential_types.cc
+++ b/google/cloud/examples/grpc_credential_types.cc
@@ -129,7 +129,7 @@ google::iam::credentials::v1::GenerateAccessTokenResponse UseAccessToken(
 void UseAccessTokenUntilExpired(google::cloud::iam::IAMCredentialsClient client,
                                 std::vector<std::string> const& argv) {
   auto token = UseAccessToken(std::move(client), argv);
-  auto const project_id = argv.at(1);
+  auto const& project_id = argv.at(1);
   auto const expiration =
       std::chrono::system_clock::from_time_t(token.expire_time().seconds());
   auto const deadline = expiration + 4 * kTokenValidationPeriod;


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by #8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8718)
<!-- Reviewable:end -->
