### PR TITLE
cleanup(pubsub): fix clang-tidy 14 warnings

### DIFF
--- a/google/cloud/pubsub/internal/subscription_session_test.cc
+++ b/google/cloud/pubsub/internal/subscription_session_test.cc
@@ -36,7 +36,6 @@ using ::google::cloud::pubsub_testing::FakeAsyncStreamingPull;
 using ::google::cloud::testing_util::AsyncSequencer;
 using ::testing::AtLeast;
 using ::testing::AtMost;
-using ::testing::InSequence;
 
 future<Status> CreateTestSubscriptionSession(
     pubsub::Subscription const& subscription, Options opts,


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by https://github.com/googleapis/google-cloud-cpp/issues/8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8719)
<!-- Reviewable:end -->
