### PR TITLE
cleanup(pubsublite): fix clang-tidy 14 warnings

### DIFF
--- a/google/cloud/pubsublite/message_metadata_test.cc
+++ b/google/cloud/pubsublite/message_metadata_test.cc
@@ -18,16 +18,16 @@
 #include <gmock/gmock.h>
 #include <deque>
 
-using google::cloud::pubsublite::MakeMessageMetadata;
-using google::cloud::pubsublite::MessageMetadata;
-using google::cloud::pubsublite::v1::Cursor;
-using ::google::cloud::testing_util::IsProtoEqual;
-
 namespace google {
 namespace cloud {
 namespace pubsublite {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
+
+using ::google::cloud::pubsublite::MakeMessageMetadata;
+using ::google::cloud::pubsublite::MessageMetadata;
+using ::google::cloud::pubsublite::v1::Cursor;
+using ::google::cloud::testing_util::IsProtoEqual;
 
 TEST(MessageMetadata, ValidParse) {
   std::int64_t partition = 2389457;

--- a/google/cloud/pubsublite/topic_test.cc
+++ b/google/cloud/pubsublite/topic_test.cc
@@ -18,8 +18,6 @@
 #include <gmock/gmock.h>
 #include <deque>
 
-using google::cloud::pubsublite::Topic;
-
 namespace google {
 namespace cloud {
 namespace pubsublite {


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by https://github.com/googleapis/google-cloud-cpp/issues/8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8720)
<!-- Reviewable:end -->
