### PR TITLE
cleanup(spanner): fix clang-tidy 14 warnings

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -480,7 +480,7 @@ class BasicExperiment : public Experiment {
     int num_stubs = static_cast<int>(stubs.size());
     int task_id = 0;
     for (auto& t : tasks) {
-      auto client = stubs[task_id++ % num_stubs];
+      auto const& client = stubs[task_id++ % num_stubs];
       t = std::async(std::launch::async, [this, &config, thread_count,
                                           num_stubs, client] {
         return ViaStub(config, thread_count, num_stubs,

--- a/google/cloud/spanner/internal/merge_chunk_test.cc
+++ b/google/cloud/spanner/internal/merge_chunk_test.cc
@@ -164,8 +164,8 @@ TEST(MergeChunk, ErrorMismatchedTypes) {
   auto value = MakeProtoValue(std::vector<std::string>{"hello"});
   auto status = MergeChunk(value, MakeProtoValue("world"));
 
-  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
-                               testing::HasSubstr("mismatched types")));
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk), HasSubstr("mismatched types")));
 }
 
 //
@@ -180,8 +180,8 @@ TEST(MergeChunk, CannotMergeBools) {
   bool2.set_bool_value(true);
 
   auto status = MergeChunk(bool1, std::move(bool2));
-  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
-                               testing::HasSubstr("invalid type")));
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk), HasSubstr("invalid type")));
 }
 
 TEST(MergeChunk, CannotMergeNumbers) {
@@ -192,8 +192,8 @@ TEST(MergeChunk, CannotMergeNumbers) {
   number2.set_number_value(2.0);
 
   auto status = MergeChunk(number1, std::move(number2));
-  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
-                               testing::HasSubstr("invalid type")));
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk), HasSubstr("invalid type")));
 }
 
 TEST(MergeChunk, CannotMergeNull) {
@@ -204,8 +204,8 @@ TEST(MergeChunk, CannotMergeNull) {
   null2.set_null_value(google::protobuf::NullValue::NULL_VALUE);
 
   auto status = MergeChunk(null1, std::move(null2));
-  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
-                               testing::HasSubstr("invalid type")));
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk), HasSubstr("invalid type")));
 }
 
 TEST(MergeChunk, CannotMergeStruct) {
@@ -216,8 +216,8 @@ TEST(MergeChunk, CannotMergeStruct) {
   struct2.mutable_struct_value();
 
   auto status = MergeChunk(struct1, std::move(struct2));
-  EXPECT_THAT(status, StatusIs(Not(StatusCode::kOk),
-                               testing::HasSubstr("invalid type")));
+  EXPECT_THAT(status,
+              StatusIs(Not(StatusCode::kOk), HasSubstr("invalid type")));
 }
 
 }  // namespace


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by https://github.com/googleapis/google-cloud-cpp/issues/8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8721)
<!-- Reviewable:end -->
