### PR TITLE
cleanup(storage): fix clang-tidy 14 warnings

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -36,7 +36,6 @@ namespace gcs_bm = ::google::cloud::storage_benchmarks;
 using gcs_bm::ExperimentLibrary;
 using gcs_bm::ExperimentTransport;
 using gcs_bm::ThroughputOptions;
-using gcs_bm::ThroughputResult;
 
 char const kDescription[] = R"""(
 A throughput vs. CPU benchmark for the Google Cloud Storage C++ client library.

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3391,7 +3391,7 @@ class ScopedDeleter {
   void Enable(bool enable) { enabled_ = enable; }
 
  private:
-  bool enabled_;
+  bool enabled_ = true;
   std::function<Status(std::string, std::int64_t)> delete_fun_;
   std::vector<std::pair<std::string, std::int64_t>> object_list_;
 };

--- a/google/cloud/storage/internal/access_control_common_parser.cc
+++ b/google/cloud/storage/internal/access_control_common_parser.cc
@@ -35,7 +35,7 @@ Status AccessControlCommonParser::FromJson(AccessControlCommon& result,
   result.role_ = json.value("role", "");
   result.self_link_ = json.value("selfLink", "");
   if (json.count("projectTeam") != 0) {
-    auto tmp = json["projectTeam"];
+    auto const& tmp = json["projectTeam"];
     if (tmp.is_null()) return Status{};
     ProjectTeam p;
     p.project_number = tmp.value("projectNumber", "");

--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -85,7 +85,7 @@ Status ParseAcl(std::vector<BucketAccessControl>& acl,
 Status ParseBilling(absl::optional<BucketBilling>& billing,
                     nlohmann::json const& json) {
   if (!json.contains("billing")) return Status{};
-  auto b = json["billing"];
+  auto const& b = json["billing"];
   auto requester_pays = internal::ParseBoolField(b, "requesterPays");
   if (!requester_pays) return std::move(requester_pays).status();
   billing = BucketBilling{*requester_pays};
@@ -156,7 +156,7 @@ Status ParseIamConfiguration(
 Status ParseLifecycle(absl::optional<BucketLifecycle>& lifecycle,
                       nlohmann::json const& json) {
   if (!json.contains("lifecycle")) return Status{};
-  auto l = json["lifecycle"];
+  auto const& l = json["lifecycle"];
   BucketLifecycle value;
   if (l.contains("rule")) {
     for (auto const& kv : l["rule"].items()) {
@@ -172,7 +172,7 @@ Status ParseLifecycle(absl::optional<BucketLifecycle>& lifecycle,
 Status ParseLogging(absl::optional<BucketLogging>& logging,
                     nlohmann::json const& json) {
   if (!json.contains("logging")) return Status{};
-  auto l = json["logging"];
+  auto const& l = json["logging"];
   BucketLogging value;
   value.log_bucket = l.value("logBucket", "");
   value.log_object_prefix = l.value("logObjectPrefix", "");
@@ -201,8 +201,8 @@ Status ParseRetentionPolicy(
     absl::optional<BucketRetentionPolicy>& retention_policy,
     nlohmann::json const& json) {
   if (!json.contains("retentionPolicy")) return Status{};
-  auto r = json["retentionPolicy"];
-  auto is_locked = internal::ParseBoolField(r, "isLocked");
+  auto const& r = json["retentionPolicy"];
+  auto const is_locked = internal::ParseBoolField(r, "isLocked");
   if (!is_locked) return std::move(is_locked).status();
   auto retention_period = internal::ParseLongField(r, "retentionPeriod");
   if (!retention_period) return std::move(retention_period).status();
@@ -216,9 +216,9 @@ Status ParseRetentionPolicy(
 Status ParseVersioning(absl::optional<BucketVersioning>& versioning,
                        nlohmann::json const& json) {
   if (!json.contains("versioning")) return Status{};
-  auto v = json["versioning"];
+  auto const& v = json["versioning"];
   if (!v.contains("enabled")) return Status{};
-  auto enabled = internal::ParseBoolField(v, "enabled");
+  auto const& enabled = internal::ParseBoolField(v, "enabled");
   if (!enabled) return std::move(enabled).status();
   versioning = BucketVersioning{*enabled};
   return Status{};
@@ -227,7 +227,7 @@ Status ParseVersioning(absl::optional<BucketVersioning>& versioning,
 Status ParseWebsite(absl::optional<BucketWebsite>& website,
                     nlohmann::json const& json) {
   if (!json.contains("website")) return Status{};
-  auto w = json["website"];
+  auto const& w = json["website"];
   BucketWebsite value;
   value.main_page_suffix = w.value("mainPageSuffix", "");
   value.not_found_page = w.value("notFoundPage", "");

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -42,7 +42,6 @@ CurlRequestBuilder::CurlRequestBuilder(
       headers_(nullptr, &curl_slist_free_all),
       url_(std::move(base_url)),
       query_parameter_separator_(InitialQueryParameterSeparator(url_)),
-      logging_enabled_(false),
       transfer_stall_timeout_(0),
       download_stall_timeout_(0) {}
 

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -193,7 +193,7 @@ class CurlRequestBuilder {
   char const* query_parameter_separator_;
 
   std::string user_agent_prefix_;
-  bool logging_enabled_;
+  bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds transfer_stall_timeout_;
   std::chrono::seconds download_stall_timeout_;

--- a/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
@@ -139,7 +139,7 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
           .upsert_label("k0", "v0")
           .set_default_event_based_hold(true)
           .set_cors({CorsEntry{
-              /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
+              /*.max_age_seconds=*/static_cast<std::uint64_t>(1800),
               /*.method=*/{"GET", "PUT"},
               /*.origin=*/{"test-origin-0", "test-origin-1"},
               /*.response_header=*/{"test-header-0", "test-header-1"},
@@ -459,7 +459,7 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
               LifecycleRule::Delete())}})
           .SetCors({
               CorsEntry{
-                  /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
+                  /*.max_age_seconds=*/static_cast<std::uint64_t>(1800),
                   /*.method=*/{"GET", "PUT"},
                   /*.origin=*/{"test-origin-0", "test-origin-1"},
                   /*.response_header=*/{"test-header-0", "test-header-1"}},
@@ -476,11 +476,10 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
                   /*.method=*/{},
                   /*.origin=*/{},
                   /*.response_header=*/{"test-header-0", "test-header-1"}},
-              CorsEntry{
-                  /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
-                  /*.method=*/{},
-                  /*.origin=*/{},
-                  /*.response_header=*/{}},
+              CorsEntry{/*.max_age_seconds=*/static_cast<std::uint64_t>(1800),
+                        /*.method=*/{},
+                        /*.origin=*/{},
+                        /*.response_header=*/{}},
           })
           .SetDefaultEventBasedHold(true)
           .SetLabel("key0", "value0")
@@ -608,7 +607,7 @@ TEST(GrpcBucketRequestParser, UpdateBucketRequestAllOptions) {
               LifecycleRule::Delete())}})
           .set_cors({
               CorsEntry{
-                  /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
+                  /*.max_age_seconds=*/static_cast<std::uint64_t>(1800),
                   /*.method=*/{"GET", "PUT"},
                   /*.origin=*/{"test-origin-0", "test-origin-1"},
                   /*.response_header=*/{"test-header-0", "test-header-1"}},
@@ -625,11 +624,10 @@ TEST(GrpcBucketRequestParser, UpdateBucketRequestAllOptions) {
                   /*.method=*/{},
                   /*.origin=*/{},
                   /*.response_header=*/{"test-header-0", "test-header-1"}},
-              CorsEntry{
-                  /*.max_age_seconds=*/absl::make_optional(std::uint64_t(1800)),
-                  /*.method=*/{},
-                  /*.origin=*/{},
-                  /*.response_header=*/{}},
+              CorsEntry{/*.max_age_seconds=*/static_cast<std::uint64_t>(1800),
+                        /*.method=*/{},
+                        /*.origin=*/{},
+                        /*.response_header=*/{}},
           })
           .set_default_event_based_hold(true)
           .upsert_label("key0", "value0")

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -39,7 +39,7 @@ using ::google::cloud::storage::internal::raw_client_wrapper_utils::Signature;
  * @return the result from making the call;
  */
 template <typename MemberFunction>
-static typename Signature<MemberFunction>::ReturnType MakeCall(
+typename Signature<MemberFunction>::ReturnType MakeCall(
     RawClient& client, MemberFunction function,
     typename Signature<MemberFunction>::RequestType const& request,
     char const* context) {
@@ -67,7 +67,7 @@ static typename Signature<MemberFunction>::ReturnType MakeCall(
  * @return the result from making the call;
  */
 template <typename MemberFunction>
-static typename Signature<MemberFunction>::ReturnType MakeCallNoResponseLogging(
+typename Signature<MemberFunction>::ReturnType MakeCallNoResponseLogging(
     google::cloud::storage::internal::RawClient& client,
     MemberFunction function,
     typename Signature<MemberFunction>::RequestType const& request,

--- a/google/cloud/storage/internal/object_metadata_parser.cc
+++ b/google/cloud/storage/internal/object_metadata_parser.cc
@@ -69,7 +69,7 @@ StatusOr<ObjectMetadata> ObjectMetadataParser::FromJson(
   result.content_type_ = json.value("contentType", "");
   result.crc32c_ = json.value("crc32c", "");
   if (json.count("customerEncryption") != 0) {
-    auto field = json["customerEncryption"];
+    auto const& field = json["customerEncryption"];
     CustomerEncryption e;
     e.encryption_algorithm = field.value("encryptionAlgorithm", "");
     e.key_sha256 = field.value("keySha256", "");

--- a/google/cloud/storage/internal/patch_builder.cc
+++ b/google/cloud/storage/internal/patch_builder.cc
@@ -29,6 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 struct PatchBuilder::Impl {
+  Impl() = default;  // NOLINT(bugprone-exception-escape)
+
   std::string ToString() const {
     if (empty()) {
       return "{}";

--- a/google/cloud/storage/internal/patch_builder_test.cc
+++ b/google/cloud/storage/internal/patch_builder_test.cc
@@ -56,9 +56,12 @@ TEST(PatchBuilderTest, Bool) {
 
 TEST(PatchBuilderTest, Int) {
   PatchBuilder builder;
-  builder.AddIntField("set-value", std::int32_t(0), std::int32_t(42));
-  builder.AddIntField("unset-value", std::int32_t(42), std::int32_t(0));
-  builder.AddIntField("untouched-value", std::int32_t(7), std::int32_t(7));
+  builder.AddIntField("set-value", static_cast<std::int32_t>(0),
+                      static_cast<std::int32_t>(42));
+  builder.AddIntField("unset-value", static_cast<std::int32_t>(42),
+                      static_cast<std::int32_t>(0));
+  builder.AddIntField("untouched-value", static_cast<std::int32_t>(7),
+                      static_cast<std::int32_t>(7));
   nlohmann::json expected{
       {"set-value", 42},
       {"unset-value", nullptr},
@@ -121,19 +124,23 @@ TEST(PatchBuilderTest, SetBoolField) {
 
 TEST(PatchBuilderTest, SetIntField) {
   PatchBuilder builder;
-  builder.SetIntField("field-32-7", std::int32_t(7));
-  builder.SetIntField("field-32-0", std::int32_t(0));
-  builder.SetIntField("field-u32-7", std::uint32_t(7));
-  builder.SetIntField("field-u32-0", std::uint32_t(0));
-  builder.SetIntField("field-64-7", std::int64_t(7));
-  builder.SetIntField("field-64-0", std::int64_t(0));
-  builder.SetIntField("field-u64-7", std::uint64_t(7));
-  builder.SetIntField("field-u64-0", std::uint64_t(0));
+  builder.SetIntField("field-32-7", static_cast<std::int32_t>(7));
+  builder.SetIntField("field-32-0", static_cast<std::int32_t>(0));
+  builder.SetIntField("field-u32-7", static_cast<std::uint32_t>(7));
+  builder.SetIntField("field-u32-0", static_cast<std::uint32_t>(0));
+  builder.SetIntField("field-64-7", static_cast<std::int64_t>(7));
+  builder.SetIntField("field-64-0", static_cast<std::int64_t>(0));
+  builder.SetIntField("field-u64-7", static_cast<std::uint64_t>(7));
+  builder.SetIntField("field-u64-0", static_cast<std::uint64_t>(0));
   nlohmann::json expected{
-      {"field-32-7", std::int32_t(7)},   {"field-32-0", std::int32_t(0)},
-      {"field-u32-7", std::uint32_t(7)}, {"field-u32-0", std::uint32_t(0)},
-      {"field-64-7", std::int64_t(7)},   {"field-64-0", std::int64_t(0)},
-      {"field-u64-7", std::uint64_t(7)}, {"field-u64-0", std::uint64_t(0)},
+      {"field-32-7", static_cast<std::int32_t>(7)},
+      {"field-32-0", static_cast<std::int32_t>(0)},
+      {"field-u32-7", static_cast<std::uint32_t>(7)},
+      {"field-u32-0", static_cast<std::uint32_t>(0)},
+      {"field-64-7", static_cast<std::int64_t>(7)},
+      {"field-64-0", static_cast<std::int64_t>(0)},
+      {"field-u64-7", static_cast<std::uint64_t>(7)},
+      {"field-u64-0", static_cast<std::uint64_t>(0)},
   };
   auto actual = nlohmann::json::parse(builder.ToString());
   EXPECT_EQ(expected, actual) << builder.ToString();

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -26,7 +26,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::StatusIs;

--- a/google/cloud/storage/internal/retry_object_read_source_test.cc
+++ b/google/cloud/storage/internal/retry_object_read_source_test.cc
@@ -32,7 +32,7 @@ namespace {
 using ::testing::HasSubstr;
 using testing::MockObjectReadSource;
 using ::testing::Return;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 

--- a/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/retry_resumable_upload_session_test.cc
@@ -29,7 +29,7 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -38,7 +38,6 @@ using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
 using ::testing::HasSubstr;
-using ::testing::InSequence;
 using ::testing::NotNull;
 using ::testing::Return;
 

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -80,8 +80,7 @@ ParseAuthorizedUserRefreshResponse(
   header += ' ';
   header += access_token.value("access_token", "");
   std::string new_id = access_token.value("id_token", "");
-  auto expires_in =
-      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
   return RefreshingCredentialsWrapper::TemporaryToken{std::move(header),
                                                       new_expiration};

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -66,8 +66,7 @@ ParseComputeEngineRefreshResponse(
   header += access_token.value("token_type", "");
   header += ' ';
   header += access_token.value("access_token", "");
-  auto expires_in =
-      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
 
   return RefreshingCredentialsWrapper::TemporaryToken{std::move(header),

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -264,8 +264,7 @@ ParseServiceAccountRefreshResponse(
   std::string header =
       "Authorization: " + access_token.value("token_type", "") + " " +
       access_token.value("access_token", "");
-  auto expires_in =
-      std::chrono::seconds(access_token.value("expires_in", int(0)));
+  auto expires_in = std::chrono::seconds(access_token.value("expires_in", 0));
   auto new_expiration = now + expires_in;
 
   return RefreshingCredentialsWrapper::TemporaryToken{std::move(header),

--- a/google/cloud/storage/object_read_stream.cc
+++ b/google/cloud/storage/object_read_stream.cc
@@ -47,8 +47,9 @@ ObjectReadStream::ObjectReadStream(ObjectReadStream&& rhs) noexcept
       // that derived classes can define their own move constructor and move
       // assignment.
       buf_(std::move(rhs.buf_)) {
-  rhs.buf_ = MakeErrorStreambuf();
-  rhs.set_rdbuf(rhs.buf_.get());
+  auto buf = MakeErrorStreambuf();
+  rhs.set_rdbuf(buf.get());  // NOLINT(bugprone-use-after-move)
+  rhs.buf_ = std::move(buf);
   set_rdbuf(buf_.get());
 }
 

--- a/google/cloud/storage/object_write_stream.cc
+++ b/google/cloud/storage/object_write_stream.cc
@@ -63,8 +63,9 @@ ObjectWriteStream::ObjectWriteStream(ObjectWriteStream&& rhs) noexcept
       metadata_(std::move(rhs.metadata_)),
       headers_(std::move(rhs.headers_)),
       payload_(std::move(rhs.payload_)) {
-  rhs.buf_ = MakeErrorStreambuf();
-  rhs.set_rdbuf(rhs.buf_.get());
+  auto buf = MakeErrorStreambuf();
+  rhs.set_rdbuf(buf.get());  // NOLINT(bugprone-use-after-move)
+  rhs.buf_ = std::move(buf);
   set_rdbuf(buf_.get());
   if (!buf_) {
     setstate(std::ios::badbit | std::ios::eofbit);

--- a/google/cloud/storage/parallel_upload.cc
+++ b/google/cloud/storage/parallel_upload.cc
@@ -63,9 +63,7 @@ ParallelUploadStateImpl::ParallelUploadStateImpl(
     : deleter_(std::move(deleter)),
       composer_(std::move(composer)),
       destination_object_name_(std::move(destination_object_name)),
-      expected_generation_(expected_generation),
-      finished_{},
-      num_unfinished_streams_{} {
+      expected_generation_(expected_generation) {
   if (!cleanup_on_failures) {
     deleter_->Enable(false);
   }

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -225,9 +225,9 @@ class ParallelUploadStateImpl
   std::string destination_object_name_;
   std::int64_t expected_generation_;
   // Set when all streams are closed and composed but before cleanup.
-  bool finished_;
+  bool finished_ = false;
   // Tracks how many streams are still written to.
-  std::size_t num_unfinished_streams_;
+  std::size_t num_unfinished_streams_ = 0;
   std::vector<StreamInfo> streams_;
   absl::optional<StatusOr<ObjectMetadata>> res_;
   Status cleanup_status_;

--- a/google/cloud/storage/parallel_uploads_test.cc
+++ b/google/cloud/storage/parallel_uploads_test.cc
@@ -40,7 +40,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
-using ::google::cloud::testing_util::chrono_literals::operator"" _ms;
+using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;

--- a/google/cloud/storage/tests/error_injection_integration_test.cc
+++ b/google/cloud/storage/tests/error_injection_integration_test.cc
@@ -30,7 +30,7 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::chrono_literals::operator"" _us;
+using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -25,7 +25,6 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::testing::AnyOf;
 using ::testing::Eq;
 using ::testing::HasSubstr;


### PR DESCRIPTION
I found these while trying to build with OpenSSL 3.0. Motivated by https://github.com/googleapis/google-cloud-cpp/issues/8544

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8722)
<!-- Reviewable:end -->
