### PR TITLE
ci(spanner): revert the toleration of a CreateBackup() error

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -438,17 +438,6 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
   breq.mutable_encryption_config()->set_kms_key_name(encryption_key.FullName());
   auto backup = database_admin_client_.CreateBackup(breq).get();
   {
-    // TODO(#8594): Remove this when we know how to deal with the issue.
-    auto matcher =
-        StatusIs(StatusCode::kFailedPrecondition,
-                 HasSubstr("exceeded the maximum timestamp staleness"));
-    testing::StringMatchResultListener listener;
-    if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
-      GTEST_SKIP();
-    }
-  }
-  {
     // TODO(#8616): Remove this when we know how to deal with the issue.
     auto matcher = testing_util::StatusIs(
         StatusCode::kDeadlineExceeded,

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -166,17 +166,6 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
 
   auto backup = backup_future.get();
   {
-    // TODO(#8594): Remove this when we know how to deal with the issue.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kFailedPrecondition,
-        testing::HasSubstr("exceeded the maximum timestamp staleness"));
-    testing::StringMatchResultListener listener;
-    if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db.FullName()));
-      GTEST_SKIP();
-    }
-  }
-  {
     // TODO(#8616): Remove this when we know how to deal with the issue.
     auto matcher = testing_util::StatusIs(
         StatusCode::kDeadlineExceeded,

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -357,17 +357,6 @@ TEST_F(BackupExtraIntegrationTest, BackupRestoreWithCMEK) {
                                   absl::nullopt, encryption_config)
                     .get();
   {
-    // TODO(#8594): Remove this when we know how to deal with the issue.
-    auto matcher =
-        StatusIs(StatusCode::kFailedPrecondition,
-                 HasSubstr("exceeded the maximum timestamp staleness"));
-    testing::StringMatchResultListener listener;
-    if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
-      GTEST_SKIP();
-    }
-  }
-  {
     // TODO(#8616): Remove this when we know how to deal with the issue.
     auto matcher = testing_util::StatusIs(
         StatusCode::kDeadlineExceeded,

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -133,17 +133,6 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
 
   auto backup = backup_future.get();
   {
-    // TODO(#8594): Remove this when we know how to deal with the issue.
-    auto matcher = testing_util::StatusIs(
-        StatusCode::kFailedPrecondition,
-        testing::HasSubstr("exceeded the maximum timestamp staleness"));
-    testing::StringMatchResultListener listener;
-    if (matcher.impl().MatchAndExplain(backup, &listener)) {
-      EXPECT_STATUS_OK(database_admin_client_.DropDatabase(db));
-      GTEST_SKIP();
-    }
-  }
-  {
     // TODO(#8616): Remove this when we know how to deal with the issue.
     auto matcher = testing_util::StatusIs(
         StatusCode::kDeadlineExceeded,


### PR DESCRIPTION
Revert #8605 given the indication that the "Read-only transaction
timestamp has exceeded the maximum timestamp staleness" failed
precondition from CreateBackup() has been avoided in the backend.

We'll close #8594 in a few days if things remain quiet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8737)
<!-- Reviewable:end -->
