### PR TITLE
impl(rest): better errors in SignUsingSha256()

### DIFF
--- a/google/cloud/internal/openssl_util.cc
+++ b/google/cloud/internal/openssl_util.cc
@@ -16,11 +16,15 @@
 #include "google/cloud/internal/base64_transforms.h"
 #include <openssl/bio.h>
 #include <openssl/buffer.h>
+#include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/md5.h>
 #include <openssl/opensslv.h>
 #include <openssl/pem.h>
+#include <algorithm>
+#include <array>
 #include <memory>
+#include <type_traits>
 
 namespace google {
 namespace cloud {
@@ -28,106 +32,126 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 namespace {
+struct OpenSslDeleter {
+  void operator()(EVP_MD_CTX* ptr) {
 // The name of the function to free an EVP_MD_CTX changed in OpenSSL 1.1.0.
 #if (OPENSSL_VERSION_NUMBER < 0x10100000L)  // Older than version 1.1.0.
-inline std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)>
-GetDigestCtx() {
-  return std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_destroy)>(
-      EVP_MD_CTX_create(), &EVP_MD_CTX_destroy);
-};
+    EVP_MD_CTX_destroy(ptr);
 #else
-inline std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)> GetDigestCtx() {
-  return std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>(
-      EVP_MD_CTX_new(), &EVP_MD_CTX_free);
-};
+    EVP_MD_CTX_free(ptr);
 #endif
+  }
+
+  void operator()(EVP_PKEY* ptr) { EVP_PKEY_free(ptr); }
+  void operator()(BIO* ptr) { BIO_free(ptr); }
+};
+
+std::unique_ptr<EVP_MD_CTX, OpenSslDeleter> GetDigestCtx() {
+// The name of the function to create an EVP_MD_CTX changed in OpenSSL 1.1.0.
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L)  // Older than version 1.1.0.
+  return std::unique_ptr<EVP_MD_CTX, OpenSslDeleter>(EVP_MD_CTX_create());
+#else
+  return std::unique_ptr<EVP_MD_CTX, OpenSslDeleter>(EVP_MD_CTX_new());
+#endif
+}
+
+std::string CaptureSslErrors() {
+  std::string msg;
+  while (auto code = ERR_get_error()) {
+    // OpenSSL guarantees that 256 bytes is enough:
+    //   https://www.openssl.org/docs/man1.1.1/man3/ERR_error_string_n.html
+    //   https://www.openssl.org/docs/man1.0.2/man3/ERR_error_string_n.html
+    // we could not find a macro or constant to replace the 256 literal.
+    auto constexpr kMaxOpenSslErrorLength = 256;
+    std::array<char, kMaxOpenSslErrorLength> buf{};
+    ERR_error_string_n(code, buf.data(), buf.size());
+    msg += buf.data();
+  }
+  return msg;
+}
+
 }  // namespace
 
 StatusOr<std::vector<std::uint8_t>> SignUsingSha256(
     std::string const& str, std::string const& pem_contents) {
-  auto digest_ctx = GetDigestCtx();
-  if (!digest_ctx) {
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not create context for OpenSSL digest. ");
-  }
-
-  EVP_MD const* digest_type = EVP_sha256();
-  if (digest_type == nullptr) {
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not find specified digest in OpenSSL. ");
-  }
-
-  auto pem_buffer = std::unique_ptr<BIO, decltype(&BIO_free)>(
-      BIO_new_mem_buf(pem_contents.data(),
-                      static_cast<int>(pem_contents.length())),
-      &BIO_free);
+  ERR_clear_error();
+  auto pem_buffer = std::unique_ptr<BIO, OpenSslDeleter>(BIO_new_mem_buf(
+      pem_contents.data(), static_cast<int>(pem_contents.length())));
   if (!pem_buffer) {
     return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not create PEM buffer. ");
+                  "Invalid ServiceAccountCredentials - "
+                  "could not create PEM buffer: " +
+                      CaptureSslErrors());
   }
 
-  auto private_key = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>(
-      PEM_read_bio_PrivateKey(
+  auto private_key =
+      std::unique_ptr<EVP_PKEY, OpenSslDeleter>(PEM_read_bio_PrivateKey(
           pem_buffer.get(),
           nullptr,  // EVP_PKEY **x
           nullptr,  // pem_password_cb *cb -- a custom callback.
           // void *u -- this represents the password for the PEM (only
           // applicable for formats such as PKCS12 (.p12 files) that use
           // a password, which we don't currently support.
-          nullptr),
-      &EVP_PKEY_free);
+          nullptr));
   if (!private_key) {
     return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not parse PEM to get private key ");
+                  "Invalid ServiceAccountCredentials - "
+                  "could not parse PEM to get private key: " +
+                      CaptureSslErrors());
   }
 
-  int const digest_sign_success_code = 1;
-  if (digest_sign_success_code !=
-      EVP_DigestSignInit(digest_ctx.get(),
-                         nullptr,  // `EVP_PKEY_CTX **pctx`
-                         digest_type,
-                         nullptr,  // `ENGINE *e`
-                         private_key.get())) {
+  auto digest_ctx = GetDigestCtx();
+  if (!digest_ctx) {
     return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not initialize PEM digest. ");
+                  "Invalid ServiceAccountCredentials - "
+                  "could not create context for OpenSSL digest: " +
+                      CaptureSslErrors());
   }
 
-  if (digest_sign_success_code !=
-      EVP_DigestSignUpdate(digest_ctx.get(), str.data(), str.length())) {
+  auto constexpr kOpenSslSuccess = 1;
+  if (EVP_DigestSignInit(digest_ctx.get(), nullptr, EVP_sha256(), nullptr,
+                         private_key.get()) != kOpenSslSuccess) {
     return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not update PEM digest. ");
+                  "Invalid ServiceAccountCredentials - "
+                  "could not initialize signing digest: " +
+                      CaptureSslErrors());
   }
 
-  std::size_t signed_str_size = 0;
-  // Calling this method with a nullptr buffer will populate our size var
-  // with the resulting buffer's size. This allows us to then call it again,
-  // with the correct buffer and size, which actually populates the buffer.
-  if (digest_sign_success_code !=
-      EVP_DigestSignFinal(digest_ctx.get(),
-                          nullptr,  // unsigned char *sig
-                          &signed_str_size)) {
+  if (EVP_DigestSignUpdate(digest_ctx.get(), str.data(), str.size()) !=
+      kOpenSslSuccess) {
     return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not finalize PEM digest (1/2). ");
+                  "Invalid ServiceAccountCredentials - could not sign blob: " +
+                      CaptureSslErrors());
   }
 
-  std::vector<unsigned char> signed_str(signed_str_size);
-  if (digest_sign_success_code != EVP_DigestSignFinal(digest_ctx.get(),
-                                                      signed_str.data(),
-                                                      &signed_str_size)) {
+  // The OpenSSL "C" APIs uses `size_t`, I (coryan) believe all platforms we
+  // support satisfy this assertion, and suspect this is true in all platforms.
+  // However, if the code ever finds its way to one where it is not true, it
+  // would be better to get a compile-time error.
+  static_assert(std::is_same<std::size_t, size_t>::value,
+                "Expect std::size_t == size_t");
+  // The signed SHA256 size depends on the size (the experts say "modulus") of
+  // they key.  First query the size:
+  std::size_t actual_len = 0;
+  if (EVP_DigestSignFinal(digest_ctx.get(), nullptr, &actual_len) !=
+      kOpenSslSuccess) {
     return Status(StatusCode::kInvalidArgument,
-                  "Invalid ServiceAccountCredentials: "
-                  "could not finalize PEM digest (2/2). ");
+                  "Invalid ServiceAccountCredentials - could not sign blob: " +
+                      CaptureSslErrors());
   }
 
-  return StatusOr<std::vector<unsigned char>>(
-      {signed_str.begin(), signed_str.end()});
+  // Then compute the actual signed digest. Note that OpenSSL requires a
+  // `unsigned char*` buffer, so we feed it that.
+  std::vector<unsigned char> buffer(actual_len);
+  if (EVP_DigestSignFinal(digest_ctx.get(), buffer.data(), &actual_len) !=
+      kOpenSslSuccess) {
+    return Status(StatusCode::kInvalidArgument,
+                  "Invalid ServiceAccountCredentials - could not sign blob: " +
+                      CaptureSslErrors());
+  }
+
+  return StatusOr<std::vector<std::uint8_t>>(
+      {buffer.begin(), std::next(buffer.begin(), actual_len)});
 }
 
 StatusOr<std::vector<std::uint8_t>> UrlsafeBase64Decode(


### PR DESCRIPTION
Add the OpenSSL errors if there are any failures. Also some (I think)
clean ups on the use of `std::unique_ptr<>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8738)
<!-- Reviewable:end -->
