### PR TITLE
refactor(storage): move `UploadChunk()` implementation

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -485,8 +485,88 @@ StatusOr<EmptyResponse> GrpcClient::DeleteResumableUpload(
 }
 
 StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
-    UploadChunkRequest const&) {
-  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+    UploadChunkRequest const& request) {
+  auto context = absl::make_unique<grpc::ClientContext>();
+  ApplyQueryParameters(*context, request, "resource");
+  auto writer = CreateUploadWriter(std::move(context));
+
+  std::size_t const maximum_chunk_size =
+      google::storage::v2::ServiceConstants::MAX_WRITE_CHUNK_BYTES;
+  std::string chunk;
+  chunk.reserve(maximum_chunk_size);
+  auto offset = static_cast<google::protobuf::int64>(request.range_begin());
+
+  auto flush_chunk = [&](bool has_more) {
+    if (chunk.size() < maximum_chunk_size && has_more) return true;
+    if (chunk.empty() && !request.last_chunk()) return true;
+
+    google::storage::v2::WriteObjectRequest write_request;
+    write_request.set_upload_id(request.upload_session_url());
+    write_request.set_write_offset(offset);
+    write_request.set_finish_write(false);
+    auto write_size = chunk.size();
+
+    auto& data = *write_request.mutable_checksummed_data();
+    data.set_content(std::move(chunk));
+    chunk.clear();
+    chunk.reserve(maximum_chunk_size);
+    data.set_crc32c(crc32c::Crc32c(data.content()));
+
+    auto options = grpc::WriteOptions();
+    if (request.last_chunk() && !has_more) {
+      auto const& hashes = request.full_object_hashes();
+      if (!hashes.md5.empty()) {
+        auto md5 = GrpcObjectMetadataParser::MD5ToProto(hashes.md5);
+        if (md5) {
+          write_request.mutable_object_checksums()->set_md5_hash(
+              *std::move(md5));
+        }
+      }
+      if (!hashes.crc32c.empty()) {
+        auto crc32c = GrpcObjectMetadataParser::Crc32cToProto(hashes.crc32c);
+        if (crc32c) {
+          write_request.mutable_object_checksums()->set_crc32c(
+              *std::move(crc32c));
+        }
+      }
+      write_request.set_finish_write(true);
+      options.set_last_message();
+    }
+
+    if (!writer->Write(write_request, options)) return false;
+    // After the first message, clear the object specification and checksums,
+    // there is no need to resend it.
+    write_request.clear_write_object_spec();
+    write_request.clear_object_checksums();
+    offset += write_size;
+
+    return true;
+  };
+
+  auto close_writer = [&]() -> StatusOr<QueryResumableUploadResponse> {
+    auto result = writer->Close();
+    writer.reset();
+    if (!result) return std::move(result).status();
+    return GrpcObjectRequestParser::FromProto(*std::move(result), options());
+  };
+
+  auto buffers = request.payload();
+  do {
+    std::size_t consumed = 0;
+    for (auto const& b : buffers) {
+      // flush_chunk() guarantees that maximum_chunk_size < chunk.size()
+      auto capacity = maximum_chunk_size - chunk.size();
+      if (capacity == 0) break;
+      auto n = (std::min)(capacity, b.size());
+      chunk.append(b.data(), b.data() + n);
+      consumed += n;
+    }
+    PopFrontBytes(buffers, consumed);
+
+    if (!flush_chunk(!buffers.empty())) return close_writer();
+  } while (!buffers.empty());
+
+  return close_writer();
 }
 
 StatusOr<ListBucketAclResponse> GrpcClient::ListBucketAcl(

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -463,17 +463,15 @@ GrpcObjectRequestParser::ToProto(InsertObjectMediaRequest const& request) {
   return r;
 }
 
-ResumableUploadResponse GrpcObjectRequestParser::FromProto(
+QueryResumableUploadResponse GrpcObjectRequestParser::FromProto(
     google::storage::v2::WriteObjectResponse const& p, Options const& options) {
-  ResumableUploadResponse response;
-  response.upload_state = ResumableUploadResponse::kInProgress;
+  QueryResumableUploadResponse response;
   if (p.has_persisted_size()) {
     response.committed_size = static_cast<std::uint64_t>(p.persisted_size());
   }
   if (p.has_resource()) {
     response.payload =
         GrpcObjectMetadataParser::FromProto(p.resource(), options);
-    response.upload_state = ResumableUploadResponse::kDone;
   }
   return response;
 }

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -46,7 +46,7 @@ struct GrpcObjectRequestParser {
 
   static StatusOr<google::storage::v2::WriteObjectRequest> ToProto(
       InsertObjectMediaRequest const& request);
-  static ResumableUploadResponse FromProto(
+  static QueryResumableUploadResponse FromProto(
       google::storage::v2::WriteObjectResponse const& p,
       Options const& options);
 

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -684,7 +684,6 @@ TEST(GrpcObjectRequestParser, WriteObjectResponseSimple) {
       &input));
 
   auto const actual = GrpcObjectRequestParser::FromProto(input, Options{});
-  EXPECT_EQ(actual.upload_state, ResumableUploadResponse::kInProgress);
   EXPECT_EQ(actual.committed_size.value_or(0), 123456);
   EXPECT_FALSE(actual.payload.has_value());
 }
@@ -701,7 +700,6 @@ TEST(GrpcObjectRequestParser, WriteObjectResponseWithResource) {
       &input));
 
   auto const actual = GrpcObjectRequestParser::FromProto(input, Options{});
-  EXPECT_EQ(actual.upload_state, ResumableUploadResponse::kDone);
   EXPECT_FALSE(actual.committed_size.has_value());
   ASSERT_TRUE(actual.payload.has_value());
   EXPECT_EQ(actual.payload->name(), "test-object-name");

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -45,13 +45,24 @@ GrpcResumableUploadSession::GrpcResumableUploadSession(
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadChunk(
     ConstBufferSequence const& payload) {
-  return UploadGeneric(payload, false, {});
+  auto request = UploadChunkRequest(session_id_params_.upload_id,
+                                    committed_size_, payload);
+  request.set_multiple_options(
+      request_.GetOption<UserProject>(), request_.GetOption<Fields>(),
+      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  return HandleResponse(client_->UploadChunk(request));
 }
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& payload, std::uint64_t,
     HashValues const& full_object_hashes) {
-  return UploadGeneric(payload, true, full_object_hashes);
+  auto request = UploadChunkRequest(
+      session_id_params_.upload_id, committed_size_, payload,
+      committed_size_ + TotalBytes(payload), full_object_hashes);
+  request.set_multiple_options(
+      request_.GetOption<UserProject>(), request_.GetOption<Fields>(),
+      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  return HandleResponse(client_->UploadChunk(request));
 }
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::ResetSession() {
@@ -67,85 +78,20 @@ std::string const& GrpcResumableUploadSession::session_id() const {
   return session_url_;
 }
 
-StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadGeneric(
-    ConstBufferSequence buffers, bool final_chunk, HashValues const& hashes) {
-  auto context = absl::make_unique<grpc::ClientContext>();
-  ApplyQueryParameters(*context, request_, "resource");
-  auto writer = client_->CreateUploadWriter(std::move(context));
+StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::HandleResponse(
+    StatusOr<QueryResumableUploadResponse> response) {
+  if (!response) return std::move(response).status();
+  committed_size_ = response->committed_size.value_or(0);
 
-  std::size_t const maximum_chunk_size =
-      google::storage::v2::ServiceConstants::MAX_WRITE_CHUNK_BYTES;
-  std::string chunk;
-  chunk.reserve(maximum_chunk_size);
-  auto flush_chunk = [&](bool has_more) {
-    if (chunk.size() < maximum_chunk_size && has_more) return true;
-    if (chunk.empty() && !final_chunk) return true;
-
-    google::storage::v2::WriteObjectRequest request;
-    request.set_upload_id(session_id_params_.upload_id);
-    request.set_write_offset(
-        static_cast<google::protobuf::int64>(committed_size_));
-    request.set_finish_write(false);
-
-    auto& data = *request.mutable_checksummed_data();
-    auto const n = chunk.size();
-    data.set_content(std::move(chunk));
-    chunk.clear();
-    chunk.reserve(maximum_chunk_size);
-    data.set_crc32c(crc32c::Crc32c(data.content()));
-
-    auto options = grpc::WriteOptions();
-    if (final_chunk && !has_more) {
-      if (!hashes.md5.empty()) {
-        auto md5 = GrpcObjectMetadataParser::MD5ToProto(hashes.md5);
-        if (md5) {
-          request.mutable_object_checksums()->set_md5_hash(*std::move(md5));
-        }
-      }
-      if (!hashes.crc32c.empty()) {
-        auto crc32c = GrpcObjectMetadataParser::Crc32cToProto(hashes.crc32c);
-        if (crc32c) {
-          request.mutable_object_checksums()->set_crc32c(*std::move(crc32c));
-        }
-      }
-      request.set_finish_write(true);
-      options.set_last_message();
-    }
-
-    if (!writer->Write(request, options)) return false;
-    // After the first message, clear the object specification and checksums,
-    // there is no need to resend it.
-    request.clear_write_object_spec();
-    request.clear_object_checksums();
-
-    committed_size_ += n;
-    return true;
-  };
-
-  auto close_writer = [&]() -> StatusOr<ResumableUploadResponse> {
-    auto result = writer->Close();
-    writer.reset();
-    if (!result) return std::move(result).status();
-    return GrpcObjectRequestParser::FromProto(*std::move(result),
-                                              client_->options());
-  };
-
-  do {
-    std::size_t consumed = 0;
-    for (auto const& b : buffers) {
-      // flush_chunk() guarantees that maximum_chunk_size < chunk.size()
-      auto capacity = maximum_chunk_size - chunk.size();
-      if (capacity == 0) break;
-      auto n = (std::min)(capacity, b.size());
-      chunk.append(b.data(), b.data() + n);
-      consumed += n;
-    }
-    PopFrontBytes(buffers, consumed);
-
-    if (!flush_chunk(!buffers.empty())) return close_writer();
-  } while (!buffers.empty());
-
-  return close_writer();
+  auto const upload_state = response->payload.has_value()
+                                ? ResumableUploadResponse::kDone
+                                : ResumableUploadResponse::kInProgress;
+  return ResumableUploadResponse{
+      /*.upload_session_url=*/session_url_,
+      /*.upload_state=*/upload_state,
+      /*.committed_size=*/std::move(response->committed_size),
+      /*.payload=*/std::move(response->payload),
+      /*.annotations=*/std::string{}};
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.h
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.h
@@ -45,14 +45,8 @@ class GrpcResumableUploadSession : public ResumableUploadSession {
   std::string const& session_id() const override;
 
  private:
-  /**
-   * Uploads a multiple of the upload quantum bytes from @p buffers
-   *
-   * This function is used by both UploadChunk() and UploadFinalChunk()
-   */
-  StatusOr<ResumableUploadResponse> UploadGeneric(ConstBufferSequence buffers,
-                                                  bool final_chunk,
-                                                  HashValues const& hashes);
+  StatusOr<ResumableUploadResponse> HandleResponse(
+      StatusOr<QueryResumableUploadResponse> response);
 
   std::shared_ptr<GrpcClient> client_;
   ResumableUploadRequest request_;

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -399,7 +399,8 @@ std::ostream& operator<<(std::ostream& os,
 /**
  * A request to send one chunk in an upload session.
  */
-class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
+class UploadChunkRequest
+    : public GenericRequest<UploadChunkRequest, UserProject> {
  public:
   UploadChunkRequest() = default;
   UploadChunkRequest(std::string upload_session_url, std::uint64_t range_begin,
@@ -421,6 +422,7 @@ class UploadChunkRequest : public GenericRequest<UploadChunkRequest> {
   std::uint64_t range_begin() const { return range_begin_; }
   std::uint64_t range_end() const { return range_begin_ + payload_size() - 1; }
   std::uint64_t source_size() const { return source_size_; }
+  bool last_chunk() const { return last_chunk_; }
   std::size_t payload_size() const { return TotalBytes(payload_); }
   ConstBufferSequence const& payload() const { return payload_; }
   HashValues const& full_object_hashes() const { return full_object_hashes_; }


### PR DESCRIPTION
This moves the implementation of `UploadChunk()` from the resumable
upload sessions to the `*Client` classes. Part of the work to
remove the resumable upload sessions.

Part of the work for #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8739)
<!-- Reviewable:end -->
