### PR TITLE
refactor(storage): conditionally build AuthorizedUserCredentials with REST lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,15 @@ option(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC
        "${GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC_DEFAULT}")
 mark_as_advanced(GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
 
+set(GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST_DEFAULT OFF)
+if (experimental-storage-oauth2-rest IN_LIST GOOGLE_CLOUD_CPP_ENABLE)
+    set(GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST_DEFAULT ON)
+endif ()
+option(GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST
+       "Enable compilation for the GCS OAuth2 using REST library (EXPERIMENTAL)"
+       "${GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST_DEFAULT}")
+mark_as_advanced(GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST)
+
 # We no longer build the generator by default, but if it was explicitly
 # requested, we add it to the list of enabled libraries.
 if (GOOGLE_CLOUD_CPP_ENABLE_GENERATOR)

--- a/ci/cloudbuild/builds/bazel-gcs-rest.sh
+++ b/ci/cloudbuild/builds/bazel-gcs-rest.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/bazel.sh
+source module ci/cloudbuild/builds/lib/integration.sh
+
+export CC=clang
+export CXX=clang++
+
+mapfile -t args < <(bazel::common_args)
+bazel test "${args[@]}" --per_file_copt=google/cloud/storage/oauth2/.*\.*@-DGOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST --test_tag_filters=-integration-test ...
+
+mapfile -t integration_args < <(integration::bazel_args)
+integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"

--- a/ci/cloudbuild/builds/install-gcs-rest.sh
+++ b/ci/cloudbuild/builds/install-gcs-rest.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+source "$(dirname "$0")/../../lib/init.sh"
+source module ci/cloudbuild/builds/lib/cmake.sh
+source module ci/cloudbuild/builds/lib/quickstart.sh
+
+export CC=gcc
+export CXX=g++
+mapfile -t cmake_args < <(cmake::common_args)
+
+INSTALL_PREFIX="/var/tmp/google-cloud-cpp"
+cmake "${cmake_args[@]}" \
+  -DCMAKE_INSTALL_PREFIX="${INSTALL_PREFIX}" \
+  -DGOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST=ON \
+  -DBUILD_SHARED_LIBS=ON
+cmake --build cmake-out
+mapfile -t ctest_args < <(ctest::common_args)
+env -C cmake-out ctest "${ctest_args[@]}" -LE "integration-test"
+cmake --install cmake-out
+
+# Tests the installed artifacts by building and running the quickstarts.
+quickstart::build_cmake_and_make "${INSTALL_PREFIX}"
+quickstart::run_cmake_and_make "${INSTALL_PREFIX}"

--- a/ci/cloudbuild/triggers/bazel-gcs-rest-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcs-rest-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: asan-ci
+substitutions:
+  _BUILD_NAME: bazel-gcs-rest
+  _DISTRO: fedora-35
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/bazel-gcs-rest-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-gcs-rest-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: asan-pr
+substitutions:
+  _BUILD_NAME: bazel-gcs-rest
+  _DISTRO: fedora-35
+  _TRIGGER_TYPE: pr
+tags:
+- pr

--- a/ci/cloudbuild/triggers/install-gcs-rest-ci.yaml
+++ b/ci/cloudbuild/triggers/install-gcs-rest-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: install-gcs-rest-ci
+substitutions:
+  _BUILD_NAME: install-gcs-rest
+  _DISTRO: fedora-35
+  _TRIGGER_TYPE: ci
+tags:
+- ci

--- a/ci/cloudbuild/triggers/install-gcs-rest-pr.yaml
+++ b/ci/cloudbuild/triggers/install-gcs-rest-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: install-gcs-rest-pr
+substitutions:
+  _BUILD_NAME: install-gcs-rest
+  _DISTRO: fedora-35
+  _TRIGGER_TYPE: pr
+tags:
+- pr

--- a/google/cloud/storage/BUILD.bazel
+++ b/google/cloud/storage/BUILD.bazel
@@ -68,6 +68,7 @@ cc_library(
     ],
     deps = [
         "//:common",
+        "//google/cloud:google_cloud_cpp_rest_internal",
         "@boringssl//:crypto",
         "@boringssl//:ssl",
         "@com_github_curl_curl//:curl",

--- a/google/cloud/storage/CMakeLists.txt
+++ b/google/cloud/storage/CMakeLists.txt
@@ -258,6 +258,7 @@ target_link_libraries(
            absl::time
            absl::variant
            google-cloud-cpp::common
+           google-cloud-cpp::rest-internal
            nlohmann_json::nlohmann_json
            Crc32c::crc32c
            CURL::libcurl
@@ -276,6 +277,10 @@ target_include_directories(
                                     $<INSTALL_INTERFACE:include>)
 target_compile_options(google_cloud_cpp_storage
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
+if (GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_ENABLE_REST)
+    target_compile_definitions(google_cloud_cpp_storage
+                               PUBLIC GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST)
+endif ()
 
 # GCC-7.3 (the default GCC version on Ubuntu:18.04) issues a warning (a member
 # variable may be used without being initialized), in this file. GCC-8.0 no
@@ -694,6 +699,7 @@ string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_storage" " -lcrc32c")
 string(
     CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
            "google_cloud_cpp_common"
+           " google_cloud_cpp_rest_internal"
            " libcurl openssl"
            " absl_memory"
            " absl_strings"

--- a/google/cloud/storage/config-grpc.cmake.in
+++ b/google/cloud/storage/config-grpc.cmake.in
@@ -15,6 +15,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_googleapis)
 find_dependency(google_cloud_cpp_grpc_utils)
+find_dependency(google_cloud_cpp_rest_internal)
 find_dependency(google_cloud_cpp_common)
 find_dependency(absl)
 find_dependency(CURL)

--- a/google/cloud/storage/config.cmake.in
+++ b/google/cloud/storage/config.cmake.in
@@ -14,6 +14,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_common)
+find_dependency(google_cloud_cpp_rest_internal)
 find_dependency(absl)
 find_dependency(CURL)
 find_dependency(Crc32c)

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -23,6 +23,10 @@ namespace oauth2 {
 StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri) {
+#if GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST
+  return google::cloud::oauth2_internal::ParseAuthorizedUserCredentials(
+      content, source, default_token_uri);
+#else
   auto credentials = nlohmann::json::parse(content, nullptr, false);
   if (!credentials.is_object()) {
     return Status(
@@ -57,6 +61,7 @@ StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
       // "token_uri" attribute in the JSON object.  In this case, we try using
       // the default value.
       credentials.value("token_uri", default_token_uri)};
+#endif
 }
 
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>

--- a/google/cloud/storage/oauth2/authorized_user_credentials.h
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.h
@@ -21,6 +21,9 @@
 #include "google/cloud/storage/oauth2/credentials.h"
 #include "google/cloud/storage/oauth2/refreshing_credentials_wrapper.h"
 #include "google/cloud/storage/version.h"
+#ifdef GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST
+#include "google/cloud/internal/oauth2_authorized_user_credentials.h"
+#endif
 #include "google/cloud/status.h"
 #include <chrono>
 #include <iostream>
@@ -32,15 +35,21 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace oauth2 {
+
+#ifdef GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST
 /// Object to hold information used to instantiate an AuthorizedUserCredentials.
+using AuthorizedUserCredentialsInfo =
+    google::cloud::oauth2_internal::AuthorizedUserCredentialsInfo;
+#else
 struct AuthorizedUserCredentialsInfo {
   std::string client_id;
   std::string client_secret;
   std::string refresh_token;
   std::string token_uri;
 };
-
+#endif
 /// Parses a user credentials JSON string into an AuthorizedUserCredentialsInfo.
+
 StatusOr<AuthorizedUserCredentialsInfo> ParseAuthorizedUserCredentials(
     std::string const& content, std::string const& source,
     std::string const& default_token_uri = GoogleOAuthRefreshEndpoint());
@@ -74,6 +83,27 @@ ParseAuthorizedUserRefreshResponse(
  * @tparam ClockType a dependency injection point to fetch the current time.
  *     This should generally not be overridden except for testing.
  */
+#ifdef GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST
+template <typename HttpRequestBuilderType =
+              storage::internal::CurlRequestBuilder,
+          typename ClockType = std::chrono::system_clock>
+class AuthorizedUserCredentials : public Credentials {
+ public:
+  explicit AuthorizedUserCredentials(AuthorizedUserCredentialsInfo info,
+                                     ChannelOptions const& channel_options = {})
+      : impl_(std::move(info), Options{}.set<CARootsFilePathOption>(
+                                   channel_options.ssl_root_path())) {}
+
+  StatusOr<std::string> AuthorizationHeader() override {
+    auto header = impl_.AuthorizationHeader();
+    if (!header.ok()) return header.status();
+    return header->first + ": " + header->second;
+  }
+
+ private:
+  google::cloud::oauth2_internal::AuthorizedUserCredentials impl_;
+};
+#else
 template <typename HttpRequestBuilderType =
               storage::internal::CurlRequestBuilder,
           typename ClockType = std::chrono::system_clock>
@@ -116,6 +146,7 @@ class AuthorizedUserCredentials : public Credentials {
   mutable std::mutex mu_;
   RefreshingCredentialsWrapper refreshing_creds_;
 };
+#endif
 
 }  // namespace oauth2
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials_test.cc
@@ -29,19 +29,21 @@ namespace oauth2 {
 namespace {
 
 using ::google::cloud::storage::internal::HttpResponse;
-using ::google::cloud::storage::testing::MockHttpRequest;
 using ::google::cloud::storage::testing::MockHttpRequestBuilder;
 using ::google::cloud::testing_util::FakeClock;
 using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
-using ::testing::_;
 using ::testing::AllOf;
-using ::testing::An;
-using ::testing::AtLeast;
 using ::testing::HasSubstr;
 using ::testing::Not;
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST
+using ::google::cloud::storage::testing::MockHttpRequest;
+using ::testing::_;
+using ::testing::An;
+using ::testing::AtLeast;
 using ::testing::Return;
 using ::testing::StrEq;
+#endif
 
 class AuthorizedUserCredentialsTest : public ::testing::Test {
  protected:
@@ -52,6 +54,7 @@ class AuthorizedUserCredentialsTest : public ::testing::Test {
   void TearDown() override { MockHttpRequestBuilder::mock_.reset(); }
 };
 
+#ifndef GOOGLE_CLOUD_CPP_STORAGE_OAUTH2_HAVE_REST
 /// @test Verify that we can create credentials from a JWT string.
 TEST_F(AuthorizedUserCredentialsTest, Simple) {
   std::string response = R"""({
@@ -247,6 +250,7 @@ TEST_F(AuthorizedUserCredentialsTest, UsesCARootsInfo) {
   EXPECT_EQ("Authorization: Mock-Type fake-token",
             credentials.AuthorizationHeader().value());
 }
+#endif
 
 /// @test Verify that parsing an authorized user account JSON string works.
 TEST_F(AuthorizedUserCredentialsTest, ParseSimple) {


### PR DESCRIPTION
This PR is the first of many to refactor storage/oauth2 to conditionally use the REST library in lieu of the curl wrappers in storage/internal. It adds two new builds to the CI process one for testing cmake builds and another to test bazel builds. Both of these new builds enable use of the REST library. All other builds continue to use the storage curl wrappers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8745)
<!-- Reviewable:end -->
