### PR TITLE
impl(storage): support for partial writes in `UploadChunkRequest`

### DIFF
--- a/google/cloud/storage/idempotency_policy_test.cc
+++ b/google/cloud/storage/idempotency_policy_test.cc
@@ -618,8 +618,7 @@ TEST(StrictIdempotencyPolicyTest, ResumableUploadIfGenerationMatch) {
 TEST(StrictIdempotencyPolicyTest, UploadChunk) {
   StrictIdempotencyPolicy policy;
   internal::UploadChunkRequest request("https://test-url.example.com", 0,
-                                       {internal::ConstBuffer{"test-payload"}},
-                                       0);
+                                       {internal::ConstBuffer{"test-payload"}});
   EXPECT_TRUE(policy.IsIdempotent(request));
 }
 

--- a/google/cloud/storage/internal/curl_client_test.cc
+++ b/google/cloud/storage/internal/curl_client_test.cc
@@ -146,7 +146,7 @@ TEST_P(CurlClientTest, UploadChunk) {
   auto actual = client_
                     ->UploadSessionChunk(UploadChunkRequest(
                         "http://localhost:1/invalid-session-id", 0,
-                        {ConstBuffer{std::string{}}}, 0))
+                        {ConstBuffer{std::string{}}}))
                     .status();
   CheckStatus(actual);
 }

--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -33,9 +33,9 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
 }
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
-    ConstBufferSequence const& buffers, std::uint64_t upload_size,
-    HashValues const& /*full_object_hashes*/) {
-  UploadChunkRequest request(session_id_, next_expected_, buffers, upload_size);
+    ConstBufferSequence const& buffers, std::uint64_t /*upload_size*/,
+    HashValues const& hashes) {
+  UploadChunkRequest request(session_id_, next_expected_, buffers, hashes);
   request.set_multiple_options(
       request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
       request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -78,16 +78,16 @@ TEST(CurlResumableUploadSessionTest, Simple) {
                   "none-match-etag");
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));
-        EXPECT_EQ(0, request.source_size());
-        EXPECT_EQ(0, request.range_begin());
+        EXPECT_FALSE(request.upload_size().has_value());
+        EXPECT_EQ(0, request.offset());
         return make_status_or(ResumableUploadResponse{
             "", ResumableUploadResponse::kInProgress, size, {}, {}});
       })
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));
-        EXPECT_EQ(2 * size, request.source_size());
-        EXPECT_EQ(size, request.range_begin());
+        EXPECT_EQ(2 * size, request.upload_size().value_or(0));
+        EXPECT_EQ(size, request.offset());
         return make_status_or(ResumableUploadResponse{
             "", ResumableUploadResponse::kDone, 2 * size, {}, {}});
       });
@@ -168,8 +168,9 @@ TEST(CurlResumableUploadSessionTest, Empty) {
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));
-        EXPECT_EQ(0, request.source_size());
-        EXPECT_EQ(0, request.range_begin());
+        EXPECT_TRUE(request.upload_size().has_value());
+        EXPECT_EQ(0, request.upload_size().value_or(0));
+        EXPECT_EQ(0, request.offset());
         return make_status_or(ResumableUploadResponse{
             "", ResumableUploadResponse::kDone, size, {}, {}});
       });

--- a/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session_test.cc
@@ -86,6 +86,7 @@ TEST(CurlResumableUploadSessionTest, Simple) {
       .WillOnce([&](UploadChunkRequest const& request) {
         EXPECT_EQ(test_url, request.upload_session_url());
         EXPECT_THAT(request.payload(), MatchesPayload(payload));
+        EXPECT_TRUE(request.upload_size().has_value());
         EXPECT_EQ(2 * size, request.upload_size().value_or(0));
         EXPECT_EQ(size, request.offset());
         return make_status_or(ResumableUploadResponse{

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -494,7 +494,7 @@ StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
       google::storage::v2::ServiceConstants::MAX_WRITE_CHUNK_BYTES;
   std::string chunk;
   chunk.reserve(maximum_chunk_size);
-  auto offset = static_cast<google::protobuf::int64>(request.range_begin());
+  auto offset = static_cast<google::protobuf::int64>(request.offset());
 
   auto flush_chunk = [&](bool has_more) {
     if (chunk.size() < maximum_chunk_size && has_more) return true;

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -56,9 +56,9 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadChunk(
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& payload, std::uint64_t,
     HashValues const& full_object_hashes) {
-  auto request = UploadChunkRequest(
-      session_id_params_.upload_id, committed_size_, payload,
-      committed_size_ + TotalBytes(payload), full_object_hashes);
+  auto request =
+      UploadChunkRequest(session_id_params_.upload_id, committed_size_, payload,
+                         full_object_hashes);
   request.set_multiple_options(
       request_.GetOption<UserProject>(), request_.GetOption<Fields>(),
       request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -399,7 +399,7 @@ std::ostream& operator<<(std::ostream& os,
 std::string UploadChunkRequest::RangeHeader() const {
   std::ostringstream os;
   os << "Content-Range: bytes ";
-  auto const size = upload_size().value_or(0);
+  auto const size = payload_size();
   if (size == 0) {
     // This typically happens when the sender realizes too late that the
     // previous chunk was really the last chunk (e.g. the file is exactly a

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -421,7 +421,11 @@ std::string UploadChunkRequest::RangeHeader() const {
 UploadChunkRequest UploadChunkRequest::RemainingChunk(
     std::uint64_t new_offset) const {
   UploadChunkRequest result = *this;
-  if (new_offset < offset()) return result;
+  if (new_offset < offset_) {
+    result.offset_ = new_offset;
+    result.payload_.clear();
+    return result;
+  }
   PopFrontBytes(result.payload_, new_offset - result.offset_);
   result.offset_ = new_offset;
   return result;

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -396,19 +396,10 @@ std::ostream& operator<<(std::ostream& os,
             << "}";
 }
 
-UploadChunkRequest UploadChunkRequest::RemainingChunk(
-    std::uint64_t new_offset) const {
-  UploadChunkRequest result = *this;
-  if (new_offset < offset()) return result;
-  PopFrontBytes(result.payload_, new_offset - result.offset_);
-  result.offset_ = new_offset;
-  return result;
-}
-
 std::string UploadChunkRequest::RangeHeader() const {
   std::ostringstream os;
   os << "Content-Range: bytes ";
-  auto const size = payload_size();
+  auto const size = upload_size().value_or(0);
   if (size == 0) {
     // This typically happens when the sender realizes too late that the
     // previous chunk was really the last chunk (e.g. the file is exactly a
@@ -417,14 +408,23 @@ std::string UploadChunkRequest::RangeHeader() const {
     // the range is special in this case.
     os << "*";
   } else {
-    os << range_begin() << "-" << range_begin() + size - 1;
+    os << offset() << "-" << offset() + size - 1;
   }
-  if (!last_chunk_) {
+  if (!upload_size().has_value()) {
     os << "/*";
   } else {
-    os << "/" << source_size();
+    os << "/" << *upload_size();
   }
   return std::move(os).str();
+}
+
+UploadChunkRequest UploadChunkRequest::RemainingChunk(
+    std::uint64_t new_offset) const {
+  UploadChunkRequest result = *this;
+  if (new_offset < offset()) return result;
+  PopFrontBytes(result.payload_, new_offset - result.offset_);
+  result.offset_ = new_offset;
+  return result;
 }
 
 std::ostream& operator<<(std::ostream& os, UploadChunkRequest const& r) {

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -396,6 +396,15 @@ std::ostream& operator<<(std::ostream& os,
             << "}";
 }
 
+UploadChunkRequest UploadChunkRequest::RemainingChunk(
+    std::uint64_t new_offset) const {
+  UploadChunkRequest result = *this;
+  if (new_offset < offset()) return result;
+  PopFrontBytes(result.payload_, new_offset - result.offset_);
+  result.offset_ = new_offset;
+  return result;
+}
+
 std::string UploadChunkRequest::RangeHeader() const {
   std::ostringstream os;
   os << "Content-Range: bytes ";

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -26,6 +26,7 @@
 #include "google/cloud/storage/upload_options.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "absl/types/optional.h"
 #include "absl/types/span.h"
 #include <numeric>
 #include <string>
@@ -428,6 +429,13 @@ class UploadChunkRequest
   bool last_chunk() const { return upload_size_.has_value(); }
   std::size_t payload_size() const { return TotalBytes(payload_); }
   std::string RangeHeader() const;
+
+  /**
+   * Returns the request to continue writing at @p new_offset.
+   *
+   * @note the result of calling this with an out of range value is undefined
+   *     behavior.
+   */
   UploadChunkRequest RemainingChunk(std::uint64_t new_offset) const;
 
   // Chunks must be multiples of 256 KiB:

--- a/google/cloud/storage/internal/object_requests_test.cc
+++ b/google/cloud/storage/internal/object_requests_test.cc
@@ -532,9 +532,8 @@ TEST(ObjectRequestsTest, UploadChunk) {
   auto const payload = std::string(2048, 'A');
   UploadChunkRequest request(url, 0, {{payload}}, HashValues{});
   EXPECT_EQ(url, request.upload_session_url());
-  EXPECT_EQ(0, request.range_begin());
-  EXPECT_EQ(2047, request.range_end());
-  EXPECT_EQ(2048, request.source_size());
+  EXPECT_EQ(0, request.offset());
+  EXPECT_EQ(2048, request.upload_size().value_or(0));
   EXPECT_EQ("Content-Range: bytes 0-2047/2048", request.RangeHeader());
 
   std::ostringstream os;


### PR DESCRIPTION
This changes the `internal::UploadChunkRequest` class to support partial
writes. The class remains immutable, but now provides a function to
return a new `UploadChunkRequest` with the remaining data (but the
original options) after a partial write.

Part of the work for #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8747)
<!-- Reviewable:end -->
