### PR TITLE
test(spanner): a more flexible PickInstanceConfig()

### DIFF
--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/integration_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
 #include <gmock/gmock.h>
 #include <algorithm>
 #include <regex>
@@ -161,13 +162,18 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
   ASSERT_FALSE(in.project_id().empty());
   ASSERT_FALSE(in.instance_id().empty());
 
-  auto instance_config = spanner_testing::PickInstanceConfig(
-      in.project_id(), std::regex(".*us-west.*"), generator_);
-  ASSERT_FALSE(instance_config.empty()) << "could not get an instance config";
+  auto instance_config_name = spanner_testing::PickInstanceConfig(
+      in.project(), generator_,
+      [](google::spanner::admin::instance::v1::InstanceConfig const&
+             instance_config) {
+        return absl::StrContains(instance_config.name(), "us-west");
+      });
+  ASSERT_FALSE(instance_config_name.empty())
+      << "could not get an instance config";
 
   auto instance =
       client_
-          .CreateInstance(CreateInstanceRequestBuilder(in, instance_config)
+          .CreateInstance(CreateInstanceRequestBuilder(in, instance_config_name)
                               .SetDisplayName("test-display-name")
                               .SetNodeCount(1)
                               .SetLabels({{"label-key", "label-value"}})
@@ -178,7 +184,7 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
   EXPECT_EQ(instance->name(), in.FullName());
   EXPECT_EQ(instance->display_name(), "test-display-name");
   EXPECT_NE(instance->node_count(), 0);
-  EXPECT_EQ(instance->config(), instance_config);
+  EXPECT_EQ(instance->config(), instance_config_name);
   EXPECT_EQ(instance->labels().at("label-key"), "label-value");
 
   // Then update the instance

--- a/google/cloud/spanner/testing/pick_instance_config.h
+++ b/google/cloud/spanner/testing/pick_instance_config.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/internal/random.h"
-#include <regex>
+#include "google/cloud/project.h"
+#include <google/spanner/admin/instance/v1/spanner_instance_admin.pb.h>
+#include <functional>
 #include <string>
 
 namespace google {
@@ -25,12 +27,19 @@ namespace cloud {
 namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/// Pick one instance_config from a list given a PRNG generator, project_id,
-/// and a regex for filtering, if none matches the filter, it will return the
-/// value for the first element.
-std::string PickInstanceConfig(std::string const& project_id,
-                               std::regex const& filter_regex,
-                               google::cloud::internal::DefaultPRNG& generator);
+/**
+ * Returns the name of one instance config that satisfies the given
+ * predicate from amongst all those that exist within the given project.
+ *
+ * If multiple instance configs qualify, the one returned is chosen
+ * at random using the PRNG. If none qualify, the first candidate is
+ * returned. If there are no candidates, the empty string is returned.
+ */
+std::string PickInstanceConfig(
+    Project const& project, google::cloud::internal::DefaultPRNG& generator,
+    std::function<
+        bool(google::spanner::admin::instance::v1::InstanceConfig const&)>
+        predicate);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner_testing


### PR DESCRIPTION
Change PickInstanceConfig() to take a predicate over InstanceConfig
values instead of a regex to match against InstanceConfig.name. This
provides a flexibility that will be needed for an upcoming feature
where we will need to select an instance config based upon more
complex conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8748)
<!-- Reviewable:end -->
