### PR TITLE
chore(spanner): use upper-case SQL keywords consistently

### DIFF
--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -192,7 +192,7 @@ TEST(ClientTest, ExecuteQuerySuccess) {
       .WillOnce(Return(ByMove(RowStream(std::move(source)))));
 
   KeySet keys = KeySet::All();
-  auto rows = client.ExecuteQuery(SqlStatement("select * from table;"));
+  auto rows = client.ExecuteQuery(SqlStatement("SELECT * FROM Table;"));
 
   using RowType = std::tuple<std::string, std::int64_t>;
   auto expected = std::vector<RowType>{
@@ -233,7 +233,7 @@ TEST(ClientTest, ExecuteQueryFailure) {
       .WillOnce(Return(ByMove(RowStream(std::move(source)))));
 
   KeySet keys = KeySet::All();
-  auto rows = client.ExecuteQuery(SqlStatement("select * from table;"));
+  auto rows = client.ExecuteQuery(SqlStatement("SELECT * FROM Table;"));
 
   auto tups = StreamOf<std::tuple<std::string>>(rows);
   auto iter = tups.begin();
@@ -821,7 +821,7 @@ TEST(ClientTest, CommitMutatorWithTags) {
   Client client(conn);
   auto mutator = [&client](Transaction const& txn) -> StatusOr<Mutations> {
     auto query_rows = client.ExecuteQuery(
-        txn, SqlStatement("select * from table;"),
+        txn, SqlStatement("SELECT * FROM Table;"),
         QueryOptions{}.set_request_tag("action=ExecuteQuery"));
     auto result = client.ExecuteBatchDml(
         txn, {SqlStatement("UPDATE Foo SET Bar = 2")},
@@ -1004,7 +1004,7 @@ TEST(ClientTest, ProfileQuerySuccess) {
       .WillOnce(Return(ByMove(ProfileQueryResult(std::move(source)))));
 
   KeySet keys = KeySet::All();
-  auto rows = client.ProfileQuery(SqlStatement("select * from table;"));
+  auto rows = client.ProfileQuery(SqlStatement("SELECT * FROM Table;"));
 
   using RowType = std::tuple<std::string, std::int64_t>;
   auto expected = std::vector<RowType>{
@@ -1071,7 +1071,7 @@ TEST(ClientTest, ProfileQueryWithOptionsSuccess) {
   auto rows = client.ProfileQuery(
       Transaction::SingleUseOptions(
           /*max_staleness=*/std::chrono::nanoseconds(std::chrono::minutes(5))),
-      SqlStatement("select * from table;"));
+      SqlStatement("SELECT * FROM Table;"));
 
   using RowType = std::tuple<std::string, std::int64_t>;
   auto expected = std::vector<RowType>{

--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -632,7 +632,7 @@ TEST_F(ClientIntegrationTest, PartitionQuery) {
   auto ro_transaction = MakeReadOnlyTransaction();
   auto query_partitions = client_->PartitionQuery(
       ro_transaction,
-      SqlStatement("select SingerId, FirstName, LastName from Singers"));
+      SqlStatement("SELECT SingerId, FirstName, LastName FROM Singers"));
   ASSERT_STATUS_OK(query_partitions);
 
   std::vector<std::string> serialized_partitions;

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -707,7 +707,7 @@ TEST(ConnectionImplTest, ExecuteQueryGetSessionFailure) {
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
   for (auto& row : rows) {
     EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
                               HasSubstr("uh-oh in GetSession")));
@@ -729,7 +729,7 @@ TEST(ConnectionImplTest, ExecuteQueryStreamingReadFailure) {
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
   for (auto& row : rows) {
     EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
                               HasSubstr("uh-oh in GrpcReader::Finish")));
@@ -767,7 +767,7 @@ TEST(ConnectionImplTest, ExecuteQueryReadSuccess) {
 
   auto rows = conn->ExecuteQuery(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
   using RowType = std::tuple<std::int64_t, std::string>;
   auto expected = std::vector<RowType>{
       RowType(12, "Steve"),
@@ -797,7 +797,7 @@ TEST(ConnectionImplTest, ExecuteQueryImplicitBeginTransaction) {
   spanner::Transaction txn =
       MakeReadOnlyTransaction(spanner::Transaction::ReadOnlyOptions());
   auto rows =
-      conn->ExecuteQuery({txn, spanner::SqlStatement("select * from table")});
+      conn->ExecuteQuery({txn, spanner::SqlStatement("SELECT * FROM Table")});
   EXPECT_TRUE(ContainsNoRows(rows));
   EXPECT_THAT(txn,
               HasSessionAndTransaction("test-session-name", "00FEDCBA", ""));
@@ -1071,7 +1071,7 @@ TEST(ConnectionImplTest, ExecuteDmlGetSessionFailure) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ExecuteDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ExecuteDml({txn, spanner::SqlStatement("DELETE * FROM Table")});
 
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in GetSession")));
@@ -1099,7 +1099,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteSuccess) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ExecuteDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ExecuteDml({txn, spanner::SqlStatement("DELETE * FROM Table")});
 
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result->RowsModified(), 42);
@@ -1125,7 +1125,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeletePermanentFailure) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ExecuteDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ExecuteDml({txn, spanner::SqlStatement("DELETE * FROM table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in ExecuteDml")));
 }
@@ -1154,7 +1154,7 @@ TEST(ConnectionImplTest, ExecuteDmlDeleteTooManyTransientFailures) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ExecuteDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ExecuteDml({txn, spanner::SqlStatement("DELETE * FROM table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("try-again in ExecuteDml")));
 }
@@ -1186,11 +1186,11 @@ TEST(ConnectionImplTest, ExecuteDmlTransactionAtomicity) {
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   // The first operation fails with the status of the operation's RPC
   // (`ExecuteSql` in this case).
-  EXPECT_THAT(conn->ExecuteDml({txn, spanner::SqlStatement("some statement")}),
+  EXPECT_THAT(conn->ExecuteDml({txn, spanner::SqlStatement("SOME STATEMENT")}),
               StatusIs(op_status.code(), HasSubstr(op_status.message())));
   // Subsequent operations fail with the status of `BeginTransaction`.
   EXPECT_THAT(
-      conn->ExecuteDml({txn, spanner::SqlStatement("another statement")}),
+      conn->ExecuteDml({txn, spanner::SqlStatement("ANOTHER STATEMENT")}),
       StatusIs(begin_status.code(), HasSubstr(begin_status.message())));
   EXPECT_THAT(conn->Commit({txn, {}}),
               StatusIs(begin_status.code(), HasSubstr(begin_status.message())));
@@ -1213,7 +1213,7 @@ TEST(ConnectionImplTest, ExecuteDmlTransactionMissing) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   EXPECT_THAT(
-      conn->ExecuteDml({txn, spanner::SqlStatement("select 1")}),
+      conn->ExecuteDml({txn, spanner::SqlStatement("SELECT 1")}),
       StatusIs(StatusCode::kInternal,
                HasSubstr(
                    "Begin transaction requested but no transaction returned")));
@@ -1258,7 +1258,7 @@ TEST(ConnectionImplTest, ProfileQuerySuccess) {
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
   using RowType = std::tuple<std::int64_t, std::string>;
   auto expected = std::vector<RowType>{
       RowType(12, "Steve"),
@@ -1300,7 +1300,7 @@ TEST(ConnectionImplTest, ProfileQueryGetSessionFailure) {
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
   for (auto& row : result) {
     EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
                               HasSubstr("uh-oh in GetSession")));
@@ -1322,7 +1322,7 @@ TEST(ConnectionImplTest, ProfileQueryStreamingReadFailure) {
 
   auto result = conn->ProfileQuery(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
   for (auto& row : result) {
     EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied,
                               HasSubstr("uh-oh in GrpcReader::Finish")));
@@ -1341,7 +1341,7 @@ TEST(ConnectionImplTest, ProfileDmlGetSessionFailure) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ProfileDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ProfileDml({txn, spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in GetSession")));
 }
@@ -1377,7 +1377,7 @@ TEST(ConnectionImplTest, ProfileDmlDeleteSuccess) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ProfileDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ProfileDml({txn, spanner::SqlStatement("DELETE * FROM Table")});
 
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result->RowsModified(), 42);
@@ -1419,7 +1419,7 @@ TEST(ConnectionImplTest, ProfileDmlDeletePermanentFailure) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ProfileDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ProfileDml({txn, spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in ExecuteDml")));
 }
@@ -1448,7 +1448,7 @@ TEST(ConnectionImplTest, ProfileDmlDeleteTooManyTransientFailures) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->ProfileDml({txn, spanner::SqlStatement("delete * from table")});
+      conn->ProfileDml({txn, spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("try-again in ExecuteDml")));
 }
@@ -1474,7 +1474,7 @@ TEST(ConnectionImplTest, AnalyzeSqlSuccess) {
 
   auto result = conn->AnalyzeSql(
       {MakeSingleUseTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table")});
+       spanner::SqlStatement("SELECT * FROM Table")});
 
   auto constexpr kTextExpectedPlan = R"pb(
     plan_nodes: { index: 42 }
@@ -1498,7 +1498,7 @@ TEST(ConnectionImplTest, AnalyzeSqlGetSessionFailure) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->AnalyzeSql({txn, spanner::SqlStatement("delete * from table")});
+      conn->AnalyzeSql({txn, spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in GetSession")));
 }
@@ -1523,7 +1523,7 @@ TEST(ConnectionImplTest, AnalyzeSqlDeletePermanentFailure) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->AnalyzeSql({txn, spanner::SqlStatement("delete * from table")});
+      conn->AnalyzeSql({txn, spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in ExecuteDml")));
 }
@@ -1552,7 +1552,7 @@ TEST(ConnectionImplTest, AnalyzeSqlDeleteTooManyTransientFailures) {
   spanner::Transaction txn =
       MakeReadWriteTransaction(spanner::Transaction::ReadWriteOptions());
   auto result =
-      conn->AnalyzeSql({txn, spanner::SqlStatement("delete * from table")});
+      conn->AnalyzeSql({txn, spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
                                HasSubstr("try-again in ExecuteDml")));
 }
@@ -1583,9 +1583,9 @@ TEST(ConnectionImplTest, ExecuteBatchDmlSuccess) {
       .WillOnce(Return(response));
 
   auto request = {
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
   };
 
   auto conn = MakeConnectionImpl(db, {mock});
@@ -1627,9 +1627,9 @@ TEST(ConnectionImplTest, ExecuteBatchDmlPartialFailure) {
   EXPECT_CALL(*mock, ExecuteBatchDml).WillOnce(Return(response));
 
   auto request = {
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
   };
 
   auto conn = MakeConnectionImpl(db, {mock});
@@ -1664,9 +1664,9 @@ TEST(ConnectionImplTest, ExecuteBatchDmlPermanentFailure) {
   }
 
   auto request = {
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
   };
 
   auto conn = MakeLimitedRetryConnection(db, mock);
@@ -1698,9 +1698,9 @@ TEST(ConnectionImplTest, ExecuteBatchDmlTooManyTransientFailures) {
   }
 
   auto request = {
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
-      spanner::SqlStatement("update ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
+      spanner::SqlStatement("UPDATE ..."),
   };
 
   auto conn = MakeLimitedRetryConnection(db, mock);
@@ -1735,7 +1735,7 @@ TEST(ConnectionImplTest, ExecuteBatchDmlNoResultSets) {
         .WillOnce(Return(response));
   }
 
-  auto request = {spanner::SqlStatement("update ...")};
+  auto request = {spanner::SqlStatement("UPDATE ...")};
   auto conn = MakeConnectionImpl(db, {mock});
   auto txn = spanner::MakeReadWriteTransaction();
   auto result = conn->ExecuteBatchDml({txn, request});
@@ -1767,7 +1767,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteSuccess) {
       .WillOnce(Return(ByMove(MakeReader({kTextResponse}))));
 
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table"),
+      {spanner::SqlStatement("DELETE * FROM Table"),
        spanner::QueryOptions().set_request_tag("tag")});
 
   ASSERT_STATUS_OK(result);
@@ -1784,7 +1784,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlGetSessionFailure) {
           Return(Status(StatusCode::kPermissionDenied, "uh-oh in GetSession")));
 
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table")});
+      {spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in GetSession")));
 }
@@ -1808,7 +1808,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeletePermanentFailure) {
       .WillOnce(Return(ByMove(
           MakeReader({}, {grpc::StatusCode::INTERNAL, "permanent failure"}))));
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table")});
+      {spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result,
               StatusIs(StatusCode::kInternal, HasSubstr("permanent failure")));
 }
@@ -1835,7 +1835,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlDeleteTooManyTransientFailures) {
       });
 
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table")});
+      {spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result,
               StatusIs(StatusCode::kUnavailable,
                        HasSubstr("try-again in ExecutePartitionedDml")));
@@ -1870,7 +1870,7 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlRetryableInternalErrors) {
       .WillOnce(Return(ByMove(MakeReader({kTextResponse}))));
 
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table")});
+      {spanner::SqlStatement("DELETE * FROM Table")});
 
   ASSERT_STATUS_OK(result);
   EXPECT_EQ(result->row_count_lower_bound, 99999);
@@ -1891,7 +1891,7 @@ TEST(ConnectionImplTest,
                               "uh-oh in ExecutePartitionedDml")));
 
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table")});
+      {spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr("uh-oh in ExecutePartitionedDml")));
 }
@@ -1912,7 +1912,7 @@ TEST(ConnectionImplTest,
                                     "try-again in ExecutePartitionedDml")));
 
   auto result = conn->ExecutePartitionedDml(
-      {spanner::SqlStatement("delete * from table")});
+      {spanner::SqlStatement("DELETE * FROM Table")});
   EXPECT_THAT(result,
               StatusIs(StatusCode::kUnavailable,
                        HasSubstr("try-again in ExecutePartitionedDml")));
@@ -2447,7 +2447,7 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
     transaction: {
       begin { read_only { strong: true return_read_timestamp: true } }
     }
-    sql: "select * from table"
+    sql: "SELECT * FROM Table"
     params: {}
     partition_options: {}
   )pb";
@@ -2458,7 +2458,7 @@ TEST(ConnectionImplTest, PartitionQuerySuccess) {
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce(Return(partition_response));
 
-  spanner::SqlStatement sql_statement("select * from table");
+  spanner::SqlStatement sql_statement("SELECT * FROM Table");
   StatusOr<std::vector<spanner::QueryPartition>> result = conn->PartitionQuery(
       {MakeReadOnlyTransaction(spanner::Transaction::ReadOnlyOptions()),
        sql_statement, spanner::PartitionOptions()});
@@ -2492,7 +2492,7 @@ TEST(ConnectionImplTest, PartitionQueryPermanentFailure) {
 
   StatusOr<std::vector<spanner::QueryPartition>> result = conn->PartitionQuery(
       {MakeReadOnlyTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table"),
+       spanner::SqlStatement("SELECT * FROM Table"),
        spanner::PartitionOptions()});
   EXPECT_THAT(result, StatusIs(StatusCode::kPermissionDenied,
                                HasSubstr(failed_status.message())));
@@ -2522,7 +2522,7 @@ TEST(ConnectionImplTest, PartitionQueryTooManyTransientFailures) {
 
   StatusOr<std::vector<spanner::QueryPartition>> result = conn->PartitionQuery(
       {MakeReadOnlyTransaction(spanner::Transaction::ReadOnlyOptions()),
-       spanner::SqlStatement("select * from table"),
+       spanner::SqlStatement("SELECT * FROM Table"),
        spanner::PartitionOptions()});
   EXPECT_THAT(result, StatusIs(StatusCode::kUnavailable,
                                HasSubstr(failed_status.message())));
@@ -2950,37 +2950,37 @@ TEST(ConnectionImplTest, OperationsFailOnInvalidatedTransaction) {
       StatusIs(StatusCode::kInvalidArgument,
                HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(conn->ExecuteQuery({txn, spanner::SqlStatement("select 1")})
+  EXPECT_THAT(conn->ExecuteQuery({txn, spanner::SqlStatement("SELECT 1")})
                   .begin()
                   ->status(),
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("BeginTransaction failed")));
 
   EXPECT_THAT(
-      conn->ExecuteDml({txn, spanner::SqlStatement("delete * from table")}),
+      conn->ExecuteDml({txn, spanner::SqlStatement("DELETE * FROM Table")}),
       StatusIs(StatusCode::kInvalidArgument,
                HasSubstr("BeginTransaction failed")));
 
-  EXPECT_THAT(conn->ProfileQuery({txn, spanner::SqlStatement("select 1")})
+  EXPECT_THAT(conn->ProfileQuery({txn, spanner::SqlStatement("SELECT 1")})
                   .begin()
                   ->status(),
               StatusIs(StatusCode::kInvalidArgument,
                        HasSubstr("BeginTransaction failed")));
 
   EXPECT_THAT(
-      conn->ProfileDml({txn, spanner::SqlStatement("delete * from table")}),
+      conn->ProfileDml({txn, spanner::SqlStatement("DELETE * FROM Table")}),
       StatusIs(StatusCode::kInvalidArgument,
                HasSubstr("BeginTransaction failed")));
 
   EXPECT_THAT(
-      conn->AnalyzeSql({txn, spanner::SqlStatement("select * from table")}),
+      conn->AnalyzeSql({txn, spanner::SqlStatement("SELECT * FROM Table")}),
       StatusIs(StatusCode::kInvalidArgument,
                HasSubstr("BeginTransaction failed")));
 
   // ExecutePartitionedDml creates its own transaction so it's not tested here.
 
   EXPECT_THAT(
-      conn->PartitionQuery({txn, spanner::SqlStatement("select * from table"),
+      conn->PartitionQuery({txn, spanner::SqlStatement("SELECT * FROM Table"),
                             spanner::PartitionOptions()}),
       StatusIs(StatusCode::kInvalidArgument,
                HasSubstr("BeginTransaction failed")));

--- a/google/cloud/spanner/query_partition_test.cc
+++ b/google/cloud/spanner/query_partition_test.cc
@@ -59,7 +59,7 @@ using ::google::cloud::testing_util::IsOk;
 using ::testing::Not;
 
 TEST(QueryPartitionTest, MakeQueryPartition) {
-  std::string stmt("select * from foo where name = @name");
+  std::string stmt("SELECT * FROM foo WHERE name = @name");
   SqlStatement::ParamType params = {{"name", Value("Bob")}};
   std::string partition_token("token");
   std::string session_id("session");
@@ -78,7 +78,7 @@ TEST(QueryPartitionTest, MakeQueryPartition) {
 }
 
 TEST(QueryPartitionTest, Constructor) {
-  std::string stmt("select * from foo where name = @name");
+  std::string stmt("SELECT * FROM foo WHERE name = @name");
   SqlStatement::ParamType params = {{"name", Value("Bob")}};
   std::string partition_token("token");
   std::string session_id("session");
@@ -97,7 +97,7 @@ TEST(QueryPartitionTest, Constructor) {
 }
 
 TEST(QueryPartitionTest, RegularSemantics) {
-  std::string stmt("select * from foo where name = @name");
+  std::string stmt("SELECT * FROM foo WHERE name = @name");
   SqlStatement::ParamType params = {{"name", Value("Bob")}};
   std::string partition_token("token");
   std::string session_id("session");
@@ -124,7 +124,7 @@ TEST(QueryPartitionTest, RegularSemantics) {
 TEST(QueryPartitionTest, SerializeDeserialize) {
   QueryPartitionTester expected_partition(spanner_internal::MakeQueryPartition(
       "txn-id", "tag", "session", "token",
-      SqlStatement("select * from foo where name = @name",
+      SqlStatement("SELECT * FROM foo WHERE name = @name",
                    {{"name", Value("Bob")}})));
   StatusOr<QueryPartition> partition = DeserializeQueryPartition(
       *(SerializeQueryPartition(expected_partition.Partition())));
@@ -154,14 +154,14 @@ TEST(QueryPartitionTest, FailedDeserialize) {
 TEST(QueryPartitionTest, MakeSqlParams) {
   QueryPartitionTester expected_partition(spanner_internal::MakeQueryPartition(
       "txn-id", "tag", "session", "token",
-      SqlStatement("select * from foo where name = @name",
+      SqlStatement("SELECT * FROM foo WHERE name = @name",
                    {{"name", Value("Bob")}})));
 
   Connection::SqlParams params =
       spanner_internal::MakeSqlParams(expected_partition.Partition());
 
   EXPECT_EQ(params.statement,
-            SqlStatement("select * from foo where name = @name",
+            SqlStatement("SELECT * FROM foo WHERE name = @name",
                          {{"name", Value("Bob")}}));
   EXPECT_EQ(*params.partition_token, "token");
   EXPECT_THAT(params.transaction,

--- a/google/cloud/spanner/sql_statement_test.cc
+++ b/google/cloud/spanner/sql_statement_test.cc
@@ -32,7 +32,7 @@ using ::testing::Eq;
 using ::testing::UnorderedPointwise;
 
 TEST(SqlStatementTest, SqlAccessor) {
-  char const* statement = "select * from foo";
+  char const* statement = "SELECT * FROM foo";
   SqlStatement stmt(statement);
   EXPECT_EQ(statement, stmt.sql());
 }
@@ -40,7 +40,7 @@ TEST(SqlStatementTest, SqlAccessor) {
 TEST(SqlStatementTest, ParamsAccessor) {
   SqlStatement::ParamType params = {{"last", Value("Blues")},
                                     {"first", Value("Elwood")}};
-  SqlStatement stmt("select * from foo", params);
+  SqlStatement stmt("SELECT * FROM foo", params);
   EXPECT_TRUE(params == stmt.params());
 }
 
@@ -48,7 +48,7 @@ TEST(SqlStatementTest, ParameterNames) {
   std::vector<std::string> expected = {"first", "last"};
   SqlStatement::ParamType params = {{"last", Value("Blues")},
                                     {"first", Value("Elwood")}};
-  SqlStatement stmt("select * from foo", params);
+  SqlStatement stmt("SELECT * FROM foo", params);
   auto results = stmt.ParameterNames();
   EXPECT_THAT(expected, UnorderedPointwise(Eq(), results));
 }
@@ -57,7 +57,7 @@ TEST(SqlStatementTest, GetParameterExists) {
   auto expected = Value("Elwood");
   SqlStatement::ParamType params = {{"last", Value("Blues")},
                                     {"first", Value("Elwood")}};
-  SqlStatement stmt("select * from foo", params);
+  SqlStatement stmt("SELECT * FROM foo", params);
   auto results = stmt.GetParameter("first");
   ASSERT_STATUS_OK(results);
   EXPECT_EQ(expected, *results);
@@ -67,14 +67,14 @@ TEST(SqlStatementTest, GetParameterExists) {
 TEST(SqlStatementTest, GetParameterNotExist) {
   SqlStatement::ParamType params = {{"last", Value("Blues")},
                                     {"first", Value("Elwood")}};
-  SqlStatement stmt("select * from foo", params);
+  SqlStatement stmt("SELECT * FROM foo", params);
   auto results = stmt.GetParameter("middle");
   EXPECT_THAT(results,
               StatusIs(StatusCode::kNotFound, "No such parameter: middle"));
 }
 
 TEST(SqlStatementTest, OStreamOperatorNoParams) {
-  SqlStatement s1("SELECT * FROM TABLE FOO;");
+  SqlStatement s1("SELECT * FROM foo;");
   std::stringstream ss;
   ss << s1;
   EXPECT_EQ(s1.sql(), ss.str());
@@ -83,13 +83,13 @@ TEST(SqlStatementTest, OStreamOperatorNoParams) {
 TEST(SqlStatementTest, OStreamOperatorWithParams) {
   SqlStatement::ParamType params = {{"last", Value("Blues")},
                                     {"first", Value("Elwood")}};
-  SqlStatement stmt("select * from foo", params);
+  SqlStatement stmt("SELECT * FROM foo", params);
   std::string expected1(
-      "select * from foo\n"
+      "SELECT * FROM foo\n"
       "[param]: {first=Elwood}\n"
       "[param]: {last=Blues}");
   std::string expected2(
-      "select * from foo\n"
+      "SELECT * FROM foo\n"
       "[param]: {last=Blues}\n"
       "[param]: {first=Elwood}");
   std::stringstream ss;
@@ -112,8 +112,8 @@ TEST(SqlStatementTest, Equality) {
 }
 
 TEST(SqlStatementTest, ToProtoStatementOnly) {
-  SqlStatement stmt("select * from foo");
-  auto constexpr kText = R"pb(sql: "select * from foo")pb";
+  SqlStatement stmt("SELECT * FROM foo");
+  auto constexpr kText = R"pb(sql: "SELECT * FROM foo")pb";
   spanner_internal::SqlStatementProto expected;
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &expected));
   EXPECT_THAT(spanner_internal::ToProto(std::move(stmt)),


### PR DESCRIPTION
To enhance readability, and to make things more consistent, use the
conventional form of upper-case keywords in SQL statements everywhere.