### PR TITLE
impl(pubsub): Bypass SequentialBatchSink for empty ordering keys

### DIFF
--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -90,7 +90,8 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
       auto factory = [topic, opts, sink, cq](std::string const& key) {
         auto used_sink = sink;
         if (!key.empty()) {
-          used_sink = pubsub_internal::SequentialBatchSink::Create(sink);
+          used_sink = pubsub_internal::SequentialBatchSink::Create(
+              std::move(used_sink));
         }
         return pubsub_internal::BatchingPublisherConnection::Create(
             topic, opts, key, std::move(used_sink), cq);

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -90,6 +90,7 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
       auto factory = [topic, opts, sink, cq](std::string const& key) {
         auto used_sink = sink;
         if (!key.empty()) {
+          // Only wrap the sink if there is an ordering key.
           used_sink = pubsub_internal::SequentialBatchSink::Create(
               std::move(used_sink));
         }

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -88,9 +88,12 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
         pubsub_internal::DefaultBatchSink::Create(stub, cq, opts);
     if (opts.get<pubsub::MessageOrderingOption>()) {
       auto factory = [topic, opts, sink, cq](std::string const& key) {
+        auto used_sink = sink;
+        if (!key.empty()) {
+          used_sink = pubsub_internal::SequentialBatchSink::Create(sink);
+        }
         return pubsub_internal::BatchingPublisherConnection::Create(
-            topic, opts, key,
-            pubsub_internal::SequentialBatchSink::Create(sink), cq);
+            topic, opts, key, std::move(used_sink), cq);
       };
       return pubsub_internal::OrderingKeyPublisherConnection::Create(
           std::move(factory));


### PR DESCRIPTION
This should increase throughput of messages without ordering keys which are sent when message ordering is enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8753)
<!-- Reviewable:end -->
