### PR TITLE
impl(spanner): carry over some updates to AsyncPollingLoopImpl::OnPoll()

### DIFF
--- a/google/cloud/internal/async_polling_loop.cc
+++ b/google/cloud/internal/async_polling_loop.cc
@@ -139,16 +139,14 @@ class AsyncPollingLoopImpl
         // We should not be fabricating a `Status` value here. Rather, we
         // should cancel the operation and wait for the next poll to return
         // an accurate status to the user, otherwise they will have no idea
-        // how to react.
+        // how to react. But for now, we leave the operation running. It
+        // may eventually complete.
         return promise_.set_value(Status(
             StatusCode::kDeadlineExceeded,
             location_ + "() - polling loop terminated by polling policy"));
       }
+      // This could be a transient error if the policy is exhausted.
       return promise_.set_value(std::move(op).status());
-    }
-    if (op) {
-      std::unique_lock<std::mutex> lk(mu_);
-      op_name_ = std::move(*op->mutable_name());
     }
     return Wait();
   }


### PR DESCRIPTION
Pick up some less-polemic updates to `OnPoll()` from the closed #8695:
 - Add clarifying comments when we satisfy the promise with an error.
 - Don't even try to update `op_name_`; it must be set by the time we
   reach `OnPoll()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8756)
<!-- Reviewable:end -->
