### PR TITLE
cleanup(spanner): use the new PickInstanceConfig() API in samples

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -163,7 +163,7 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
       in.project(), generator_,
       [](google::spanner::admin::instance::v1::InstanceConfig const&
              instance_config) {
-        return absl::StrContains(instance_config.name(), "us-west");
+        return absl::StrContains(instance_config.name(), "/regional-us-west");
       });
   ASSERT_FALSE(instance_config_name.empty())
       << "could not get an instance config";

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -166,7 +166,7 @@ TEST_F(InstanceAdminClientTest, InstanceCRUDOperations) {
       in.project(), generator_,
       [](google::spanner::admin::instance::v1::InstanceConfig const&
              instance_config) {
-        return absl::StrContains(instance_config.name(), "us-west");
+        return absl::StrContains(instance_config.name(), "/regional-us-west");
       });
   ASSERT_FALSE(instance_config_name.empty())
       << "could not get an instance config";

--- a/google/cloud/spanner/testing/pick_instance_config.h
+++ b/google/cloud/spanner/testing/pick_instance_config.h
@@ -37,8 +37,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 std::string PickInstanceConfig(
     Project const& project, google::cloud::internal::DefaultPRNG& generator,
-    std::function<
-        bool(google::spanner::admin::instance::v1::InstanceConfig const&)>
+    std::function<bool(
+        google::spanner::admin::instance::v1::InstanceConfig const&)> const&
         predicate);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Use the new `spanner_testing::PickInstanceConfig()` predicate support
to replace the special `PickConfig()` function in the Spanner samples.

Simplify the `PickInstanceConfig()` implementation.  There is no need
to wrap the `ListInstanceConfigs()` in a lambda.

Plus some other miscellaneous cleanup:
 - Tighten up the `PickInstanceConfig()` predicate in the integration
   tests.
 - Use `config_id` consistently to distinguish instance configs from
   their ID.
 - Adjust some sample banners to use the real sample tag.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8758)
<!-- Reviewable:end -->
