### PR TITLE
fix(pubsublite): cleanup client on multipartition publisher failure

### DIFF
--- a/google/cloud/pubsublite/internal/multipartition_publisher.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.cc
@@ -185,6 +185,10 @@ void MultipartitionPublisher::RouteAndPublish(PublishState state) {
 
 future<StatusOr<MessageMetadata>> MultipartitionPublisher::Publish(
     PubSubMessage m) {
+  if (!service_composite_.status().ok()) {
+    return make_ready_future(
+        StatusOr<MessageMetadata>{service_composite_.status()});
+  }
   PublishState state;
   state.message = std::move(m);
   {

--- a/google/cloud/pubsublite/internal/multipartition_publisher.h
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.h
@@ -76,6 +76,8 @@ class MultipartitionPublisher
 
   void HandleNumPartitions(std::uint32_t num_partitions);
 
+  void CleanupOutstandingResources(Status const& status);
+
   PartitionPublisherFactory publisher_factory_;
 
   std::mutex mu_;

--- a/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
@@ -116,13 +116,40 @@ TEST_F(MultipartitionPublisherNoneInitializedTest,
               AsyncGetTopicPartitions(IsProtoEqual(ExamplePartitionsRequest())))
       .WillOnce(
           Return(ByMove(ReadyTopicPartitionsFuture(kOutOfBoundsPartition))));
+  EXPECT_CALL(alarm_token_, Destroy);
   auto start = multipartition_publisher_->Start();
 
   EXPECT_EQ(start.get(), Status(StatusCode::kInternal,
                                 "Returned partition count is too big: " +
                                     std::to_string(kOutOfBoundsPartition)));
 
+  multipartition_publisher_->Shutdown().get();
+}
+
+TEST_F(MultipartitionPublisherNoneInitializedTest,
+       FirstPollInvalidValuePublisherAbortsAfterPublishing) {
+  InSequence seq;
+
+  promise<StatusOr<TopicPartitions>> num_partitions;
+  EXPECT_CALL(*admin_connection_,
+              AsyncGetTopicPartitions(IsProtoEqual(ExamplePartitionsRequest())))
+      .WillOnce(Return(ByMove(num_partitions.get_future())));
+  auto start = multipartition_publisher_->Start();
+  future<StatusOr<MessageMetadata>> publish_response =
+      multipartition_publisher_->Publish(PubSubMessage{});
+
+  // failing client should destroy alarm
   EXPECT_CALL(alarm_token_, Destroy);
+  num_partitions.set_value(ExamplePartitionsResponse(kOutOfBoundsPartition));
+
+  EXPECT_EQ(publish_response.get().status(),
+            (Status{StatusCode::kInternal,
+                    "Returned partition count is too big: " +
+                        std::to_string(kOutOfBoundsPartition)}));
+  EXPECT_EQ(start.get(), Status(StatusCode::kInternal,
+                                "Returned partition count is too big: " +
+                                    std::to_string(kOutOfBoundsPartition)));
+
   multipartition_publisher_->Shutdown().get();
 }
 


### PR DESCRIPTION
Without this change, then `Publish` futures created before the first num-partitions poll fail will only be satisfied once `Shutdown` is called. Additionally, this change shuts down the alarm on first poll failure. If the alarm kept running, it would be useless.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8759)
<!-- Reviewable:end -->
