### PR TITLE
impl(storage): implement `RetryClient::UploadChunk()`

### DIFF
--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -393,9 +393,188 @@ StatusOr<EmptyResponse> RetryClient::DeleteResumableUpload(
                   __func__);
 }
 
+// Implements the retry loop for a resumable upload session.
+//
+// A description of resumable uploads can be found at:
+//     https://cloud.google.com/storage/docs/performing-resumable-uploads
+//
+// A description of the gRPC analog can be found in the proto file. Pay
+// particular attention to the documentation for `WriteObject()`,
+// `WriteObjectRequest`, `StartResumablewrite()` and `QueryResumableWrite()`:
+//    https://github.com/googleapis/googleapis/blob/master/google/storage/v2/storage.proto
+//
+// At a high level one starts a resumable upload by creating a "session". These
+// sessions are persistent (they survive disconnections from the service). One
+// can even resume uploads after shutting down and restarting an application.
+// Their current state can be queried using a simple RPC (or a PUT request
+// without payload).
+//
+// Resumable uploads make progress by sending "chunks", either a single PUT
+// request in REST-based transports, or a client-side streaming RPC for
+// gRPC-based transports.
+//
+// Resumable uploads complete when the application sends the last bytes of the
+// object. In the client library we mostly start uploads without knowing the
+// number of bytes until a "final" chunk.  In this final chunk we set the
+// `Content-Range:` header to the `bytes X-N/N` format (there is an equivalent
+// form in gRPC).  In some cases the application can short-circuit this by
+// setting the X-Upload-Content-Length header when the upload is created.
+//
+// When a chunk upload fails the application should query the state of the
+// session before continuing.
+//
+// There are a couple of subtle cases:
+// - A chunk uploads can "succeed", but report that 0 bytes were committed,
+//   or not report how many bytes were committed.  The application should
+//   query the state of the upload in this case:
+//       https://cloud.google.com/storage/docs/performing-resumable-uploads#status-check
+//   > If Cloud Storage has not yet persisted any bytes, the 308 response does
+//   > **not have a Range header**. In this case, you should start your upload
+//   > from the beginning.
+// - A chunk upload can partially succeed, in this case the application should
+//   resend the remaining bytes.
+// - Resending already persisted bytes is safe:
+//       https://cloud.google.com/storage/docs/performing-resumable-uploads#resume-upload
+//   > Cloud Storage ignores any bytes you send at an offset that
+//   > Cloud Storage has already persisted.
+//
+// In summary, after a failed upload operation the retry loop may need to query
+// the status of the session before uploading more data. Note that the query
+// operations themselves may fail with transients, and thus need to be performed
+// as part of the retry loop.
+//
+// To simplify the loop we keep a pointer to the current "operation" that the
+// retry loop is trying to get to succeed. First we try an upload, if that
+// fails (a transient failure, or a 0-committed-bytes success) we switch to
+// trying the ResetSession() operation until it succeeds, at which point we
+// can start the upload operations again.
+//
 StatusOr<QueryResumableUploadResponse> RetryClient::UploadChunk(
-    UploadChunkRequest const&) {
-  return Status(StatusCode::kUnimplemented, "TODO(#8621)");
+    UploadChunkRequest const& request) {
+  Status last_status(StatusCode::kDeadlineExceeded,
+                     "Retry policy exhausted before first attempt was made.");
+
+  auto retry_policy = retry_policy_prototype_->clone();
+  auto backoff_policy = backoff_policy_prototype_->clone();
+
+  // `operation` represents the RPC we will make. In the happy case it is just
+  // calls to `upload()`, but on a transient error we switch to calling
+  // `ResetSession()` until there is a successful result.
+  using Action =
+      std::function<StatusOr<QueryResumableUploadResponse>(std::uint64_t)>;
+
+  auto upload = Action([&request, this](std::uint64_t committed_size) {
+    return client_->UploadChunk(request.RemainingChunk(committed_size));
+  });
+  auto reset = Action([&request, this](std::uint64_t) {
+    QueryResumableUploadRequest query(request.upload_session_url());
+    query.set_multiple_options(request.GetOption<QuotaUser>(),
+                               request.GetOption<UserIp>());
+    return this->QueryResumableUpload(query);
+  });
+
+  auto return_error = [](Status const& last_status,
+                         RetryPolicy const& retry_policy,
+                         char const* error_message) {
+    std::ostringstream os;
+    if (retry_policy.IsExhausted()) {
+      os << "Retry policy exhausted in " << error_message << ": "
+         << last_status.message();
+    } else {
+      os << "Permanent error in " << error_message << ": "
+         << last_status.message();
+    }
+    return Status(last_status.code(), std::move(os).str());
+  };
+
+  auto* operation = &upload;
+  auto committed_size = request.offset();
+  auto const expected_committed_size =
+      request.offset() + request.payload_size();
+
+  while (!retry_policy->IsExhausted()) {
+    auto result = (*operation)(committed_size);
+    if (!result) {
+      // On a failure we preserve the error, query if retry policy, backoff, and
+      // switch to calling QueryResumableUpload().
+      last_status = std::move(result).status();
+      if (!retry_policy->OnFailure(last_status)) {
+        return return_error(std::move(last_status), *retry_policy, __func__);
+      }
+
+      auto delay = backoff_policy->OnCompletion();
+      std::this_thread::sleep_for(delay);
+      operation = &reset;
+      continue;
+    }
+
+    // While normally a `UploadFinalChunk()` call completes an upload, sometimes
+    // the upload can complete in a regular `UploadChunk()` or a
+    // `ResetSession()` call. For example, the server can detect a completed
+    // upload "early" if the application includes the X-Upload-Content-Length`
+    // header.
+    if (result->payload.has_value()) return result;
+
+    // This indicates that the response was missing a `Range:` header, or that
+    // the range header was in the wrong format. Either way, treat that as a
+    // (transient) failure and query the current status to find out what to do
+    // next.
+    if (!result->committed_size.has_value()) {
+      if (operation != &reset) {
+        operation = &reset;
+        continue;
+      }
+      // When a reset returns a response without a committed size we can safely
+      // treat that as 0.
+      result->committed_size = 0;
+    }
+
+    // With a successful operation, we can continue (or go back to) uploading.
+    operation = &upload;
+
+    // This should not happen, it indicates an invalid sequence of responses
+    // from the server.
+    if (*result->committed_size < request.offset()) {
+      std::stringstream os;
+      os << __func__ << ": server previously confirmed " << request.offset()
+         << " bytes as committed, but the current response only reports "
+         << result->committed_size.value_or(0) << " bytes as committed."
+         << " This is most likely a bug in the GCS client library, possibly"
+         << " related to parsing the server response."
+         << " Please contact support or report the problem at"
+         << " https://github.com/googleapis/google-cloud-cpp/issues/new"
+         << " Include as much information as you can including this message";
+      os << ", session_id=" << request.upload_session_url();
+      os << ", result=" << *result;
+      os << ", request=" << request;
+      return Status(StatusCode::kInternal, os.str());
+    }
+    if (*result->committed_size > expected_committed_size) {
+      std::stringstream os;
+      os << __func__ << ": the server indicates that "
+         << result->committed_size.value_or(0) << " bytes are committed "
+         << " but given the current request no more than "
+         << expected_committed_size << " should be."
+         << " This could be caused by multiple applications trying to use the"
+         << " same resumable upload, but could be a bug in the library or"
+         << " the service. If you believe this is a bug, please contact support"
+         << " or report the bug at"
+         << " https://github.com/googleapis/google-cloud-cpp/issues/new"
+         << " Include as much information as you can including this message";
+      os << ", session_id=" << request.upload_session_url();
+      os << ", result=" << *result;
+      os << ", request=" << request;
+      return Status(StatusCode::kInternal, os.str());
+    }
+
+    committed_size = *result->committed_size;
+    // On a full write we can return immediately.
+    if (committed_size == expected_committed_size) return result;
+  }
+  std::ostringstream os;
+  os << "Retry policy exhausted in " << __func__ << ": "
+     << last_status.message();
+  return Status(last_status.code(), std::move(os).str());
 }
 
 StatusOr<ListBucketAclResponse> RetryClient::ListBucketAcl(

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -29,6 +29,8 @@ namespace {
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::AtLeast;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
@@ -152,6 +154,357 @@ TEST(RetryClientTest, QueryResumableUploadHandlesTransient) {
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(response->committed_size.value_or(0), 1234);
   EXPECT_FALSE(response->payload.has_value());
+}
+
+/// @test Verify that transient failures are handled as expected.
+TEST(RetryClientTest, UploadChunkHandleTransient) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(quantum, '0');
+
+  // Verify that a transient on a UploadChunk() results in calls to
+  // QueryResumableUpload() and that transients in these calls are retried too.
+  ::testing::InSequence sequence;
+  EXPECT_CALL(*mock, UploadChunk).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(Return(TransientError()))
+      .WillOnce(Return(QueryResumableUploadResponse{0, absl::nullopt}));
+
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+
+  // A simpler scenario where only the UploadChunk() calls fail.
+  EXPECT_CALL(*mock, UploadChunk).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{2 * quantum, absl::nullopt}));
+
+  // Even simpler scenario where only the UploadChunk() calls succeeds.
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{3 * quantum, absl::nullopt}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-session-id", 0, {{payload}}));
+  EXPECT_STATUS_OK(response);
+  EXPECT_EQ(quantum, response->committed_size.value_or(0));
+
+  response = client->UploadChunk(
+      UploadChunkRequest("test-only-session-id", quantum, {{payload}}));
+  EXPECT_STATUS_OK(response);
+  EXPECT_EQ(2 * quantum, response->committed_size.value_or(0));
+
+  response = client->UploadChunk(
+      UploadChunkRequest("test-only-session-id", 2 * quantum, {{payload}}));
+  EXPECT_STATUS_OK(response);
+  EXPECT_EQ(3 * quantum, response->committed_size.value_or(0));
+}
+
+/// @test Verify that we can restore a session and continue writing.
+TEST(RetryClientTest, UploadChunkRestoreSession) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const p0(quantum, '0');
+  std::string const p1(quantum, '1');
+
+  auto const restored_committed_size = std::uint64_t{4 * quantum};
+  auto committed_size = restored_committed_size;
+
+  ::testing::InSequence sequence;
+
+  EXPECT_CALL(*mock, UploadChunk).WillOnce([&](UploadChunkRequest const&) {
+    committed_size += quantum;
+    return QueryResumableUploadResponse{committed_size, absl::nullopt};
+  });
+  EXPECT_CALL(*mock, UploadChunk).WillOnce([&](UploadChunkRequest const&) {
+    committed_size += quantum;
+    return QueryResumableUploadResponse{committed_size, absl::nullopt};
+  });
+
+  auto response = client->UploadChunk(UploadChunkRequest(
+      "test-only-upload-id", restored_committed_size, {{p0}}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(restored_committed_size + quantum,
+            response->committed_size.value_or(0));
+
+  response = client->UploadChunk(UploadChunkRequest(
+      "test-only-upload-id", restored_committed_size + quantum, {{p1}}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(restored_committed_size + 2 * quantum,
+            response->committed_size.value_or(0));
+}
+
+/// @test Verify that transient failures with partial writes are handled
+TEST(RetryClientTest, UploadChunkHandleTransientPartialFailures) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto const payload = std::string(quantum, 'X') + std::string(quantum, 'Y') +
+                       std::string(quantum, 'Z');
+
+  ::testing::InSequence sequence;
+  // An initial call to UploadChunk() fails with a retryable error.
+  EXPECT_CALL(*mock, UploadChunk).WillOnce(Return(TransientError()));
+  // When calling QueryResumableUpload() we discover that they have been
+  // partially successful.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+  // We expect that the next call skips these initial bytes, and simulate
+  // another transient failure
+  EXPECT_CALL(*mock, UploadChunk).WillOnce([&](UploadChunkRequest const& r) {
+    EXPECT_EQ(r.offset(), quantum);
+    EXPECT_THAT(r.payload(), ElementsAre(payload.substr(quantum)));
+    return TransientError();
+  });
+  // We expect another call to QueryResumableUpload(), and simulate another
+  // partial failure.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{2 * quantum, absl::nullopt}));
+  // This should trigger another UploadChunk() request with the remaining data.
+  EXPECT_CALL(*mock, UploadChunk).WillOnce([&](UploadChunkRequest const& r) {
+    EXPECT_EQ(r.offset(), 2 * quantum);
+    EXPECT_THAT(r.payload(), ElementsAre(payload.substr(2 * quantum)));
+    return QueryResumableUploadResponse{3 * quantum, absl::nullopt};
+  });
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(3 * quantum, response->committed_size.value_or(0));
+}
+
+/// @test Verify that a permanent error on UploadChunk results in a failure.
+TEST(RetryClientTest, UploadChunkPermanentError) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(quantum, '0');
+
+  EXPECT_CALL(*mock, UploadChunk).WillOnce(Return(PermanentError()));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  EXPECT_THAT(response, StatusIs(PermanentError().code(),
+                                 HasSubstr(PermanentError().message())));
+}
+
+/// @test Verify that a permanent error on QueryResumableUpload results in a
+/// failure.
+TEST(RetryClientTest, UploadChunkPermanentErrorOnQuery) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(quantum, '0');
+  EXPECT_CALL(*mock, UploadChunk).WillOnce(Return(TransientError()));
+  EXPECT_CALL(*mock, QueryResumableUpload).WillOnce(Return(PermanentError()));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  EXPECT_THAT(response, StatusIs(PermanentError().code(),
+                                 HasSubstr(PermanentError().message())));
+}
+
+/// @test Verify that unexpected results return an error.
+TEST(RetryClientTest, UploadChunkHandleRollback) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(quantum, '0');
+
+  // Simulate a response where the service rolls back the previous value of
+  // `committed_size`
+  auto const hwm = 4 * quantum;
+  auto const rollback = 3 * quantum;
+  EXPECT_LT(rollback, hwm);
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(Return(QueryResumableUploadResponse{hwm, absl::nullopt}))
+      .WillOnce(Return(QueryResumableUploadResponse{rollback, absl::nullopt}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", rollback, {{payload}}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(response->committed_size.value_or(0), hwm);
+
+  response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", hwm, {{payload}}));
+  EXPECT_THAT(
+      response,
+      StatusIs(
+          StatusCode::kInternal,
+          HasSubstr("This is most likely a bug in the GCS client library")));
+}
+
+/// @test Verify that unexpected results return an error.
+TEST(RetryClientTest, UploadChunkHandleOvercommit) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(quantum, '0');
+
+  // Simulate a response where the service rolls back the previous value of
+  // `committed_size`
+  auto const excess = 4 * quantum;
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(Return(QueryResumableUploadResponse{excess, absl::nullopt}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  EXPECT_THAT(
+      response,
+      StatusIs(StatusCode::kInternal,
+               HasSubstr("This could be caused by multiple applications trying "
+                         "to use the same resumable upload")));
+}
+
+/// @test Verify that retry exhaustion following a short write fails.
+TEST(RetryClientTest, UploadChunkExhausted) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  std::string const payload(std::string(quantum * 2, 'X'));
+
+  EXPECT_CALL(*mock, UploadChunk)
+      .Times(4)
+      .WillRepeatedly(Return(TransientError()));
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .Times(AtLeast(2))
+      .WillRepeatedly(Return(QueryResumableUploadResponse{0, absl::nullopt}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  EXPECT_THAT(response, StatusIs(StatusCode::kUnavailable));
+}
+
+TEST(RetryClientTest, UploadChunkUploadChunkPolicyExhaustedOnStart) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client = RetryClient::Create(
+      std::shared_ptr<internal::RawClient>(mock),
+      BasicTestPolicies()
+          .set<RetryPolicyOption>(
+              LimitedTimeRetryPolicy(std::chrono::seconds(0)).clone())
+          .set<IdempotencyPolicyOption>(StrictIdempotencyPolicy().clone()));
+
+  auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'X');
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  EXPECT_THAT(
+      response,
+      StatusIs(StatusCode::kDeadlineExceeded,
+               HasSubstr("Retry policy exhausted before first attempt")));
+}
+
+/// @test Verify that responses without a range header are handled.
+TEST(RetryClientTest, UploadChunkMissingRangeHeaderInUpload) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto const payload = std::string(quantum, '0');
+
+  ::testing::InSequence sequence;
+  // Simulate an upload that "succeeds", but returns a missing value for the
+  // committed size.
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{/*committed_size=*/absl::nullopt,
+                                              /*.payload=*/absl::nullopt}));
+  // This should trigger a QueryResumableUpload(), simulate a good response.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+
+  // The test will create a second request that finalizes the upload. Respond
+  // without a committed size also, this should be interpreted as success and
+  // not require an additional query.
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(Return(QueryResumableUploadResponse{
+          /*.committed_size=*/absl::nullopt, /*.payload=*/ObjectMetadata()}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(quantum, response->committed_size.value_or(0));
+
+  response = client->UploadChunk(UploadChunkRequest(
+      "test-only-upload-id", quantum, {{payload}}, HashValues{}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_FALSE(response->committed_size.has_value());
+  EXPECT_TRUE(response->payload.has_value());
+}
+
+/// @test Verify that responses without a range header are handled.
+TEST(RetryClientTest, UploadChunkMissingRangeHeaderInQueryResumableUpload) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto const payload = std::string(quantum, '0');
+
+  ::testing::InSequence sequence;
+  // Assume the first upload works, but it is missing any information about
+  // what bytes got uploaded.
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{/*committed_size=*/absl::nullopt,
+                                              /*.payload=*/absl::nullopt}));
+  // This should trigger a `QueryResumableUpload()`, which should also have its
+  // Range header missing indicating no bytes were uploaded.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{absl::nullopt, absl::nullopt}));
+
+  // This should trigger a second upload, which we will let succeed.
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{/*committed_size=*/quantum,
+                                              /*.payload=*/absl::nullopt}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(quantum, response->committed_size.value_or(0));
 }
 
 }  // namespace


### PR DESCRIPTION
This implements the resumable uploads retry loop as part of the
`RetryClient`.  The retry loop for this function is different, as it
requires querying the state of the upload via an alternative function
on a transient failure.

Part of the work for #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8762)
<!-- Reviewable:end -->
