### PR TITLE
cleanup(dialogflow): endpoint env vars

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -356,6 +356,7 @@ service {
   additional_proto_files: ["google/protobuf/struct.proto"]
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
+  service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
 }
 
@@ -378,6 +379,7 @@ service {
   additional_proto_files: ["google/protobuf/struct.proto"]
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
+  service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
 }
 
@@ -479,6 +481,7 @@ service {
   service_proto_path: "google/cloud/dialogflow/v2/environment.proto"
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
+  service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
 }
 
@@ -493,6 +496,7 @@ service {
   service_proto_path: "google/cloud/dialogflow/v2/version.proto"
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
+  service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
 }
 

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -41,8 +41,53 @@ which should give you a taste of the Dialogflow API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ EDIT HERE _ENDPOINT=...` changes the default endpoint
-  ( EDIT HERE .googleapis.com) used by ` EDIT HERE Connection`.
+- `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `AgentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_CHANGELOGS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ChangelogsConnection`.
+
+- `GOOGLE_CLOUD_CPP_DEPLOYMENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `DeploymentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `EntityTypesConnection`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `EnvironmentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_EXPERIMENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ExperimentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_FLOWS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `FlowsConnection`.
+
+- `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `IntentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_PAGES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `PagesConnection`.
+
+- `GOOGLE_CLOUD_CPP_SECURITY_SETTINGS_SERVICE_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `SecuritySettingsServiceConnection`.
+
+- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `SessionEntityTypesConnection`.
+
+- `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `SessionsConnection`.
+
+- `GOOGLE_CLOUD_CPP_TEST_CASES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `TestCasesConnection`.
+
+- `GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `TransitionRouteGroupsConnection`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `VersionsConnection`.
+
+- `GOOGLE_CLOUD_CPP_WEBHOOKS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `WebhooksConnection`.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dialogflow_cx/internal/environments_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_option_defaults.cc
@@ -34,8 +34,8 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options EnvironmentsDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
-      std::move(options), "GOOGLE_CLOUD_CPP_ENVIRONMENTS_ENDPOINT", "",
-      "dialogflow.googleapis.com");
+      std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT",
+      "", "dialogflow.googleapis.com");
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::EnvironmentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/versions_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_option_defaults.cc
@@ -34,7 +34,7 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options VersionsDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
-      std::move(options), "GOOGLE_CLOUD_CPP_VERSIONS_ENDPOINT", "",
+      std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT", "",
       "dialogflow.googleapis.com");
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -107,11 +107,8 @@ if (BUILD_TESTING)
     google_cloud_cpp_add_common_options(dialogflow_es_quickstart)
     add_test(
         NAME dialogflow_es_quickstart
-        COMMAND
-            cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
-            $<TARGET_FILE:dialogflow_es_quickstart> GOOGLE_CLOUD_PROJECT
-            # EDIT HERE
-    )
+        COMMAND cmake -P "${PROJECT_SOURCE_DIR}/cmake/quickstart-runner.cmake"
+                $<TARGET_FILE:dialogflow_es_quickstart> GOOGLE_CLOUD_PROJECT)
     set_tests_properties(dialogflow_es_quickstart
                          PROPERTIES LABELS "integration-test;quickstart")
 endif ()

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -41,8 +41,56 @@ which should give you a taste of the Dialogflow API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ EDIT HERE _ENDPOINT=...` changes the default endpoint
-  ( EDIT HERE .googleapis.com) used by ` EDIT HERE Connection`.
+- `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `AgentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_ANSWER_RECORDS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `AnswerRecordsConnection`.
+
+- `GOOGLE_CLOUD_CPP_CONTEXTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ContextsConnection`.
+
+- `GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ConversationDatasetsConnection`.
+
+- `GOOGLE_CLOUD_CPP_CONVERSATION_MODELS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ConversationModelsConnection`.
+
+- `GOOGLE_CLOUD_CPP_CONVERSATION_PROFILES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ConversationProfilesConnection`.
+
+- `GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ConversationsConnection`.
+
+- `GOOGLE_CLOUD_CPP_DOCUMENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `DocumentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `EntityTypesConnection`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `EnvironmentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_FULFILLMENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `FulfillmentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `IntentsConnection`.
+
+- `GOOGLE_CLOUD_CPP_KNOWLEDGE_BASES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `KnowledgeBasesConnection`.
+
+- `GOOGLE_CLOUD_CPP_PARTICIPANTS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `ParticipantsConnection`.
+
+- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `SessionEntityTypesConnection`.
+
+- `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `SessionsConnection`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` changes the default endpoint
+  (dialogflow.googleapis.com) used by `VersionsConnection`.
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dialogflow_es/internal/environments_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/environments_option_defaults.cc
@@ -34,8 +34,8 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options EnvironmentsDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
-      std::move(options), "GOOGLE_CLOUD_CPP_ENVIRONMENTS_ENDPOINT", "",
-      "dialogflow.googleapis.com");
+      std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT",
+      "", "dialogflow.googleapis.com");
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::EnvironmentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/versions_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/versions_option_defaults.cc
@@ -34,7 +34,7 @@ auto constexpr kBackoffScaling = 2.0;
 
 Options VersionsDefaultOptions(Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
-      std::move(options), "GOOGLE_CLOUD_CPP_VERSIONS_ENDPOINT", "",
+      std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT", "",
       "dialogflow.googleapis.com");
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");


### PR DESCRIPTION
Document service environment endpoints in Dialogflow. (I think this is too easy to forget. I will edit the howto generate a library doc so that it doesn't happen again).

The two dialogflow editions have the same environment variables. I considered differentiating them, but decided not to. Two of the variables conflict with other libraries though. Those two were changed.

```sh
# Command (run before the changes in this PR)
grep -rho "\"GOOGLE_CLOUD_CPP_.*_ENDPOINT\"" | sort | uniq -cd

# Output
      2 "GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT"
      2 "GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT"
      3 "GOOGLE_CLOUD_CPP_ENVIRONMENTS_ENDPOINT"
      2 "GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT"
      2 "GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT"
      2 "GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT"
      9 "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT"
      3 "GOOGLE_CLOUD_CPP_VERSIONS_ENDPOINT"
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8763)
<!-- Reviewable:end -->
