### PR TITLE
refactor(GCS+gRPC): write resumable session using RU

### DIFF
--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -721,11 +721,10 @@ google::storage::v2::QueryWriteStatusRequest GrpcObjectRequestParser::ToProto(
   return r;
 }
 
-ResumableUploadResponse GrpcObjectRequestParser::FromProto(
+QueryResumableUploadResponse GrpcObjectRequestParser::FromProto(
     google::storage::v2::QueryWriteStatusResponse const& response,
     Options const& options) {
-  ResumableUploadResponse result;
-  result.upload_state = ResumableUploadResponse::kInProgress;
+  QueryResumableUploadResponse result;
   if (response.has_persisted_size()) {
     result.committed_size =
         static_cast<std::uint64_t>(response.persisted_size());
@@ -733,7 +732,6 @@ ResumableUploadResponse GrpcObjectRequestParser::FromProto(
   if (response.has_resource()) {
     result.payload =
         GrpcObjectMetadataParser::FromProto(response.resource(), options);
-    result.upload_state = ResumableUploadResponse::kDone;
   }
   return result;
 }

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -70,7 +70,7 @@ struct GrpcObjectRequestParser {
 
   static google::storage::v2::QueryWriteStatusRequest ToProto(
       QueryResumableUploadRequest const& request);
-  static ResumableUploadResponse FromProto(
+  static QueryResumableUploadResponse FromProto(
       google::storage::v2::QueryWriteStatusResponse const& response,
       Options const& options);
 };

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -1177,7 +1177,6 @@ TEST(GrpcObjectRequestParser, QueryResumableUploadResponseSimple) {
       &input));
 
   auto const actual = GrpcObjectRequestParser::FromProto(input, Options{});
-  EXPECT_EQ(actual.upload_state, ResumableUploadResponse::kInProgress);
   EXPECT_EQ(actual.committed_size.value_or(0), 123456);
   EXPECT_FALSE(actual.payload.has_value());
 }
@@ -1194,7 +1193,6 @@ TEST(GrpcObjectRequestParser, QueryResumableUploadResponseWithResource) {
       &input));
 
   auto const actual = GrpcObjectRequestParser::FromProto(input, Options{});
-  EXPECT_EQ(actual.upload_state, ResumableUploadResponse::kDone);
   EXPECT_FALSE(actual.committed_size.has_value());
   ASSERT_TRUE(actual.payload.has_value());
   EXPECT_EQ(actual.payload->name(), "test-object-name");


### PR DESCRIPTION
This continues moving the implementation of `ResumableUploadSession` in
terms of session-less "resumable uploads".  The expectation is that
a session-less implementation will be easier to reason about and have
fewer problems when resuming uploads.

Part of the work for #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8764)
<!-- Reviewable:end -->
