### PR TITLE
refactor(spanner): extract instance ID generation into helper func

### DIFF
--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -21,23 +21,27 @@ namespace cloud {
 namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/**
- * Generate a random instance name for InstanceAdminClient CRUD tests.
- */
-std::string RandomInstanceName(
-    google::cloud::internal::DefaultPRNG& generator) {
-  // An instance ID must be between 2 and 64 characters, fitting the regular
-  // expression `[a-z][-a-z0-9]*[a-z0-9]`
-  std::size_t const max_size = 64;
+namespace {
+
+std::string RandomId(std::string prefix, std::size_t max_size,
+                     internal::DefaultPRNG& generator) {
   auto now = std::chrono::system_clock::now();
-  std::string date = google::cloud::internal::FormatUtcDate(now);
-  std::string prefix = "temporary-instance-" + date + "-";
+  prefix.push_back('-');
+  prefix.append(internal::FormatUtcDate(now));
+  prefix.push_back('-');
   auto size = static_cast<int>(max_size - 1 - prefix.size());
   return prefix +
-         google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789-") +
-         google::cloud::internal::Sample(generator, 1,
-                                         "abcdefghijlkmnopqrstuvwxyz");
+         internal::Sample(generator, size,
+                          "abcdefghijlkmnopqrstuvwxyz0123456789-") +
+         internal::Sample(generator, 1, "abcdefghijlkmnopqrstuvwxyz");
+}
+
+}  // namespace
+
+std::string RandomInstanceName(internal::DefaultPRNG& generator) {
+  // An instance ID must be between 2 and 64 characters, matching the
+  // regular expression `[a-z][-a-z0-9]*[a-z0-9]`.
+  return RandomId("temporary-instance", 64, generator);
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/testing/random_instance_name.h
+++ b/google/cloud/spanner/testing/random_instance_name.h
@@ -24,8 +24,8 @@ namespace cloud {
 namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/// Create a random instance name given a PRNG generator.
-std::string RandomInstanceName(google::cloud::internal::DefaultPRNG& generator);
+/// Returns a random instance ID given a PRNG generator.
+std::string RandomInstanceName(internal::DefaultPRNG&);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner_testing


### PR DESCRIPTION
This facilitates an upcoming change where we will need to generate
another form of instance ID, which has a different prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8771)
<!-- Reviewable:end -->
