### PR TITLE
refactor(spanner): move random-instance regex into CleanupStaleInstances

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -70,21 +70,8 @@ bool Emulator() {
 class CleanupStaleInstances : public ::testing::Environment {
  public:
   void SetUp() override {
-    std::regex instance_name_regex(
-        R"(projects/.+/instances/)"
-        R"((temporary-instance-(\d{4}-\d{2}-\d{2})-.+))");
-
-    // Make sure we're using a correct regex.
-    EXPECT_EQ(2, instance_name_regex.mark_count());
-    auto generator = internal::MakeDefaultPRNG();
-    Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator));
-    auto fq_instance_name = in.FullName();
-    std::smatch m;
-    EXPECT_TRUE(std::regex_match(fq_instance_name, m, instance_name_regex));
-    EXPECT_EQ(3, m.size());
-
-    EXPECT_STATUS_OK(spanner_testing::CleanupStaleInstances(
-        in.project_id(), instance_name_regex));
+    EXPECT_STATUS_OK(
+        spanner_testing::CleanupStaleInstances(Project(ProjectId())));
   }
 };
 

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -73,21 +73,8 @@ bool Emulator() {
 class CleanupStaleInstances : public ::testing::Environment {
  public:
   void SetUp() override {
-    std::regex instance_name_regex(
-        R"(projects/.+/instances/)"
-        R"((temporary-instance-(\d{4}-\d{2}-\d{2})-.+))");
-
-    // Make sure we're using a correct regex.
-    EXPECT_EQ(2, instance_name_regex.mark_count());
-    auto generator = internal::MakeDefaultPRNG();
-    Instance in(ProjectId(), spanner_testing::RandomInstanceName(generator));
-    auto fq_instance_name = in.FullName();
-    std::smatch m;
-    EXPECT_TRUE(std::regex_match(fq_instance_name, m, instance_name_regex));
-    EXPECT_EQ(3, m.size());
-
-    EXPECT_STATUS_OK(spanner_testing::CleanupStaleInstances(
-        in.project_id(), instance_name_regex));
+    EXPECT_STATUS_OK(
+        spanner_testing::CleanupStaleInstances(Project(ProjectId())));
   }
 };
 

--- a/google/cloud/spanner/testing/cleanup_stale_instances.h
+++ b/google/cloud/spanner/testing/cleanup_stale_instances.h
@@ -16,9 +16,8 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_CLEANUP_STALE_INSTANCES_H
 
 #include "google/cloud/spanner/version.h"
+#include "google/cloud/project.h"
 #include "google/cloud/status.h"
-#include <regex>
-#include <string>
 
 namespace google {
 namespace cloud {
@@ -26,15 +25,10 @@ namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * Delete any instances (and their backups) within the project @p project_id
- * that match the @p instance_name_regex and are named with a YYYY-MM-DD prior
- * to yesterday.
- *
- * instance_name_regex.mark_count() must be (at least) 2, where the first two
- * capture groups are the instance ID and the YYYY-MM-DD fragment respectively.
+ * Deletes any instances (and their backups) within the @p project that
+ * are named with a YYYY-MM-DD component prior to yesterday (in UTC).
  */
-Status CleanupStaleInstances(std::string const& project_id,
-                             std::regex const& instance_name_regex);
+Status CleanupStaleInstances(Project const& project);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner_testing


### PR DESCRIPTION
Move the regex for random instance names, and the check that it indeed
matches, into `CleanupStaleInstances()` itself.

Also factor out the "cutoff date" logic into a helper function, in
preparation for an upcoming change where we will need to cleanup an
additional form of instance resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8772)
<!-- Reviewable:end -->
