### PR TITLE
fix(pubsublite): multipartition publisher ordering

### DIFF
--- a/google/cloud/pubsublite/internal/multipartition_publisher.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.cc
@@ -180,7 +180,8 @@ void MultipartitionPublisher::PublishLoop() {
       messages_.pop_front();
       messages_left = !messages_.empty();
       if (!messages_left) in_publish_loop_ = false;
-      state.num_partitions = partition_publishers_.size();
+      state.num_partitions =
+          static_cast<std::uint32_t>(partition_publishers_.size());
     }
     RouteAndPublish(std::move(state));
   }

--- a/google/cloud/pubsublite/internal/multipartition_publisher.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.cc
@@ -198,6 +198,8 @@ future<StatusOr<MessageMetadata>> MultipartitionPublisher::Publish(
     std::lock_guard<std::mutex> g{mu_};
     to_return = state.publish_promise.get_future();
     messages_.push_back(std::move(state));
+    // message will be published whenever we successfully read the number of
+    // partitions and publishers are created
     if (partition_publishers_.empty()) return to_return;
   }
   TryPublishMessages();

--- a/google/cloud/pubsublite/internal/multipartition_publisher.h
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.h
@@ -24,6 +24,7 @@
 #include "google/cloud/pubsublite/topic.h"
 #include <google/cloud/pubsublite/v1/admin.pb.h>
 #include <google/cloud/pubsublite/v1/publisher.pb.h>
+#include <deque>
 #include <mutex>
 #include <vector>
 
@@ -74,6 +75,8 @@ class MultipartitionPublisher
 
   void RouteAndPublish(PublishState state);
 
+  void PublishLoop();
+
   void HandleNumPartitions(std::uint32_t num_partitions);
 
   PartitionPublisherFactory publisher_factory_;
@@ -89,6 +92,8 @@ class MultipartitionPublisher
   std::vector<PublishState> initial_publish_buffer_;  // ABSL_GUARDED_BY(mu_)
   absl::optional<promise<void>>
       outstanding_num_partitions_req_;  // ABSL_GUARDED_BY(mu_)
+  bool in_publish_loop_ = false;        // ABSL_GUARDED_BY(mu_)
+  std::deque<PublishState> messages_;   // ABSL_GUARDED_BY(mu_)
   std::shared_ptr<google::cloud::pubsublite::AdminServiceConnection> const
       admin_connection_;
   ServiceComposite service_composite_;

--- a/google/cloud/pubsublite/internal/multipartition_publisher.h
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.h
@@ -85,11 +85,6 @@ class MultipartitionPublisher
 
   std::vector<std::shared_ptr<Publisher<google::cloud::pubsublite::v1::Cursor>>>
       partition_publishers_;  // ABSL_GUARDED_BY(mu_)
-  // stores messages intended to be `Publish`ed when there were no partition
-  // publishers available
-  // this buffer will be cleared and messages will be sent when the first
-  // partition publisher becomes available
-  std::vector<PublishState> initial_publish_buffer_;  // ABSL_GUARDED_BY(mu_)
   absl::optional<promise<void>>
       outstanding_num_partitions_req_;  // ABSL_GUARDED_BY(mu_)
   bool in_publish_loop_ = false;        // ABSL_GUARDED_BY(mu_)

--- a/google/cloud/pubsublite/internal/multipartition_publisher.h
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.h
@@ -75,7 +75,7 @@ class MultipartitionPublisher
 
   void RouteAndPublish(PublishState state);
 
-  void PublishLoop();
+  void TryPublishMessages();
 
   void HandleNumPartitions(std::uint32_t num_partitions);
 

--- a/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
@@ -408,6 +408,87 @@ TEST_F(MultipartitionPublisherTest, PublishBeforePublisherCreatedGood) {
   EXPECT_EQ(start.get(), Status());
 }
 
+TEST_F(MultipartitionPublisherTest,
+       PublishInCallbackBeforePublisherCreatedGood) {
+  InSequence seq;
+
+  promise<StatusOr<TopicPartitions>> num_partitions;
+  EXPECT_CALL(*admin_connection_,
+              AsyncGetTopicPartitions(IsProtoEqual(ExamplePartitionsRequest())))
+      .WillOnce(Return(ByMove(num_partitions.get_future())));
+
+  auto start = multipartition_publisher_->Start();
+
+  PubSubMessage m0;
+  *m0.mutable_data() = "data0";
+  future<StatusOr<MessageMetadata>> message0 =
+      multipartition_publisher_->Publish(m0);
+  PubSubMessage m1;
+  *m1.mutable_data() = "data1";
+  future<StatusOr<MessageMetadata>> message1 =
+      multipartition_publisher_->Publish(m1);
+
+  EXPECT_CALL(partition_publisher_factory_, Call(0))
+      .WillOnce(Return(partition_publisher_0_));
+  promise<Status> partition_publisher_start_0;
+  EXPECT_CALL(*partition_publisher_0_, Start)
+      .WillOnce(Return(ByMove(partition_publisher_start_0.get_future())));
+  EXPECT_CALL(partition_publisher_factory_, Call(1))
+      .WillOnce(Return(partition_publisher_1_));
+  promise<Status> partition_publisher_start_1;
+  EXPECT_CALL(*partition_publisher_1_, Start)
+      .WillOnce(Return(ByMove(partition_publisher_start_1.get_future())));
+
+  EXPECT_CALL(routing_policy_, Route(2)).WillOnce(Return(1));
+  promise<StatusOr<Cursor>> m0_promise;
+  EXPECT_CALL(*partition_publisher_1_, Publish(IsProtoEqual(m0)))
+      .WillOnce(Return(ByMove(m0_promise.get_future())));
+
+  EXPECT_CALL(routing_policy_, Route(2)).WillOnce(Return(0));
+  promise<StatusOr<Cursor>> m1_promise;
+  EXPECT_CALL(*partition_publisher_0_, Publish(IsProtoEqual(m1)))
+      .WillOnce(Return(ByMove(m1_promise.get_future())));
+
+  PubSubMessage m2;
+  *m2.mutable_data() = "data2";
+  future<StatusOr<MessageMetadata>> message2;
+  message0 = message0.then([&](future<StatusOr<MessageMetadata>> res) {
+    // should be the third message published
+    message2 = multipartition_publisher_->Publish(m2);
+    return make_ready_future(res.get());
+  });
+
+  EXPECT_CALL(routing_policy_, Route(2)).WillOnce(Return(0));
+  promise<StatusOr<Cursor>> m2_promise;
+  EXPECT_CALL(*partition_publisher_0_, Publish(IsProtoEqual(m2)))
+      .WillOnce(Return(ByMove(m2_promise.get_future())));
+
+  num_partitions.set_value(ExamplePartitionsResponse(2));
+
+  Cursor cursor;
+  cursor.set_offset(kOffsetPlaceholder);
+
+  m0_promise.set_value(cursor);
+  m1_promise.set_value(cursor);
+  m2_promise.set_value(cursor);
+
+  EXPECT_EQ(*message0.get(), (MessageMetadata{1, cursor}));
+  EXPECT_EQ(*message1.get(), (MessageMetadata{0, cursor}));
+  EXPECT_EQ(*message2.get(), (MessageMetadata{0, cursor}));
+
+  EXPECT_CALL(alarm_token_, Destroy);
+  EXPECT_CALL(*partition_publisher_0_, Shutdown)
+      .WillOnce(Return(ByMove(make_ready_future())));
+  EXPECT_CALL(*partition_publisher_1_, Shutdown)
+      .WillOnce(Return(ByMove(make_ready_future())));
+  multipartition_publisher_->Shutdown();
+
+  partition_publisher_start_0.set_value(Status());
+  partition_publisher_start_1.set_value(Status());
+
+  EXPECT_EQ(start.get(), Status());
+}
+
 class InitializedMultipartitionPublisherTest
     : public MultipartitionPublisherTest {
  protected:

--- a/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
@@ -453,7 +453,9 @@ TEST_F(MultipartitionPublisherTest,
   *m2.mutable_data() = "data2";
   future<StatusOr<MessageMetadata>> message2;
   message0 = message0.then([&](future<StatusOr<MessageMetadata>> res) {
-    // should be the third message published
+    // should be the third message published (no race) as we know that
+    // `message0` shouldn't be satisfied yet and this test case executes in a
+    // single thread
     message2 = multipartition_publisher_->Publish(m2);
     return make_ready_future(res.get());
   });


### PR DESCRIPTION
in the following case:
thread 1: call `Publish` on `5` messages before publishers are instantiated
alarm thread: instantiate publishers and start loop of calling `PartitionPublisher::Publish` on above messages
alarm thread: call `PartitionPublisher::Publish` on first message
thread 1: call `Publish` on `6`th message which is `PartitionPublisher::Publish`ed due to publishers having been instantiated
alarm thread: `2`nd to `5`th messages are `PartitionPublisher::Publish`ed

this leads to incorrect ordering

This PR implements `MultipartitionPublisher::Publish` via an internal buffer to remove these types of race conditions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8773)
<!-- Reviewable:end -->
