### PR TITLE
fix: temporarily disable google/cloud/storagetransfer on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,13 @@ noted, the APIs in these libraries are stable, and are ready for production use.
   necessarily depends on these implementation details. We updated the
   [mocking examples][storage-mocking-link] to guide you in changing any tests.
 
+### [Storage Transfer Service](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/storagetransfer/README.md)
+
+**BREAKING CHANGES**
+
+The library has been disabled on macOS due to a protobuf naming clash. See
+[#8785](https://github.com/googleapis/google-cloud-cpp/issues/8785) for details.
+
 ### New Libraries
 
 We are introducing 2 new client libraries for GCP services. While we do not

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -34,6 +34,11 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
+    # TODO(#8785): Enable on macOS and windows.
+    target_compatible_with = select({
+        "@platforms//os:macos": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -34,7 +34,7 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(#8785): Enable on macOS and windows.
+    # TODO(#8785): Enable on macOS.
     target_compatible_with = select({
         "@platforms//os:macos": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-# TODO(8785): Enable on macOS.
+# TODO(#8785): Enable on macOS.
 if (APPLE)
     message(
         WARNING

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -14,6 +14,16 @@
 # limitations under the License.
 # ~~~
 
+# TODO(8785): Enable on macOS.
+if (APPLE)
+    message(
+        WARNING
+            "Cannot build google/cloud/storagetransfer on Apple platforms."
+            " More details at https://github.com/googleapis/google-cloud-cpp/issues/8785 ."
+    )
+    return()
+endif ()
+
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Storage Transfer API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Storage Transfer API")


### PR DESCRIPTION
See https://github.com/googleapis/google-cloud-cpp/issues/8785 about a name clash on `UID_MAX` from `<sys/syslimits.h>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8789)
<!-- Reviewable:end -->
