### PR TITLE
cleanup(pubsublite): change `Topic` var names

### DIFF
--- a/google/cloud/pubsublite/topic.h
+++ b/google/cloud/pubsublite/topic.h
@@ -33,9 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class Topic {
  public:
   Topic(std::string project_id, std::string location_id, std::string topic_id)
-      : project_id_(std::move(project_id)),
+      : project_id_{std::move(project_id)},
         location_id_{std::move(location_id)},
-        topic_id_(std::move(topic_id)) {}
+        topic_id_{std::move(topic_id)} {}
 
   std::string const& project_id() const { return project_id_; }
 

--- a/google/cloud/pubsublite/topic.h
+++ b/google/cloud/pubsublite/topic.h
@@ -32,35 +32,35 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class Topic {
  public:
-  Topic(std::string project, std::string location, std::string topic_name)
-      : project_(std::move(project)),
+  Topic(std::string project_id, std::string location, std::string topic_id)
+      : project_id_(std::move(project_id)),
         location_{std::move(location)},
-        topic_name_(std::move(topic_name)) {}
+        topic_id_(std::move(topic_id)) {}
 
-  std::string const& project() const { return project_; }
+  std::string const& project_id() const { return project_id_; }
 
   std::string const& location() const { return location_; }
 
-  std::string const& topic_name() const { return topic_name_; }
+  std::string const& topic_id() const { return topic_id_; }
 
   /**
    * Returns the fully qualified topic name as a string of the form:
    * "projects/<project-id>/locations/<location>/topics/<topic-id>"
    */
   std::string FullName() const {
-    return absl::StrCat("projects/", project_, "/locations/", location_,
-                        "/topics/", topic_name_);
+    return absl::StrCat("projects/", project_id_, "/locations/", location_,
+                        "/topics/", topic_id_);
   }
 
  private:
-  std::string project_;
+  std::string project_id_;
   std::string location_;
-  std::string topic_name_;
+  std::string topic_id_;
 };
 
 inline bool operator==(Topic const& a, Topic const& b) {
-  return a.project() == b.project() && a.location() == b.location() &&
-         a.topic_name() == b.topic_name();
+  return a.project_id() == b.project_id() && a.location() == b.location() &&
+         a.topic_id() == b.topic_id();
 }
 
 inline bool operator!=(Topic const& a, Topic const& b) { return !(a == b); }

--- a/google/cloud/pubsublite/topic.h
+++ b/google/cloud/pubsublite/topic.h
@@ -32,14 +32,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class Topic {
  public:
-  Topic(std::string project_id, std::string location, std::string topic_id)
+  Topic(std::string project_id, std::string location_id, std::string topic_id)
       : project_id_(std::move(project_id)),
-        location_{std::move(location)},
+        location_id_{std::move(location_id)},
         topic_id_(std::move(topic_id)) {}
 
   std::string const& project_id() const { return project_id_; }
 
-  std::string const& location() const { return location_; }
+  std::string const& location_id() const { return location_id_; }
 
   std::string const& topic_id() const { return topic_id_; }
 
@@ -48,19 +48,19 @@ class Topic {
    * "projects/<project-id>/locations/<location>/topics/<topic-id>"
    */
   std::string FullName() const {
-    return absl::StrCat("projects/", project_id_, "/locations/", location_,
+    return absl::StrCat("projects/", project_id_, "/locations/", location_id_,
                         "/topics/", topic_id_);
   }
 
  private:
   std::string project_id_;
-  std::string location_;
+  std::string location_id_;
   std::string topic_id_;
 };
 
 inline bool operator==(Topic const& a, Topic const& b) {
-  return a.project_id() == b.project_id() && a.location() == b.location() &&
-         a.topic_id() == b.topic_id();
+  return a.project_id() == b.project_id() &&
+         a.location_id() == b.location_id() && a.topic_id() == b.topic_id();
 }
 
 inline bool operator!=(Topic const& a, Topic const& b) { return !(a == b); }

--- a/google/cloud/pubsublite/topic_test.cc
+++ b/google/cloud/pubsublite/topic_test.cc
@@ -30,9 +30,9 @@ TEST(Topic, BasicTopic) {
   std::string topic_name = "topic_name";
 
   Topic topic{project, location, topic_name};
-  EXPECT_EQ(project, topic.project());
+  EXPECT_EQ(project, topic.project_id());
   EXPECT_EQ(location, topic.location());
-  EXPECT_EQ(topic_name, topic.topic_name());
+  EXPECT_EQ(topic_name, topic.topic_id());
   EXPECT_EQ(topic.FullName(),
             "projects/project/locations/location/topics/topic_name");
 }

--- a/google/cloud/pubsublite/topic_test.cc
+++ b/google/cloud/pubsublite/topic_test.cc
@@ -31,7 +31,7 @@ TEST(Topic, BasicTopic) {
 
   Topic topic{project, location, topic_name};
   EXPECT_EQ(project, topic.project_id());
-  EXPECT_EQ(location, topic.location());
+  EXPECT_EQ(location, topic.location_id());
   EXPECT_EQ(topic_name, topic.topic_id());
   EXPECT_EQ(topic.FullName(),
             "projects/project/locations/location/topics/topic_name");


### PR DESCRIPTION
this PR changes the `Topic` constructor arguments to be the same as they are in the Cloud Console
ex. `project_id`, `location_id`, `topic_id`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8790)
<!-- Reviewable:end -->
