### PR TITLE
cleanup: use new CompileProtos support for CMake proto-list/deps

### DIFF
--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -35,22 +35,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/accessapproval.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/accessapproval.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_accessapproval_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/accessapproval/v1/accessapproval.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_accessapproval_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(accessapproval_protos)
-target_link_libraries(
-    google_cloud_cpp_accessapproval_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_accessapproval_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -35,25 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/apigateway.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/apigateway.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_apigateway_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/apigateway/v1/apigateway.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/apigateway/v1/apigateway_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_apigateway_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(apigateway_protos)
-target_link_libraries(
-    google_cloud_cpp_apigateway_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_apigateway_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -35,24 +35,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/apigeeconnect.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/apigeeconnect.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_apigeeconnect_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/apigeeconnect/v1/connection.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/apigeeconnect/v1/tether.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_apigeeconnect_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(apigeeconnect_protos)
-target_link_libraries(
-    google_cloud_cpp_apigeeconnect_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_apigeeconnect_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -35,42 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/appengine.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/appengine.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_appengine_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/legacy/audit_data.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/logging/v1/request_log.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/app_yaml.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/appengine.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/application.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/audit_data.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/certificate.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/deploy.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/deployed_files.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/domain.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/domain_mapping.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/firewall.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/instance.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/location.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/network_settings.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/operation.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/appengine/v1/version.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_appengine_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(appengine_protos)
-target_link_libraries(
-    google_cloud_cpp_appengine_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::logging_type_type_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_appengine_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -35,37 +35,20 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/artifactregistry.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/artifactregistry.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_artifactregistry_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/apt_artifact.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/artifact.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/file.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/package.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/repository.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/settings.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/tag.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/version.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/artifactregistry/v1/yum_artifact.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_artifactregistry_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(artifactregistry_protos)
-target_link_libraries(
-    google_cloud_cpp_artifactregistry_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_artifactregistry_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -45,24 +45,20 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/assuredworkloads.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/assuredworkloads.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_assuredworkloads_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/assuredworkloads/v1/assuredworkloads.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_assuredworkloads_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(assuredworkloads_protos)
-target_link_libraries(
-    google_cloud_cpp_assuredworkloads_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_assuredworkloads_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -35,42 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/automl.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/automl.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_automl_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/annotation_payload.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/annotation_spec.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/classification.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/data_items.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/dataset.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/detection.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/geometry.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/image.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/io.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/model.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/model_evaluation.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/operations.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/prediction_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/text.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/text_extraction.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/text_segment.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/text_sentiment.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/automl/v1/translation.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_automl_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(automl_protos)
-target_link_libraries(
-    google_cloud_cpp_automl_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_automl_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -36,31 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/billing.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/billing.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_billing_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/billing/budgets/v1/budget_model.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/billing/budgets/v1/budget_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/billing/v1/cloud_billing.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/billing/v1/cloud_catalog.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_billing_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(billing_protos)
-target_link_libraries(
-    google_cloud_cpp_billing_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::type_date_protos
-           google-cloud-cpp::type_expr_protos
-           google-cloud-cpp::type_money_protos)
+target_link_libraries(google_cloud_cpp_billing_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -42,34 +42,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/channel.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/channel.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_channel_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/channel_partner_links.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/customers.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/entitlements.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/offers.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/operations.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/products.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/channel/v1/subscriber_event.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_channel_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(channel_protos)
-target_link_libraries(
-    google_cloud_cpp_channel_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_money_protos
-           google-cloud-cpp::type_postal_address_protos)
+target_link_libraries(google_cloud_cpp_channel_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -35,25 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/cloudbuild.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/cloudbuild.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_cloudbuild_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/cloudbuild/v1/cloudbuild.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_cloudbuild_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(cloudbuild_protos)
-target_link_libraries(
-    google_cloud_cpp_cloudbuild_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_httpbody_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_cloudbuild_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -35,27 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/composer.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/composer.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_composer_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orchestration/airflow/service/v1/environments.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orchestration/airflow/service/v1/image_versions.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orchestration/airflow/service/v1/operations.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_composer_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(composer_protos)
-target_link_libraries(
-    google_cloud_cpp_composer_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_date_protos)
+target_link_libraries(google_cloud_cpp_composer_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -37,25 +37,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/contactcenterinsights.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/contactcenterinsights.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_contactcenterinsights_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/contactcenterinsights/v1/contact_center_insights.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/contactcenterinsights/v1/resources.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_contactcenterinsights_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(contactcenterinsights_protos)
-target_link_libraries(
-    google_cloud_cpp_contactcenterinsights_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_contactcenterinsights_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -35,23 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/container.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/container.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_container_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/container/v1/cluster_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_container_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(container_protos)
-target_link_libraries(
-    google_cloud_cpp_container_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::rpc_code_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_container_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -35,26 +35,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/datamigration.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/datamigration.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_datamigration_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/clouddms/logging/v1/clouddms_platform_logs.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/clouddms/v1/clouddms.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/clouddms/v1/clouddms_resources.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_datamigration_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(datamigration_protos)
-target_link_libraries(
-    google_cloud_cpp_datamigration_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_datamigration_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -39,30 +39,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/dataproc.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/dataproc.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_dataproc_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/autoscaling_policies.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/batches.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/clusters.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/jobs.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/operations.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/shared.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/dataproc/v1/workflow_templates.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_dataproc_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(dataproc_protos)
-target_link_libraries(
-    google_cloud_cpp_dataproc_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_dataproc_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/dlp/CMakeLists.txt
+++ b/google/cloud/dlp/CMakeLists.txt
@@ -35,27 +35,16 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/dlp.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/dlp.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_dlp_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/privacy/dlp/v2/dlp.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/privacy/dlp/v2/storage.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_dlp_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(dlp_protos)
-target_link_libraries(
-    google_cloud_cpp_dlp_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_date_protos
-           google-cloud-cpp::type_dayofweek_protos
-           google-cloud-cpp::type_timeofday_protos)
+target_link_libraries(google_cloud_cpp_dlp_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -35,33 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/documentai.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/documentai.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_documentai_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/documentai/v1/document.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/documentai/v1/document_io.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/documentai/v1/document_processor_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/documentai/v1/geometry.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/documentai/v1/operation_metadata.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_documentai_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(documentai_protos)
-target_link_libraries(
-    google_cloud_cpp_documentai_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_color_protos
-           google-cloud-cpp::type_date_protos
-           google-cloud-cpp::type_datetime_protos
-           google-cloud-cpp::type_money_protos
-           google-cloud-cpp::type_postal_address_protos)
+target_link_libraries(google_cloud_cpp_documentai_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -35,28 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/eventarc.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/eventarc.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_eventarc_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/eventarc/publishing/v1/publisher.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/eventarc/v1/channel.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/eventarc/v1/channel_connection.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/eventarc/v1/eventarc.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/eventarc/v1/trigger.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_eventarc_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(eventarc_protos)
-target_link_libraries(
-    google_cloud_cpp_eventarc_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_eventarc_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -35,25 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/filestore.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/filestore.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_filestore_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/filestore/v1/cloud_filestore_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_filestore_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(filestore_protos)
-target_link_libraries(
-    google_cloud_cpp_filestore_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::cloud_common_common_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_filestore_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -35,29 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/functions.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/functions.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_functions_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/functions/v1/functions.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/functions/v1/operations.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_functions_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(functions_protos)
-target_link_libraries(
-    google_cloud_cpp_functions_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_functions_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/gameservices/CMakeLists.txt
+++ b/google/cloud/gameservices/CMakeLists.txt
@@ -35,32 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/gameservices.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/gameservices.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_gameservices_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/game_server_clusters.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/game_server_clusters_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/game_server_configs.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/game_server_configs_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/game_server_deployments.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/game_server_deployments_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/realms.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gaming/v1/realms_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_gameservices_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(gameservices_protos)
-target_link_libraries(
-    google_cloud_cpp_gameservices_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_gameservices_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -35,28 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/gkehub.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/gkehub.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_gkehub_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gkehub/v1/configmanagement/configmanagement.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gkehub/v1/multiclusteringress/multiclusteringress.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gkehub/v1/feature.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gkehub/v1/membership.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/gkehub/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_gkehub_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(gkehub_protos)
-target_link_libraries(
-    google_cloud_cpp_gkehub_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_gkehub_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -35,7 +35,6 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
-
 google_cloud_cpp_load_protolist(
     grafeas_list
     "${CMAKE_SOURCE_DIR}/external/googleapis/protolists/grafeas.list")

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -35,26 +35,16 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/iap.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/iap.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_iap_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/iap/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_iap_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(iap_protos)
-target_link_libraries(
-    google_cloud_cpp_iap_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_iap_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -34,24 +34,16 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/ids.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/ids.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_ids_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/ids/v1/ids.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_ids_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(ids_protos)
-target_link_libraries(
-    google_cloud_cpp_ids_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_ids_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/iot/CMakeLists.txt
+++ b/google/cloud/iot/CMakeLists.txt
@@ -34,28 +34,16 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/iot.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/iot.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_iot_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/iot/v1/device_manager.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/iot/v1/resources.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_iot_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(iot_protos)
-target_link_libraries(
-    google_cloud_cpp_iot_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_iot_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -35,24 +35,16 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/kms.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/kms.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_kms_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/kms/v1/ekm_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/kms/v1/resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/kms/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_kms_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(kms_protos)
-target_link_libraries(
-    google_cloud_cpp_kms_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_kms_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -36,21 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/language.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/language.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_language_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/language/v1/language_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_language_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(language_protos)
-target_link_libraries(
-    google_cloud_cpp_language_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos)
+target_link_libraries(google_cloud_cpp_language_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -38,25 +38,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/managedidentities.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/managedidentities.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_managedidentities_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/managedidentities/v1/managed_identities_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/managedidentities/v1/resource.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_managedidentities_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(managedidentities_protos)
-target_link_libraries(
-    google_cloud_cpp_managedidentities_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_managedidentities_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -36,24 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/memcache.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/memcache.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_memcache_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/memcache/v1/cloud_memcache.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_memcache_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(memcache_protos)
-target_link_libraries(
-    google_cloud_cpp_memcache_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_memcache_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -35,26 +35,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/networkmanagement.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/networkmanagement.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_networkmanagement_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/networkmanagement/v1/connectivity_test.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/networkmanagement/v1/reachability.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/networkmanagement/v1/trace.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_networkmanagement_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(networkmanagement_protos)
-target_link_libraries(
-    google_cloud_cpp_networkmanagement_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_networkmanagement_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -35,32 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/notebooks.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/notebooks.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_notebooks_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/environment.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/event.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/execution.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/instance.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/instance_config.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/managed_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/runtime.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/schedule.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/notebooks/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_notebooks_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(notebooks_protos)
-target_link_libraries(
-    google_cloud_cpp_notebooks_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_notebooks_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/orgpolicy/CMakeLists.txt
+++ b/google/cloud/orgpolicy/CMakeLists.txt
@@ -36,24 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/orgpolicy.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/orgpolicy.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_orgpolicy_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v2/constraint.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v2/orgpolicy.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_orgpolicy_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(orgpolicy_protos)
-target_link_libraries(
-    google_cloud_cpp_orgpolicy_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_orgpolicy_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -35,43 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/osconfig.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/osconfig.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_osconfig_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/agentendpoint/v1/config_common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/agentendpoint/v1/inventory.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/agentendpoint/v1/os_policy.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/agentendpoint/v1/patch_jobs.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/agentendpoint/v1/tasks.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/inventory.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/os_policy.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/os_policy_assignment_reports.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/os_policy_assignments.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/osconfig_common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/osconfig_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/osconfig_zonal_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/patch_deployments.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/patch_jobs.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/osconfig/v1/vulnerability.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_osconfig_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(osconfig_protos)
-target_link_libraries(
-    google_cloud_cpp_osconfig_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_date_protos
-           google-cloud-cpp::type_datetime_protos
-           google-cloud-cpp::type_dayofweek_protos
-           google-cloud-cpp::type_timeofday_protos)
+target_link_libraries(google_cloud_cpp_osconfig_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -36,24 +36,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/policytroubleshooter.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/policytroubleshooter.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_policytroubleshooter_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/policytroubleshooter/v1/checker.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/policytroubleshooter/v1/explanations.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_policytroubleshooter_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(policytroubleshooter_protos)
-target_link_libraries(
-    google_cloud_cpp_policytroubleshooter_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_policytroubleshooter_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -36,26 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/privateca.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/privateca.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_privateca_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/security/privateca/v1/resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/security/privateca/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_privateca_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(privateca_protos)
-target_link_libraries(
-    google_cloud_cpp_privateca_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_privateca_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -35,20 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/profiler.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/profiler.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_profiler_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/cloudprofiler/v2/profiler.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_profiler_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(profiler_protos)
-target_link_libraries(
-    google_cloud_cpp_profiler_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_http_protos)
+target_link_libraries(google_cloud_cpp_profiler_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -35,29 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/pubsublite.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/pubsublite.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_pubsublite_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/admin.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/cursor.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/publisher.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/subscriber.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/pubsublite/v1/topic_stats.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_pubsublite_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(pubsublite_protos)
-target_link_libraries(
-    google_cloud_cpp_pubsublite_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_pubsublite_protos PUBLIC ${proto_deps})
 
 add_library(
     google_cloud_cpp_pubsublite # cmake-format: sort

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -36,26 +36,17 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/redis.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/redis.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_redis_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/redis/v1/cloud_redis.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_redis_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(redis_protos)
-target_link_libraries(
-    google_cloud_cpp_redis_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_dayofweek_protos
-           google-cloud-cpp::type_timeofday_protos)
+target_link_libraries(google_cloud_cpp_redis_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -36,35 +36,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/resourcemanager.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/resourcemanager.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_resourcemanager_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v2/constraint.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v2/orgpolicy.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcemanager/v3/folders.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcemanager/v3/organizations.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcemanager/v3/projects.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcemanager/v3/tag_bindings.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcemanager/v3/tag_keys.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcemanager/v3/tag_values.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_resourcemanager_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(resourcemanager_protos)
-target_link_libraries(
-    google_cloud_cpp_resourcemanager_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_resourcemanager_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -39,22 +39,20 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/resourcesettings.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/resourcesettings.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_resourcesettings_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/resourcesettings/v1/resource_settings.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_resourcesettings_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(resourcesettings_protos)
-target_link_libraries(
-    google_cloud_cpp_resourcesettings_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_resourcesettings_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -35,38 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/retail.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/retail.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_retail_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/catalog.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/catalog_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/completion_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/import_config.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/prediction_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/product.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/product_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/promotion.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/purge_config.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/search_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/user_event.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/retail/v2/user_event_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_retail_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(retail_protos)
-target_link_libraries(
-    google_cloud_cpp_retail_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_httpbody_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_date_protos)
+target_link_libraries(google_cloud_cpp_retail_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -35,25 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/scheduler.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/scheduler.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_scheduler_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/scheduler/v1/cloudscheduler.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/scheduler/v1/job.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/scheduler/v1/target.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_scheduler_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(scheduler_protos)
-target_link_libraries(
-    google_cloud_cpp_scheduler_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_scheduler_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -35,28 +35,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/secretmanager.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/secretmanager.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_secretmanager_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/secretmanager/logging/v1/secret_event.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/secretmanager/v1/resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/secretmanager/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_secretmanager_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(secretmanager_protos)
-target_link_libraries(
-    google_cloud_cpp_secretmanager_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_secretmanager_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -35,30 +35,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/servicecontrol.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/servicecontrol.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_servicecontrol_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/check_error.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/distribution.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/http_request.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/log_entry.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/metric_value.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/operation.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/quota_controller.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicecontrol/v1/service_controller.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_servicecontrol_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(servicecontrol_protos)
-target_link_libraries(
-    google_cloud_cpp_servicecontrol_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_distribution_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::logging_type_type_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_servicecontrol_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -35,30 +35,20 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/servicedirectory.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/servicedirectory.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_servicedirectory_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/servicedirectory/v1/endpoint.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/servicedirectory/v1/lookup_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/servicedirectory/v1/namespace.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/servicedirectory/v1/registration_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/servicedirectory/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_servicedirectory_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(servicedirectory_protos)
-target_link_libraries(
-    google_cloud_cpp_servicedirectory_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_servicedirectory_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -35,46 +35,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/servicemanagement.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/servicemanagement.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_servicemanagement_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicemanagement/v1/resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/servicemanagement/v1/servicemanager.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_servicemanagement_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(servicemanagement_protos)
-target_link_libraries(
-    google_cloud_cpp_servicemanagement_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_auth_protos
-           google-cloud-cpp::api_backend_protos
-           google-cloud-cpp::api_billing_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_config_change_protos
-           google-cloud-cpp::api_context_protos
-           google-cloud-cpp::api_control_protos
-           google-cloud-cpp::api_documentation_protos
-           google-cloud-cpp::api_endpoint_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_label_protos
-           google-cloud-cpp::api_launch_stage_protos
-           google-cloud-cpp::api_log_protos
-           google-cloud-cpp::api_logging_protos
-           google-cloud-cpp::api_metric_protos
-           google-cloud-cpp::api_monitored_resource_protos
-           google-cloud-cpp::api_monitoring_protos
-           google-cloud-cpp::api_quota_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::api_service_protos
-           google-cloud-cpp::api_source_info_protos
-           google-cloud-cpp::api_system_parameter_protos
-           google-cloud-cpp::api_usage_protos
-           google-cloud-cpp::api_visibility_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_servicemanagement_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -35,33 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/serviceusage.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/serviceusage.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_serviceusage_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/serviceusage/v1/resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/api/serviceusage/v1/serviceusage.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_serviceusage_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(serviceusage_protos)
-target_link_libraries(
-    google_cloud_cpp_serviceusage_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_auth_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_documentation_protos
-           google-cloud-cpp::api_endpoint_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_label_protos
-           google-cloud-cpp::api_launch_stage_protos
-           google-cloud-cpp::api_monitored_resource_protos
-           google-cloud-cpp::api_monitoring_protos
-           google-cloud-cpp::api_quota_protos
-           google-cloud-cpp::api_usage_protos
-           google-cloud-cpp::api_visibility_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_serviceusage_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -35,24 +35,17 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/shell.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/shell.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_shell_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/shell/v1/cloudshell.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_shell_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(shell_protos)
-target_link_libraries(
-    google_cloud_cpp_shell_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_shell_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -36,19 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
-add_library(google_cloud_cpp_speech_protos INTERFACE)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/speech.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/speech.deps")
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_speech_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(speech_protos)
-target_link_libraries(
-    google_cloud_cpp_speech_protos
-    INTERFACE #
-              google-cloud-cpp::cloud_speech_protos
-              google-cloud-cpp::api_annotations_protos
-              google-cloud-cpp::api_client_protos
-              google-cloud-cpp::api_field_behavior_protos
-              google-cloud-cpp::api_http_protos
-              google-cloud-cpp::api_resource_protos
-              google-cloud-cpp::longrunning_operations_protos
-              google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_speech_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -45,27 +45,19 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/storagetransfer.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/storagetransfer.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_storagetransfer_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/storagetransfer/v1/transfer.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/storagetransfer/v1/transfer_types.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_storagetransfer_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(storagetransfer_protos)
-target_link_libraries(
-    google_cloud_cpp_storagetransfer_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_code_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_date_protos
-           google-cloud-cpp::type_timeofday_protos)
+target_link_libraries(google_cloud_cpp_storagetransfer_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -36,39 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/talent.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/talent.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_talent_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/company.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/company_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/completion_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/event.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/event_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/filters.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/histogram.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/job.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/job_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/tenant.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/talent/v4/tenant_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_talent_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(talent_protos)
-target_link_libraries(
-    google_cloud_cpp_talent_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_latlng_protos
-           google-cloud-cpp::type_money_protos
-           google-cloud-cpp::type_postal_address_protos
-           google-cloud-cpp::type_timeofday_protos)
+target_link_libraries(google_cloud_cpp_talent_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -35,30 +35,17 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/tasks.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/tasks.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_tasks_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/cloudtasks.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/queue.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/target.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tasks/v2/task.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_tasks_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(tasks_protos)
-target_link_libraries(
-    google_cloud_cpp_tasks_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_tasks_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -36,17 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
-add_library(google_cloud_cpp_texttospeech_protos INTERFACE)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/texttospeech.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/texttospeech.deps")
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_texttospeech_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(texttospeech_protos)
-target_link_libraries(
-    google_cloud_cpp_texttospeech_protos
-    INTERFACE #
-              google-cloud-cpp::cloud_texttospeech_protos
-              google-cloud-cpp::api_annotations_protos
-              google-cloud-cpp::api_client_protos
-              google-cloud-cpp::api_field_behavior_protos
-              google-cloud-cpp::api_http_protos
-              google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_texttospeech_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -34,24 +34,16 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/tpu.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/tpu.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_tpu_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/tpu/v1/cloud_tpu.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_tpu_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(tpu_protos)
-target_link_libraries(
-    google_cloud_cpp_tpu_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_tpu_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -35,18 +35,17 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
-add_library(google_cloud_cpp_trace_protos INTERFACE)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/trace.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/trace.deps")
+google_cloud_cpp_grpcpp_library(
+    google_cloud_cpp_trace_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(trace_protos)
-target_link_libraries(
-    google_cloud_cpp_trace_protos
-    INTERFACE #
-              google-cloud-cpp::devtools_cloudtrace_v2_tracing_protos
-              google-cloud-cpp::api_annotations_protos
-              google-cloud-cpp::api_client_protos
-              google-cloud-cpp::api_field_behavior_protos
-              google-cloud-cpp::api_http_protos
-              google-cloud-cpp::api_resource_protos
-              google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_trace_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/translate/CMakeLists.txt
+++ b/google/cloud/translate/CMakeLists.txt
@@ -35,24 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/translate.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/translate.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_translate_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/translate/v3/translation_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_translate_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(translate_protos)
-target_link_libraries(
-    google_cloud_cpp_translate_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_translate_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -36,23 +36,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/videointelligence.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/videointelligence.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_videointelligence_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/videointelligence/v1/video_intelligence.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_videointelligence_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(videointelligence_protos)
-target_link_libraries(
-    google_cloud_cpp_videointelligence_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_videointelligence_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -35,31 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/vision.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/vision.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_vision_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vision/v1/geometry.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vision/v1/image_annotator.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vision/v1/product_search.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vision/v1/product_search_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vision/v1/text_annotation.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vision/v1/web_detection.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_vision_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(vision_protos)
-target_link_libraries(
-    google_cloud_cpp_vision_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_color_protos
-           google-cloud-cpp::type_latlng_protos)
+target_link_libraries(google_cloud_cpp_vision_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -35,25 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/vmmigration.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/vmmigration.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_vmmigration_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vmmigration/v1/vmmigration.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_vmmigration_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(vmmigration_protos)
-target_link_libraries(
-    google_cloud_cpp_vmmigration_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_error_details_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_vmmigration_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -36,24 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/vpcaccess.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/vpcaccess.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_vpcaccess_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/vpcaccess/v1/vpc_access.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_vpcaccess_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(vpcaccess_protos)
-target_link_libraries(
-    google_cloud_cpp_vpcaccess_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_vpcaccess_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -35,22 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/webrisk.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/webrisk.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_webrisk_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/webrisk/v1/webrisk.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_webrisk_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(webrisk_protos)
-target_link_libraries(
-    google_cloud_cpp_webrisk_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_webrisk_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -36,31 +36,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/websecurityscanner.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/websecurityscanner.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_websecurityscanner_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/crawled_url.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/finding.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/finding_addon.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/finding_type_stats.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/scan_config.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/scan_config_error.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/scan_run.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/scan_run_error_trace.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/scan_run_warning_trace.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/websecurityscanner/v1/web_security_scanner.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_websecurityscanner_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(websecurityscanner_protos)
-target_link_libraries(
-    google_cloud_cpp_websecurityscanner_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_websecurityscanner_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -36,27 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/workflows.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/workflows.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_workflows_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/workflows/executions/v1/executions.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/workflows/type/engine_call.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/workflows/type/executions_system.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/workflows/v1/workflows.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_workflows_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(workflows_protos)
-target_link_libraries(
-    google_cloud_cpp_workflows_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos)
+target_link_libraries(google_cloud_cpp_workflows_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files


### PR DESCRIPTION
Note: A few `google/cloud/*/CMakeLists.txt` files remain using the
old proto-list/deps lists because of an issue I don't yet understand.
I'll address them separately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8792)
<!-- Reviewable:end -->
