### PR TITLE
fix(spanner)!: FLOAT64 NaN values are considered equal

### DIFF
--- a/google/cloud/spanner/value.cc
+++ b/google/cloud/spanner/value.cc
@@ -44,12 +44,11 @@ bool Equal(google::spanner::v1::Type const& pt1,  // NOLINT(misc-no-recursion)
     case google::spanner::v1::TypeCode::INT64:
       return pv1.string_value() == pv2.string_value();
     case google::spanner::v1::TypeCode::FLOAT64:
-      // NaN should always compare not equal, even to itself.
-      if (pv1.string_value() == "NaN" || pv2.string_value() == "NaN") {
-        return false;
+      if (pv1.kind_case() == google::protobuf::Value::kNumberValue) {
+        return pv1.number_value() == pv2.number_value();
       }
-      return pv1.string_value() == pv2.string_value() &&
-             pv1.number_value() == pv2.number_value();
+      // FLOAT64 NaN values are considered equal for sorting purposes.
+      return pv1.string_value() == pv2.string_value();
     case google::spanner::v1::TypeCode::STRING:
     case google::spanner::v1::TypeCode::BYTES:
     case google::spanner::v1::TypeCode::JSON:

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -350,10 +350,11 @@ TEST(Value, DoubleNaN) {
   Value v{nan};
   EXPECT_TRUE(std::isnan(*v.get<double>()));
 
-  // Since IEEE 754 defines that nan is not equal to itself, then a Value with
-  // NaN should not be equal to itself.
+  // Unlike IEEE 754, which defines that NaN is not equal to itself,
+  // Spanner NaN values are considered equal (for easy sorting), so
+  // spanner::Value behaves the same way.
   EXPECT_NE(nan, nan);
-  EXPECT_NE(v, v);
+  EXPECT_EQ(v, v);
 }
 
 TEST(Value, BytesDecodingError) {
@@ -655,9 +656,9 @@ TEST(Value, ProtoConversionFloat64) {
   auto const nan = std::nan("NaN");
   v = Value(nan);
   p = spanner_internal::ToProto(v);
-  // Note: NaN is defined to be not equal to everything, including itself, so
-  // we instead ensure that it is not equal with EXPECT_NE.
-  EXPECT_NE(v, spanner_internal::FromProto(p.first, p.second));
+  // Note: Unlike IEEE 754, Spanner NaN values are considered equal
+  // (for easy sorting), so spanner::Value behaves the same way.
+  EXPECT_EQ(v, spanner_internal::FromProto(p.first, p.second));
   EXPECT_EQ(google::spanner::v1::TypeCode::FLOAT64, p.first.code());
   EXPECT_EQ("NaN", p.second.string_value());
 }


### PR DESCRIPTION
Unlike IEEE 754, which defines that NaN is not equal to itself,
Spanner NaN values are considered equal (for easy sorting), so
spanner::Value should behave the same way for FLOAT64.

http://cloud/spanner/docs/reference/standard-sql/data-types#orderable_floating_points

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8805)
<!-- Reviewable:end -->
