### PR TITLE
refactor(common): split `internal::void_t`

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -67,6 +67,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/throw_delegate.h",
     "internal/tuple.h",
     "internal/type_list.h",
+    "internal/type_traits.h",
     "internal/user_agent_prefix.h",
     "internal/utility.h",
     "internal/version_info.h",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -99,6 +99,7 @@ add_library(
     internal/throw_delegate.h
     internal/tuple.h
     internal/type_list.h
+    internal/type_traits.h
     internal/user_agent_prefix.cc
     internal/user_agent_prefix.h
     internal/utility.h

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_INVOKE_RESULT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_INVOKE_RESULT_H
 
+#include "google/cloud/internal/type_traits.h"
 #include "google/cloud/version.h"
 #include <type_traits>
 
@@ -22,21 +23,6 @@ namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
-/**
- * A helper to detect if expressions are valid and use SFINAE.
- *
- * This class will be introduced in C++17, it makes it easier to write SFINAE
- * expressions, basically you use `void_t< some expression here >` in the SFINAE
- * branch that is trying to test if `some expression here` is valid. If the
- * expression is valid it expands to `void` and your branch continues, if it is
- * invalid it fails and the default SFINAE branch is used.
- *
- * @see https://en.cppreference.com/w/cpp/types/void_t for more details about
- *   this class.
- */
-template <typename...>
-using void_t = void;
-
 /**
  * A helper class to determine the result type of a function-like object.
  *

--- a/google/cloud/internal/invoke_result.h
+++ b/google/cloud/internal/invoke_result.h
@@ -23,6 +23,7 @@ namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
 /**
  * A helper class to determine the result type of a function-like object.
  *

--- a/google/cloud/internal/type_traits.h
+++ b/google/cloud/internal/type_traits.h
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_TRAITS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_TRAITS_H
+
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+/**
+ * A helper to detect if expressions are valid and use SFINAE.
+ *
+ * This class will be introduced in C++17, it makes it easier to write SFINAE
+ * expressions, basically you use `void_t< some expression here >` in the SFINAE
+ * branch that is trying to test if `some expression here` is valid. If the
+ * expression is valid it expands to `void` and your branch continues, if it is
+ * invalid it fails and the default SFINAE branch is used.
+ *
+ * @see https://en.cppreference.com/w/cpp/types/void_t for more details about
+ *   this class.
+ */
+template <typename...>
+using void_t = void;
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_TYPE_TRAITS_H

--- a/google/cloud/internal/type_traits.h
+++ b/google/cloud/internal/type_traits.h
@@ -21,6 +21,7 @@ namespace google {
 namespace cloud {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
 /**
  * A helper to detect if expressions are valid and use SFINAE.
  *


### PR DESCRIPTION
I am going to use this template by itself.  Seems better to use a
separate file, matching the name of the C++17 header that contains it.

Motivated by #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8808)
<!-- Reviewable:end -->
