### PR TITLE
cleanup: use new CompileProtos support in remaining CMakeLists

### DIFF
--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -36,30 +36,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/accesscontextmanager.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/accesscontextmanager.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_accesscontextmanager_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/identity/accesscontextmanager/type/device_resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/identity/accesscontextmanager/v1/access_context_manager.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/identity/accesscontextmanager/v1/access_level.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/identity/accesscontextmanager/v1/access_policy.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/identity/accesscontextmanager/v1/gcp_user_access_binding.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/identity/accesscontextmanager/v1/service_perimeter.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_accesscontextmanager_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(accesscontextmanager_protos)
-target_link_libraries(
-    google_cloud_cpp_accesscontextmanager_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos)
+target_link_libraries(google_cloud_cpp_accesscontextmanager_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -48,36 +48,22 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/asset.list")
+# orgpolicy/v**1** is used *indirectly* by google/cloud/asset, therefore it does
+# not appear in protolists/asset.list. In addition, it is not compiled by any
+# other library. So, added manually.
+list(APPEND proto_list
+     "${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v1/orgpolicy.proto")
+google_cloud_cpp_load_protodeps(
+    proto_deps "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/asset.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_asset_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/asset/v1/asset_service.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/asset/v1/assets.proto
-    # Note that we compile orgpolicy/**v2** in google/cloud/orgpolicy
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/orgpolicy/v1/orgpolicy.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_asset_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(asset_protos)
-target_link_libraries(
-    google_cloud_cpp_asset_protos
-    PUBLIC #
-           google-cloud-cpp::accesscontextmanager_protos
-           google-cloud-cpp::osconfig_protos
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::longrunning_operations_protos
-           google-cloud-cpp::rpc_code_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_date_protos
-           google-cloud-cpp::type_datetime_protos
-           google-cloud-cpp::type_dayofweek_protos
-           google-cloud-cpp::type_expr_protos
-           google-cloud-cpp::type_timeofday_protos)
+target_link_libraries(google_cloud_cpp_asset_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -39,25 +39,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/binaryauthorization.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/binaryauthorization.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_binaryauthorization_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/binaryauthorization/v1/resources.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/binaryauthorization/v1/service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_binaryauthorization_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(binaryauthorization_protos)
-target_link_libraries(
-    google_cloud_cpp_binaryauthorization_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::grafeas_protos)
+target_link_libraries(google_cloud_cpp_binaryauthorization_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -37,28 +37,21 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/containeranalysis.list"
+)
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/containeranalysis.deps"
+)
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_containeranalysis_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/containeranalysis/v1/containeranalysis.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_containeranalysis_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(containeranalysis_protos)
-target_link_libraries(
-    google_cloud_cpp_containeranalysis_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::iam_v1_iam_policy_protos
-           google-cloud-cpp::iam_v1_options_protos
-           google-cloud-cpp::iam_v1_policy_protos
-           google-cloud-cpp::rpc_status_protos
-           google-cloud-cpp::type_expr_protos
-           google-cloud-cpp::grafeas_protos)
+target_link_libraries(google_cloud_cpp_containeranalysis_protos
+                      PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/debugger/CMakeLists.txt
+++ b/google/cloud/debugger/CMakeLists.txt
@@ -36,24 +36,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/debugger.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/debugger.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_debugger_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/clouddebugger/v2/controller.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/clouddebugger/v2/data.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/devtools/clouddebugger/v2/debugger.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_debugger_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(debugger_protos)
-target_link_libraries(
-    google_cloud_cpp_debugger_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::devtools_source_v1_source_context_protos)
+target_link_libraries(google_cloud_cpp_debugger_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -35,23 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/oslogin.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/oslogin.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_oslogin_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/oslogin/common/common.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/oslogin/v1/oslogin.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_oslogin_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(oslogin_protos)
-target_link_libraries(
-    google_cloud_cpp_oslogin_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos)
+target_link_libraries(google_cloud_cpp_oslogin_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -35,26 +35,18 @@ if (PROTO_INCLUDE_DIR)
 endif ()
 
 include(CompileProtos)
+google_cloud_cpp_load_protolist(
+    proto_list
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protolists/recommender.list")
+google_cloud_cpp_load_protodeps(
+    proto_deps
+    "${PROJECT_SOURCE_DIR}/external/googleapis/protodeps/recommender.deps")
 google_cloud_cpp_grpcpp_library(
-    google_cloud_cpp_recommender_protos
-    # cmake-format: sort
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/recommender/logging/v1/action_log.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/recommender/v1/insight.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/recommender/v1/recommendation.proto
-    ${EXTERNAL_GOOGLEAPIS_SOURCE}/google/cloud/recommender/v1/recommender_service.proto
-    PROTO_PATH_DIRECTORIES
-    "${EXTERNAL_GOOGLEAPIS_SOURCE}"
+    google_cloud_cpp_recommender_protos # cmake-format: sort
+    ${proto_list} PROTO_PATH_DIRECTORIES "${EXTERNAL_GOOGLEAPIS_SOURCE}"
     "${PROTO_INCLUDE_DIR}")
 external_googleapis_set_version_and_alias(recommender_protos)
-target_link_libraries(
-    google_cloud_cpp_recommender_protos
-    PUBLIC #
-           google-cloud-cpp::api_annotations_protos
-           google-cloud-cpp::api_client_protos
-           google-cloud-cpp::api_field_behavior_protos
-           google-cloud-cpp::api_http_protos
-           google-cloud-cpp::api_resource_protos
-           google-cloud-cpp::type_money_protos)
+target_link_libraries(google_cloud_cpp_recommender_protos PUBLIC ${proto_deps})
 
 file(
     GLOB source_files


### PR DESCRIPTION
This completes the work started in #8792 by udpating the remaining
`google/cloud/*/CMakeLists.txt` files.

In order to do so, we need to introduce a couple of special cases
(to omit some targets, and transform others) when processing the
`<library>.deps` files.

Also, `google/cloud/asset/CMakeLists.txt` has a special case to
deal with `google/cloud/orgpolicy/v1/orgpolicy.proto`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8809)
<!-- Reviewable:end -->
