### PR TITLE
cleanup(pubsublite): multipartition publisher finishes w/ err message

### DIFF
--- a/google/cloud/pubsublite/internal/multipartition_publisher.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher.cc
@@ -222,17 +222,17 @@ void MultipartitionPublisher::Flush() {
 
 future<void> MultipartitionPublisher::Shutdown() {
   cancel_token_ = nullptr;
+  auto shutdown = service_composite_.Shutdown();
+
   std::deque<PublishState> messages;
   {
     std::lock_guard<std::mutex> g{mu_};
     messages.swap(messages_);
   }
   for (auto& state : messages) {
-    state.publish_promise.set_value(Status{
-        StatusCode::kFailedPrecondition, "Multipartition publisher shutdown."});
+    state.publish_promise.set_value(service_composite_.status());
   }
 
-  auto shutdown = service_composite_.Shutdown();
   std::lock_guard<std::mutex> g{mu_};
   if (outstanding_num_partitions_req_) {
     return outstanding_num_partitions_req_->get_future().then(

--- a/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
+++ b/google/cloud/pubsublite/internal/multipartition_publisher_test.cc
@@ -127,6 +127,33 @@ TEST_F(MultipartitionPublisherNoneInitializedTest,
 }
 
 TEST_F(MultipartitionPublisherNoneInitializedTest,
+       PublishThenFirstPollInvalidValuePublisherAborts) {
+  InSequence seq;
+
+  PubSubMessage m0;
+  *m0.mutable_data() = "data1";
+  future<StatusOr<MessageMetadata>> message0 =
+      multipartition_publisher_->Publish(m0);
+
+  EXPECT_CALL(*admin_connection_,
+              AsyncGetTopicPartitions(IsProtoEqual(ExamplePartitionsRequest())))
+      .WillOnce(
+          Return(ByMove(ReadyTopicPartitionsFuture(kOutOfBoundsPartition))));
+  auto start = multipartition_publisher_->Start();
+
+  Status expected_status =
+      Status(StatusCode::kInternal, "Returned partition count is too big: " +
+                                        std::to_string(kOutOfBoundsPartition));
+
+  EXPECT_EQ(start.get(), expected_status);
+
+  EXPECT_CALL(alarm_token_, Destroy);
+  multipartition_publisher_->Shutdown().get();
+
+  EXPECT_EQ(message0.get().status(), expected_status);
+}
+
+TEST_F(MultipartitionPublisherNoneInitializedTest,
        PublishAndShutdownBeforePublisherCreated) {
   InSequence seq;
 
@@ -154,11 +181,9 @@ TEST_F(MultipartitionPublisherNoneInitializedTest,
       ExamplePartitionsResponse(1));  // shouldn't do anything
 
   EXPECT_EQ(message0.get().status(),
-            Status(StatusCode::kFailedPrecondition,
-                   "Multipartition publisher shutdown."));
+            (Status{StatusCode::kAborted, "`Shutdown` called"}));
   EXPECT_EQ(message1.get().status(),
-            Status(StatusCode::kFailedPrecondition,
-                   "Multipartition publisher shutdown."));
+            (Status{StatusCode::kAborted, "`Shutdown` called"}));
 
   EXPECT_EQ(start.get(), Status());
 }


### PR DESCRIPTION
To be more consistent with the behavior of the single partition publisher and to better implement the propagation of permanent failures to outstanding `Publish` futures, this PR has `MultipartitionPublisher` satisfy all its unsent messages with `service_composite_.status()` when `Shutdown` is called.