### PR TITLE
refactor(storage): helper function to copy request options

### DIFF
--- a/google/cloud/storage/internal/curl_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/curl_resumable_upload_session.cc
@@ -23,10 +23,7 @@ namespace internal {
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadChunk(
     ConstBufferSequence const& buffers) {
   UploadChunkRequest request(session_id_, next_expected_, buffers);
-  request.set_multiple_options(
-      request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
-      request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
-      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  request_.ForEachOption(CopyCommonOptions(request));
   auto result = client_->UploadSessionChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -36,10 +33,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
     ConstBufferSequence const& buffers, std::uint64_t /*upload_size*/,
     HashValues const& hashes) {
   UploadChunkRequest request(session_id_, next_expected_, buffers, hashes);
-  request.set_multiple_options(
-      request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
-      request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
-      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  request_.ForEachOption(CopyCommonOptions(request));
   auto result = client_->UploadSessionChunk(request);
   Update(result, TotalBytes(buffers));
   return result;
@@ -47,10 +41,7 @@ StatusOr<ResumableUploadResponse> CurlResumableUploadSession::UploadFinalChunk(
 
 StatusOr<ResumableUploadResponse> CurlResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_);
-  request.set_multiple_options(
-      request_.GetOption<CustomHeader>(), request_.GetOption<Fields>(),
-      request_.GetOption<IfMatchEtag>(), request_.GetOption<IfNoneMatchEtag>(),
-      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  request_.ForEachOption(CopyCommonOptions(request));
   auto result = client_->QueryResumableSession(request);
   Update(result, 0);
   return result;

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -19,8 +19,10 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/internal/type_traits.h"
 #include <iostream>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 namespace google {
@@ -94,7 +96,7 @@ class GenericRequestBase<Derived, Option> {
   }
 
   template <typename Callable>
-  void ForEachOption(Callable& c) const {
+  void ForEachOption(Callable&& c) const {
     c(option_);
   }
 
@@ -144,7 +146,7 @@ class GenericRequestBase : public GenericRequestBase<Derived, Options...> {
   }
 
   template <typename Callable>
-  void ForEachOption(Callable& c) const {
+  void ForEachOption(Callable&& c) const {
     c(option_);
     GenericRequestBase<Derived, Options...>::ForEachOption(c);
   }
@@ -259,6 +261,43 @@ class GenericRequest
     return Super::template GetOption<Option>();
   }
 };
+
+template <typename Request, typename Option, typename AlwaysVoid = void>
+struct SupportsOption {
+  using type = std::false_type;
+};
+
+template <typename Request, typename Option>
+struct SupportsOption<
+    Request, Option,
+    google::cloud::internal::void_t<decltype(std::declval<Request>().set_option(
+        std::declval<Option>()))>> {
+  using type = std::true_type;
+};
+
+template <typename Destination>
+struct CopyCommonOptionsFunctor {
+  Destination& destination;
+
+  template <typename Option>
+  void impl(std::false_type, Option const&) {}
+
+  template <typename Option>
+  void impl(std::true_type, Option const& o) {
+    destination.set_option(o);
+  }
+
+  template <typename Option>
+  void operator()(Option const& o) {
+    using supported = typename SupportsOption<Destination, Option>::type;
+    impl(supported{}, o);
+  }
+};
+
+template <typename Destination>
+CopyCommonOptionsFunctor<Destination> CopyCommonOptions(Destination& d) {
+  return CopyCommonOptionsFunctor<Destination>{d};
+}
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/grpc_resumable_upload_session.cc
+++ b/google/cloud/storage/internal/grpc_resumable_upload_session.cc
@@ -47,9 +47,7 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadChunk(
     ConstBufferSequence const& payload) {
   auto request = UploadChunkRequest(session_id_params_.upload_id,
                                     committed_size_, payload);
-  request.set_multiple_options(
-      request_.GetOption<UserProject>(), request_.GetOption<Fields>(),
-      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  request_.ForEachOption(CopyCommonOptions(request));
   return HandleResponse(client_->UploadChunk(request));
 }
 
@@ -59,14 +57,13 @@ StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::UploadFinalChunk(
   auto request =
       UploadChunkRequest(session_id_params_.upload_id, committed_size_, payload,
                          full_object_hashes);
-  request.set_multiple_options(
-      request_.GetOption<UserProject>(), request_.GetOption<Fields>(),
-      request_.GetOption<QuotaUser>(), request_.GetOption<UserIp>());
+  request_.ForEachOption(CopyCommonOptions(request));
   return HandleResponse(client_->UploadChunk(request));
 }
 
 StatusOr<ResumableUploadResponse> GrpcResumableUploadSession::ResetSession() {
   QueryResumableUploadRequest request(session_id_params_.upload_id);
+  request_.ForEachOption(CopyCommonOptions(request));
   auto result = client_->QueryResumableSession(request);
   if (!result) return result;
 


### PR DESCRIPTION
In a few places we need to copy all the options from a request to
another request, sometimes with a different type for the destination
request.

Part of the changes for #8621

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8812)
<!-- Reviewable:end -->
