### PR TITLE
doc(bigtable): deprecate DataClient member fns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,21 @@ namespace. The function continues to exist but in an internal file and
 namespace. For status on this see
 https://github.com/googleapis/google-cloud-cpp/issues/8234.
 </details>
+<br>
+
+On 2023-05-01 (or shortly after) we will mark `bigtable::DataClient` as `final`
+and remove the following member functions:
+* `DataClient::Channel()`
+* `DataClient::reset()`
+* `DataClient::BackgroundThreadsFactory()`
+
+Application developers should not need to interact with this class directly.
+Please use `google::cloud::bigtable::MakeDataClient(...)` with the options from
+`google::cloud::GrpcOptionList<>` if you need to configure the gRPC channel or
+background threads.
+
+For status on this, see https://github.com/googleapis/google-cloud-cpp/issues/8800
+</details>
 
 ## v1.40.0 - TBD
 

--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -189,6 +189,11 @@ class DefaultDataClient : public DataClient {
     return impl_.BackgroundThreadsFactory();
   }
 
+  std::shared_ptr<grpc::Channel> ChannelImpl() override {
+    return impl_.Channel();
+  }
+  void resetImpl() override { impl_.reset(); }
+
   void ApplyOptions(grpc::ClientContext* context) {
     if (!authority_.empty()) context->set_authority(authority_);
     if (user_project_) {

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -196,7 +196,7 @@ class DataClient {
    * The client library calls this method to avoid deprecation warnings from
    * calling `Channel()` directly.
    */
-  virtual std::shared_ptr<grpc::Channel> ChannelImpl() { return {}; }
+  virtual std::shared_ptr<grpc::Channel> ChannelImpl() { return nullptr; }
 
   /**
    * The client library calls this method to avoid deprecation warnings from
@@ -234,10 +234,11 @@ inline std::string InstanceName(std::shared_ptr<DataClient> const& client) {
 namespace internal {
 class DataClientTester {
  public:
-  static std::shared_ptr<grpc::Channel> Channel(std::shared_ptr<DataClient> c) {
+  static std::shared_ptr<grpc::Channel> Channel(
+      std::shared_ptr<DataClient> const& c) {
     return c->ChannelImpl();
   }
-  static void reset(std::shared_ptr<DataClient> c) { c->resetImpl(); }
+  static void reset(std::shared_ptr<DataClient> const& c) { c->resetImpl(); }
 };
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/data_client_test.cc
+++ b/google/cloud/bigtable/data_client_test.cc
@@ -31,14 +31,14 @@ TEST(DataClientTest, Default) {
   EXPECT_EQ("test-project", data_client->project_id());
   EXPECT_EQ("test-instance", data_client->instance_id());
 
-  auto channel0 = data_client->Channel();
+  auto channel0 = internal::DataClientTester::Channel(data_client);
   EXPECT_TRUE(channel0);
 
-  auto channel1 = data_client->Channel();
+  auto channel1 = internal::DataClientTester::Channel(data_client);
   EXPECT_EQ(channel0.get(), channel1.get());
 
-  data_client->reset();
-  channel1 = data_client->Channel();
+  internal::DataClientTester::reset(data_client);
+  channel1 = internal::DataClientTester::Channel(data_client);
   EXPECT_TRUE(channel1);
   EXPECT_NE(channel0.get(), channel1.get());
 }
@@ -50,14 +50,14 @@ TEST(DataClientTest, MakeClient) {
   EXPECT_EQ("test-project", data_client->project_id());
   EXPECT_EQ("test-instance", data_client->instance_id());
 
-  auto channel0 = data_client->Channel();
+  auto channel0 = internal::DataClientTester::Channel(data_client);
   EXPECT_TRUE(channel0);
 
-  auto channel1 = data_client->Channel();
+  auto channel1 = internal::DataClientTester::Channel(data_client);
   EXPECT_EQ(channel0.get(), channel1.get());
 
-  data_client->reset();
-  channel1 = data_client->Channel();
+  internal::DataClientTester::reset(data_client);
+  channel1 = internal::DataClientTester::Channel(data_client);
   EXPECT_TRUE(channel1);
   EXPECT_NE(channel0.get(), channel1.get());
 }

--- a/google/cloud/bigtable/internal/logging_data_client.h
+++ b/google/cloud/bigtable/internal/logging_data_client.h
@@ -50,8 +50,12 @@ class LoggingDataClient : public DataClient {
   std::shared_ptr<grpc::Channel> Channel() override {
     return child_->ChannelImpl();
   }
+  std::shared_ptr<grpc::Channel> ChannelImpl() override {
+    return child_->ChannelImpl();
+  }
 
   void reset() override { child_->resetImpl(); }
+  void resetImpl() override { child_->resetImpl(); }
 
   grpc::Status MutateRow(grpc::ClientContext* context,
                          btproto::MutateRowRequest const& request,

--- a/google/cloud/bigtable/internal/logging_data_client.h
+++ b/google/cloud/bigtable/internal/logging_data_client.h
@@ -48,10 +48,10 @@ class LoggingDataClient : public DataClient {
   }
 
   std::shared_ptr<grpc::Channel> Channel() override {
-    return child_->Channel();
+    return child_->ChannelImpl();
   }
 
-  void reset() override { child_->reset(); }
+  void reset() override { child_->resetImpl(); }
 
   grpc::Status MutateRow(grpc::ClientContext* context,
                          btproto::MutateRowRequest const& request,

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -559,7 +559,7 @@ TEST(ConnectionRefresh, Disabled) {
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   for (int i = 0; i < internal::DefaultConnectionPoolSize(); ++i) {
-    auto channel = data_client->Channel();
+    auto channel = internal::DataClientTester::Channel(data_client);
     EXPECT_EQ(GRPC_CHANNEL_IDLE, channel->GetState(false));
   }
   // Make sure things still work.
@@ -572,7 +572,8 @@ TEST(ConnectionRefresh, Disabled) {
   // state.
   auto check_if_some_channel_is_ready = [&] {
     for (int i = 0; i < internal::DefaultConnectionPoolSize(); ++i) {
-      if (data_client->Channel()->GetState(false) == GRPC_CHANNEL_READY) {
+      auto channel = internal::DataClientTester::Channel(data_client);
+      if (channel->GetState(false) == GRPC_CHANNEL_READY) {
         return true;
       }
     }
@@ -590,7 +591,8 @@ TEST(ConnectionRefresh, Frequent) {
           .set<MinConnectionRefreshOption>(std::chrono::milliseconds(100)));
 
   for (;;) {
-    if (data_client->Channel()->GetState(false) == GRPC_CHANNEL_READY) {
+    auto channel = internal::DataClientTester::Channel(data_client);
+    if (channel->GetState(false) == GRPC_CHANNEL_READY) {
       // We've found a channel which changed its state from IDLE to READY,
       // which means that our refreshing mechanism works.
       break;

--- a/google/cloud/bigtable/version.h
+++ b/google/cloud/bigtable/version.h
@@ -19,6 +19,12 @@
 #include "google/cloud/version.h"
 #include <string>
 
+#define GOOGLE_CLOUD_CPP_BIGTABLE_DATA_CLIENT_DEPRECATED(name)              \
+  GOOGLE_CLOUD_CPP_DEPRECATED(                                              \
+      "google::cloud::bigtable::DataClient::" name                          \
+      " is deprecated, and will be removed on or shortly after 2023-05-01." \
+      " See GitHub issue #8800 for more information.")
+
 // This preprocessor symbol is deprecated and should never be used anywhere. It
 // exists solely for backward compatibility to avoid breaking anyone who may
 // have been using it.


### PR DESCRIPTION
The deprecation part of #8800 

I added compiler warnings for `Channel()` and `reset()` to the base class, a la [this spanner warning](https://github.com/googleapis/google-cloud-cpp/blob/c3042b5b54f489341e2801f15b27fa3d70966625/google/cloud/spanner/version.h#L23).

We still call `BackgroundThreadsFactory()` in `Table`: https://github.com/googleapis/google-cloud-cpp/blob/c3042b5b54f489341e2801f15b27fa3d70966625/google/cloud/bigtable/table.h#L228

I am relying on documentation to communicate the future removal of `DataClient::BackgroundThreadsFactory()`. I could not figure out a way to add a compiler warning to this function that:
1. doesn't break customer code extending `DataClient`. (Note that such code might not exist)
2. doesn't yield a compiler warning for us

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8813)
<!-- Reviewable:end -->
