### PR TITLE
refactor(pubsub): containing publisher conn

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -45,6 +45,7 @@ add_library(
     internal/batch_sink.h
     internal/batching_publisher_connection.cc
     internal/batching_publisher_connection.h
+    internal/containing_publisher_connection.h
     internal/create_channel.cc
     internal/create_channel.h
     internal/default_batch_sink.cc

--- a/google/cloud/pubsub/google_cloud_cpp_pubsub.bzl
+++ b/google/cloud/pubsub/google_cloud_cpp_pubsub.bzl
@@ -23,6 +23,7 @@ google_cloud_cpp_pubsub_hdrs = [
     "connection_options.h",
     "internal/batch_sink.h",
     "internal/batching_publisher_connection.h",
+    "internal/containing_publisher_connection.h",
     "internal/create_channel.h",
     "internal/default_batch_sink.h",
     "internal/defaults.h",

--- a/google/cloud/pubsub/internal/containing_publisher_connection.h
+++ b/google/cloud/pubsub/internal/containing_publisher_connection.h
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_CONTAINING_PUBLISHER_CONNECTION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_CONTAINING_PUBLISHER_CONNECTION_H
+
+#include "google/cloud/pubsub/publisher.h"
+#include <memory>
+
+namespace google {
+namespace cloud {
+namespace pubsub_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+class ContainingPublisherConnection
+    : public google::cloud::pubsub::PublisherConnection {
+ public:
+  ContainingPublisherConnection(std::shared_ptr<BackgroundThreads> background,
+                                std::shared_ptr<PublisherConnection> child)
+      : background_(std::move(background)), child_(std::move(child)) {}
+
+  ~ContainingPublisherConnection() override = default;
+
+  future<StatusOr<std::string>> Publish(PublishParams p) override {
+    return child_->Publish(std::move(p));
+  }
+  void Flush(FlushParams p) override { child_->Flush(std::move(p)); }
+  void ResumePublish(ResumePublishParams p) override {
+    child_->ResumePublish(std::move(p));
+  }
+
+ private:
+  std::shared_ptr<BackgroundThreads> background_;
+  std::shared_ptr<PublisherConnection> child_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace pubsub_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_PUBSUB_INTERNAL_CONTAINING_PUBLISHER_CONNECTION_H

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/publisher_connection.h"
 #include "google/cloud/pubsub/internal/batching_publisher_connection.h"
+#include "google/cloud/pubsub/internal/containing_publisher_connection.h"
 #include "google/cloud/pubsub/internal/create_channel.h"
 #include "google/cloud/pubsub/internal/default_batch_sink.h"
 #include "google/cloud/pubsub/internal/defaults.h"
@@ -37,26 +38,6 @@ namespace cloud {
 namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
-class ContainingPublisherConnection : public PublisherConnection {
- public:
-  ContainingPublisherConnection(std::shared_ptr<BackgroundThreads> background,
-                                std::shared_ptr<PublisherConnection> child)
-      : background_(std::move(background)), child_(std::move(child)) {}
-
-  ~ContainingPublisherConnection() override = default;
-
-  future<StatusOr<std::string>> Publish(PublishParams p) override {
-    return child_->Publish(std::move(p));
-  }
-  void Flush(FlushParams p) override { child_->Flush(std::move(p)); }
-  void ResumePublish(ResumePublishParams p) override {
-    child_->ResumePublish(std::move(p));
-  }
-
- private:
-  std::shared_ptr<BackgroundThreads> background_;
-  std::shared_ptr<PublisherConnection> child_;
-};
 
 std::shared_ptr<pubsub_internal::PublisherStub> DecoratePublisherStub(
     Options const& opts,
@@ -110,7 +91,8 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
     connection = pubsub_internal::FlowControlledPublisherConnection::Create(
         std::move(opts), std::move(connection));
   }
-  return std::make_shared<pubsub::ContainingPublisherConnection>(
+  return std::make_shared<
+      google::cloud::pubsub_internal::ContainingPublisherConnection>(
       std::move(background), std::move(connection));
 }
 }  // namespace

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -91,8 +91,7 @@ std::shared_ptr<pubsub::PublisherConnection> ConnectionFromDecoratedStub(
     connection = pubsub_internal::FlowControlledPublisherConnection::Create(
         std::move(opts), std::move(connection));
   }
-  return std::make_shared<
-      google::cloud::pubsub_internal::ContainingPublisherConnection>(
+  return std::make_shared<pubsub_internal::ContainingPublisherConnection>(
       std::move(background), std::move(connection));
 }
 }  // namespace


### PR DESCRIPTION
Migrated `ContainingPublisherConnection` in `pubsub` from a source file to an internal header so that we can use it in the Pub/Sub Lite factory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8818)
<!-- Reviewable:end -->
