### PR TITLE
impl: add simple exception-detection support for clang-cl

### DIFF
--- a/google/cloud/internal/port_platform.h
+++ b/google/cloud/internal/port_platform.h
@@ -70,9 +70,9 @@
 #ifdef GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
 #  error "GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS should not be set directly."
 #elif defined(__clang__)
-#  if defined(__EXCEPTIONS) && __has_feature(cxx_exceptions)
+#  if (defined(__EXCEPTIONS) || defined(COMPILER_MSVC)) && __has_feature(cxx_exceptions)
 #    define GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS 1
-#  endif  // defined(__EXCEPTIONS) && __has_feature(cxx_exceptions)
+#  endif  // (defined(__EXCEPTIONS) || defined(COMPILER_MSVC)) && __has_feature(cxx_exceptions)
 #elif defined(_MSC_VER)
 #  if defined(_CPPUNWIND)
 #    define GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS 1


### PR DESCRIPTION
Use `defined(__clang__)` and `defined(COMPILER_MSVC)` to detect
clang-cl.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8822)
<!-- Reviewable:end -->
