### PR TITLE
chore: remove several `experimental-` targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -44,7 +44,9 @@ TRANSITION_LIBRARIES = [
     "managedidentities",
     "profiler",
     "resourcesettings",
-    # 2022-02-28
+]
+
+GA_LIBRARIES = [
     "accessapproval",
     "accesscontextmanager",
     "apigateway",
@@ -106,9 +108,6 @@ TRANSITION_LIBRARIES = [
     "webrisk",
     "websecurityscanner",
     "workflows",
-]
-
-GA_LIBRARIES = [
 ]
 
 [cc_library(

--- a/google/cloud/accessapproval/config.cmake.in
+++ b/google/cloud/accessapproval/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_accessapproval-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-accessapproval)
-    add_library(google-cloud-cpp::experimental-accessapproval ALIAS google-cloud-cpp::accessapproval)
-endif ()

--- a/google/cloud/accessapproval/quickstart/CMakeLists.txt
+++ b/google/cloud/accessapproval/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-accessapproval)
+target_link_libraries(quickstart google-cloud-cpp::accessapproval)

--- a/google/cloud/accesscontextmanager/config.cmake.in
+++ b/google/cloud/accesscontextmanager/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_accesscontextmanager-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-accesscontextmanager)
-    add_library(google-cloud-cpp::experimental-accesscontextmanager ALIAS google-cloud-cpp::accesscontextmanager)
-endif ()

--- a/google/cloud/accesscontextmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-accesscontextmanager)
+target_link_libraries(quickstart google-cloud-cpp::accesscontextmanager)

--- a/google/cloud/apigateway/config.cmake.in
+++ b/google/cloud/apigateway/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_apigateway-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-apigateway)
-    add_library(google-cloud-cpp::experimental-apigateway ALIAS google-cloud-cpp::apigateway)
-endif ()

--- a/google/cloud/apigateway/quickstart/CMakeLists.txt
+++ b/google/cloud/apigateway/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-apigateway)
+target_link_libraries(quickstart google-cloud-cpp::apigateway)

--- a/google/cloud/appengine/config.cmake.in
+++ b/google/cloud/appengine/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_appengine-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-appengine)
-    add_library(google-cloud-cpp::experimental-appengine ALIAS google-cloud-cpp::appengine)
-endif ()

--- a/google/cloud/appengine/quickstart/CMakeLists.txt
+++ b/google/cloud/appengine/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-appengine)
+target_link_libraries(quickstart google-cloud-cpp::appengine)

--- a/google/cloud/artifactregistry/config.cmake.in
+++ b/google/cloud/artifactregistry/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_artifactregistry-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-artifactregistry)
-    add_library(google-cloud-cpp::experimental-artifactregistry ALIAS google-cloud-cpp::artifactregistry)
-endif ()

--- a/google/cloud/artifactregistry/quickstart/CMakeLists.txt
+++ b/google/cloud/artifactregistry/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-artifactregistry)
+target_link_libraries(quickstart google-cloud-cpp::artifactregistry)

--- a/google/cloud/asset/config.cmake.in
+++ b/google/cloud/asset/config.cmake.in
@@ -22,7 +22,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_asset-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-asset)
-    add_library(google-cloud-cpp::experimental-asset ALIAS google-cloud-cpp::asset)
-endif ()

--- a/google/cloud/asset/quickstart/CMakeLists.txt
+++ b/google/cloud/asset/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-asset)
+target_link_libraries(quickstart google-cloud-cpp::asset)

--- a/google/cloud/assuredworkloads/config.cmake.in
+++ b/google/cloud/assuredworkloads/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_assuredworkloads-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-assuredworkloads)
-    add_library(google-cloud-cpp::experimental-assuredworkloads ALIAS google-cloud-cpp::assuredworkloads)
-endif ()

--- a/google/cloud/assuredworkloads/quickstart/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-assuredworkloads)
+target_link_libraries(quickstart google-cloud-cpp::assuredworkloads)

--- a/google/cloud/automl/config.cmake.in
+++ b/google/cloud/automl/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_automl-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-automl)
-    add_library(google-cloud-cpp::experimental-automl ALIAS google-cloud-cpp::automl)
-endif ()

--- a/google/cloud/automl/quickstart/CMakeLists.txt
+++ b/google/cloud/automl/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-automl)
+target_link_libraries(quickstart google-cloud-cpp::automl)

--- a/google/cloud/billing/config.cmake.in
+++ b/google/cloud/billing/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_billing-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-billing)
-    add_library(google-cloud-cpp::experimental-billing ALIAS google-cloud-cpp::billing)
-endif ()

--- a/google/cloud/billing/quickstart/CMakeLists.txt
+++ b/google/cloud/billing/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-billing)
+target_link_libraries(quickstart google-cloud-cpp::billing)

--- a/google/cloud/binaryauthorization/config.cmake.in
+++ b/google/cloud/binaryauthorization/config.cmake.in
@@ -21,7 +21,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_binaryauthorization-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-binaryauthorization)
-    add_library(google-cloud-cpp::experimental-binaryauthorization ALIAS google-cloud-cpp::binaryauthorization)
-endif ()

--- a/google/cloud/binaryauthorization/quickstart/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-binaryauthorization)
+target_link_libraries(quickstart google-cloud-cpp::binaryauthorization)

--- a/google/cloud/channel/config.cmake.in
+++ b/google/cloud/channel/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_channel-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-channel)
-    add_library(google-cloud-cpp::experimental-channel ALIAS google-cloud-cpp::channel)
-endif ()

--- a/google/cloud/channel/quickstart/CMakeLists.txt
+++ b/google/cloud/channel/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-channel)
+target_link_libraries(quickstart google-cloud-cpp::channel)

--- a/google/cloud/cloudbuild/config.cmake.in
+++ b/google/cloud/cloudbuild/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_cloudbuild-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-cloudbuild)
-    add_library(google-cloud-cpp::experimental-cloudbuild ALIAS google-cloud-cpp::cloudbuild)
-endif ()

--- a/google/cloud/cloudbuild/quickstart/CMakeLists.txt
+++ b/google/cloud/cloudbuild/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-cloudbuild)
+target_link_libraries(quickstart google-cloud-cpp::cloudbuild)

--- a/google/cloud/composer/config.cmake.in
+++ b/google/cloud/composer/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_composer-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-composer)
-    add_library(google-cloud-cpp::experimental-composer ALIAS google-cloud-cpp::composer)
-endif ()

--- a/google/cloud/composer/quickstart/CMakeLists.txt
+++ b/google/cloud/composer/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-composer)
+target_link_libraries(quickstart google-cloud-cpp::composer)

--- a/google/cloud/container/config.cmake.in
+++ b/google/cloud/container/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_container-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-container)
-    add_library(google-cloud-cpp::experimental-container ALIAS google-cloud-cpp::container)
-endif ()

--- a/google/cloud/container/quickstart/CMakeLists.txt
+++ b/google/cloud/container/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-container)
+target_link_libraries(quickstart google-cloud-cpp::container)

--- a/google/cloud/containeranalysis/config.cmake.in
+++ b/google/cloud/containeranalysis/config.cmake.in
@@ -21,7 +21,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_containeranalysis-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-containeranalysis)
-    add_library(google-cloud-cpp::experimental-containeranalysis ALIAS google-cloud-cpp::containeranalysis)
-endif ()

--- a/google/cloud/containeranalysis/quickstart/CMakeLists.txt
+++ b/google/cloud/containeranalysis/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-containeranalysis)
+target_link_libraries(quickstart google-cloud-cpp::containeranalysis)

--- a/google/cloud/datamigration/config.cmake.in
+++ b/google/cloud/datamigration/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_datamigration-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-datamigration)
-    add_library(google-cloud-cpp::experimental-datamigration ALIAS google-cloud-cpp::datamigration)
-endif ()

--- a/google/cloud/datamigration/quickstart/CMakeLists.txt
+++ b/google/cloud/datamigration/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-datamigration)
+target_link_libraries(quickstart google-cloud-cpp::datamigration)

--- a/google/cloud/debugger/config.cmake.in
+++ b/google/cloud/debugger/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_debugger-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-debugger)
-    add_library(google-cloud-cpp::experimental-debugger ALIAS google-cloud-cpp::debugger)
-endif ()

--- a/google/cloud/debugger/quickstart/CMakeLists.txt
+++ b/google/cloud/debugger/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-debugger)
+target_link_libraries(quickstart google-cloud-cpp::debugger)

--- a/google/cloud/dlp/config.cmake.in
+++ b/google/cloud/dlp/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_dlp-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-dlp)
-    add_library(google-cloud-cpp::experimental-dlp ALIAS google-cloud-cpp::dlp)
-endif ()

--- a/google/cloud/dlp/quickstart/CMakeLists.txt
+++ b/google/cloud/dlp/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-dlp)
+target_link_libraries(quickstart google-cloud-cpp::dlp)

--- a/google/cloud/eventarc/config.cmake.in
+++ b/google/cloud/eventarc/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_eventarc-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-eventarc)
-    add_library(google-cloud-cpp::experimental-eventarc ALIAS google-cloud-cpp::eventarc)
-endif ()

--- a/google/cloud/eventarc/quickstart/CMakeLists.txt
+++ b/google/cloud/eventarc/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-eventarc)
+target_link_libraries(quickstart google-cloud-cpp::eventarc)

--- a/google/cloud/filestore/config.cmake.in
+++ b/google/cloud/filestore/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_filestore-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-filestore)
-    add_library(google-cloud-cpp::experimental-filestore ALIAS google-cloud-cpp::filestore)
-endif ()

--- a/google/cloud/filestore/quickstart/CMakeLists.txt
+++ b/google/cloud/filestore/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-filestore)
+target_link_libraries(quickstart google-cloud-cpp::filestore)

--- a/google/cloud/functions/config.cmake.in
+++ b/google/cloud/functions/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_functions-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-functions)
-    add_library(google-cloud-cpp::experimental-functions ALIAS google-cloud-cpp::functions)
-endif ()

--- a/google/cloud/functions/quickstart/CMakeLists.txt
+++ b/google/cloud/functions/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-functions)
+target_link_libraries(quickstart google-cloud-cpp::functions)

--- a/google/cloud/gameservices/config.cmake.in
+++ b/google/cloud/gameservices/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_gameservices-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-gameservices)
-    add_library(google-cloud-cpp::experimental-gameservices ALIAS google-cloud-cpp::gameservices)
-endif ()

--- a/google/cloud/gameservices/quickstart/CMakeLists.txt
+++ b/google/cloud/gameservices/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-gameservices)
+target_link_libraries(quickstart google-cloud-cpp::gameservices)

--- a/google/cloud/gkehub/config.cmake.in
+++ b/google/cloud/gkehub/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_gkehub-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-gkehub)
-    add_library(google-cloud-cpp::experimental-gkehub ALIAS google-cloud-cpp::gkehub)
-endif ()

--- a/google/cloud/gkehub/quickstart/CMakeLists.txt
+++ b/google/cloud/gkehub/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-gkehub)
+target_link_libraries(quickstart google-cloud-cpp::gkehub)

--- a/google/cloud/iap/config.cmake.in
+++ b/google/cloud/iap/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_iap-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-iap)
-    add_library(google-cloud-cpp::experimental-iap ALIAS google-cloud-cpp::iap)
-endif ()

--- a/google/cloud/iap/quickstart/CMakeLists.txt
+++ b/google/cloud/iap/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-iap)
+target_link_libraries(quickstart google-cloud-cpp::iap)

--- a/google/cloud/ids/config.cmake.in
+++ b/google/cloud/ids/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_ids-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-ids)
-    add_library(google-cloud-cpp::experimental-ids ALIAS google-cloud-cpp::ids)
-endif ()

--- a/google/cloud/ids/quickstart/CMakeLists.txt
+++ b/google/cloud/ids/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-ids)
+target_link_libraries(quickstart google-cloud-cpp::ids)

--- a/google/cloud/iot/config.cmake.in
+++ b/google/cloud/iot/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_iot-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-iot)
-    add_library(google-cloud-cpp::experimental-iot ALIAS google-cloud-cpp::iot)
-endif ()

--- a/google/cloud/iot/quickstart/CMakeLists.txt
+++ b/google/cloud/iot/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-iot)
+target_link_libraries(quickstart google-cloud-cpp::iot)

--- a/google/cloud/kms/config.cmake.in
+++ b/google/cloud/kms/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_kms-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-kms)
-    add_library(google-cloud-cpp::experimental-kms ALIAS google-cloud-cpp::kms)
-endif ()

--- a/google/cloud/kms/quickstart/CMakeLists.txt
+++ b/google/cloud/kms/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-kms)
+target_link_libraries(quickstart google-cloud-cpp::kms)

--- a/google/cloud/memcache/config.cmake.in
+++ b/google/cloud/memcache/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_memcache-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-memcache)
-    add_library(google-cloud-cpp::experimental-memcache ALIAS google-cloud-cpp::memcache)
-endif ()

--- a/google/cloud/memcache/quickstart/CMakeLists.txt
+++ b/google/cloud/memcache/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-memcache)
+target_link_libraries(quickstart google-cloud-cpp::memcache)

--- a/google/cloud/monitoring/config.cmake.in
+++ b/google/cloud/monitoring/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_monitoring-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-monitoring)
-    add_library(google-cloud-cpp::experimental-monitoring ALIAS google-cloud-cpp::monitoring)
-endif ()

--- a/google/cloud/monitoring/quickstart/CMakeLists.txt
+++ b/google/cloud/monitoring/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-monitoring)
+target_link_libraries(quickstart google-cloud-cpp::monitoring)

--- a/google/cloud/networkmanagement/config.cmake.in
+++ b/google/cloud/networkmanagement/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_networkmanagement-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-networkmanagement)
-    add_library(google-cloud-cpp::experimental-networkmanagement ALIAS google-cloud-cpp::networkmanagement)
-endif ()

--- a/google/cloud/networkmanagement/quickstart/CMakeLists.txt
+++ b/google/cloud/networkmanagement/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-networkmanagement)
+target_link_libraries(quickstart google-cloud-cpp::networkmanagement)

--- a/google/cloud/notebooks/config.cmake.in
+++ b/google/cloud/notebooks/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_notebooks-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-notebooks)
-    add_library(google-cloud-cpp::experimental-notebooks ALIAS google-cloud-cpp::notebooks)
-endif ()

--- a/google/cloud/notebooks/quickstart/CMakeLists.txt
+++ b/google/cloud/notebooks/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-notebooks)
+target_link_libraries(quickstart google-cloud-cpp::notebooks)

--- a/google/cloud/orgpolicy/config.cmake.in
+++ b/google/cloud/orgpolicy/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_orgpolicy-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-orgpolicy)
-    add_library(google-cloud-cpp::experimental-orgpolicy ALIAS google-cloud-cpp::orgpolicy)
-endif ()

--- a/google/cloud/orgpolicy/quickstart/CMakeLists.txt
+++ b/google/cloud/orgpolicy/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-orgpolicy)
+target_link_libraries(quickstart google-cloud-cpp::orgpolicy)

--- a/google/cloud/oslogin/config.cmake.in
+++ b/google/cloud/oslogin/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_oslogin-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-oslogin)
-    add_library(google-cloud-cpp::experimental-oslogin ALIAS google-cloud-cpp::oslogin)
-endif ()

--- a/google/cloud/oslogin/quickstart/CMakeLists.txt
+++ b/google/cloud/oslogin/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-oslogin)
+target_link_libraries(quickstart google-cloud-cpp::oslogin)

--- a/google/cloud/policytroubleshooter/config.cmake.in
+++ b/google/cloud/policytroubleshooter/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_policytroubleshooter-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-policytroubleshooter)
-    add_library(google-cloud-cpp::experimental-policytroubleshooter ALIAS google-cloud-cpp::policytroubleshooter)
-endif ()

--- a/google/cloud/policytroubleshooter/quickstart/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-policytroubleshooter)
+target_link_libraries(quickstart google-cloud-cpp::policytroubleshooter)

--- a/google/cloud/privateca/config.cmake.in
+++ b/google/cloud/privateca/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_privateca-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-privateca)
-    add_library(google-cloud-cpp::experimental-privateca ALIAS google-cloud-cpp::privateca)
-endif ()

--- a/google/cloud/privateca/quickstart/CMakeLists.txt
+++ b/google/cloud/privateca/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-privateca)
+target_link_libraries(quickstart google-cloud-cpp::privateca)

--- a/google/cloud/recommender/config.cmake.in
+++ b/google/cloud/recommender/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_recommender-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-recommender)
-    add_library(google-cloud-cpp::experimental-recommender ALIAS google-cloud-cpp::recommender)
-endif ()

--- a/google/cloud/recommender/quickstart/CMakeLists.txt
+++ b/google/cloud/recommender/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-recommender)
+target_link_libraries(quickstart google-cloud-cpp::recommender)

--- a/google/cloud/redis/config.cmake.in
+++ b/google/cloud/redis/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_redis-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-redis)
-    add_library(google-cloud-cpp::experimental-redis ALIAS google-cloud-cpp::redis)
-endif ()

--- a/google/cloud/redis/quickstart/CMakeLists.txt
+++ b/google/cloud/redis/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-redis)
+target_link_libraries(quickstart google-cloud-cpp::redis)

--- a/google/cloud/resourcemanager/config.cmake.in
+++ b/google/cloud/resourcemanager/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_resourcemanager-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-resourcemanager)
-    add_library(google-cloud-cpp::experimental-resourcemanager ALIAS google-cloud-cpp::resourcemanager)
-endif ()

--- a/google/cloud/resourcemanager/quickstart/CMakeLists.txt
+++ b/google/cloud/resourcemanager/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-resourcemanager)
+target_link_libraries(quickstart google-cloud-cpp::resourcemanager)

--- a/google/cloud/retail/config.cmake.in
+++ b/google/cloud/retail/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_retail-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-retail)
-    add_library(google-cloud-cpp::experimental-retail ALIAS google-cloud-cpp::retail)
-endif ()

--- a/google/cloud/retail/quickstart/CMakeLists.txt
+++ b/google/cloud/retail/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-retail)
+target_link_libraries(quickstart google-cloud-cpp::retail)

--- a/google/cloud/scheduler/config.cmake.in
+++ b/google/cloud/scheduler/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_scheduler-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-scheduler)
-    add_library(google-cloud-cpp::experimental-scheduler ALIAS google-cloud-cpp::scheduler)
-endif ()

--- a/google/cloud/scheduler/quickstart/CMakeLists.txt
+++ b/google/cloud/scheduler/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-scheduler)
+target_link_libraries(quickstart google-cloud-cpp::scheduler)

--- a/google/cloud/secretmanager/config.cmake.in
+++ b/google/cloud/secretmanager/config.cmake.in
@@ -20,8 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_secretmanager-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-secretmanager)
-    add_library(google-cloud-cpp::experimental-secretmanager ALIAS
-                google-cloud-cpp::secretmanager)
-endif ()

--- a/google/cloud/secretmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/secretmanager/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-secretmanager)
+target_link_libraries(quickstart google-cloud-cpp::secretmanager)

--- a/google/cloud/securitycenter/config.cmake.in
+++ b/google/cloud/securitycenter/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_securitycenter-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-securitycenter)
-    add_library(google-cloud-cpp::experimental-securitycenter ALIAS google-cloud-cpp::securitycenter)
-endif ()

--- a/google/cloud/securitycenter/quickstart/CMakeLists.txt
+++ b/google/cloud/securitycenter/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-securitycenter)
+target_link_libraries(quickstart google-cloud-cpp::securitycenter)

--- a/google/cloud/servicecontrol/config.cmake.in
+++ b/google/cloud/servicecontrol/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_servicecontrol-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-servicecontrol)
-    add_library(google-cloud-cpp::experimental-servicecontrol ALIAS google-cloud-cpp::servicecontrol)
-endif ()

--- a/google/cloud/servicecontrol/quickstart/CMakeLists.txt
+++ b/google/cloud/servicecontrol/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-servicecontrol)
+target_link_libraries(quickstart google-cloud-cpp::servicecontrol)

--- a/google/cloud/servicedirectory/config.cmake.in
+++ b/google/cloud/servicedirectory/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_servicedirectory-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-servicedirectory)
-    add_library(google-cloud-cpp::experimental-servicedirectory ALIAS google-cloud-cpp::servicedirectory)
-endif ()

--- a/google/cloud/servicedirectory/quickstart/CMakeLists.txt
+++ b/google/cloud/servicedirectory/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-servicedirectory)
+target_link_libraries(quickstart google-cloud-cpp::servicedirectory)

--- a/google/cloud/servicemanagement/config.cmake.in
+++ b/google/cloud/servicemanagement/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_servicemanagement-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-servicemanagement)
-    add_library(google-cloud-cpp::experimental-servicemanagement ALIAS google-cloud-cpp::servicemanagement)
-endif ()

--- a/google/cloud/servicemanagement/quickstart/CMakeLists.txt
+++ b/google/cloud/servicemanagement/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-servicemanagement)
+target_link_libraries(quickstart google-cloud-cpp::servicemanagement)

--- a/google/cloud/serviceusage/config.cmake.in
+++ b/google/cloud/serviceusage/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_serviceusage-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-serviceusage)
-    add_library(google-cloud-cpp::experimental-serviceusage ALIAS google-cloud-cpp::serviceusage)
-endif ()

--- a/google/cloud/serviceusage/quickstart/CMakeLists.txt
+++ b/google/cloud/serviceusage/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-serviceusage)
+target_link_libraries(quickstart google-cloud-cpp::serviceusage)

--- a/google/cloud/shell/config.cmake.in
+++ b/google/cloud/shell/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_shell-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-shell)
-    add_library(google-cloud-cpp::experimental-shell ALIAS google-cloud-cpp::shell)
-endif ()

--- a/google/cloud/shell/quickstart/CMakeLists.txt
+++ b/google/cloud/shell/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-shell)
+target_link_libraries(quickstart google-cloud-cpp::shell)

--- a/google/cloud/storagetransfer/config.cmake.in
+++ b/google/cloud/storagetransfer/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_storagetransfer-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-storagetransfer)
-    add_library(google-cloud-cpp::experimental-storagetransfer ALIAS google-cloud-cpp::storagetransfer)
-endif ()

--- a/google/cloud/storagetransfer/quickstart/CMakeLists.txt
+++ b/google/cloud/storagetransfer/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-storagetransfer)
+target_link_libraries(quickstart google-cloud-cpp::storagetransfer)

--- a/google/cloud/talent/config.cmake.in
+++ b/google/cloud/talent/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_talent-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-talent)
-    add_library(google-cloud-cpp::experimental-talent ALIAS google-cloud-cpp::talent)
-endif ()

--- a/google/cloud/talent/quickstart/CMakeLists.txt
+++ b/google/cloud/talent/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-talent)
+target_link_libraries(quickstart google-cloud-cpp::talent)

--- a/google/cloud/tasks/config.cmake.in
+++ b/google/cloud/tasks/config.cmake.in
@@ -20,8 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_tasks-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-tasks)
-    add_library(google-cloud-cpp::experimental-tasks ALIAS
-                google-cloud-cpp::tasks)
-endif ()

--- a/google/cloud/tasks/quickstart/CMakeLists.txt
+++ b/google/cloud/tasks/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-tasks)
+target_link_libraries(quickstart google-cloud-cpp::tasks)

--- a/google/cloud/texttospeech/config.cmake.in
+++ b/google/cloud/texttospeech/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_texttospeech-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-texttospeech)
-    add_library(google-cloud-cpp::experimental-texttospeech ALIAS google-cloud-cpp::texttospeech)
-endif ()

--- a/google/cloud/texttospeech/quickstart/CMakeLists.txt
+++ b/google/cloud/texttospeech/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-texttospeech)
+target_link_libraries(quickstart google-cloud-cpp::texttospeech)

--- a/google/cloud/tpu/config.cmake.in
+++ b/google/cloud/tpu/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_tpu-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-tpu)
-    add_library(google-cloud-cpp::experimental-tpu ALIAS google-cloud-cpp::tpu)
-endif ()

--- a/google/cloud/tpu/quickstart/CMakeLists.txt
+++ b/google/cloud/tpu/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-tpu)
+target_link_libraries(quickstart google-cloud-cpp::tpu)

--- a/google/cloud/trace/config.cmake.in
+++ b/google/cloud/trace/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_trace-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-trace)
-    add_library(google-cloud-cpp::experimental-trace ALIAS google-cloud-cpp::trace)
-endif ()

--- a/google/cloud/trace/quickstart/CMakeLists.txt
+++ b/google/cloud/trace/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-trace)
+target_link_libraries(quickstart google-cloud-cpp::trace)

--- a/google/cloud/translate/config.cmake.in
+++ b/google/cloud/translate/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_translate-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-translate)
-    add_library(google-cloud-cpp::experimental-translate ALIAS google-cloud-cpp::translate)
-endif ()

--- a/google/cloud/translate/quickstart/CMakeLists.txt
+++ b/google/cloud/translate/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-translate)
+target_link_libraries(quickstart google-cloud-cpp::translate)

--- a/google/cloud/videointelligence/config.cmake.in
+++ b/google/cloud/videointelligence/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_videointelligence-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-videointelligence)
-    add_library(google-cloud-cpp::experimental-videointelligence ALIAS google-cloud-cpp::videointelligence)
-endif ()

--- a/google/cloud/videointelligence/quickstart/CMakeLists.txt
+++ b/google/cloud/videointelligence/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-videointelligence)
+target_link_libraries(quickstart google-cloud-cpp::videointelligence)

--- a/google/cloud/vision/config.cmake.in
+++ b/google/cloud/vision/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_vision-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-vision)
-    add_library(google-cloud-cpp::experimental-vision ALIAS google-cloud-cpp::vision)
-endif ()

--- a/google/cloud/vision/quickstart/CMakeLists.txt
+++ b/google/cloud/vision/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-vision)
+target_link_libraries(quickstart google-cloud-cpp::vision)

--- a/google/cloud/vmmigration/config.cmake.in
+++ b/google/cloud/vmmigration/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_vmmigration-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-vmmigration)
-    add_library(google-cloud-cpp::experimental-vmmigration ALIAS google-cloud-cpp::vmmigration)
-endif ()

--- a/google/cloud/vmmigration/quickstart/CMakeLists.txt
+++ b/google/cloud/vmmigration/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-vmmigration)
+target_link_libraries(quickstart google-cloud-cpp::vmmigration)

--- a/google/cloud/vpcaccess/config.cmake.in
+++ b/google/cloud/vpcaccess/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_vpcaccess-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-vpcaccess)
-    add_library(google-cloud-cpp::experimental-vpcaccess ALIAS google-cloud-cpp::vpcaccess)
-endif ()

--- a/google/cloud/vpcaccess/quickstart/CMakeLists.txt
+++ b/google/cloud/vpcaccess/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-vpcaccess)
+target_link_libraries(quickstart google-cloud-cpp::vpcaccess)

--- a/google/cloud/webrisk/config.cmake.in
+++ b/google/cloud/webrisk/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_webrisk-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-webrisk)
-    add_library(google-cloud-cpp::experimental-webrisk ALIAS google-cloud-cpp::webrisk)
-endif ()

--- a/google/cloud/webrisk/quickstart/CMakeLists.txt
+++ b/google/cloud/webrisk/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-webrisk)
+target_link_libraries(quickstart google-cloud-cpp::webrisk)

--- a/google/cloud/websecurityscanner/config.cmake.in
+++ b/google/cloud/websecurityscanner/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_websecurityscanner-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-websecurityscanner)
-    add_library(google-cloud-cpp::experimental-websecurityscanner ALIAS google-cloud-cpp::websecurityscanner)
-endif ()

--- a/google/cloud/websecurityscanner/quickstart/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/quickstart/CMakeLists.txt
@@ -29,5 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart
-                      google-cloud-cpp::experimental-websecurityscanner)
+target_link_libraries(quickstart google-cloud-cpp::websecurityscanner)

--- a/google/cloud/workflows/config.cmake.in
+++ b/google/cloud/workflows/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_workflows-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-workflows)
-    add_library(google-cloud-cpp::experimental-workflows ALIAS google-cloud-cpp::workflows)
-endif ()

--- a/google/cloud/workflows/quickstart/CMakeLists.txt
+++ b/google/cloud/workflows/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-workflows)
+target_link_libraries(quickstart google-cloud-cpp::workflows)


### PR DESCRIPTION
Now that these libraries have been GA for a while, it is time to remove
`experimental-*` targets created to smooth the experimental --> GA
transition.

Part of the work for #8793

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8823)
<!-- Reviewable:end -->
