### PR TITLE
cleanup(bigtable): disable deprecation warnings properly (maybe)

### DIFF
--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -189,11 +189,6 @@ class DefaultDataClient : public DataClient {
     return impl_.BackgroundThreadsFactory();
   }
 
-  std::shared_ptr<grpc::Channel> ChannelImpl() override {
-    return impl_.Channel();
-  }
-  void resetImpl() override { impl_.reset(); }
-
   void ApplyOptions(grpc::ClientContext* context) {
     if (!authority_.empty()) context->set_authority(authority_);
     if (user_project_) {

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -32,7 +32,6 @@ namespace internal {
 class AsyncRetryBulkApply;
 class AsyncRowSampler;
 class BulkMutator;
-class DataClientTester;
 class LoggingDataClient;
 }  // namespace internal
 
@@ -110,7 +109,6 @@ class DataClient {
   friend class internal::AsyncRetryBulkApply;
   friend class internal::AsyncRowSampler;
   friend class internal::BulkMutator;
-  friend class internal::DataClientTester;
   friend class RowReader;
   template <typename RowFunctor, typename FinishFunctor>
   friend class AsyncRowReader;
@@ -191,18 +189,6 @@ class DataClient {
                          google::bigtable::v2::MutateRowsRequest const& request,
                          grpc::CompletionQueue* cq) = 0;
   //@}
-
-  /**
-   * The client library calls this method to avoid deprecation warnings from
-   * calling `Channel()` directly.
-   */
-  virtual std::shared_ptr<grpc::Channel> ChannelImpl() { return nullptr; }
-
-  /**
-   * The client library calls this method to avoid deprecation warnings from
-   * calling `reset()` directly.
-   */
-  virtual void resetImpl() {}
 };
 
 /// Create a new data client configured via @p options.
@@ -231,16 +217,6 @@ inline std::string InstanceName(std::shared_ptr<DataClient> const& client) {
          client->instance_id();
 }
 
-namespace internal {
-class DataClientTester {
- public:
-  static std::shared_ptr<grpc::Channel> Channel(
-      std::shared_ptr<DataClient> const& c) {
-    return c->ChannelImpl();
-  }
-  static void reset(std::shared_ptr<DataClient> const& c) { c->resetImpl(); }
-};
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
 }  // namespace cloud

--- a/google/cloud/bigtable/data_client_test.cc
+++ b/google/cloud/bigtable/data_client_test.cc
@@ -23,6 +23,9 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+// TODO(#8800) - remove after `DataClient` deprecation is complete
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+
 TEST(DataClientTest, Default) {
   auto data_client =
       CreateDefaultDataClient("test-project", "test-instance",
@@ -31,14 +34,14 @@ TEST(DataClientTest, Default) {
   EXPECT_EQ("test-project", data_client->project_id());
   EXPECT_EQ("test-instance", data_client->instance_id());
 
-  auto channel0 = internal::DataClientTester::Channel(data_client);
+  auto channel0 = data_client->Channel();
   EXPECT_TRUE(channel0);
 
-  auto channel1 = internal::DataClientTester::Channel(data_client);
+  auto channel1 = data_client->Channel();
   EXPECT_EQ(channel0.get(), channel1.get());
 
-  internal::DataClientTester::reset(data_client);
-  channel1 = internal::DataClientTester::Channel(data_client);
+  data_client->reset();
+  channel1 = data_client->Channel();
   EXPECT_TRUE(channel1);
   EXPECT_NE(channel0.get(), channel1.get());
 }
@@ -50,17 +53,20 @@ TEST(DataClientTest, MakeClient) {
   EXPECT_EQ("test-project", data_client->project_id());
   EXPECT_EQ("test-instance", data_client->instance_id());
 
-  auto channel0 = internal::DataClientTester::Channel(data_client);
+  auto channel0 = data_client->Channel();
   EXPECT_TRUE(channel0);
 
-  auto channel1 = internal::DataClientTester::Channel(data_client);
+  auto channel1 = data_client->Channel();
   EXPECT_EQ(channel0.get(), channel1.get());
 
-  internal::DataClientTester::reset(data_client);
-  channel1 = internal::DataClientTester::Channel(data_client);
+  data_client->reset();
+  channel1 = data_client->Channel();
   EXPECT_TRUE(channel1);
   EXPECT_NE(channel0.get(), channel1.get());
 }
+
+// TODO(#8800) - remove after `DataClient` deprecation is complete
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 TEST(DataClientTest, Logging) {
   testing_util::ScopedEnvironment env("GOOGLE_CLOUD_CPP_ENABLE_TRACING", "rpc");

--- a/google/cloud/bigtable/internal/logging_data_client.h
+++ b/google/cloud/bigtable/internal/logging_data_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/data_client.h"
 #include <memory>
 #include <string>
+// TODO(#8800) - delete this class when deprecation is complete
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {
@@ -48,14 +50,10 @@ class LoggingDataClient : public DataClient {
   }
 
   std::shared_ptr<grpc::Channel> Channel() override {
-    return child_->ChannelImpl();
-  }
-  std::shared_ptr<grpc::Channel> ChannelImpl() override {
-    return child_->ChannelImpl();
+    return child_->Channel();
   }
 
-  void reset() override { child_->resetImpl(); }
-  void resetImpl() override { child_->resetImpl(); }
+  void reset() override { child_->reset(); }
 
   grpc::Status MutateRow(grpc::ClientContext* context,
                          btproto::MutateRowRequest const& request,
@@ -154,5 +152,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google
+
+// TODO(#8800) - delete this class when deprecation is complete
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_LOGGING_DATA_CLIENT_H

--- a/google/cloud/bigtable/testing/inprocess_data_client.h
+++ b/google/cloud/bigtable/testing/inprocess_data_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/data_client.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <string>
+// TODO(#8800) - delete this class when deprecation is complete
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {
@@ -146,5 +148,8 @@ class InProcessDataClient : public bigtable::DataClient {
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google
+
+// TODO(#8800) - delete this class when deprecation is complete
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_INPROCESS_DATA_CLIENT_H

--- a/google/cloud/bigtable/testing/mock_data_client.h
+++ b/google/cloud/bigtable/testing/mock_data_client.h
@@ -18,6 +18,8 @@
 #include "google/cloud/bigtable/table.h"
 #include <gmock/gmock.h>
 #include <string>
+// TODO(#8800) - delete this class when deprecation is complete
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 namespace google {
 namespace cloud {
@@ -148,5 +150,8 @@ class MockDataClient : public bigtable::DataClient {
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google
+
+// TODO(#8800) - delete this class when deprecation is complete
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_DATA_CLIENT_H

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -540,6 +540,9 @@ TEST_F(DataIntegrationTest, TableApplyWithLogging) {
   EXPECT_THAT(log.ExtractLines(), Not(Contains(HasSubstr("MutateRow"))));
 }
 
+// TODO(#8800) - remove after deprecation is complete
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+
 TEST(ConnectionRefresh, Disabled) {
   auto data_client = bigtable::MakeDataClient(
       testing::TableTestEnvironment::project_id(),
@@ -559,7 +562,7 @@ TEST(ConnectionRefresh, Disabled) {
   std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
   for (int i = 0; i < internal::DefaultConnectionPoolSize(); ++i) {
-    auto channel = internal::DataClientTester::Channel(data_client);
+    auto channel = data_client->Channel();
     EXPECT_EQ(GRPC_CHANNEL_IDLE, channel->GetState(false));
   }
   // Make sure things still work.
@@ -572,8 +575,7 @@ TEST(ConnectionRefresh, Disabled) {
   // state.
   auto check_if_some_channel_is_ready = [&] {
     for (int i = 0; i < internal::DefaultConnectionPoolSize(); ++i) {
-      auto channel = internal::DataClientTester::Channel(data_client);
-      if (channel->GetState(false) == GRPC_CHANNEL_READY) {
+      if (data_client->Channel()->GetState(false) == GRPC_CHANNEL_READY) {
         return true;
       }
     }
@@ -591,8 +593,7 @@ TEST(ConnectionRefresh, Frequent) {
           .set<MinConnectionRefreshOption>(std::chrono::milliseconds(100)));
 
   for (;;) {
-    auto channel = internal::DataClientTester::Channel(data_client);
-    if (channel->GetState(false) == GRPC_CHANNEL_READY) {
+    if (data_client->Channel()->GetState(false) == GRPC_CHANNEL_READY) {
       // We've found a channel which changed its state from IDLE to READY,
       // which means that our refreshing mechanism works.
       break;
@@ -607,6 +608,9 @@ TEST(ConnectionRefresh, Frequent) {
                             {row_key, kFamily4, "c1", 2000, "v2000"}};
   Apply(table, row_key, created);
 }
+
+// TODO(#8800) - remove after deprecation is complete
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This reverts a lot of #8813

Thank you to @devbww for reminding me about `disable_deprecation_warnings.inc`

I included the deprecation warning for all classes that derive from `DataClient` (`internal::LoggingDataClient`, `testing::MockDataClient`, and `testing::InProcessDataClient`). I am not sure the `testing::*` classes will break our CI build. I am just being safe.

I might add a compiler warning for `DataClient::BackgroundThreadsFactory()` and disable it in `table.h` in a subsequent PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8827)
<!-- Reviewable:end -->
