### PR TITLE
cleanup(bigtable): disable deprecation warnings for DefaultDataClient

### DIFF
--- a/google/cloud/bigtable/data_client.cc
+++ b/google/cloud/bigtable/data_client.cc
@@ -36,6 +36,9 @@ DataClient::PrepareAsyncSampleRowKeys(grpc::ClientContext*,
 
 namespace {
 
+// TODO(#8800) - remove after `DataClient` deprecation is complete
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
+
 /**
  * Implement a simple DataClient.
  *
@@ -202,6 +205,9 @@ class DefaultDataClient : public DataClient {
   absl::optional<std::string> user_project_;
   internal::CommonClient<btproto::Bigtable> impl_;
 };
+
+// TODO(#8800) - remove after `DataClient` deprecation is complete
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 }  // namespace
 


### PR DESCRIPTION
I missed this one: https://source.cloud.google.com/results/invocations/35c67e54-4f87-42b8-b383-b5526f0af405/log

sorry for iterating in the CI build.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8828)
<!-- Reviewable:end -->
