### PR TITLE
fix(storage): disable checksums for transcoded objects

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -90,6 +90,7 @@ function integration::bazel_args() {
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY=${GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY}"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE=${GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE}"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME}"
+    "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME=${GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME}"
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_ROOTS_PEM=/dev/shm/roots.pem"
     # We only set these environment variables on GCB-based builds, as the
     # corresponding endpoints (e.g., https://private.googleapis.com) are not

--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -52,6 +52,9 @@ $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT="storage-test-iam-sa@${env:GO
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_SERVICE_ACCOUNT="kokoro-run@${env:GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_CMEK_KEY="projects/${env:GOOGLE_CLOUD_PROJECT}/locations/us/keyRings/gcs-testing-us-kr/cryptoKeys/integration-tests-key"
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME="projects/${env:GOOGLE_CLOUD_PROJECT}/topics/gcs-changes"
+# We need a gzip file to test ReadObject() with decompressive transcoding
+#  https://cloud.google.com/storage/docs/transcoding#decompressive_transcoding
+$env:GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME="${env:PROJECT_ROOT}/ci/abi-dumps/google_cloud_cpp_storage.expected.abi.dump.gz"
 
 # Cloud Spanner configuration parameters
 $env:GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID="test-instance"

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -68,6 +68,9 @@ export GOOGLE_CLOUD_CPP_STORAGE_TEST_TOPIC_NAME="projects/${GOOGLE_CLOUD_PROJECT
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_HMAC_SERVICE_ACCOUNT="fake-service-account-hmac@example.com"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_KEYFILE="${PROJECT_ROOT}/google/cloud/storage/tests/test_service_account.not-a-test.json"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_SIGNING_CONFORMANCE_FILENAME="${PROJECT_ROOT}/google/cloud/storage/tests/v4_signatures.json"
+# We need a gzip file to test ReadObject() with decompressive transcoding
+#  https://cloud.google.com/storage/docs/transcoding#decompressive_transcoding
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME="${PROJECT_ROOT}/ci/abi-dumps/google_cloud_cpp_storage.expected.abi.dump.gz"
 
 # Cloud Spanner configuration parameters
 export GOOGLE_CLOUD_CPP_SPANNER_TEST_INSTANCE_ID="test-instance"

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -52,6 +52,8 @@ ReadSourceResult MakeReadResult(std::size_t bytes_received,
   if (f != end && !r.storage_class) r.storage_class = f->second;
   f = r.response.headers.find("x-goog-stored-content-length");
   if (f != end && !r.size) r.size = std::stoull(f->second);
+  f = r.response.headers.find("x-guploader-response-body-transformations");
+  if (f != end && !r.transformation) r.transformation = f->second;
 
   // Prefer "Content-Range" over "Content-Length" because the former works for
   // ranged downloads.

--- a/google/cloud/storage/internal/curl_download_request_test.cc
+++ b/google/cloud/storage/internal/curl_download_request_test.cc
@@ -97,8 +97,8 @@ TEST(CurlDownloadRequest, MakeReadResultDecompressiveTranscoding) {
         {"x-hashes", "crc32c=123"}},
        absl::nullopt},
       {"guploader",
-       {{"x-guploader-response-body-transformation", "gunzipped"}},
-       absl::nullopt},
+       {{"x-guploader-response-body-transformations", "gunzipped"}},
+       "gunzipped"},
   };
 
   for (auto const& test : cases) {

--- a/google/cloud/storage/internal/curl_download_request_test.cc
+++ b/google/cloud/storage/internal/curl_download_request_test.cc
@@ -84,6 +84,30 @@ TEST(CurlDownloadRequest, MakeReadResult) {
   }
 }
 
+TEST(CurlDownloadRequest, MakeReadResultDecompressiveTranscoding) {
+  struct Test {
+    std::string name;
+    std::multimap<std::string, std::string> headers;
+    absl::optional<std::string> expected_transformation;
+  } cases[] = {
+      {"empty", {}, absl::nullopt},
+      {"irrelevant headers",
+       {{"x-generation", "123"},
+        {"x-goog-stuff", "thing"},
+        {"x-hashes", "crc32c=123"}},
+       absl::nullopt},
+      {"guploader",
+       {{"x-guploader-response-body-transformation", "gunzipped"}},
+       absl::nullopt},
+  };
+
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Test case: " + test.name);
+    auto const actual = MakeReadResult(42, HttpResponse{200, {}, test.headers});
+    EXPECT_EQ(test.expected_transformation, actual.transformation);
+  }
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/object_read_source.h
+++ b/google/cloud/storage/internal/object_read_source.h
@@ -53,6 +53,7 @@ struct ReadSourceResult {
   absl::optional<std::int64_t> metageneration;
   absl::optional<std::string> storage_class;
   absl::optional<std::uint64_t> size;
+  absl::optional<std::string> transformation;
 
   ReadSourceResult() = default;
   ReadSourceResult(std::size_t b, HttpResponse r)

--- a/google/cloud/storage/internal/object_read_streambuf.h
+++ b/google/cloud/storage/internal/object_read_streambuf.h
@@ -78,6 +78,9 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
     return storage_class_;
   }
   absl::optional<std::uint64_t> const& size() const { return size_; }
+  absl::optional<std::string> const& transformation() const {
+    return transformation_;
+  }
 
  private:
   int_type ReportError(Status status);
@@ -102,6 +105,7 @@ class ObjectReadStreambuf : public std::basic_streambuf<char> {
   absl::optional<std::int64_t> metageneration_;
   absl::optional<std::string> storage_class_;
   absl::optional<std::uint64_t> size_;
+  absl::optional<std::string> transformation_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/object_read_stream.h
+++ b/google/cloud/storage/object_read_stream.h
@@ -148,7 +148,7 @@ class ObjectReadStream : public std::basic_istream<char> {
    * want to use the generation number to guarantee all the downloads are
    * actually referencing the same object.  One could do this by first querying
    * the metadata before the first download, but this is less efficient as it
-   * requires one additional server roundtrip.
+   * requires one additional server round trip.
    *
    * Note that all these attributes are `absl::optional<>`, as the attributes
    * may not be known (or exist) if there is an error during the download. If

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ set(storage_client_integration_tests
     curl_download_request_integration_test.cc
     curl_request_integration_test.cc
     curl_sign_blob_integration_test.cc
+    decompressive_transcoding_integration_test.cc
     error_injection_integration_test.cc
     grpc_bucket_metadata_integration_test.cc
     grpc_integration_test.cc

--- a/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
+++ b/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
@@ -1,0 +1,135 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/client.h"
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/random.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <fstream>
+#include <thread>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::IsOk;
+
+class DecompressiveTranscodingIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {
+ protected:
+  void SetUp() override {
+    google::cloud::storage::testing::StorageIntegrationTest::SetUp();
+    bucket_name_ = google::cloud::internal::GetEnv(
+                       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
+                       .value_or("");
+    ASSERT_FALSE(bucket_name_.empty());
+  }
+
+  std::string const& bucket_name() const { return bucket_name_; }
+
+ private:
+  std::string bucket_name_;
+};
+
+TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadJson) {
+  // TODO(storage-testbench#321) - fix transcoding support in the emulator
+  if (UsingEmulator()) GTEST_SKIP();
+
+  auto const gzip_filename = google::cloud::internal::GetEnv(
+                                 "GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME")
+                                 .value_or("");
+  ASSERT_FALSE(gzip_filename.empty());
+  std::ifstream gz(gzip_filename, std::ios::binary);
+  auto const contents = std::string{std::istreambuf_iterator<char>(gz), {}};
+  ASSERT_TRUE(gz.good());
+
+  auto client = Client(
+      Options{}
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
+
+  auto object_name = MakeRandomObjectName();
+  auto insert = client.InsertObject(
+      bucket_name(), object_name, contents, IfGenerationMatch(0),
+      WithObjectMetadata(
+          ObjectMetadata().set_content_encoding("gzip").set_content_type(
+              "text/plain")));
+  ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
+  EXPECT_EQ(insert->content_encoding(), "gzip");
+  EXPECT_EQ(insert->content_type(), "text/plain");
+
+  // TODO(#8829) - decompressive transcoding does not work with gRPC
+  if (UsingGrpc()) return;
+
+  auto reader =
+      client.ReadObject(bucket_name(), object_name, IfGenerationNotMatch(0));
+  ASSERT_STATUS_OK(reader.status());
+  auto decompressed = std::string{std::istreambuf_iterator<char>(reader), {}};
+  ASSERT_STATUS_OK(reader.status());
+
+  // The whole point is to decompress the data and return something different.
+  ASSERT_NE(decompressed.substr(0, 32), contents.substr(0, 32));
+}
+
+TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadXml) {
+  // TODO(storage-testbench#321) - fix transcoding support in the emulator
+  if (UsingEmulator()) GTEST_SKIP();
+
+  auto const gzip_filename = google::cloud::internal::GetEnv(
+                                 "GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME")
+                                 .value_or("");
+  ASSERT_FALSE(gzip_filename.empty());
+  std::ifstream gz(gzip_filename, std::ios::binary);
+  auto const contents = std::string{std::istreambuf_iterator<char>(gz), {}};
+  ASSERT_TRUE(gz.good());
+
+  auto client = Client(
+      Options{}
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
+
+  auto object_name = MakeRandomObjectName();
+  auto insert = client.InsertObject(
+      bucket_name(), object_name, contents, IfGenerationMatch(0),
+      WithObjectMetadata(
+          ObjectMetadata().set_content_encoding("gzip").set_content_type(
+              "text/plain")));
+  ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
+  EXPECT_EQ(insert->content_encoding(), "gzip");
+  EXPECT_EQ(insert->content_type(), "text/plain");
+
+  // TODO(#8829) - decompressive transcoding does not work with gRPC
+  if (UsingGrpc()) return;
+
+  auto reader = client.ReadObject(bucket_name(), object_name);
+  ASSERT_STATUS_OK(reader.status());
+  auto decompressed = std::string{std::istreambuf_iterator<char>(reader), {}};
+  ASSERT_STATUS_OK(reader.status());
+
+  // The whole point is to decompress the data and return something different.
+  ASSERT_NE(decompressed.substr(0, 32), contents.substr(0, 32));
+}
+
+}  // anonymous namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
+++ b/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
@@ -1,4 +1,4 @@
-// Copyright 2018 Google LLC
+// Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 #include "google/cloud/storage/testing/storage_integration_test.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
-#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <fstream>

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -24,6 +24,7 @@ storage_client_integration_tests = [
     "curl_download_request_integration_test.cc",
     "curl_request_integration_test.cc",
     "curl_sign_blob_integration_test.cc",
+    "decompressive_transcoding_integration_test.cc",
     "error_injection_integration_test.cc",
     "grpc_bucket_metadata_integration_test.cc",
     "grpc_integration_test.cc",


### PR DESCRIPTION
GCS can decompress some objects during download.  For these objects the
returned checksum/hashes matches the compressed data, but the computed
checksums match the decompressed data.

Part of the work for #8286

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8830)
<!-- Reviewable:end -->
