### PR TITLE
cleanup(storage): fix clang-tidy warnings

### DIFF
--- a/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_parallel_uploads_benchmark.cc
@@ -92,9 +92,8 @@ struct Options {
   std::int64_t maximum_object_size = 8 * gcs_bm::kGiB;
   std::size_t minimum_num_shards = 1;
   std::size_t maximum_num_shards = 128;
-  long minimum_sample_count = 0;  // NOLINT(google-runtime-int)
-  // NOLINTNEXTLINE(google-runtime-int)
-  long maximum_sample_count = std::numeric_limits<long>::max();
+  std::int32_t minimum_sample_count = 0;
+  std::int32_t maximum_sample_count = std::numeric_limits<std::int32_t>::max();
 };
 
 StatusOr<std::string> CreateTempFile(
@@ -335,12 +334,12 @@ google::cloud::StatusOr<Options> ParseArgsDefault(
        "continue the test until at least this number of samples are "
        "obtained",
        [&options](std::string const& val) {
-         options.minimum_sample_count = std::stol(val);
+         options.minimum_sample_count = std::stoi(val);
        }},
       {"--maximum-sample-count",
        "stop the test when this number of samples are obtained",
        [&options](std::string const& val) {
-         options.maximum_sample_count = std::stol(val);
+         options.maximum_sample_count = std::stoi(val);
        }},
   };
   auto usage = BuildUsage(desc, argv[0]);

--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -222,9 +222,9 @@ integrity checks using the DisableMD5Hash() and DisableCrc32cChecksum() options.
   return UploadStreamResumable(source, request);
 }
 
-// NOLINTNEXTLINE(readability-make-member-function-const)
 StatusOr<ObjectMetadata> Client::UploadStreamResumable(
-    std::istream& source, internal::ResumableUploadRequest const& request) {
+    std::istream& source,
+    internal::ResumableUploadRequest const& request) const {
   auto response = internal::CreateOrResume(*raw_client_, request);
   if (!response) return std::move(response).status();
 
@@ -337,8 +337,7 @@ Status Client::DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
   return Status();
 }
 
-// NOLINTNEXTLINE(readability-make-member-function-const)
-std::string Client::SigningEmail(SigningAccount const& signing_account) {
+std::string Client::SigningEmail(SigningAccount const& signing_account) const {
   if (signing_account.has_value()) {
     return signing_account.value();
   }
@@ -476,8 +475,8 @@ std::string CreateRandomPrefixName(std::string const& prefix) {
 namespace internal {
 
 ScopedDeleter::ScopedDeleter(
-    std::function<Status(std::string, std::int64_t)> delete_fun)
-    : delete_fun_(std::move(delete_fun)) {}
+    std::function<Status(std::string, std::int64_t)> df)
+    : delete_fun_(std::move(df)) {}
 
 ScopedDeleter::~ScopedDeleter() {
   if (enabled_) {

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3176,13 +3176,14 @@ class Client {
       std::string const& file_name, internal::ResumableUploadRequest request);
 
   StatusOr<ObjectMetadata> UploadStreamResumable(
-      std::istream& source, internal::ResumableUploadRequest const& request);
+      std::istream& source,
+      internal::ResumableUploadRequest const& request) const;
 
   Status DownloadFileImpl(internal::ReadObjectRangeRequest const& request,
                           std::string const& file_name);
 
   /// Determine the email used to sign a blob.
-  std::string SigningEmail(SigningAccount const& signing_account);
+  std::string SigningEmail(SigningAccount const& signing_account) const;
 
   /// Represents the result of signing a blob, including the key used in the
   /// signature.
@@ -3373,8 +3374,7 @@ class ScopedDeleter {
  public:
   // The actual deletion depends on local's types in a very non-trivial way,
   // so we abstract this away by providing the function to delete one object.
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  ScopedDeleter(std::function<Status(std::string, std::int64_t)> delete_fun);
+  explicit ScopedDeleter(std::function<Status(std::string, std::int64_t)> df);
   ScopedDeleter(ScopedDeleter const&) = delete;
   ScopedDeleter& operator=(ScopedDeleter const&) = delete;
   ~ScopedDeleter();

--- a/google/cloud/storage/iam_policy.cc
+++ b/google/cloud/storage/iam_policy.cc
@@ -428,32 +428,26 @@ NativeIamPolicy& NativeIamPolicy::operator=(NativeIamPolicy const& other) {
   return *this;
 }
 
-// XXXXNOLINTNEXTLINE(readability-identifier-naming)
 std::int32_t NativeIamPolicy::version() const {
   return pimpl_->native_json.value("version", 0);
 }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 void NativeIamPolicy::set_version(std::int32_t version) {
   pimpl_->native_json["version"] = version;
 }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 std::string NativeIamPolicy::etag() const {
   return pimpl_->native_json.value("etag", "");
 }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 void NativeIamPolicy::set_etag(std::string etag) {
   pimpl_->native_json["etag"] = std::move(etag);
 }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 std::vector<NativeIamBinding>& NativeIamPolicy::bindings() {
   return pimpl_->bindings;
 }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
 std::vector<NativeIamBinding> const& NativeIamPolicy::bindings() const {
   return pimpl_->bindings;
 }

--- a/google/cloud/storage/iam_policy.cc
+++ b/google/cloud/storage/iam_policy.cc
@@ -428,7 +428,7 @@ NativeIamPolicy& NativeIamPolicy::operator=(NativeIamPolicy const& other) {
   return *this;
 }
 
-// NOLINTNEXTLINE(readability-identifier-naming)
+// XXXXNOLINTNEXTLINE(readability-identifier-naming)
 std::int32_t NativeIamPolicy::version() const {
   return pimpl_->native_json.value("version", 0);
 }

--- a/google/cloud/storage/internal/tuple_filter_test.cc
+++ b/google/cloud/storage/internal/tuple_filter_test.cc
@@ -29,33 +29,28 @@ TEST(TupleFilter, EmptyTuple) {
 
 TEST(TupleFilter, FullMatch) {
   auto res = StaticTupleFilter<std::is_integral>(
-      std::tuple<int, short, long>(1, 2, 3));  // NOLINT(google-runtime-int)
+      std::tuple<int, std::int32_t, std::int64_t>(1, 2, 3));
   static_assert(std::tuple_size<decltype(res)>::value == 3, "");
   auto i1 = std::get<0>(res);
   auto i2 = std::get<1>(res);
   auto i3 = std::get<2>(res);
   static_assert(std::is_same<decltype(i1), int>::value, "");
-  // NOLINTNEXTLINE(google-runtime-int)
-  static_assert(std::is_same<decltype(i2), short>::value, "");
-  // NOLINTNEXTLINE(google-runtime-int)
-  static_assert(std::is_same<decltype(i3), long>::value, "");
+  static_assert(std::is_same<decltype(i2), std::int32_t>::value, "");
+  static_assert(std::is_same<decltype(i3), std::int64_t>::value, "");
   EXPECT_EQ(1, std::get<0>(res));
   EXPECT_EQ(2, std::get<1>(res));
   EXPECT_EQ(3, std::get<2>(res));
 }
 
 TEST(TupleFilter, NoMatch) {
-  auto res =
-      // NOLINTNEXTLINE(google-runtime-int)
-      StaticTupleFilter<std::is_pointer>(std::tuple<int, short, long>(1, 2, 3));
+  auto res = StaticTupleFilter<std::is_pointer>(
+      std::tuple<int, std::int32_t, std::int64_t>(1, 2, 3));
   static_assert(std::tuple_size<decltype(res)>::value == 0, "");
 }
 
 TEST(TupleFilter, Selective) {
-  // NOLINTNEXTLINE(google-runtime-int)
-  auto res = StaticTupleFilter<NotAmong<long, short>::TPred>(
-      // NOLINTNEXTLINE(google-runtime-int)
-      std::tuple<int, std::string, short>(5, "asd", 7));
+  auto res = StaticTupleFilter<NotAmong<std::int64_t, std::int16_t>::TPred>(
+      std::tuple<int, std::string, std::int16_t>(5, "asd", 7));
   static_assert(std::tuple_size<decltype(res)>::value == 2, "");
   auto i1 = std::get<0>(res);
   auto i2 = std::get<1>(res);
@@ -68,8 +63,7 @@ TEST(TupleFilter, Selective) {
 // Test that forwarding rvalues works.
 TEST(TupleFilter, NonCopyable) {
   std::unique_ptr<int> iptr = absl::make_unique<int>(42);
-  // NOLINTNEXTLINE(google-runtime-int)
-  auto res = std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(
+  auto res = std::get<0>(StaticTupleFilter<NotAmong<std::int64_t>::TPred>(
       std::tuple<std::unique_ptr<int>>(std::move(iptr))));
   EXPECT_EQ(42, *res);
   static_assert(std::is_same<std::unique_ptr<int>, decltype(res)>::value, "");
@@ -81,9 +75,8 @@ TEST(TupleFilter, ByReference) {
   // This wouldn't work because get<0> returns a std::unique_ptr<int>&:
   // auto res = std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(
   //     std::tie(iptr)));
-  auto& res =
-      // NOLINTNEXTLINE(google-runtime-int)
-      std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(std::tie(iptr)));
+  auto& res = std::get<0>(
+      StaticTupleFilter<NotAmong<std::int64_t>::TPred>(std::tie(iptr)));
   // res is only an alias to iptr
   EXPECT_EQ(&res, &iptr);
   EXPECT_EQ(42, *res);
@@ -96,8 +89,7 @@ TEST(TupleFilter, TupleByReference) {
   // This wouldn't work because get<0> returns a std::unique_ptr<int>&:
   // auto res = std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(
   //     std::tie(iptr)));
-  // NOLINTNEXTLINE(google-runtime-int)
-  auto& res = std::get<0>(StaticTupleFilter<NotAmong<long>::TPred>(t));
+  auto& res = std::get<0>(StaticTupleFilter<NotAmong<std::int64_t>::TPred>(t));
   // res is only an alias to iptr
   EXPECT_EQ(&res, &iptr);
   EXPECT_EQ(42, *res);

--- a/google/cloud/storage/oauth2/service_account_credentials_test.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials_test.cc
@@ -367,8 +367,7 @@ TEST_F(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
   auto info = ParseServiceAccountCredentials(kJsonKeyfileContents, "test");
   ASSERT_STATUS_OK(info);
 
-  // NOLINTNEXTLINE(google-runtime-int)
-  auto make_request_assertion = [&info](long timestamp) {
+  auto make_request_assertion = [&info](std::int64_t timestamp) {
     return [timestamp, &info](std::string const& p) {
       std::string const prefix =
           std::string("grant_type=") + kGrantParamEscaped + "&assertion=";

--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -44,8 +44,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  */
 class MaxStreams {
  public:
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  MaxStreams(std::size_t value) : value_(value) {}
+  explicit MaxStreams(std::size_t value) : value_(value) {}
   std::size_t value() const { return value_; }
 
  private:
@@ -61,8 +60,7 @@ class MaxStreams {
  */
 class MinStreamSize {
  public:
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  MinStreamSize(std::uintmax_t value) : value_(value) {}
+  explicit MinStreamSize(std::uintmax_t value) : value_(value) {}
   std::uintmax_t value() const { return value_; }
 
  private:
@@ -253,8 +251,8 @@ struct ComposeManyApplyHelper {
 
 class SetOptionsApplyHelper {
  public:
-  // NOLINTNEXTLINE(google-explicit-constructor)
-  SetOptionsApplyHelper(ResumableUploadRequest& request) : request_(request) {}
+  explicit SetOptionsApplyHelper(ResumableUploadRequest& request)
+      : request_(request) {}
 
   template <typename... Options>
   void operator()(Options&&... options) const {

--- a/google/cloud/storage/well_known_headers.h
+++ b/google/cloud/storage/well_known_headers.h
@@ -267,13 +267,10 @@ std::ostream& operator<<(std::ostream& os, SourceEncryptionKey const& rhs);
  */
 template <typename Generator>
 EncryptionKeyData CreateKeyFromGenerator(Generator& gen) {
-  constexpr int kKeySize = 256 / std::numeric_limits<unsigned char>::digits;
-
-  // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto minchar = (std::numeric_limits<char>::min)();
-  // NOLINTNEXTLINE(readability-identifier-naming)
-  constexpr auto maxchar = (std::numeric_limits<char>::max)();
-  std::uniform_int_distribution<int> uni(minchar, maxchar);
+  auto constexpr kKeySize = 256 / std::numeric_limits<unsigned char>::digits;
+  auto constexpr kMinChar = (std::numeric_limits<char>::min)();
+  auto constexpr kMaxChar = (std::numeric_limits<char>::max)();
+  std::uniform_int_distribution<int> uni(kMinChar, kMaxChar);
   std::string key(static_cast<std::size_t>(kKeySize), ' ');
   std::generate_n(key.begin(), key.size(),
                   [&uni, &gen] { return static_cast<char>(uni(gen)); });


### PR DESCRIPTION
Fixed the root cause of a number of clang-tidy warnings and remove the
comments disabling them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8832)
<!-- Reviewable:end -->
