### PR TITLE
feat(storage): configure gRPC channel w Options

### DIFF
--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -34,8 +34,7 @@ namespace {
 std::shared_ptr<grpc::Channel> CreateGrpcChannel(
     google::cloud::internal::GrpcAuthenticationStrategy& auth,
     Options const& options, int channel_id) {
-  grpc::ChannelArguments args;
-  // Just configure for the regular path.
+  auto args = internal::MakeChannelArguments(options);
   args.SetInt("grpc.channel_id", channel_id);
   return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
 }


### PR DESCRIPTION
We probably want to respect the common options that configure a gRPC channel in storage. https://github.com/googleapis/google-cloud-cpp/blob/c16f539c5794750ff067f3b5d83738c69d0a5317/google/cloud/grpc_options.cc#L37-L47

<hr />

I did not add any tests. I could have factored out the creation of the `grpc::ChannelArguments` for testing.... but I couldn't guarantee that function would be called.

An interesting way to test this would be to use a mock [grpc authentication strategy](https://github.com/googleapis/google-cloud-cpp/blob/f779bb99395bbdfe3aac51864ff2abf2a0b6dffc/google/cloud/internal/unified_grpc_credentials.h#L32-L42). We could have some:
```c++
namespace google::cloud::internal {

class MockGrpcAuthenticationStrategy : public GrpcAuthenticationStrategy {
  MOCK_METHOD( ... );
};

struct MockGrpcAuthenticationStrategyOption {
  using Type = std::shared_ptr<MockGrpcAuthenticationStrategy>;
};

}  // namespace google::cloud::internal
```

... that tells [this](https://github.com/googleapis/google-cloud-cpp/blob/f779bb99395bbdfe3aac51864ff2abf2a0b6dffc/google/cloud/internal/unified_grpc_credentials.cc#L31-L32) to just return the mock. then we can test:
```c++
EXPECT_CALL(*mock, CreateChannel)
    .WillOnce([](std::string const& endpoint, grpc::ChannelArguments const& arguments) {
      // inspect arguments, e.g. with g::c::internal::GetIntChannelArguments(...)
    });
```

<hr />

If someone asks me to implement this mock thingy to test the code, I will.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8835)
<!-- Reviewable:end -->
