### PR TITLE
cleanup(bigtable): move refresh into `bigtable_internal`

### DIFF
--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -60,9 +60,10 @@ class CommonClient {
             google::cloud::internal::DefaultBackgroundThreads(1)),
         refresh_cq_(
             std::make_shared<CompletionQueue>(background_threads_->cq())),
-        refresh_state_(std::make_shared<ConnectionRefreshState>(
-            refresh_cq_, opts_.get<MinConnectionRefreshOption>(),
-            opts_.get<MaxConnectionRefreshOption>())) {}
+        refresh_state_(
+            std::make_shared<bigtable_internal::ConnectionRefreshState>(
+                refresh_cq_, opts_.get<MinConnectionRefreshOption>(),
+                opts_.get<MaxConnectionRefreshOption>())) {}
 
   ~CommonClient() {
     // This will stop the refresh of the channels.
@@ -186,7 +187,7 @@ class CommonClient {
   // completion queue in the operations scheduled on it. In order to do it, we
   // need to hold one instance by a shared pointer.
   std::shared_ptr<CompletionQueue> refresh_cq_;
-  std::shared_ptr<ConnectionRefreshState> refresh_state_;
+  std::shared_ptr<bigtable_internal::ConnectionRefreshState> refresh_state_;
 };
 
 }  // namespace internal

--- a/google/cloud/bigtable/internal/connection_refresh_state.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state.cc
@@ -16,9 +16,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 /**
@@ -138,8 +137,7 @@ void OutstandingTimers::CancelAll() {
   }
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/internal/connection_refresh_state.h
+++ b/google/cloud/bigtable/internal/connection_refresh_state.h
@@ -27,9 +27,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 class OutstandingTimers
     : public std::enable_shared_from_this<OutstandingTimers> {
@@ -86,9 +85,8 @@ void ScheduleChannelRefresh(
     std::shared_ptr<ConnectionRefreshState> const& state,
     std::shared_ptr<grpc::Channel> const& channel);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/internal/connection_refresh_state_test.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state_test.cc
@@ -17,9 +17,8 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 using TimerFuture = future<StatusOr<std::chrono::system_clock::time_point>>;
 
@@ -107,8 +106,7 @@ TEST_F(OutstandingTimersTest, TimerRegisteredAfterCancelAllGetCancelled) {
   continuation_promise.get_future().get();
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8837)
<!-- Reviewable:end -->
