### PR TITLE
refactor(bigtable): channel refresh

### DIFF
--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -148,10 +148,9 @@ class CommonClient {
     args.SetInt(GRPC_ARG_CHANNEL_ID, idx);
     auto res = grpc::CreateCustomChannel(
         opts_.get<EndpointOption>(), opts_.get<GrpcCredentialOption>(), args);
-    if (opts_.get<MaxConnectionRefreshOption>().count() == 0) {
-      return res;
+    if (refresh_state_->enabled()) {
+      ScheduleChannelRefresh(refresh_cq_, refresh_state_, res);
     }
-    ScheduleChannelRefresh(refresh_cq_, refresh_state_, res);
     return res;
   }
 

--- a/google/cloud/bigtable/internal/connection_refresh_state.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state.cc
@@ -48,6 +48,10 @@ std::chrono::milliseconds ConnectionRefreshState::RandomizedRefreshDelay() {
           max_conn_refresh_period_.count())(rng_));
 }
 
+bool ConnectionRefreshState::enabled() const {
+  return max_conn_refresh_period_.count() != 0;
+}
+
 void ScheduleChannelRefresh(
     std::shared_ptr<CompletionQueue> const& cq,
     std::shared_ptr<ConnectionRefreshState> const& state,

--- a/google/cloud/bigtable/internal/connection_refresh_state.h
+++ b/google/cloud/bigtable/internal/connection_refresh_state.h
@@ -68,6 +68,7 @@ class ConnectionRefreshState {
       std::chrono::milliseconds max_conn_refresh_period);
   std::chrono::milliseconds RandomizedRefreshDelay();
   OutstandingTimers& timers() { return *timers_; }
+  bool enabled() const;
 
  private:
   std::mutex mu_;

--- a/google/cloud/bigtable/internal/connection_refresh_state_test.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state_test.cc
@@ -106,6 +106,20 @@ TEST_F(OutstandingTimersTest, TimerRegisteredAfterCancelAllGetCancelled) {
   continuation_promise.get_future().get();
 }
 
+TEST(ConnectionRefreshState, Enabled) {
+  using ms = std::chrono::milliseconds;
+  ConnectionRefreshState state(std::make_shared<CompletionQueue>(), ms(0),
+                               ms(1000));
+  EXPECT_TRUE(state.enabled());
+}
+
+TEST(ConnectionRefreshState, Disabled) {
+  using ms = std::chrono::milliseconds;
+  ConnectionRefreshState state(std::make_shared<CompletionQueue>(), ms(0),
+                               ms(0));
+  EXPECT_FALSE(state.enabled());
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal
 }  // namespace cloud


### PR DESCRIPTION
This itty bitty refactor will make the channel creation by the stub factory read better (in my opinion)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8840)
<!-- Reviewable:end -->
