### PR TITLE
test(storage): relax integration test checks

### DIFF
--- a/google/cloud/storage/tests/curl_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_request_integration_test.cc
@@ -293,7 +293,7 @@ TEST(CurlRequestTest, HandleTeapot) {
   auto response = RetryMakeRequest(factory, {}, 418);
   ASSERT_STATUS_OK(response);
   ASSERT_EQ(418, response->status_code) << "response=" << *response;
-  EXPECT_THAT(response->payload, HasSubstr("[ teapot ]"));
+  EXPECT_THAT(response->payload, HasSubstr("teapot"));
 }
 
 /// @test Verify the response includes the header values.


### PR DESCRIPTION
I am planning to replace the implementation of `httpbin` in the
testbench, the new implementation has a less amusing payload for
`418 - I AM A TEAPOT` errors. The new expectation passes with both the
current and the upcoming `echo` service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8846)
<!-- Reviewable:end -->
