### PR TITLE
fix: correct check for storage vs. rest enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ cmake_dependent_option(
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_REST)
 
 # Prevent users for setting incompatible flags.
-if (GOOGLE_CLOUD_CPP_ENABLE_STORAGE AND NOT GOOGLE_CLOUD_CPP_ENABLE_REST)
+if (storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND NOT GOOGLE_CLOUD_CPP_ENABLE_REST)
     message(
         FATAL_ERROR
             "If storage is enabled (e.g. -DGOOGLE_CLOUD_ENABLE=storage), "


### PR DESCRIPTION
We cannot enable the storage library and disable the `rest-internal`
library, unfortunately the check was based on the wrong variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8849)
<!-- Reviewable:end -->
