### PR TITLE
fix: correct check for storage vs. rest enabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,13 +272,18 @@ cmake_dependent_option(
     ON "GOOGLE_CLOUD_CPP_ENABLE_REST_EXPRESSION" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_REST)
 
-# Prevent users for setting incompatible flags.
+# Detect incompatible flags and let the customer know what to do.
 if (storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND NOT GOOGLE_CLOUD_CPP_ENABLE_REST)
     message(
         FATAL_ERROR
-            "If storage is enabled (e.g. -DGOOGLE_CLOUD_ENABLE=storage), "
-            "the REST library cannot be disabled "
-            "(e.g. -DGOOGLE_CLOUD_CPP_ENABLE_REST=OFF)")
+            "If storage is enabled (e.g. -DGOOGLE_CLOUD_CPP_ENABLE=storage),"
+            " the REST library cannot be disabled,"
+            " i.e., you cannot set -DGOOGLE_CLOUD_CPP_ENABLE_REST=OFF."
+            " If you do want to use the storage library,"
+            " then do not use -DGOOGLE_CLOUD_CPP_ENABLE_REST=OFF."
+            " If you do not want to use the storage library,"
+            " then provide a -DGOOGLE_CLOUD_CPP_ENABLE=... list and do not"
+            " include storage in that list.")
 endif ()
 
 # Enable testing in this directory so we can do a top-level `make test`. This

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ cmake_dependent_option(
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_REST)
 
 # Prevent users for setting incompatible flags.
-if (GOOGLE_CLOUD_CPP_ENABLE_STORAGE AND NOT GOOGLE_CLOUD_CPP_ENABLE_REST)
+if (storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND NOT GOOGLE_CLOUD_CPP_ENABLE_REST)
     message(
         FATAL_ERROR
             "If storage is enabled (e.g. -DGOOGLE_CLOUD_ENABLE=storage), "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,8 @@ cmake_dependent_option(
 mark_as_advanced(GOOGLE_CLOUD_CPP_ENABLE_REST)
 
 # Detect incompatible flags and let the customer know what to do.
-if (storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND NOT GOOGLE_CLOUD_CPP_ENABLE_REST)
+if (storage IN_LIST GOOGLE_CLOUD_CPP_ENABLE AND NOT
+                                                GOOGLE_CLOUD_CPP_ENABLE_REST)
     message(
         FATAL_ERROR
             "If storage is enabled (e.g. -DGOOGLE_CLOUD_CPP_ENABLE=storage),"


### PR DESCRIPTION
We cannot enable the storage library and disable the `rest-internal`
library, unfortunately the check was based on the wrong variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8850)
<!-- Reviewable:end -->
