### PR TITLE
fix(storage): set CURLOPT_BUFFERSIZE once per handle

### DIFF
--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -230,16 +230,11 @@ void CurlDownloadRequest::CleanupHandles() {
 }
 
 void CurlDownloadRequest::SetOptions() {
-  // We get better performance using a slightly larger buffer (128KiB) than the
-  // default buffer size set by libcurl (16KiB)
-  auto constexpr kDefaultBufferSize = 128 * 1024L;
-
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
   handle_.SetOption(CURLOPT_NOSIGNAL, 1L);
   handle_.SetOption(CURLOPT_NOPROGRESS, 1L);
-  handle_.SetOption(CURLOPT_BUFFERSIZE, kDefaultBufferSize);
   if (!payload_.empty()) {
     handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
     handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -136,7 +136,7 @@ void AssertOptionSuccessImpl(
                  << "], error description=" << curl_easy_strerror(e);
 }
 
-CurlHandle::CurlHandle() : handle_(curl_easy_init(), &curl_easy_cleanup) {
+CurlHandle::CurlHandle() : handle_(MakeCurlPtr()) {
   if (handle_.get() == nullptr) {
     google::cloud::internal::ThrowRuntimeError("Cannot initialize CURL handle");
   }

--- a/google/cloud/storage/internal/curl_handle_factory.cc
+++ b/google/cloud/storage/internal/curl_handle_factory.cc
@@ -45,7 +45,7 @@ DefaultCurlHandleFactory::DefaultCurlHandleFactory(Options const& o) {
 }
 
 CurlPtr DefaultCurlHandleFactory::CreateHandle() {
-  CurlPtr curl(curl_easy_init(), &curl_easy_cleanup);
+  auto curl = MakeCurlPtr();
   SetCurlOptions(curl.get());
   return curl;
 }
@@ -103,7 +103,7 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
     SetCurlOptions(curl.get());
     return curl;
   }
-  CurlPtr curl(curl_easy_init(), &curl_easy_cleanup);
+  auto curl = MakeCurlPtr();
   SetCurlOptions(curl.get());
   return curl;
 }

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -103,12 +103,7 @@ Status CurlRequest::OnError(Status status) {
 }
 
 StatusOr<HttpResponse> CurlRequest::MakeRequestImpl() {
-  // We get better performance using a slightly larger buffer (128KiB) than the
-  // default buffer size set by libcurl (16KiB)
-  auto constexpr kDefaultBufferSize = 128 * 1024L;
-
   response_payload_.clear();
-  handle_.SetOption(CURLOPT_BUFFERSIZE, kDefaultBufferSize);
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -211,6 +211,15 @@ bool SslLockingCallbacksInstalled() {
 #endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 }
 
+CurlPtr MakeCurlPtr() {
+  auto handle = CurlPtr(curl_easy_init(), &curl_easy_cleanup);
+  // We get better performance using a slightly larger buffer (128KiB) than the
+  // default buffer size set by libcurl (16KiB).  We ignore errors because
+  // failing to set this parameter just affects performance by a small amount.
+  (void)curl_easy_setopt(handle.get(), CURLOPT_BUFFERSIZE, 128 * 1024L);
+  return handle;
+}
+
 std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,
                                  char const* data, std::size_t size) {
   if (size <= 2) {

--- a/google/cloud/storage/internal/curl_wrappers.h
+++ b/google/cloud/storage/internal/curl_wrappers.h
@@ -39,6 +39,9 @@ namespace internal {
 /// Hold a CURL* handle and automatically clean it up.
 using CurlPtr = std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>;
 
+/// Create a new (wrapped) CURL* with one-time configuration options set.
+CurlPtr MakeCurlPtr();
+
 /// Hold a CURLM* handle and automatically clean it up.
 using CurlMulti = std::unique_ptr<CURLM, decltype(&curl_multi_cleanup)>;
 


### PR DESCRIPTION
It seems that, despite all existing precautions, we are still getting
errors on `curl_setopt(..., CURLOPT_BUFFERSIZE, value)` because the
option cannot be set until some internal cleanup happens.  Since `value`
is always the same, we can set it when the handle is created, and avoid
the cleanup problems.

Part of the work for #7051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8865)
<!-- Reviewable:end -->
