### PR TITLE
fix(rest): set CURLOPT_BUFFERSIZE once per handle

### DIFF
--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -136,7 +136,7 @@ void AssertOptionSuccessImpl(
                  << "], error description=" << curl_easy_strerror(e);
 }
 
-CurlHandle::CurlHandle() : handle_(curl_easy_init(), &curl_easy_cleanup) {
+CurlHandle::CurlHandle() : handle_(MakeCurlPtr()) {
   if (handle_.get() == nullptr) {
     google::cloud::internal::ThrowRuntimeError("Cannot initialize CURL handle");
   }

--- a/google/cloud/internal/curl_handle_factory.cc
+++ b/google/cloud/internal/curl_handle_factory.cc
@@ -46,7 +46,7 @@ DefaultCurlHandleFactory::DefaultCurlHandleFactory(Options const& o) {
 }
 
 CurlPtr DefaultCurlHandleFactory::CreateHandle() {
-  CurlPtr curl(curl_easy_init(), &curl_easy_cleanup);
+  auto curl = MakeCurlPtr();
   SetCurlOptions(curl.get());
   return curl;
 }
@@ -104,7 +104,7 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
     SetCurlOptions(curl.get());
     return curl;
   }
-  CurlPtr curl(curl_easy_init(), &curl_easy_cleanup);
+  auto curl = MakeCurlPtr();
   SetCurlOptions(curl.get());
   return curl;
 }

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -612,9 +612,6 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
 
 Status CurlImpl::MakeRequestImpl() {
   TRACE_STATE() << "url_ " << url_ << "\n";
-  // Setting BUFFERSIZE is a request, not an order. libcurl can and will write
-  // fewer bytes as it wishes.
-  handle_.SetOption(CURLOPT_BUFFERSIZE, spill_.max_size());
   handle_.SetOption(CURLOPT_URL, url_.c_str());
   handle_.SetOption(CURLOPT_HTTPHEADER, request_headers_.get());
   handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());

--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -210,6 +210,15 @@ bool SslLockingCallbacksInstalled() {
 #endif  // GOOGLE_CLOUD_CPP_SSL_REQUIRES_LOCKS
 }
 
+CurlPtr MakeCurlPtr() {
+  auto handle = CurlPtr(curl_easy_init(), &curl_easy_cleanup);
+  // We get better performance using a slightly larger buffer (128KiB) than the
+  // default buffer size set by libcurl (16KiB).  We ignore errors because
+  // failing to set this parameter just affects performance by a small amount.
+  (void)curl_easy_setopt(handle.get(), CURLOPT_BUFFERSIZE, 128 * 1024L);
+  return handle;
+}
+
 std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,
                                  char const* data, std::size_t size) {
   if (size <= 2) {

--- a/google/cloud/internal/curl_wrappers.h
+++ b/google/cloud/internal/curl_wrappers.h
@@ -35,6 +35,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /// Hold a CURL* handle and automatically clean it up.
 using CurlPtr = std::unique_ptr<CURL, decltype(&curl_easy_cleanup)>;
 
+/// Create a new (wrapped) CURL* with one-time configuration options set.
+CurlPtr MakeCurlPtr();
+
 /// Hold a CURLM* handle and automatically clean it up.
 using CurlMulti = std::unique_ptr<CURLM, decltype(&curl_multi_cleanup)>;
 


### PR DESCRIPTION
It seems that, despite all existing precautions, we are still getting
errors on `curl_setopt(..., CURLOPT_BUFFERSIZE, value)` because the
option cannot be set until some internal cleanup happens.  Since `value`
is always the same, we can set it when the handle is created, and avoid
the cleanup problems.

Motivated by #7051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8866)
<!-- Reviewable:end -->
