### PR TITLE
fix(rest): use Status for errors in `curl_easy_setopt()`

### DIFF
--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -127,15 +127,6 @@ extern "C" int RestCurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
 
 }  // namespace
 
-void AssertOptionSuccessImpl(
-    CURLcode e, CURLoption opt, char const* where,
-    absl::FunctionRef<std::string()> const& format_parameter) {
-  GCP_LOG(FATAL) << where << "() - error [" << e
-                 << "] while setting curl option [" << opt << "] to ["
-                 << format_parameter()
-                 << "], error description=" << curl_easy_strerror(e);
-}
-
 CurlHandle::CurlHandle() : handle_(MakeCurlPtr()) {
   if (handle_.get() == nullptr) {
     google::cloud::internal::ThrowRuntimeError("Cannot initialize CURL handle");
@@ -146,8 +137,8 @@ CurlHandle::~CurlHandle() { FlushDebug(__func__); }
 
 void CurlHandle::SetSocketCallback(SocketOptions const& options) {
   socket_options_ = options;
-  SetOption(CURLOPT_SOCKOPTDATA, &socket_options_);
-  SetOption(CURLOPT_SOCKOPTFUNCTION, &RestCurlSetSocketOptions);
+  (void)SetOption(CURLOPT_SOCKOPTDATA, &socket_options_);
+  (void)SetOption(CURLOPT_SOCKOPTFUNCTION, &RestCurlSetSocketOptions);
 }
 
 std::int32_t CurlHandle::GetResponseCode() {
@@ -176,13 +167,13 @@ std::string CurlHandle::GetPeer() {
 void CurlHandle::EnableLogging(bool enabled) {
   if (enabled) {
     debug_info_ = std::make_shared<DebugInfo>();
-    SetOption(CURLOPT_DEBUGDATA, debug_info_.get());
-    SetOption(CURLOPT_DEBUGFUNCTION, &RestCurlHandleDebugCallback);
-    SetOption(CURLOPT_VERBOSE, 1L);
+    (void)SetOption(CURLOPT_DEBUGDATA, debug_info_.get());
+    (void)SetOption(CURLOPT_DEBUGFUNCTION, &RestCurlHandleDebugCallback);
+    (void)SetOption(CURLOPT_VERBOSE, 1L);
   } else {
-    SetOption(CURLOPT_DEBUGDATA, nullptr);
-    SetOption(CURLOPT_DEBUGFUNCTION, nullptr);
-    SetOption(CURLOPT_VERBOSE, 0L);
+    (void)SetOption(CURLOPT_DEBUGDATA, nullptr);
+    (void)SetOption(CURLOPT_DEBUGFUNCTION, nullptr);
+    (void)SetOption(CURLOPT_VERBOSE, 0L);
   }
 }
 

--- a/google/cloud/internal/curl_handle.h
+++ b/google/cloud/internal/curl_handle.h
@@ -31,39 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CurlHandle;
 class CurlHandleFactory;
 
-void AssertOptionSuccessImpl(
-    CURLcode e, CURLoption opt, char const* where,
-    absl::FunctionRef<std::string()> const& format_parameter);
-
-inline void AssertOptionSuccess(CURLcode e, CURLoption opt, char const* where,
-                                char const* param) {
-  if (e == CURLE_OK) return;
-  AssertOptionSuccessImpl(e, opt, where,
-                          [param] { return std::string{param}; });
-}
-
-inline void AssertOptionSuccess(CURLcode e, CURLoption opt, char const* where,
-                                std::intmax_t param) {
-  if (e == CURLE_OK) return;
-  AssertOptionSuccessImpl(e, opt, where,
-                          [param] { return std::to_string(param); });
-}
-
-inline void AssertOptionSuccess(CURLcode e, CURLoption opt, char const* where,
-                                std::nullptr_t) {
-  if (e == CURLE_OK) return;
-  AssertOptionSuccessImpl(e, opt, where, [] { return "nullptr"; });
-}
-
-template <typename T,
-          typename std::enable_if<!std::is_integral<T>::value, int>::type = 0>
-void AssertOptionSuccess(CURLcode e, CURLoption opt, char const* where, T) {
-  if (e == CURLE_OK) return;
-  AssertOptionSuccessImpl(e, opt, where, [] {
-    return std::string{"a value of type="} + typeid(T).name();
-  });
-}
-
 CurlHandle GetCurlHandle(std::shared_ptr<CurlHandleFactory> const& factory);
 
 /**
@@ -108,14 +75,14 @@ class CurlHandle {
   }
 
   template <typename T>
-  void SetOption(CURLoption option, T&& param) {
+  Status SetOption(CURLoption option, T&& param) {
     auto e = curl_easy_setopt(handle_.get(), option, std::forward<T>(param));
-    AssertOptionSuccess(e, option, __func__, param);
+    return AsStatus(e, __func__);
   }
 
-  void SetOption(CURLoption option, std::nullptr_t) {
+  Status SetOption(CURLoption option, std::nullptr_t) {
     auto e = curl_easy_setopt(handle_.get(), option, nullptr);
-    AssertOptionSuccess(e, option, __func__, nullptr);
+    return AsStatus(e, __func__);
   }
 
   /**

--- a/google/cloud/internal/curl_handle_test.cc
+++ b/google/cloud/internal/curl_handle_test.cc
@@ -61,37 +61,6 @@ TEST(CurlHandleTest, AsStatus) {
   }
 }
 
-TEST(AssertOptionSuccess, StringWithError) {
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          "some-path"),
-      "test-function");
-}
-
-TEST(AssertOptionSuccess, IntWithError) {
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          1234),
-      "test-function");
-}
-
-TEST(AssertOptionSuccess, NullptrWithError) {
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          nullptr),
-      "test-function");
-}
-
-int TestFunction() { return 42; }
-
-TEST(AssertOptionSuccess, FunctionPtrWithError) {
-  EXPECT_EQ(42, TestFunction());
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          &TestFunction),
-      "test-function");
-}
-
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -567,20 +567,24 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
   auto bytes_read = DrainSpillBuffer();
   if (curl_closed_) return bytes_read;
 
-  handle_.SetOption(CURLOPT_WRITEFUNCTION, &RestCurlRequestWrite);
-  handle_.SetOption(CURLOPT_WRITEDATA, this);
-  handle_.SetOption(CURLOPT_HEADERFUNCTION, &RestCurlRequestHeader);
-  handle_.SetOption(CURLOPT_HEADERDATA, this);
+  Status status;
+  status = handle_.SetOption(CURLOPT_WRITEFUNCTION, &RestCurlRequestWrite);
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_WRITEDATA, this);
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_HEADERFUNCTION, &RestCurlRequestHeader);
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_HEADERDATA, this);
+  if (!status.ok()) return OnTransferError(std::move(status));
   handle_.FlushDebug(__func__);
 
   if (!curl_closed_ && paused_) {
     paused_ = false;
-    auto status = handle_.EasyPause(CURLPAUSE_RECV_CONT);
+    status = handle_.EasyPause(CURLPAUSE_RECV_CONT);
     TRACE_STATE() << ", status=" << status << "\n";
-    if (!status.ok()) return status;
+    if (!status.ok()) return OnTransferError(std::move(status));
   }
 
-  Status status;
   if (buffer_.empty()) {
     // Once we have received the status and all the headers, we have read
     // enough to satisfy calls to any of RestResponse's methods, and we can
@@ -612,15 +616,24 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
 
 Status CurlImpl::MakeRequestImpl() {
   TRACE_STATE() << "url_ " << url_ << "\n";
-  handle_.SetOption(CURLOPT_URL, url_.c_str());
-  handle_.SetOption(CURLOPT_HTTPHEADER, request_headers_.get());
-  handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  Status status;
+  status = handle_.SetOption(CURLOPT_URL, url_.c_str());
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_HTTPHEADER, request_headers_.get());
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_USERAGENT, user_agent_.c_str());
+  if (!status.ok()) return OnTransferError(std::move(status));
   handle_.EnableLogging(logging_enabled_);
+  if (!status.ok()) return OnTransferError(std::move(status));
   handle_.SetSocketCallback(socket_options_);
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_NOSIGNAL, 1);
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_TCP_KEEPALIVE, 1L);
+  if (!status.ok()) return OnTransferError(std::move(status));
+
   handle_.SetOptionUnchecked(CURLOPT_HTTP_VERSION,
                              VersionToCurlCode(http_version_));
-  handle_.SetOption(CURLOPT_NOSIGNAL, 1);
-  handle_.SetOption(CURLOPT_TCP_KEEPALIVE, 1L);
 
   auto error = curl_multi_add_handle(multi_.get(), handle_.handle_.get());
 
@@ -643,21 +656,29 @@ Status CurlImpl::MakeRequestImpl() {
 Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
                              std::vector<absl::Span<char const>> payload) {
   using HttpMethod = CurlImpl::HttpMethod;
-  handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodAsChar(method));
-  handle_.SetOption(CURLOPT_UPLOAD, 0L);
-  handle_.SetOption(CURLOPT_FOLLOWLOCATION,
-                    options_.get<CurlFollowLocationOption>() ? 1L : 0L);
+  Status status;
+  status = handle_.SetOption(CURLOPT_CUSTOMREQUEST, HttpMethodAsChar(method));
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status = handle_.SetOption(CURLOPT_UPLOAD, 0L);
+  if (!status.ok()) return OnTransferError(std::move(status));
+  status =
+      handle_.SetOption(CURLOPT_FOLLOWLOCATION,
+                        options_.get<CurlFollowLocationOption>() ? 1L : 0L);
+  if (!status.ok()) return OnTransferError(std::move(status));
 
   if (method == HttpMethod::kGet) {
-    handle_.SetOption(CURLOPT_NOPROGRESS, 1L);
+    status = handle_.SetOption(CURLOPT_NOPROGRESS, 1L);
     if (download_stall_timeout_.count() != 0) {
       // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
       auto const timeout = static_cast<long>(download_stall_timeout_.count());
-      handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
+      status = handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
+      if (!status.ok()) return OnTransferError(std::move(status));
       // Timeout if the request sends or receives less than 1 byte/second (i.e.
       // effectively no bytes) for `download_stall_timeout_` seconds.
-      handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
-      handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
+      status = handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
+      if (!status.ok()) return OnTransferError(std::move(status));
+      status = handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
+      if (!status.ok()) return OnTransferError(std::move(status));
     }
     return MakeRequestImpl();
   }
@@ -665,11 +686,14 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
   if (transfer_stall_timeout_.count() != 0) {
     // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
     auto const timeout = static_cast<long>(transfer_stall_timeout_.count());
-    handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
+    status = handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
+    if (!status.ok()) return OnTransferError(std::move(status));
     // Timeout if the request sends or receives less than 1 byte/second (i.e.
     // effectively no bytes) for `transfer_stall_timeout_` seconds.
-    handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
-    handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
+    status = handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
+    if (!status.ok()) return OnTransferError(std::move(status));
+    status = handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
+    if (!status.ok()) return OnTransferError(std::move(status));
   }
 
   if (method == HttpMethod::kDelete || payload.empty())
@@ -678,8 +702,10 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
   // TODO(#7955): add support for multi-Span POST
   if (method == HttpMethod::kPost) {
     if (payload.size() == 1) {
-      handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload[0].size());
-      handle_.SetOption(CURLOPT_POSTFIELDS, payload[0].data());
+      status = handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload[0].size());
+      if (!status.ok()) return OnTransferError(std::move(status));
+      status = handle_.SetOption(CURLOPT_POSTFIELDS, payload[0].data());
+      if (!status.ok()) return OnTransferError(std::move(status));
       return MakeRequestImpl();
     }
     return Status{
@@ -690,9 +716,13 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
 
   if (method == HttpMethod::kPut || method == HttpMethod::kPatch) {
     WriteVector writev{std::move(payload)};
-    handle_.SetOption(CURLOPT_READFUNCTION, &RestCurlRequestOnReadData);
-    handle_.SetOption(CURLOPT_READDATA, &writev);
-    handle_.SetOption(CURLOPT_UPLOAD, 1L);
+    status =
+        handle_.SetOption(CURLOPT_READFUNCTION, &RestCurlRequestOnReadData);
+    if (!status.ok()) return OnTransferError(std::move(status));
+    status = handle_.SetOption(CURLOPT_READDATA, &writev);
+    if (!status.ok()) return OnTransferError(std::move(status));
+    status = handle_.SetOption(CURLOPT_UPLOAD, 1L);
+    if (!status.ok()) return OnTransferError(std::move(status));
     return MakeRequestImpl();
   }
 

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -668,6 +668,7 @@ Status CurlImpl::MakeRequest(CurlImpl::HttpMethod method,
 
   if (method == HttpMethod::kGet) {
     status = handle_.SetOption(CURLOPT_NOPROGRESS, 1L);
+    if (!status.ok()) return OnTransferError(std::move(status));
     if (download_stall_timeout_.count() != 0) {
       // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
       auto const timeout = static_cast<long>(download_stall_timeout_.count());


### PR DESCRIPTION
If `curl_easy_setopt()` (via `CurlHandle::SetOption()`) fails return a
`Status` and remove the handle from the connection pool.

Motivated by #7051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8869)
<!-- Reviewable:end -->
