### PR TITLE
fix(storage): use Status for `CurlHandle::SetOption()`

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -428,8 +428,9 @@ StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObject(
     builder.AddHeader("Cache-Control: no-transform");
   }
 
-  return std::unique_ptr<ObjectReadSource>(
-      std::move(builder).BuildDownloadRequest());
+  auto download = std::move(builder).BuildDownloadRequest();
+  if (!download) return std::move(download).status();
+  return std::unique_ptr<ObjectReadSource>(*std::move(download));
 }
 
 StatusOr<ListObjectsResponse> CurlClient::ListObjects(
@@ -1218,8 +1219,9 @@ StatusOr<std::unique_ptr<ObjectReadSource>> CurlClient::ReadObjectXml(
     builder.AddHeader("Cache-Control: no-transform");
   }
 
-  return std::unique_ptr<ObjectReadSource>(
-      std::move(builder).BuildDownloadRequest());
+  auto download = std::move(builder).BuildDownloadRequest();
+  if (!download) return std::move(download).status();
+  return std::unique_ptr<ObjectReadSource>(*std::move(download));
 }
 
 StatusOr<ObjectMetadata> CurlClient::InsertObjectMediaMultipart(

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -248,7 +248,6 @@ Status CurlDownloadRequest::SetOptions() {
   if (!status.ok()) return OnTransferError(std::move(status));
 
   if (!payload_.empty()) {
-    if (!status.ok()) return OnTransferError(std::move(status));
     status = handle_.SetOption(CURLOPT_POSTFIELDSIZE, payload_.length());
     if (!status.ok()) return OnTransferError(std::move(status));
     status = handle_.SetOption(CURLOPT_POSTFIELDS, payload_.c_str());

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -95,7 +95,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   void CleanupHandles();
 
   /// Set the underlying CurlHandle options on a new CurlDownloadRequest.
-  void SetOptions();
+  Status SetOptions();
 
   /// Handle a completed (even interrupted) download.
   void OnTransferDone();

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -127,15 +127,6 @@ extern "C" int CurlSetSocketOptions(void* userdata, curl_socket_t curlfd,
 
 }  // namespace
 
-void AssertOptionSuccessImpl(
-    CURLcode e, CURLoption opt, char const* where,
-    absl::FunctionRef<std::string()> const& format_parameter) {
-  GCP_LOG(FATAL) << where << "() - error [" << e
-                 << "] while setting curl option [" << opt << "] to ["
-                 << format_parameter()
-                 << "], error description=" << curl_easy_strerror(e);
-}
-
 CurlHandle::CurlHandle() : handle_(MakeCurlPtr()) {
   if (handle_.get() == nullptr) {
     google::cloud::internal::ThrowRuntimeError("Cannot initialize CURL handle");

--- a/google/cloud/storage/internal/curl_handle_test.cc
+++ b/google/cloud/storage/internal/curl_handle_test.cc
@@ -62,37 +62,6 @@ TEST(CurlHandleTest, AsStatus) {
   }
 }
 
-TEST(AssertOptionSuccess, StringWithError) {
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          "some-path"),
-      "test-function");
-}
-
-TEST(AssertOptionSuccess, IntWithError) {
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          1234),
-      "test-function");
-}
-
-TEST(AssertOptionSuccess, NullptrWithError) {
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          nullptr),
-      "test-function");
-}
-
-int TestFunction() { return 42; }
-
-TEST(AssertOptionSuccess, FunctionPtrWithError) {
-  EXPECT_EQ(42, TestFunction());
-  EXPECT_DEATH_IF_SUPPORTED(
-      AssertOptionSuccess(CURLE_NOT_BUILT_IN, CURLOPT_CAINFO, "test-function",
-                          &TestFunction),
-      "test-function");
-}
-
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -60,7 +60,7 @@ CurlRequest CurlRequestBuilder::BuildRequest() && {
   return request;
 }
 
-std::unique_ptr<CurlDownloadRequest>
+StatusOr<std::unique_ptr<CurlDownloadRequest>>
 CurlRequestBuilder::BuildDownloadRequest() && {
   ValidateBuilderState(__func__);
   auto agent = user_agent_prefix_ + UserAgentSuffix();
@@ -73,7 +73,8 @@ CurlRequestBuilder::BuildDownloadRequest() && {
   request->logging_enabled_ = logging_enabled_;
   request->socket_options_ = socket_options_;
   request->download_stall_timeout_ = download_stall_timeout_;
-  request->SetOptions();
+  auto status = request->SetOptions();
+  if (!status.ok()) return status;
   return request;
 }
 

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -53,7 +53,7 @@ class CurlRequestBuilder {
    * This function invalidates the builder. The application should not use this
    * builder once this function is called.
    */
-  std::unique_ptr<CurlDownloadRequest> BuildDownloadRequest() &&;
+  StatusOr<std::unique_ptr<CurlDownloadRequest>> BuildDownloadRequest() &&;
 
   /// Adds one of the well-known parameters as a query parameter
   template <typename P>

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -334,8 +334,9 @@ Status AttemptRegression7051() {
   {
     auto r_partial_close = make_download();
     if (!r_partial_close) return std::move(r_partial_close).status();
-    if ((*r_partial_close)->id() != id)
+    if ((*r_partial_close)->id() != id) {
       return error("r_partial_close.id() != id");
+    }
     auto read = (*r_partial_close)->Read(buffer, kBufferSize);
     if (!read) return std::move(read).status();
     auto close = (*r_partial_close)->Close();


### PR DESCRIPTION
If `CurlHandle::SetOption()` fails, return a `Status` and remove the
handle from the connection pool.

Motivated by #7051

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8871)
<!-- Reviewable:end -->
