### PR TITLE
feat(spanner): spanner::Value support for spanner::PgNumeric

### DIFF
--- a/google/cloud/spanner/samples/postgresql_samples.cc
+++ b/google/cloud/spanner/samples/postgresql_samples.cc
@@ -349,7 +349,7 @@ void CastDataType(google::cloud::spanner::Client client) {
              '2021-11-03T09:35:01UTC'::TIMESTAMPTZ as timestamp
   )""");
   using RowType =
-      std::tuple<std::string, std::int64_t, google::cloud::spanner::Numeric,
+      std::tuple<std::string, std::int64_t, google::cloud::spanner::PgNumeric,
                  google::cloud::spanner::Bytes, double, bool,
                  google::cloud::spanner::Timestamp>;
   auto rows = client.ExecuteQuery(std::move(sql));

--- a/google/cloud/spanner/value.h
+++ b/google/cloud/spanner/value.h
@@ -194,6 +194,10 @@ class Value {
   /// @copydoc Value(bool)
   explicit Value(Json v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
+  explicit Value(Numeric v) : Value(PrivateConstructor{}, std::move(v)) {}
+  /// @copydoc Value(bool)
+  explicit Value(PgNumeric v) : Value(PrivateConstructor{}, std::move(v)) {}
+  /// @copydoc Value(bool)
   explicit Value(Timestamp v) : Value(PrivateConstructor{}, std::move(v)) {}
   /// @copydoc Value(bool)
   explicit Value(CommitTimestamp v)
@@ -201,9 +205,6 @@ class Value {
   /// @copydoc Value(bool)
   explicit Value(absl::CivilDay v)
       : Value(PrivateConstructor{}, std::move(v)) {}
-  /// @copydoc Value(bool)
-  template <DecimalMode Mode>
-  explicit Value(Decimal<Mode> v) : Value(PrivateConstructor{}, std::move(v)) {}
 
   /**
    * Constructs an instance from common C++ literal types that closely, though
@@ -365,27 +366,8 @@ class Value {
   static bool TypeProtoIs(std::string const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Bytes const&, google::spanner::v1::Type const&);
   static bool TypeProtoIs(Json const&, google::spanner::v1::Type const&);
-  template <DecimalMode Mode>
-  static bool TypeProtoIs(Decimal<Mode> const&,
-                          google::spanner::v1::Type const& type) {
-    if (type.code() == google::spanner::v1::TypeCode::NUMERIC) {
-      using google::spanner::v1::TypeAnnotationCode;
-      switch (Mode) {
-        case DecimalMode::kGoogleSQL:
-          if (type.type_annotation() ==
-              TypeAnnotationCode::TYPE_ANNOTATION_CODE_UNSPECIFIED) {
-            return true;
-          }
-          break;
-        case DecimalMode::kPostgreSQL:
-          if (type.type_annotation() == TypeAnnotationCode::PG_NUMERIC) {
-            return true;
-          }
-          break;
-      }
-    }
-    return false;
-  }
+  static bool TypeProtoIs(Numeric const&, google::spanner::v1::Type const&);
+  static bool TypeProtoIs(PgNumeric const&, google::spanner::v1::Type const&);
   template <typename T>
   static bool TypeProtoIs(absl::optional<T>,
                           google::spanner::v1::Type const& type) {
@@ -432,27 +414,13 @@ class Value {
   static google::spanner::v1::Type MakeTypeProto(std::string const&);
   static google::spanner::v1::Type MakeTypeProto(Bytes const&);
   static google::spanner::v1::Type MakeTypeProto(Json const&);
+  static google::spanner::v1::Type MakeTypeProto(Numeric const&);
+  static google::spanner::v1::Type MakeTypeProto(PgNumeric const&);
   static google::spanner::v1::Type MakeTypeProto(Timestamp);
   static google::spanner::v1::Type MakeTypeProto(CommitTimestamp);
   static google::spanner::v1::Type MakeTypeProto(absl::CivilDay);
   static google::spanner::v1::Type MakeTypeProto(int);
   static google::spanner::v1::Type MakeTypeProto(char const*);
-  template <DecimalMode Mode>
-  static google::spanner::v1::Type MakeTypeProto(Decimal<Mode> const&) {
-    google::spanner::v1::Type t;
-    t.set_code(google::spanner::v1::TypeCode::NUMERIC);
-    using google::spanner::v1::TypeAnnotationCode;
-    switch (Mode) {
-      case DecimalMode::kGoogleSQL:
-        // Prefer to leave type_annotation unset over setting it to
-        // TypeAnnotationCode::TYPE_ANNOTATION_CODE_UNSPECIFIED.
-        break;
-      case DecimalMode::kPostgreSQL:
-        t.set_type_annotation(TypeAnnotationCode::PG_NUMERIC);
-        break;
-    }
-    return t;
-  }
   template <typename T>
   static google::spanner::v1::Type MakeTypeProto(absl::optional<T> const&) {
     return MakeTypeProto(T{});
@@ -508,17 +476,13 @@ class Value {
   static google::protobuf::Value MakeValueProto(std::string s);
   static google::protobuf::Value MakeValueProto(Bytes b);
   static google::protobuf::Value MakeValueProto(Json j);
+  static google::protobuf::Value MakeValueProto(Numeric n);
+  static google::protobuf::Value MakeValueProto(PgNumeric n);
   static google::protobuf::Value MakeValueProto(Timestamp ts);
   static google::protobuf::Value MakeValueProto(CommitTimestamp ts);
   static google::protobuf::Value MakeValueProto(absl::CivilDay d);
   static google::protobuf::Value MakeValueProto(int i);
   static google::protobuf::Value MakeValueProto(char const* s);
-  template <DecimalMode Mode>
-  static google::protobuf::Value MakeValueProto(Decimal<Mode> d) {
-    google::protobuf::Value v;
-    v.set_string_value(std::move(d).ToString());
-    return v;
-  }
   template <typename T>
   static google::protobuf::Value MakeValueProto(absl::optional<T> opt) {
     if (opt.has_value()) return MakeValueProto(*std::move(opt));
@@ -577,6 +541,12 @@ class Value {
                                   google::spanner::v1::Type const&);
   static StatusOr<Json> GetValue(Json const&, google::protobuf::Value const&,
                                  google::spanner::v1::Type const&);
+  static StatusOr<Numeric> GetValue(Numeric const&,
+                                    google::protobuf::Value const&,
+                                    google::spanner::v1::Type const&);
+  static StatusOr<PgNumeric> GetValue(PgNumeric const&,
+                                      google::protobuf::Value const&,
+                                      google::spanner::v1::Type const&);
   static StatusOr<Timestamp> GetValue(Timestamp, google::protobuf::Value const&,
                                       google::spanner::v1::Type const&);
   static StatusOr<CommitTimestamp> GetValue(CommitTimestamp,
@@ -585,17 +555,6 @@ class Value {
   static StatusOr<absl::CivilDay> GetValue(absl::CivilDay,
                                            google::protobuf::Value const&,
                                            google::spanner::v1::Type const&);
-  template <DecimalMode Mode>
-  static StatusOr<Decimal<Mode>> GetValue(Decimal<Mode> const&,
-                                          google::protobuf::Value const& pv,
-                                          google::spanner::v1::Type const&) {
-    if (pv.kind_case() != google::protobuf::Value::kStringValue) {
-      return Status(StatusCode::kUnknown, "missing NUMERIC");
-    }
-    auto decoded = MakeDecimal<Mode>(pv.string_value());
-    if (!decoded) return decoded.status();
-    return *decoded;
-  }
   template <typename T, typename V>
   static StatusOr<absl::optional<T>> GetValue(
       absl::optional<T> const&, V&& pv, google::spanner::v1::Type const& pt) {

--- a/google/cloud/spanner/value_test.cc
+++ b/google/cloud/spanner/value_test.cc
@@ -225,6 +225,7 @@ TEST(Value, Equality) {
       {Value(Bytes("foo")), Value(Bytes("bar"))},
       {Value(Json("42")), Value(Json("true"))},
       {Value(MakeNumeric(0).value()), Value(MakeNumeric(1).value())},
+      {Value(MakePgNumeric(0).value()), Value(MakePgNumeric(1).value())},
       {Value(absl::CivilDay(1970, 1, 1)), Value(absl::CivilDay(2020, 3, 15))},
       {Value(std::vector<double>{1.2, 3.4}),
        Value(std::vector<double>{4.5, 6.7})},
@@ -1122,6 +1123,7 @@ TEST(Value, OutputStream) {
       {Value(Json()), "null", normal},
       {Value(Json("true")), "true", normal},
       {Value(MakeNumeric(1234567890).value()), "1234567890", normal},
+      {Value(MakePgNumeric(1234567890).value()), "1234567890", normal},
       {Value(absl::CivilDay()), "1970-01-01", normal},
       {Value(Timestamp()), "1970-01-01T00:00:00Z", normal},
 
@@ -1163,6 +1165,8 @@ TEST(Value, OutputStream) {
       {Value(std::vector<absl::CivilDay>{2}), "[1970-01-01, 1970-01-01]",
        normal},
       {Value(std::vector<Timestamp>{1}), "[1970-01-01T00:00:00Z]", normal},
+
+      // Tests arrays with null elements
       {Value(std::vector<absl::optional<double>>{1, {}, 2}), "[1, NULL, 2]",
        normal},
 
@@ -1276,6 +1280,12 @@ TEST(Value, OutputStreamMatchesT) {
   StreamMatchesValueStream(MakeNumeric("999").value());
   StreamMatchesValueStream(MakeNumeric(3.14159).value());
   StreamMatchesValueStream(MakeNumeric(42).value());
+
+  // PgNumeric
+  StreamMatchesValueStream(MakePgNumeric("999").value());
+  StreamMatchesValueStream(MakePgNumeric(3.14159).value());
+  StreamMatchesValueStream(MakePgNumeric(42).value());
+  StreamMatchesValueStream(MakePgNumeric("NaN").value());
 
   // Date
   StreamMatchesValueStream(absl::CivilDay(1, 1, 1));


### PR DESCRIPTION
Add support for `spanner::PgNumeric` to build a `spanner::Value`
with `Type { .code=NUMERIC, .type_annotation=PG_NUMERIC }`.

`TypeCode::NUMERIC` now takes the `type_annotation` into account
for equality tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8872)
<!-- Reviewable:end -->
