### PR TITLE
cleanup(bigtable): preserve policy defaults

### DIFF
--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/bigtable/internal/defaults.h"
 #include "google/cloud/bigtable/internal/client_options_defaults.h"
 #include "google/cloud/bigtable/options.h"
+#include "google/cloud/bigtable/rpc_policy_parameters.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"
@@ -171,13 +172,14 @@ Options DefaultDataOptions(Options opts) {
   }
   if (!opts.has<bigtable_internal::DataRetryPolicyOption>()) {
     opts.set<bigtable_internal::DataRetryPolicyOption>(
-        bigtable_internal::DataLimitedTimeRetryPolicy(std::chrono::minutes(30))
+        bigtable_internal::DataLimitedTimeRetryPolicy(
+            kBigtableLimits.maximum_retry_period)
             .clone());
   }
   if (!opts.has<bigtable_internal::DataBackoffPolicyOption>()) {
     opts.set<bigtable_internal::DataBackoffPolicyOption>(
-        ExponentialBackoffPolicy(std::chrono::seconds(1),
-                                 std::chrono::minutes(5), kBackoffScaling)
+        ExponentialBackoffPolicy(kBigtableLimits.initial_delay / 2,
+                                 kBigtableLimits.maximum_delay, kBackoffScaling)
             .clone());
   }
   if (!opts.has<bigtable_internal::IdempotentMutationPolicyOption>()) {

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -14,8 +14,8 @@
 
 #include "google/cloud/bigtable/internal/defaults.h"
 #include "google/cloud/bigtable/internal/client_options_defaults.h"
+#include "google/cloud/bigtable/internal/rpc_policy_parameters.h"
 #include "google/cloud/bigtable/options.h"
-#include "google/cloud/bigtable/rpc_policy_parameters.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/connection_options.h"
 #include "google/cloud/grpc_options.h"


### PR DESCRIPTION
It seems like we should preserve the policy defaults for the Data API, instead of using the generator's defaults. That way code that goes from: `Table table(MakeDataClient());` -> `Table table(MakeDataConnection())` acts sort of the same.

Note that bigtable's exponential backoff policy expects different input parameters than the common backoff policy: https://github.com/googleapis/google-cloud-cpp/blob/2618390d2ca7409f1408ed19633ade2c34a9661a/google/cloud/bigtable/rpc_backoff_policy.h#L94

<hr />

Now everything gets a constant https://github.com/googleapis/google-cloud-cpp/pull/8867#discussion_r864316634

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8884)
<!-- Reviewable:end -->
