### PR TITLE
doc(spanner): add a comment about building a "NaN" PgNumeric

### DIFF
--- a/google/cloud/spanner/numeric.h
+++ b/google/cloud/spanner/numeric.h
@@ -219,6 +219,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *
  *  - [-+]?[0-9]+(.[0-9]*)?([eE][-+]?[0-9]+)?
  *  - [-+]?.[0-9]+([eE][-+]?[0-9]+)?
+ *  - [Nn][Aa][Nn]                  // "not a number" for kPostgreSQL mode
  *
  * For example, "0", "-999", "3.141592654", "299792458", "6.02214076e23", etc.
  * There must be digits either before or after any decimal point.


### PR DESCRIPTION
Restore a comment about building a PgNumeric from (case-insensitive)
"NaN", which was lost during the shuffle of implementation strategies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8891)
<!-- Reviewable:end -->
