### PR TITLE
fix(storage): resume "gunzipped" downloads

### DIFF
--- a/google/cloud/storage/internal/retry_object_read_source.cc
+++ b/google/cloud/storage/internal/retry_object_read_source.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include "google/cloud/log.h"
+#include <algorithm>
 #include <thread>
 
 namespace google {
@@ -49,24 +50,10 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
   if (!child_) {
     return Status(StatusCode::kFailedPrecondition, "Stream is not open");
   }
-  // This lambda handles a successful read, avoiding some repetition below.
-  auto handle_result = [this](StatusOr<ReadSourceResult> const& r) {
-    if (!r) {
-      GCP_LOG(INFO) << "current_offset=" << current_offset_
-                    << ", status=" << r.status();
-      return false;
-    }
-    if (r->generation) generation_ = *r->generation;
-    if (offset_direction_ == kFromEnd) {
-      current_offset_ -= r->bytes_received;
-    } else {
-      current_offset_ += r->bytes_received;
-    }
-    return true;
-  };
+
   // Read some data, if successful return immediately, saving some allocations.
   auto result = child_->Read(buf, n);
-  if (handle_result(result)) return result;
+  if (HandleResult(result)) return result;
   bool has_emulator_instructions = false;
   std::string instructions;
   if (request_.HasOption<CustomHeader>()) {
@@ -102,16 +89,10 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
     if (generation_) {
       request_.set_option(Generation(*generation_));
     }
-    auto new_child =
-        client_->ReadObjectNotWrapped(request_, *retry_policy, *backoff_policy);
-    if (!new_child) {
-      // We've exhausted the retry policy while trying to create the child.
-      // There is nothing else we can do, return immediately.
-      return new_child.status();
-    }
-    child_ = std::move(*new_child);
+    auto status = MakeChild(*retry_policy, *backoff_policy);
+    if (!status.ok()) return status;
   }
-  if (handle_result(result)) return result;
+  if (HandleResult(result)) return result;
   // We have exhausted the retry policy, return the error.
   auto status = std::move(result).status();
   std::stringstream os;
@@ -121,6 +102,81 @@ StatusOr<ReadSourceResult> RetryObjectReadSource::Read(char* buf,
     os << "Retry policy exhausted in Read(): " << status.message();
   }
   return Status(status.code(), std::move(os).str());
+}
+
+bool RetryObjectReadSource::HandleResult(StatusOr<ReadSourceResult> const& r) {
+  if (!r) {
+    GCP_LOG(INFO) << "current_offset=" << current_offset_
+                  << ", is_gunzipped=" << is_gunzipped_
+                  << ", status=" << r.status();
+    return false;
+  }
+  GCP_LOG(INFO) << "current_offset=" << current_offset_
+                << ", is_gunzipped=" << is_gunzipped_
+                << ", response=" << r->response;
+
+  if (r->generation) generation_ = *r->generation;
+  if (r->transformation.value_or("") == "gunzipped") is_gunzipped_ = true;
+  // Since decompressive transcoding does not respect `ReadLast()` we need
+  // to ensure the offset is incremented, so the discard loop works.
+  if (is_gunzipped_) offset_direction_ = kFromBeginning;
+  if (offset_direction_ == kFromEnd) {
+    current_offset_ -= r->bytes_received;
+  } else {
+    current_offset_ += r->bytes_received;
+  }
+  return true;
+}
+
+// NOLINTNEXTLINE(misc-no-recursion)
+Status RetryObjectReadSource::MakeChild(RetryPolicy& retry_policy,
+                                        BackoffPolicy& backoff_policy) {
+  GCP_LOG(INFO) << "current_offset=" << current_offset_
+                << ", is_gunzipped=" << is_gunzipped_;
+
+  auto on_success = [this](std::unique_ptr<ObjectReadSource> child) {
+    child_ = std::move(child);
+    return Status{};
+  };
+
+  auto child =
+      client_->ReadObjectNotWrapped(request_, retry_policy, backoff_policy);
+  if (!child) return std::move(child).status();
+  if (!is_gunzipped_) return on_success(*std::move(child));
+
+  // Downloads under decompressive transcoding do not respect the Read-Range
+  // header. Restarting the download effectively restarts the read from the
+  // first byte.
+  child = ReadDiscard(*std::move(child), current_offset_);
+  if (child) return on_success(*std::move(child));
+
+  // Try again, eventually the retry policy will expire and this will fail.
+  if (!retry_policy.OnFailure(child.status())) return std::move(child).status();
+  std::this_thread::sleep_for(backoff_policy.OnCompletion());
+
+  return MakeChild(retry_policy, backoff_policy);
+}
+
+StatusOr<std::unique_ptr<ObjectReadSource>> RetryObjectReadSource::ReadDiscard(
+    std::unique_ptr<ObjectReadSource> child, std::int64_t count) const {
+  GCP_LOG(INFO) << "discarding " << count << " bytes to reach previous offset";
+  // Discard data until we are at the same offset as before.
+  std::vector<char> buffer(128 * 1024);
+  while (count > 0) {
+    auto const read_size =
+        (std::min)(static_cast<std::int64_t>(buffer.size()), count);
+    auto result =
+        child->Read(buffer.data(), static_cast<std::size_t>(read_size));
+    if (!result) return std::move(result).status();
+    count -= result->bytes_received;
+    if (result->response.status_code != HttpStatusCode::kContinue &&
+        count != 0) {
+      return Status{StatusCode::kInternal,
+                    "could not read back to previous offset (" +
+                        std::to_string(current_offset_) + ")"};
+    }
+  }
+  return child;
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_object_read_source.h
+++ b/google/cloud/storage/internal/retry_object_read_source.h
@@ -49,6 +49,11 @@ class RetryObjectReadSource : public ObjectReadSource {
   StatusOr<ReadSourceResult> Read(char* buf, std::size_t n) override;
 
  private:
+  bool HandleResult(StatusOr<ReadSourceResult> const& r);
+  Status MakeChild(RetryPolicy& retry_policy, BackoffPolicy& backoff_policy);
+  StatusOr<std::unique_ptr<ObjectReadSource>> ReadDiscard(
+      std::unique_ptr<ObjectReadSource> child, std::int64_t count) const;
+
   std::shared_ptr<RetryClient> client_;
   ReadObjectRangeRequest request_;
   std::unique_ptr<ObjectReadSource> child_;
@@ -56,7 +61,8 @@ class RetryObjectReadSource : public ObjectReadSource {
   std::unique_ptr<RetryPolicy const> retry_policy_prototype_;
   std::unique_ptr<BackoffPolicy const> backoff_policy_prototype_;
   OffsetDirection offset_direction_;
-  std::int64_t current_offset_;
+  std::int64_t current_offset_ = 0;
+  bool is_gunzipped_ = false;
 };
 
 }  // namespace internal


### PR DESCRIPTION
GCS can automatically decompress objects compressed with `gzip`.
However, it does not support the `Read-Range` header for such downloads,
all such downloads start from the first byte.  To resume an interrupted
download that is being automatically "gunzipped" (aka a download under
"decompressive transcoding") we need to discard all data until the
last received offset from the first download.

Fixes #8286, a future PR will add an integration test, see #8893.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8894)
<!-- Reviewable:end -->
