### PR TITLE
fix(storage): handle full but not finalized uploads

### DIFF
--- a/google/cloud/storage/internal/object_write_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_write_streambuf_test.cc
@@ -460,6 +460,10 @@ TEST(ObjectWriteStreambufTest, Regression8868) {
   EXPECT_EQ(close->committed_size.value_or(0), quantum);
   EXPECT_TRUE(close->payload.has_value());
 
+  // Before the fixes for #8868 this second call (which is legal, though maybe
+  // a bit silly) would crash.  Basically the class assumed that the final
+  // UploadChunk() would always return an error or a full payload.  That is now
+  // guaranteed by the RetryClient.
   close = streambuf.Close();
   ASSERT_STATUS_OK(close);
   EXPECT_FALSE(streambuf.IsOpen());

--- a/google/cloud/storage/internal/object_write_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_write_streambuf_test.cc
@@ -414,6 +414,59 @@ TEST(ObjectWriteStreambufTest, CreatedForFinalizedUpload) {
   ASSERT_STATUS_OK(close_result);
 }
 
+/// @test A regression test for #8868.
+///    https://github.com/googleapis/google-cloud-cpp/issues/8868
+TEST(ObjectWriteStreambufTest, Regression8868) {
+  auto mock = absl::make_unique<testing::MockClient>();
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto const payload = std::string(quantum, '0');
+  using ::testing::Return;
+
+  ::testing::InSequence sequence;
+  // Simulate an upload chunk that has some kind of transient error.
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")));
+  // This should trigger a `QueryResumableUpload()`, simulate the case where
+  // all the data is reported as "committed", but the payload is not reported
+  // back.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+  EXPECT_CALL(*mock, UploadChunk)
+      .WillOnce(
+          Return(QueryResumableUploadResponse{quantum, ObjectMetadata()}));
+
+  using us = std::chrono::microseconds;
+  auto retry = RetryClient::Create(
+      std::move(mock),
+      Options{}
+          .set<Oauth2CredentialsOption>(oauth2::CreateAnonymousCredentials())
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(3).clone())
+          .set<BackoffPolicyOption>(
+              ExponentialBackoffPolicy(us(1), us(2), 2).clone())
+          .set<IdempotencyPolicyOption>(
+              AlwaysRetryIdempotencyPolicy{}.clone()));
+  ObjectWriteStreambuf streambuf(
+      std::move(retry), ResumableUploadRequest(), "test-only-upload-id",
+      /*committed_size=*/0,
+      /*metadata=*/absl::nullopt,
+      /*max_buffer_size=*/2 * quantum, CreateNullHashFunction(), HashValues{},
+      CreateNullHashValidator(), AutoFinalizeConfig::kEnabled);
+  EXPECT_TRUE(streambuf.IsOpen());
+  streambuf.sputn(payload.data(), payload.size());
+  auto close = streambuf.Close();
+  ASSERT_STATUS_OK(close);
+  EXPECT_FALSE(streambuf.IsOpen());
+  EXPECT_EQ(close->committed_size.value_or(0), quantum);
+  EXPECT_TRUE(close->payload.has_value());
+
+  close = streambuf.Close();
+  ASSERT_STATUS_OK(close);
+  EXPECT_FALSE(streambuf.IsOpen());
+  EXPECT_EQ(close->committed_size.value_or(0), quantum);
+  EXPECT_TRUE(close->payload.has_value());
+}
+
 /// @test Verify that last error status is accessible for small payload.
 TEST(ObjectWriteStreambufTest, ErrorInSmallPayload) {
   auto mock = absl::make_unique<testing::MockClient>();

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -552,7 +552,7 @@ StatusOr<QueryResumableUploadResponse> RetryClient::UploadChunk(
 
     if (committed_size != expected_committed_size || request.last_chunk()) {
       // If we still have to send data, restart the loop. On the last chunk,
-      // event if the service reports all the data as received, we need to keep
+      // even if the service reports all the data as received, we need to keep
       // "finalizing" the object until the object metadata is returned. Note
       // that if we had the object metadata we would have already exited this
       // function.

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -560,7 +560,7 @@ TEST(RetryClientTest, UploadFinalChunkQueryTooManyMissingPayloads) {
   EXPECT_CALL(*mock, UploadChunk)
       .Times(AtLeast(2))
       .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
-  // This should trigger a `QueryResumableUpload()`, simulate the case the
+  // This should trigger a `QueryResumableUpload()`, simulate the case where the
   // service never returns a payload.
   EXPECT_CALL(*mock, QueryResumableUpload)
       .Times(AtLeast(2))

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -28,10 +28,13 @@ namespace {
 
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::google::cloud::testing_util::IsOk;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::AtLeast;
 using ::testing::ElementsAre;
 using ::testing::HasSubstr;
+using ::testing::Not;
+using ::testing::Property;
 using ::testing::Return;
 
 Options BasicTestPolicies() {
@@ -505,6 +508,68 @@ TEST(RetryClientTest, UploadChunkMissingRangeHeaderInQueryResumableUpload) {
       UploadChunkRequest("test-only-upload-id", 0, {{payload}}));
   ASSERT_STATUS_OK(response);
   EXPECT_EQ(quantum, response->committed_size.value_or(0));
+}
+
+/// @test Verify that full but unfinalized uploads are handled correctly.
+TEST(RetryClientTest, UploadFinalChunkQueryMissingPayloadTriggersRetry) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto const payload = std::string(quantum, '0');
+
+  ::testing::InSequence sequence;
+  // Simulate an upload chunk that has some kind of transient error.
+  EXPECT_CALL(*mock,
+              UploadChunk(Property(&UploadChunkRequest::last_chunk, true)))
+      .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")));
+  // This should trigger a `QueryResumableUpload()`, simulate the case where
+  // all the data is reported as "committed", but the payload is not reported
+  // back.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .WillOnce(Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+  // This should force a new UploadChunk() to finalize the object, verify this
+  // is an "empty" message, and return a successful result.
+  EXPECT_CALL(*mock,
+              UploadChunk(Property(&UploadChunkRequest::payload_size, 0)))
+      .WillOnce(
+          Return(QueryResumableUploadResponse{quantum, ObjectMetadata()}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}, HashValues{}));
+  ASSERT_STATUS_OK(response);
+  EXPECT_EQ(quantum, response->committed_size.value_or(0));
+  EXPECT_TRUE(response->payload.has_value());
+}
+
+/// @test Verify that not returning a final payload eventually becomes an error.
+TEST(RetryClientTest, UploadFinalChunkQueryTooManyMissingPayloads) {
+  auto mock = std::make_shared<testing::MockClient>();
+  auto client =
+      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
+                          BasicTestPolicies().set<IdempotencyPolicyOption>(
+                              StrictIdempotencyPolicy().clone()));
+
+  auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
+  auto const payload = std::string(quantum, '0');
+
+  // Simulate an upload chunk that has some kind of transient error.
+  EXPECT_CALL(*mock, UploadChunk)
+      .Times(AtLeast(2))
+      .WillRepeatedly(Return(Status(StatusCode::kUnavailable, "try-again")));
+  // This should trigger a `QueryResumableUpload()`, simulate the case the
+  // service never returns a payload.
+  EXPECT_CALL(*mock, QueryResumableUpload)
+      .Times(AtLeast(2))
+      .WillRepeatedly(
+          Return(QueryResumableUploadResponse{quantum, absl::nullopt}));
+
+  auto response = client->UploadChunk(
+      UploadChunkRequest("test-only-upload-id", 0, {{payload}}, HashValues{}));
+  ASSERT_THAT(response, Not(IsOk()));
 }
 
 }  // namespace


### PR DESCRIPTION
In some very rare circumstances a resumable upload may report that all
bytes have been received (and thus there is no more need to send data),
but fail to send back the finalized object metadata. In those cases we
need to retry sending the message to finalize the object.

Fixes #8868 

/FYI: @Jseph

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8896)
<!-- Reviewable:end -->
