### PR TITLE
doc(pubsub): deprecate functions consuming `ConnectionOptions`

### DIFF
--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -89,6 +89,7 @@ class PublisherConnection {
  *
  * @deprecated Please use `MakePublisherConnection(topic)` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("use MakePublisherConnection(topic) instead")
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, std::initializer_list<internal::NonConstructible>);
 
@@ -134,7 +135,7 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(Topic topic,
  * shared and reused when possible. Note that gRPC reuses existing OS resources
  * (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
- * same `ConnectionOptions` parameters. However, this behavior is not guaranteed
+ * identical values for @p options. However, this behavior is not guaranteed
  * and applications should not rely on it.
  *
  * @see `PublisherConnection`
@@ -152,6 +153,8 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(Topic topic,
  * @deprecated Please use the `MakePublisherConnection` method which accepts
  *     `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, PublisherOptions options,
     ConnectionOptions connection_options = {},

--- a/google/cloud/pubsub/publisher_connection.h
+++ b/google/cloud/pubsub/publisher_connection.h
@@ -89,7 +89,7 @@ class PublisherConnection {
  *
  * @deprecated Please use `MakePublisherConnection(topic)` instead.
  */
-GOOGLE_CLOUD_CPP_DEPRECATED("use MakePublisherConnection(topic) instead")
+GOOGLE_CLOUD_CPP_DEPRECATED("use `MakePublisherConnection(topic)` instead")
 std::shared_ptr<PublisherConnection> MakePublisherConnection(
     Topic topic, std::initializer_list<internal::NonConstructible>);
 

--- a/google/cloud/pubsub/schema_admin_connection.h
+++ b/google/cloud/pubsub/schema_admin_connection.h
@@ -102,11 +102,9 @@ class SchemaAdminConnection {
  *     existing code that calls `MakeSchemaAdminConnection({})` from breaking,
  *     due to ambiguity.
  *
- * @deprecated Please use the `MakeSchemaAdminConnection` function that accepts
- *     `google::cloud::Options` instead.
+ * @deprecated Please use `MakeSchemaAdminConnection()` instead.
  */
-GOOGLE_CLOUD_CPP_DEPRECATED(
-    "use the overload consuming google::cloud::Options instead")
+GOOGLE_CLOUD_CPP_DEPRECATED("use `MakeSchemaAdminConnection()` instead")
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
     std::initializer_list<internal::NonConstructible>);
 

--- a/google/cloud/pubsub/schema_admin_connection.h
+++ b/google/cloud/pubsub/schema_admin_connection.h
@@ -105,6 +105,8 @@ class SchemaAdminConnection {
  * @deprecated Please use the `MakeSchemaAdminConnection` function that accepts
  *     `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
     std::initializer_list<internal::NonConstructible>);
 
@@ -150,7 +152,7 @@ std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
  * should be shared and reused when possible. Note that gRPC reuses existing OS
  * resources (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
- * same `ConnectionOptions` parameters. However, this behavior is not guaranteed
+ * identical values for @p options. However, this behavior is not guaranteed
  * and applications should not rely on it.
  *
  * @see `SchemaAdminClient`
@@ -165,6 +167,8 @@ std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
  * @deprecated Please use the `MakeSchemaAdminConnection` function that accepts
  *     `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
     pubsub::ConnectionOptions const& options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -74,11 +74,10 @@ class SubscriberConnection {
  *     existing code, which calls `MakeSubscriberConnection(subscription, {})`
  *     from breaking, due to ambiguity.
  *
- * @deprecated Please use the `MakeSubscriberConnection` function which accepts
- *     `google::cloud::Options` instead.
+ * @deprecated Please use `MakeSubscriberConnection(subscription)` instead.
  */
 GOOGLE_CLOUD_CPP_DEPRECATED(
-    "use the overload consuming google::cloud::Options instead")
+    "use `MakeSubscriberConnection(subscription) instead")
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription,
     std::initializer_list<internal::NonConstructible>);

--- a/google/cloud/pubsub/subscriber_connection.h
+++ b/google/cloud/pubsub/subscriber_connection.h
@@ -77,6 +77,8 @@ class SubscriberConnection {
  * @deprecated Please use the `MakeSubscriberConnection` function which accepts
  *     `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription,
     std::initializer_list<internal::NonConstructible>);
@@ -127,7 +129,7 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
  * shared and reused when possible. Note that gRPC reuses existing OS resources
  * (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
- * same `ConnectionOptions` parameters. However, this behavior is not guaranteed
+ * identical values for @p options. However, this behavior is not guaranteed
  * and applications should not rely on it.
  *
  * @see `SubscriberConnection`
@@ -149,6 +151,8 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
  * @deprecated Please use the `MakeSubscriberConnection` function which accepts
  *     `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription, SubscriberOptions options,
     ConnectionOptions connection_options = {},

--- a/google/cloud/pubsub/subscription_admin_connection.h
+++ b/google/cloud/pubsub/subscription_admin_connection.h
@@ -198,6 +198,7 @@ class SubscriptionAdminConnection {
  *
  * @deprecated Please use `MakeSubscriptionAdminConnection()` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("use MakeSubscriptionAdminConnection() instead")
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
     std::initializer_list<internal::NonConstructible>);
 
@@ -243,7 +244,7 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
  * should be shared and reused when possible. Note that gRPC reuses existing OS
  * resources (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
- * same `ConnectionOptions` parameters. However, this behavior is not guaranteed
+ * identical values for @p options. However, this behavior is not guaranteed
  * and applications should not rely on it.
  *
  * @see `SubscriberConnection`
@@ -258,6 +259,8 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
  * @deprecated Please use the `MakeSubscriptionAdminConnection` function that
  *     accepts `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
     ConnectionOptions const& options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},

--- a/google/cloud/pubsub/topic_admin_connection.h
+++ b/google/cloud/pubsub/topic_admin_connection.h
@@ -171,6 +171,7 @@ class TopicAdminConnection {
  *
  * @deprecated Please use `MakeTopicAdminConnection()` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED("use MakeTopicAdminConnection() instead")
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
     std::initializer_list<internal::NonConstructible>);
 
@@ -214,7 +215,7 @@ std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
  * shared and reused when possible. Note that gRPC reuses existing OS resources
  * (sockets) whenever possible, so applications may experience better
  * performance on the second (and subsequent) calls to this function with the
- * same `ConnectionOptions` parameters. However, this behavior is not guaranteed
+ * identical values for @p options. However, this behavior is not guaranteed
  * and applications should not rely on it.
  *
  * @see `TopicAdminClient`
@@ -229,6 +230,8 @@ std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
  * @deprecated Please use the `MakeTopicAdminConnection` function that accepts
  *     `google::cloud::Options` instead.
  */
+GOOGLE_CLOUD_CPP_DEPRECATED(
+    "use the overload consuming google::cloud::Options instead")
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
     ConnectionOptions const& options,
     std::unique_ptr<pubsub::RetryPolicy const> retry_policy = {},


### PR DESCRIPTION
I did not set a date to retire these functions, because I do not think
we should retire them.  They are basically harmless.

Part of the work for #7348

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8900)
<!-- Reviewable:end -->
