### PR TITLE
cleanup(spanner): stop using `ConnectionOptions`

### DIFF
--- a/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/multiple_rows_cpu_benchmark.cc
@@ -291,9 +291,12 @@ class ExperimentImpl {
               << std::flush;
 
     auto connection = spanner::MakeConnection(
-        database, spanner::ConnectionOptions().set_num_channels(num_channels),
+        database,
         // This pre-creates all the Sessions we will need (one per thread).
-        spanner::SessionPoolOptions().set_min_sessions(config.maximum_threads));
+        google::cloud::Options{}
+            .set<google::cloud::GrpcNumChannelsOption>(num_channels)
+            .set<spanner::SessionPoolMinSessionsOption>(
+                config.maximum_threads));
     return spanner::Client(std::move(connection));
   }
 
@@ -303,8 +306,9 @@ class ExperimentImpl {
     std::cout << "# Creating " << num_channels << " stub"
               << (num_channels != 1 ? "s" : "") << "\n"
               << std::flush;
-    auto opts = google::cloud::internal::MakeOptions(
-        spanner::ConnectionOptions().set_num_channels(num_channels));
+    auto opts =
+        google::cloud::Options{}.set<google::cloud::GrpcNumChannelsOption>(
+            num_channels);
     opts = spanner_internal::DefaultOptions(std::move(opts));
     auto auth = google::cloud::internal::CreateAuthenticationStrategy(
         opts.get<google::cloud::GrpcCredentialOption>());

--- a/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
+++ b/google/cloud/spanner/benchmarks/single_row_throughput_benchmark.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
@@ -49,9 +50,11 @@ spanner::Client MakeClient(Config const& config, int num_channels,
             << std::flush;
 
   auto connection = spanner::MakeConnection(
-      database, spanner::ConnectionOptions().set_num_channels(num_channels),
+      database,
       // This pre-creates all the Sessions we will need (one per thread).
-      spanner::SessionPoolOptions().set_min_sessions(config.maximum_threads));
+      google::cloud::Options{}
+          .set<google::cloud::GrpcNumChannelsOption>(num_channels)
+          .set<spanner::SessionPoolMinSessionsOption>(config.maximum_threads));
   return spanner::Client(std::move(connection));
 }
 

--- a/google/cloud/spanner/connection_options_test.cc
+++ b/google/cloud/spanner/connection_options_test.cc
@@ -24,37 +24,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::testing_util::ScopedEnvironment;
-using ::testing::HasSubstr;
-using ::testing::StartsWith;
-
-TEST(ConnectionOptionsTraits, AdminEndpoint) {
-  ConnectionOptions options(grpc::InsecureChannelCredentials());
-  EXPECT_EQ(ConnectionOptionsTraits::default_endpoint(), options.endpoint());
-  options.set_endpoint("invalid-endpoint");
-  EXPECT_EQ("invalid-endpoint", options.endpoint());
-}
-
-TEST(ConnectionOptionsTraits, NumChannels) {
-  ConnectionOptions options(grpc::InsecureChannelCredentials());
-  int num_channels = options.num_channels();
-  EXPECT_EQ(ConnectionOptionsTraits::default_num_channels(), num_channels);
-  num_channels *= 2;  // ensure we change it from the default value.
-  options.set_num_channels(num_channels);
-  EXPECT_EQ(num_channels, options.num_channels());
-}
-
-TEST(ConnectionOptionsTraits, UserAgentPrefix) {
-  auto actual = ConnectionOptionsTraits::user_agent_prefix();
-  EXPECT_THAT(actual, StartsWith("gcloud-cpp/" + VersionString()));
-  EXPECT_THAT(actual, HasSubstr(google::cloud::internal::CompilerId()));
-  EXPECT_THAT(actual, HasSubstr(google::cloud::internal::CompilerVersion()));
-  EXPECT_THAT(actual, HasSubstr(google::cloud::internal::CompilerFeatures()));
-
-  ConnectionOptions options(grpc::InsecureChannelCredentials());
-  EXPECT_EQ(actual, options.user_agent_prefix());
-  options.add_user_agent_prefix("test-prefix/1.2.3");
-  EXPECT_EQ("test-prefix/1.2.3 " + actual, options.user_agent_prefix());
-}
 
 TEST(DefaultEndpoint, EnvironmentWorks) {
   EXPECT_NE("invalid-endpoint", ConnectionOptionsTraits::default_endpoint());

--- a/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/rpc_failure_threshold_integration_test.cc
@@ -115,7 +115,8 @@ Result RunExperiment(Database const& db, int iterations) {
   }();
 
   Client client(
-      MakeConnection(db, ConnectionOptions().set_channel_pool_domain(pool)));
+      MakeConnection(db, Options{}.set<GrpcChannelArgumentsOption>(
+                             {{"grpc.channel_pooling_domain", pool}})));
 
   int number_of_successes = 0;
   int number_of_failures = 0;


### PR DESCRIPTION
Prefer using `google::cloud::Options` instead.

Motivated by https://github.com/googleapis/google-cloud-cpp/pull/8900#pullrequestreview-965001024

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8903)
<!-- Reviewable:end -->
