### PR TITLE
test(storage): "gunzipped" downloads integration

### DIFF
--- a/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
+++ b/google/cloud/storage/tests/decompressive_transcoding_integration_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/str_split.h"
 #include <gmock/gmock.h>
 #include <fstream>
 #include <thread>
@@ -27,34 +28,35 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::internal::GetEnv;
 using ::google::cloud::testing_util::IsOk;
+using ::testing::ElementsAreArray;
 
 class DecompressiveTranscodingIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   void SetUp() override {
     google::cloud::storage::testing::StorageIntegrationTest::SetUp();
-    bucket_name_ = google::cloud::internal::GetEnv(
-                       "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
-                       .value_or("");
+    bucket_name_ =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
     ASSERT_FALSE(bucket_name_.empty());
+    auto const gzip_filename =
+        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME").value_or("");
+    ASSERT_FALSE(gzip_filename.empty());
+    std::ifstream gz(gzip_filename, std::ios::binary);
+    gzipped_contents_ = std::string{std::istreambuf_iterator<char>(gz), {}};
+    ASSERT_TRUE(gz.good());
   }
 
   std::string const& bucket_name() const { return bucket_name_; }
+  std::string const& gzipped_contents() const { return gzipped_contents_; }
 
  private:
   std::string bucket_name_;
+  std::string gzipped_contents_;
 };
 
 TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadJson) {
-  auto const gzip_filename = google::cloud::internal::GetEnv(
-                                 "GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME")
-                                 .value_or("");
-  ASSERT_FALSE(gzip_filename.empty());
-  std::ifstream gz(gzip_filename, std::ios::binary);
-  auto const contents = std::string{std::istreambuf_iterator<char>(gz), {}};
-  ASSERT_TRUE(gz.good());
-
   auto client = Client(
       Options{}
           .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
@@ -62,7 +64,7 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadJson) {
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(
-      bucket_name(), object_name, contents, IfGenerationMatch(0),
+      bucket_name(), object_name, gzipped_contents(), IfGenerationMatch(0),
       WithObjectMetadata(
           ObjectMetadata().set_content_encoding("gzip").set_content_type(
               "text/plain")));
@@ -81,18 +83,10 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadJson) {
   ASSERT_STATUS_OK(reader.status());
 
   // The whole point is to decompress the data and return something different.
-  ASSERT_NE(decompressed.substr(0, 32), contents.substr(0, 32));
+  ASSERT_NE(decompressed.substr(0, 32), gzipped_contents().substr(0, 32));
 }
 
 TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadXml) {
-  auto const gzip_filename = google::cloud::internal::GetEnv(
-                                 "GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME")
-                                 .value_or("");
-  ASSERT_FALSE(gzip_filename.empty());
-  std::ifstream gz(gzip_filename, std::ios::binary);
-  auto const contents = std::string{std::istreambuf_iterator<char>(gz), {}};
-  ASSERT_TRUE(gz.good());
-
   auto client = Client(
       Options{}
           .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
@@ -100,7 +94,7 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadXml) {
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(
-      bucket_name(), object_name, contents, IfGenerationMatch(0),
+      bucket_name(), object_name, gzipped_contents(), IfGenerationMatch(0),
       WithObjectMetadata(
           ObjectMetadata().set_content_encoding("gzip").set_content_type(
               "text/plain")));
@@ -118,18 +112,10 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadXml) {
   ASSERT_STATUS_OK(reader.status());
 
   // The whole point is to decompress the data and return something different.
-  ASSERT_NE(decompressed.substr(0, 32), contents.substr(0, 32));
+  ASSERT_NE(decompressed.substr(0, 32), gzipped_contents().substr(0, 32));
 }
 
 TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedJson) {
-  auto const gzip_filename = google::cloud::internal::GetEnv(
-                                 "GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME")
-                                 .value_or("");
-  ASSERT_FALSE(gzip_filename.empty());
-  std::ifstream gz(gzip_filename, std::ios::binary);
-  auto const contents = std::string{std::istreambuf_iterator<char>(gz), {}};
-  ASSERT_TRUE(gz.good());
-
   auto client = Client(
       Options{}
           .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
@@ -137,7 +123,7 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedJson) {
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(
-      bucket_name(), object_name, contents, IfGenerationMatch(0),
+      bucket_name(), object_name, gzipped_contents(), IfGenerationMatch(0),
       WithObjectMetadata(
           ObjectMetadata().set_content_encoding("gzip").set_content_type(
               "text/plain")));
@@ -153,18 +139,10 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedJson) {
   auto compressed = std::string{std::istreambuf_iterator<char>(reader), {}};
   ASSERT_STATUS_OK(reader.status());
 
-  ASSERT_EQ(compressed.substr(0, 32), contents.substr(0, 32));
+  ASSERT_EQ(compressed.substr(0, 32), gzipped_contents().substr(0, 32));
 }
 
 TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedXml) {
-  auto const gzip_filename = google::cloud::internal::GetEnv(
-                                 "GOOGLE_CLOUD_CPP_STORAGE_TEST_GZIP_FILENAME")
-                                 .value_or("");
-  ASSERT_FALSE(gzip_filename.empty());
-  std::ifstream gz(gzip_filename, std::ios::binary);
-  auto const contents = std::string{std::istreambuf_iterator<char>(gz), {}};
-  ASSERT_TRUE(gz.good());
-
   auto client = Client(
       Options{}
           .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
@@ -172,7 +150,7 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedXml) {
 
   auto object_name = MakeRandomObjectName();
   auto insert = client.InsertObject(
-      bucket_name(), object_name, contents, IfGenerationMatch(0),
+      bucket_name(), object_name, gzipped_contents(), IfGenerationMatch(0),
       WithObjectMetadata(
           ObjectMetadata().set_content_encoding("gzip").set_content_type(
               "text/plain")));
@@ -187,7 +165,70 @@ TEST_F(DecompressiveTranscodingIntegrationTest, WriteAndReadCompressedXml) {
   auto compressed = std::string{std::istreambuf_iterator<char>(reader), {}};
   ASSERT_STATUS_OK(reader.status());
 
-  ASSERT_EQ(compressed.substr(0, 32), contents.substr(0, 32));
+  ASSERT_EQ(compressed.substr(0, 32), gzipped_contents().substr(0, 32));
+}
+
+TEST_F(DecompressiveTranscodingIntegrationTest, ResumeGunzippedDownloadJson) {
+  // This test requires the emulator to force specific download failures.
+  // TODO(#8829) - decompressive transcoding does not work with gRPC
+  if (!UsingEmulator() || UsingGrpc()) GTEST_SKIP();
+
+  auto client = Client(
+      Options{}
+          .set<MaximumCurlSocketRecvSizeOption>(16 * 1024)
+          .set<DownloadBufferSizeOption>(1024)
+          .set<TransferStallTimeoutOption>(std::chrono::seconds(3))
+          .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(5).clone()));
+
+  auto object_name = MakeRandomObjectName();
+  auto insert = client.InsertObject(
+      bucket_name(), object_name, gzipped_contents(), IfGenerationMatch(0),
+      WithObjectMetadata(
+          ObjectMetadata().set_content_encoding("gzip").set_content_type(
+              "text/plain")));
+  ASSERT_STATUS_OK(insert);
+  ScheduleForDelete(*insert);
+  EXPECT_EQ(insert->content_encoding(), "gzip");
+  EXPECT_EQ(insert->content_type(), "text/plain");
+
+  // Read the (decompressed) contents of the object.
+  auto reader =
+      client.ReadObject(bucket_name(), object_name, IfGenerationNotMatch(0));
+  ASSERT_STATUS_OK(reader.status());
+  auto const decompressed =
+      std::string{std::istreambuf_iterator<char>(reader), {}};
+  ASSERT_STATUS_OK(reader.status());
+
+  // The test assumes the object is at least 512 KiB.
+  ASSERT_GT(decompressed.size(), 512 * 1024);
+
+  auto retry_response = InsertRetryTest(RetryTestRequest{{
+      RetryTestConfiguration{"storage.objects.get",
+                             {
+                                 "return-broken-stream-after-128K",
+                                 "return-broken-stream-after-256K",
+                                 "return-broken-stream-after-512K",
+                             }},
+  }});
+  ASSERT_STATUS_OK(retry_response);
+
+  reader =
+      client.ReadObject(bucket_name(), object_name, IfGenerationNotMatch(0),
+                        CustomHeader("x-retry-test-id", retry_response->id));
+  std::vector<char> buffer(128 * 1024);
+  std::string actual;
+  while (!reader.read(buffer.data(), buffer.size()).bad()) {
+    actual +=
+        std::string{buffer.data(), static_cast<std::size_t>(reader.gcount())};
+    if (reader.eof()) break;
+  }
+  ASSERT_STATUS_OK(reader.status());
+
+  EXPECT_EQ(actual.size(), decompressed.size());
+  std::vector<std::string> actual_lines = absl::StrSplit(actual, "\n");
+  std::vector<std::string> decompressed_lines =
+      absl::StrSplit(decompressed, "\n");
+  EXPECT_THAT(actual_lines, ElementsAreArray(decompressed_lines));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Adds an integration test for "gunzipped" (aka decompressive transcoding)
downloads.

Fixes #8893

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8904)
<!-- Reviewable:end -->
