### PR TITLE
doc: make the minimum Bazel and CMake versions easier to find

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,7 +390,8 @@ int main(int argc, char* argv[]) {
 * This project supports Windows, macOS, Linux
 * This project supports C++11 (and higher) compilers (we test with GCC >= 6.3,
   Clang >= 6.0, and MSVC >= 2017)
-* This project supports Bazel and CMake builds. See the [Quickstart examples](https://github.com/googleapis/google-cloud-cpp#quickstart)
+* This project supports Bazel (>= 4.0) and CMake (>= 3.5) builds. See the
+  [Quickstart examples](https://github.com/googleapis/google-cloud-cpp#quickstart)
 * This project uses dependencies described in [doc/packaging.md](https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md)
 * This project works with or without exceptions enabled
 * This project cuts [monthly releases](https://github.com/googleapis/google-cloud-cpp/releases) with detailed release notes
@@ -458,19 +459,19 @@ policy described at https://cloud.google.com/terms.
 
 Applications developers interact with a C++ library through more than just
 the C++ symbols and headers. They also need to reference the name of the
-library in their build scripts. Depending of the build system they use
+library in their build scripts. Depending on the build system they use
 this may be a CMake target, a Bazel rule, a pkg-config module, or just the
 name of some object in the file system.
 
 As with the C++ API, we try to avoid breaking changes to these interface
 points. Sometimes such changes yield benefits to our customers, in the form of
-easier-to-understand what names go with with services, or more consistency
-across services. When these benefits warrant it, we will announce these changes
-prominently in our `CHANGELOG.md` file and in the affected release's notes.
-Nevertheless, though we take commercially reasonable efforts to prevent this,
-it is possible that backwards incompatible changes go undetected and,
-therefore, undocumented. We apologize if this is the case and welcome feedback
-or bug reports to rectify the problem.
+bug fixes, increased consistency across services, or easier to understand names.
+When these benefits warrant it, we will announce these changes prominently in
+our `CHANGELOG.md` file and in the affected release's notes.  Nevertheless,
+though we take commercially reasonable efforts to prevent this, it is possible
+that backwards incompatible changes go undetected and, therefore, undocumented.
+We apologize if this is the case and welcome feedback or bug reports to rectify
+the problem.
 
 ### Experimental Libraries
 
@@ -515,7 +516,7 @@ these may work, we may accidentally break these from time to time. Examples of
 such, and the recommended alternatives, include:
 
 * CMake's `FetchContent` and/or git submodules: in these approaches the
-  `google-cloud-cpp` library becomes a sub-directory of a larger CMake build
+  `google-cloud-cpp` library becomes a subdirectory of a larger CMake build
   We do not test `google-cloud-cpp` in these  configurations, and we find them
   brittle as **all** CMake targets become visible to the larger project.
   This is both prone to conflicts, and makes it impossible to enforce that

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -214,7 +214,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/README.md
+++ b/google/cloud/README.md
@@ -21,7 +21,7 @@ notice. These include `google/cloud/internal/`, and
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/accessapproval/README.md
+++ b/google/cloud/accessapproval/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/accesscontextmanager/README.md
+++ b/google/cloud/accesscontextmanager/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/apigateway/README.md
+++ b/google/cloud/apigateway/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/apigeeconnect/README.md
+++ b/google/cloud/apigeeconnect/README.md
@@ -19,7 +19,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/appengine/README.md
+++ b/google/cloud/appengine/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/artifactregistry/README.md
+++ b/google/cloud/artifactregistry/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/asset/README.md
+++ b/google/cloud/asset/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/assuredworkloads/README.md
+++ b/google/cloud/assuredworkloads/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/automl/README.md
+++ b/google/cloud/automl/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/bigquery/README.md
+++ b/google/cloud/bigquery/README.md
@@ -12,7 +12,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/billing/README.md
+++ b/google/cloud/billing/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/binaryauthorization/README.md
+++ b/google/cloud/binaryauthorization/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/channel/README.md
+++ b/google/cloud/channel/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/cloudbuild/README.md
+++ b/google/cloud/cloudbuild/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/composer/README.md
+++ b/google/cloud/composer/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/contactcenterinsights/README.md
+++ b/google/cloud/contactcenterinsights/README.md
@@ -15,7 +15,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/container/README.md
+++ b/google/cloud/container/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/containeranalysis/README.md
+++ b/google/cloud/containeranalysis/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/datacatalog/README.md
+++ b/google/cloud/datacatalog/README.md
@@ -15,7 +15,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/datamigration/README.md
+++ b/google/cloud/datamigration/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/dataplex/README.md
+++ b/google/cloud/dataplex/README.md
@@ -18,7 +18,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/dataproc/README.md
+++ b/google/cloud/dataproc/README.md
@@ -18,7 +18,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/debugger/README.md
+++ b/google/cloud/debugger/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/dialogflow_cx/README.md
+++ b/google/cloud/dialogflow_cx/README.md
@@ -20,7 +20,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/dialogflow_es/README.md
+++ b/google/cloud/dialogflow_es/README.md
@@ -20,7 +20,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/dlp/README.md
+++ b/google/cloud/dlp/README.md
@@ -15,7 +15,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/documentai/README.md
+++ b/google/cloud/documentai/README.md
@@ -18,7 +18,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/eventarc/README.md
+++ b/google/cloud/eventarc/README.md
@@ -12,7 +12,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/filestore/README.md
+++ b/google/cloud/filestore/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/functions/README.md
+++ b/google/cloud/functions/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/gameservices/README.md
+++ b/google/cloud/gameservices/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/gkehub/README.md
+++ b/google/cloud/gkehub/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/grafeas/README.md
+++ b/google/cloud/grafeas/README.md
@@ -24,7 +24,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * Windows, macOS, Linux
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Contributing changes
 

--- a/google/cloud/iam/README.md
+++ b/google/cloud/iam/README.md
@@ -12,7 +12,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/iap/README.md
+++ b/google/cloud/iap/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/ids/README.md
+++ b/google/cloud/ids/README.md
@@ -17,7 +17,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/iot/README.md
+++ b/google/cloud/iot/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/kms/README.md
+++ b/google/cloud/kms/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/language/README.md
+++ b/google/cloud/language/README.md
@@ -16,7 +16,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/managedidentities/README.md
+++ b/google/cloud/managedidentities/README.md
@@ -16,7 +16,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/memcache/README.md
+++ b/google/cloud/memcache/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/monitoring/README.md
+++ b/google/cloud/monitoring/README.md
@@ -16,7 +16,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/networkmanagement/README.md
+++ b/google/cloud/networkmanagement/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/notebooks/README.md
+++ b/google/cloud/notebooks/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/orgpolicy/README.md
+++ b/google/cloud/orgpolicy/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/osconfig/README.md
+++ b/google/cloud/osconfig/README.md
@@ -19,7 +19,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/oslogin/README.md
+++ b/google/cloud/oslogin/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/policytroubleshooter/README.md
+++ b/google/cloud/policytroubleshooter/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/privateca/README.md
+++ b/google/cloud/privateca/README.md
@@ -15,7 +15,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/profiler/README.md
+++ b/google/cloud/profiler/README.md
@@ -22,7 +22,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/pubsub/README.md
+++ b/google/cloud/pubsub/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -18,7 +18,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/recommender/README.md
+++ b/google/cloud/recommender/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/redis/README.md
+++ b/google/cloud/redis/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/resourcemanager/README.md
+++ b/google/cloud/resourcemanager/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/resourcesettings/README.md
+++ b/google/cloud/resourcesettings/README.md
@@ -16,7 +16,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/retail/README.md
+++ b/google/cloud/retail/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/scheduler/README.md
+++ b/google/cloud/scheduler/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/secretmanager/README.md
+++ b/google/cloud/secretmanager/README.md
@@ -14,7 +14,7 @@ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/securitycenter/README.md
+++ b/google/cloud/securitycenter/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/servicecontrol/README.md
+++ b/google/cloud/servicecontrol/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/servicedirectory/README.md
+++ b/google/cloud/servicedirectory/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/servicemanagement/README.md
+++ b/google/cloud/servicemanagement/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/serviceusage/README.md
+++ b/google/cloud/serviceusage/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/shell/README.md
+++ b/google/cloud/shell/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/spanner/README.md
+++ b/google/cloud/spanner/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -16,7 +16,7 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/storage/README.md
+++ b/google/cloud/storage/README.md
@@ -17,7 +17,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/storagetransfer/README.md
+++ b/google/cloud/storagetransfer/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/talent/README.md
+++ b/google/cloud/talent/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/tasks/README.md
+++ b/google/cloud/tasks/README.md
@@ -13,7 +13,7 @@ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/texttospeech/README.md
+++ b/google/cloud/texttospeech/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/tpu/README.md
+++ b/google/cloud/tpu/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/trace/README.md
+++ b/google/cloud/trace/README.md
@@ -16,7 +16,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/translate/README.md
+++ b/google/cloud/translate/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/videointelligence/README.md
+++ b/google/cloud/videointelligence/README.md
@@ -14,7 +14,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/vision/README.md
+++ b/google/cloud/vision/README.md
@@ -15,7 +15,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/vmmigration/README.md
+++ b/google/cloud/vmmigration/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/vpcaccess/README.md
+++ b/google/cloud/vpcaccess/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/webrisk/README.md
+++ b/google/cloud/webrisk/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/websecurityscanner/README.md
+++ b/google/cloud/websecurityscanner/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 

--- a/google/cloud/workflows/README.md
+++ b/google/cloud/workflows/README.md
@@ -13,7 +13,7 @@ While this library is **GA**, please note that the Google Cloud C++ client libra
 * C++11 (and higher) compilers (we test with GCC >= 5.4, Clang >= 6.0, and
   MSVC >= 2017)
 * Environments with or without exceptions
-* Bazel and CMake builds
+* Bazel (>= 4.0) and CMake (>= 3.5) builds
 
 ## Documentation
 


### PR DESCRIPTION
Put the minimum version of these tools in all the places where we
document other minimum versions (typically the compiler). Some
additional typos and light editing the top-level README.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8909)
<!-- Reviewable:end -->
