### PR TITLE
impl(bigtable): add MockRowReader

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -185,6 +185,7 @@ add_library(
     internal/legacy_row_reader_impl.h
     internal/logging_data_client.cc
     internal/logging_data_client.h
+    internal/mock_row_reader_impl.h
     internal/prefix_range_end.cc
     internal/prefix_range_end.h
     internal/readrowsparser.cc
@@ -337,6 +338,7 @@ if (BUILD_TESTING)
         internal/defaults_test.cc
         internal/google_bytes_traits_test.cc
         internal/logging_data_client_test.cc
+        internal/mock_row_reader_impl_test.cc
         internal/prefix_range_end_test.cc
         internal/wait_for_consistency_test.cc
         metadata_update_policy_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -50,6 +50,7 @@ bigtable_client_unit_tests = [
     "internal/defaults_test.cc",
     "internal/google_bytes_traits_test.cc",
     "internal/logging_data_client_test.cc",
+    "internal/mock_row_reader_impl_test.cc",
     "internal/prefix_range_end_test.cc",
     "internal/wait_for_consistency_test.cc",
     "metadata_update_policy_test.cc",

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -84,6 +84,7 @@ google_cloud_cpp_bigtable_hdrs = [
     "internal/google_bytes_traits.h",
     "internal/legacy_row_reader_impl.h",
     "internal/logging_data_client.h",
+    "internal/mock_row_reader_impl.h",
     "internal/prefix_range_end.h",
     "internal/readrowsparser.h",
     "internal/row_reader_impl.h",

--- a/google/cloud/bigtable/internal/mock_row_reader_impl.h
+++ b/google/cloud/bigtable/internal/mock_row_reader_impl.h
@@ -1,0 +1,56 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MOCK_ROW_READER_IMPL_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MOCK_ROW_READER_IMPL_H
+
+#include "google/cloud/bigtable/internal/row_reader_impl.h"
+#include <iterator>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+class MockRowReaderImpl : public RowReaderImpl {
+ public:
+  explicit MockRowReaderImpl(std::vector<StatusOr<bigtable::Row>> rows)
+      : rows_(std::move(rows)), iter_(rows_.cbegin()), end_(rows_.cend()) {}
+
+  ~MockRowReaderImpl() override = default;
+
+  /// Skips remaining rows and invalidates current iterator.
+  void Cancel() override { iter_ = end_; };
+
+  StatusOr<OptionalRow> Advance() override {
+    if (iter_ == end_) return make_status_or<OptionalRow>(absl::nullopt);
+    auto sor = *iter_++;
+    if (!sor) return sor.status();
+    return make_status_or(absl::make_optional(*sor));
+  }
+
+ private:
+  std::vector<StatusOr<bigtable::Row>> const rows_;
+  using iter = std::vector<StatusOr<bigtable::Row>>::const_iterator;
+  iter iter_;
+  iter end_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_MOCK_ROW_READER_IMPL_H

--- a/google/cloud/bigtable/internal/mock_row_reader_impl_test.cc
+++ b/google/cloud/bigtable/internal/mock_row_reader_impl_test.cc
@@ -1,0 +1,140 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/mock_row_reader_impl.h"
+#include "google/cloud/bigtable/row_reader.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <algorithm>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::bigtable::Row;
+using ::google::cloud::bigtable::RowReader;
+using ::testing::ElementsAreArray;
+
+struct Result {
+  explicit Result(StatusOr<Row> const& in) {
+    if (in.ok()) {
+      row = in.value().row_key();
+    } else {
+      status = in.status();
+    }
+  }
+
+  Status status;
+  std::string row;
+};
+
+bool operator==(Result const& a, Result const& b) {
+  return a.status == b.status && a.row == b.row;
+}
+
+std::ostream& operator<<(std::ostream& os, Result const& a) {
+  if (!a.status.ok()) return os << "Status: " << a.status;
+  return os << "Row: " << a.row;
+}
+
+template <typename T>
+std::vector<Result> ToResult(T& rs) {
+  std::vector<Result> ret;
+  // NOLINTNEXTLINE(performance-inefficient-vector-operation)
+  for (auto const& r : rs) ret.emplace_back(r);
+  return ret;
+}
+
+TEST(MockRowReaderTest, Empty) {
+  std::vector<StatusOr<Row>> rows;
+
+  auto reader = MakeMockRowReader(rows);
+
+  auto actual = ToResult(reader);
+  auto expected = ToResult(rows);
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
+TEST(MockRowReaderTest, Rows) {
+  std::vector<StatusOr<Row>> rows = {Row("r1", {}), Row("r2", {})};
+
+  auto reader = MakeMockRowReader(rows);
+
+  auto actual = ToResult(reader);
+  auto expected = ToResult(rows);
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
+TEST(MockRowReaderTest, StatusOnly) {
+  std::vector<StatusOr<Row>> rows = {
+      Status(StatusCode::kPermissionDenied, "fail")};
+
+  auto reader = MakeMockRowReader(rows);
+
+  auto actual = ToResult(reader);
+  auto expected = ToResult(rows);
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
+TEST(MockRowReaderTest, RowsThenStatus) {
+  std::vector<StatusOr<Row>> rows = {
+      Row("r1", {}), Row("r2", {}),
+      Status(StatusCode::kPermissionDenied, "fail")};
+
+  auto reader = MakeMockRowReader(rows);
+
+  auto actual = ToResult(reader);
+  auto expected = ToResult(rows);
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
+TEST(MockRowReaderTest, ReaderEndsOnStatus) {
+  std::vector<StatusOr<Row>> rows = {
+      Status(StatusCode::kPermissionDenied, "fail"), Row("ignored", {})};
+  std::vector<StatusOr<Row>> expected_rows = {
+      Status(StatusCode::kPermissionDenied, "fail")};
+
+  auto reader = MakeMockRowReader(rows);
+
+  auto actual = ToResult(reader);
+  auto expected = ToResult(expected_rows);
+  EXPECT_THAT(actual, ElementsAreArray(expected));
+}
+
+TEST(MockRowReaderTest, CancelEndsStream) {
+  std::vector<StatusOr<Row>> rows = {Row("r1", {}), Row("r2", {})};
+
+  auto reader = MakeMockRowReader(rows);
+
+  auto it = reader.begin();
+  EXPECT_EQ(Result(*it), Result(rows[0]));
+
+  // Cancel the reader
+  reader.Cancel();
+
+  // Increment the iterator. Verify that it points to `end()` instead of "r2"
+  it++;
+  EXPECT_EQ(it, reader.end());
+
+  // Verify that new iterators are invalidated too.
+  EXPECT_EQ(reader.begin(), reader.end());
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -105,5 +105,17 @@ void RowReader::Cancel() { impl_->Cancel(); }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+bigtable::RowReader MakeMockRowReader(
+    std::vector<StatusOr<bigtable::Row>> expected) {
+  auto impl = std::make_shared<bigtable_internal::MockRowReaderImpl>(
+      std::move(expected));
+  return bigtable_internal::MakeRowReader(std::move(impl));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Most of the work for #8797 

Still TODO is to add a public factory function to our mock library. I am not going to do this until the DataConnection is ready for use. I did add the documentation now though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8912)
<!-- Reviewable:end -->
