### PR TITLE
fix(storage): all `HmacKey` requests accept `UserProject`

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2540,7 +2540,7 @@ class Client {
    * @param options a list of optional query parameters and/or request headers.
    *     In addition to the options common to all requests, this operation
    *     accepts `Deleted` `MaxResults`, `OverrideDefaultProject`,
-   *     `ServiceAccountFilter`.
+   *     and `ServiceAccountFilter`.
    *
    * @return A range to iterate over the available HMAC keys.
    *

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -31,7 +31,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 template <typename Derived, typename... Options>
-class GenericHmacKeyRequest : public GenericRequest<Derived, Options...> {
+class GenericHmacKeyRequest
+    : public GenericRequest<Derived, UserProject, Options...> {
  public:
   GenericHmacKeyRequest() = default;
   explicit GenericHmacKeyRequest(std::string project_id)
@@ -54,7 +55,7 @@ class GenericHmacKeyRequest : public GenericRequest<Derived, Options...> {
 
   Derived& set_multiple_options() { return *static_cast<Derived*>(this); }
 
-  using GenericRequest<Derived, Options...>::set_option;
+  using GenericRequest<Derived, UserProject, Options...>::set_option;
   void set_option(OverrideDefaultProject const& o) {
     if (o.has_value()) {
       project_id_ = o.value();
@@ -97,7 +98,7 @@ std::ostream& operator<<(std::ostream& os, CreateHmacKeyResponse const& r);
 /// Represents a request to call the `HmacKeys: list` API.
 class ListHmacKeysRequest
     : public GenericHmacKeyRequest<ListHmacKeysRequest, Deleted, MaxResults,
-                                   ServiceAccountFilter, UserProject> {
+                                   ServiceAccountFilter> {
  public:
   explicit ListHmacKeysRequest(std::string project_id)
       : GenericHmacKeyRequest(std::move(project_id)) {}


### PR DESCRIPTION
Fix all `HmacKey` requests to accept `UserProject`. Used the opportunity
to document the "common options", since I had to do that for these
requests anyway. And then fixed some rendering problems.

Motivated by #4208

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8928)
<!-- Reviewable:end -->
