### PR TITLE
refactor(spanner): use struct for transaction callback parameters

### DIFF
--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -270,7 +270,7 @@ StatusOr<CommitResult> Client::Commit(
       spanner_internal::Visit(
           txn, [](spanner_internal::SessionHolder& s,
                   StatusOr<google::spanner::v1::TransactionSelector> const&,
-                  std::string const&, std::int64_t) {
+                  spanner_internal::TransactionContext const&) {
             if (s) s->set_bad();
             return true;
           });

--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -147,7 +147,7 @@ MATCHER_P(HasDatabase, database, "Request has expected database") {
 MATCHER(HasBadSession, "bound to a session that's marked bad") {
   return Visit(arg, [&](SessionHolder& session,
                         StatusOr<google::spanner::v1::TransactionSelector>&,
-                        std::string const&, std::int64_t) {
+                        TransactionContext const&) {
     if (!session) {
       *result_listener << "has no session";
       return false;
@@ -183,7 +183,7 @@ void SetTransactionId(spanner::Transaction& txn, std::string tid) {
   Visit(txn,
         [&tid](SessionHolder&,
                StatusOr<google::spanner::v1::TransactionSelector>& selector,
-               std::string const&, std::int64_t) {
+               TransactionContext const&) {
           selector->set_id(std::move(tid));
           return 0;
         });
@@ -194,7 +194,7 @@ void SetTransactionInvalid(spanner::Transaction& txn, Status status) {
   Visit(txn,
         [&status](SessionHolder&,
                   StatusOr<google::spanner::v1::TransactionSelector>& selector,
-                  std::string const&, std::int64_t) {
+                  TransactionContext const&) {
           selector = std::move(status);
           return 0;
         });

--- a/google/cloud/spanner/internal/transaction_impl_test.cc
+++ b/google/cloud/spanner/internal/transaction_impl_test.cc
@@ -76,13 +76,14 @@ class Client {
     auto read = [this, &table, &keys, &columns](
                     SessionHolder& session,
                     StatusOr<TransactionSelector>& selector,
-                    std::string const& tag, std::int64_t seqno) {
-      return this->Read(session, selector, tag, seqno, table, keys, columns);
+                    TransactionContext const& ctx) {
+      return this->Read(session, selector, ctx.tag, ctx.seqno, table, keys,
+                        columns);
     };
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     try {
 #endif
-      return spanner_internal::Visit(std::move(txn), std::move(read));
+      return Visit(std::move(txn), std::move(read));
 #if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
     } catch (char const*) {
       return {};
@@ -156,7 +157,7 @@ ResultSet Client::Read(SessionHolder& session,
     switch (mode_) {
       case Mode::kReadSucceeds:
         // `begin` -> `id`, calls now parallelized
-        session = spanner_internal::MakeDissociatedSessionHolder(session_id_);
+        session = MakeDissociatedSessionHolder(session_id_);
         selector->set_id(txn_id_);
         break;
       case Mode::kReadFailsAndTxnRemainsBegin:

--- a/google/cloud/spanner/testing/matchers.h
+++ b/google/cloud/spanner/testing/matchers.h
@@ -32,10 +32,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 MATCHER_P3(
     HasSessionAndTransaction, session_id, transaction_id, transaction_tag,
     "Verifies a Transaction has the expected Session and Transaction IDs") {
-  return google::cloud::spanner_internal::Visit(
-      arg, [&](google::cloud::spanner_internal::SessionHolder& session,
+  return spanner_internal::Visit(
+      arg, [&](spanner_internal::SessionHolder& session,
                StatusOr<google::spanner::v1::TransactionSelector>& s,
-               std::string const& tag, std::int64_t) {
+               spanner_internal::TransactionContext const& ctx) {
         bool result = true;
         if (!session) {
           *result_listener << "Session ID missing (expected " << session_id
@@ -57,8 +57,8 @@ MATCHER_P3(
                            << " != " << transaction_id;
           result = false;
         }
-        if (tag != transaction_tag) {
-          *result_listener << "Transaction tag mismatch: " << tag
+        if (ctx.tag != transaction_tag) {
+          *result_listener << "Transaction tag mismatch: " << ctx.tag
                            << " != " << transaction_tag;
           result = false;
         }


### PR DESCRIPTION
Introduce `TransactionContext` to encapsulate the read-only callback
parameters to the transaction visitation functor.

When we added the first parameter, `seqno`, we said, "Great, a single
extra parameter."  When we added the second parameter, `tag`, we
said, "This might get out of hand, but there's no time to fix it now."

A third parameter is on the horizon, so let's take the opportunity to
add a "context" struct now to house all the additional transaction
data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8933)
<!-- Reviewable:end -->
