### PR TITLE
cleanup(pubsub): revert breaking change for `SubscriberOptions`

### DIFF
--- a/google/cloud/pubsub/subscriber_options.cc
+++ b/google/cloud/pubsub/subscriber_options.cc
@@ -23,6 +23,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 using seconds = std::chrono::seconds;
 
+// Cannot delegate on `SubscriberOptions(Options)` as it is deprecated.
+SubscriberOptions::SubscriberOptions() {
+  opts_ = pubsub_internal::DefaultSubscriberOptionsOnly(Options{});
+}
+
 SubscriberOptions::SubscriberOptions(Options opts) {
   internal::CheckExpectedOptions<SubscriberOptionList>(opts, __func__);
   opts_ = pubsub_internal::DefaultSubscriberOptionsOnly(std::move(opts));

--- a/google/cloud/pubsub/subscriber_options.h
+++ b/google/cloud/pubsub/subscriber_options.h
@@ -97,6 +97,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class SubscriberOptions {
  public:
   /**
+   * Initialize the subscriber options with default values.
+   *
+   * @deprecated Use `google::cloud::Options` instead.
+   */
+  GOOGLE_CLOUD_CPP_DEPRECATED("Use `google::cloud::Options` instead")
+  SubscriberOptions();
+
+  /**
    * Initialize the subscriber options.
    *
    * Expected options are any of the types in the `SubscriberOptionList`
@@ -110,7 +118,7 @@ class SubscriberOptions {
    * @deprecated Use `google::cloud::Options` instead.
    */
   GOOGLE_CLOUD_CPP_DEPRECATED("Use `google::cloud::Options` instead")
-  explicit SubscriberOptions(Options opts = {});
+  explicit SubscriberOptions(Options opts);
 
   /**
    * The maximum deadline for each incoming message.


### PR DESCRIPTION
In a previous PR I made the default constructor for `SubscriberOptions`
deprecated (this was intended) and `explicit` (this was not). This
restores the implicit default constructor for `SubscriberOptions`, so
expressions like `{}` will continue to work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8936)
<!-- Reviewable:end -->
