### PR TITLE
feat(common): `*Logging` decorator for asynchronous streaming read RPCs

### DIFF
--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -42,6 +42,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/async_streaming_read_rpc.h",
     "internal/async_streaming_read_rpc_auth.h",
     "internal/async_streaming_read_rpc_impl.h",
+    "internal/async_streaming_read_rpc_logging.h",
     "internal/background_threads_impl.h",
     "internal/completion_queue_impl.h",
     "internal/default_completion_queue_impl.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -48,6 +48,7 @@ add_library(
     internal/async_streaming_read_rpc.h
     internal/async_streaming_read_rpc_auth.h
     internal/async_streaming_read_rpc_impl.h
+    internal/async_streaming_read_rpc_logging.h
     internal/background_threads_impl.cc
     internal/background_threads_impl.h
     internal/completion_queue_impl.h
@@ -238,6 +239,7 @@ if (BUILD_TESTING)
         internal/async_retry_unary_rpc_test.cc
         internal/async_streaming_read_rpc_auth_test.cc
         internal/async_streaming_read_rpc_impl_test.cc
+        internal/async_streaming_read_rpc_logging_test.cc
         internal/background_threads_impl_test.cc
         internal/extract_long_running_result_test.cc
         internal/grpc_access_token_authentication_test.cc

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -31,6 +31,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/async_retry_unary_rpc_test.cc",
     "internal/async_streaming_read_rpc_auth_test.cc",
     "internal/async_streaming_read_rpc_impl_test.cc",
+    "internal/async_streaming_read_rpc_logging_test.cc",
     "internal/background_threads_impl_test.cc",
     "internal/extract_long_running_result_test.cc",
     "internal/grpc_access_token_authentication_test.cc",

--- a/google/cloud/internal/async_streaming_read_rpc_logging.h
+++ b/google/cloud/internal/async_streaming_read_rpc_logging.h
@@ -1,0 +1,90 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_LOGGING_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_LOGGING_H
+
+#include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/internal/log_wrapper.h"
+#include "google/cloud/tracing_options.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+template <typename Response>
+class AsyncStreamingReadRpcLogging : public AsyncStreamingReadRpc<Response> {
+ public:
+  AsyncStreamingReadRpcLogging(
+      std::unique_ptr<AsyncStreamingReadRpc<Response>> child,
+      TracingOptions tracing_options, std::string request_id)
+      : child_(std::move(child)),
+        tracing_options_(std::move(tracing_options)),
+        request_id_(std::move(request_id)) {}
+
+  void Cancel() override {
+    GCP_LOG(DEBUG) << "Cancel(" << request_id_ << ") <<";
+    child_->Cancel();
+  }
+
+  future<bool> Start() override {
+    auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+    GCP_LOG(DEBUG) << prefix << " <<";
+    return child_->Start().then([prefix](future<bool> f) {
+      auto r = f.get();
+      GCP_LOG(DEBUG) << prefix << " >> " << (r ? "true" : "false");
+      return r;
+    });
+  }
+
+  future<absl::optional<Response>> Read() override {
+    auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+    auto opt = tracing_options_;
+    GCP_LOG(DEBUG) << prefix << " <<";
+    return child_->Read().then(
+        [prefix, opt](future<absl::optional<Response>> f) {
+          auto r = f.get();
+          if (r.has_value()) {
+            GCP_LOG(DEBUG) << prefix << " >> " << DebugString(*r, opt);
+          } else {
+            GCP_LOG(DEBUG) << prefix << " >> [not-set]";
+          }
+          return r;
+        });
+  }
+
+  future<Status> Finish() override {
+    auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+    GCP_LOG(DEBUG) << prefix << " <<";
+    return child_->Finish().then([prefix](future<Status> f) {
+      auto status = f.get();
+      GCP_LOG(DEBUG) << prefix << " >> " << status;
+      return status;
+    });
+  }
+
+ private:
+  std::unique_ptr<AsyncStreamingReadRpc<Response>> child_;
+  TracingOptions tracing_options_;
+  std::string request_id_;
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ASYNC_STREAMING_READ_RPC_LOGGING_H

--- a/google/cloud/internal/async_streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/async_streaming_read_rpc_logging_test.cc
@@ -1,0 +1,122 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/async_streaming_read_rpc_logging.h"
+#include "google/cloud/status.h"
+#include "google/cloud/testing_util/scoped_log.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include "google/cloud/tracing_options.h"
+#include "absl/memory/memory.h"
+#include <google/protobuf/duration.pb.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::testing_util::ScopedLog;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::Contains;
+using ::testing::HasSubstr;
+
+template <typename Response>
+class MockAsyncStreamingReadRpc : public AsyncStreamingReadRpc<Response> {
+ public:
+  ~MockAsyncStreamingReadRpc() override = default;
+
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<Response>>, Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+};
+
+class StreamingReadRpcLoggingTest : public ::testing::Test {
+ protected:
+};
+
+using MockStream = MockAsyncStreamingReadRpc<google::protobuf::Duration>;
+using TestedStream = AsyncStreamingReadRpcLogging<google::protobuf::Duration>;
+
+TEST(StreamingReadRpcLoggingTest, Cancel) {
+  ScopedLog log;
+
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Cancel()).Times(1);
+  TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
+  stream.Cancel();
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(AllOf(HasSubstr("Cancel"), HasSubstr("test-id"))));
+}
+
+TEST(StreamingReadRpcLoggingTest, Start) {
+  ScopedLog log;
+
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
+  TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
+  EXPECT_TRUE(stream.Start().get());
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(AllOf(HasSubstr("Start"), HasSubstr("test-id"))));
+}
+
+TEST(StreamingReadRpcLoggingTest, ReadWithValue) {
+  ScopedLog log;
+
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::make_optional(google::protobuf::Duration{}));
+  });
+  TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
+  EXPECT_TRUE(stream.Read().get().has_value());
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(AllOf(HasSubstr("Read"), HasSubstr("test-id"),
+                             HasSubstr("Duration"))));
+}
+
+TEST(StreamingReadRpcLoggingTest, ReadWithoutValue) {
+  ScopedLog log;
+
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::optional<google::protobuf::Duration>{});
+  });
+  TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
+  ASSERT_FALSE(stream.Read().get().has_value());
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(AllOf(HasSubstr("Read"), HasSubstr("test-id"),
+                             HasSubstr("[not-set]"))));
+}
+
+TEST(StreamingReadRpcLoggingTest, Finish) {
+  ScopedLog log;
+
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, Finish).WillOnce([] {
+    return make_ready_future(Status{StatusCode::kUnavailable, "try-again"});
+  });
+  TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
+  EXPECT_THAT(stream.Finish().get(),
+              StatusIs(StatusCode::kUnavailable, "try-again"));
+  EXPECT_THAT(log.ExtractLines(),
+              Contains(AllOf(HasSubstr("Finish"), HasSubstr("test-id"),
+                             HasSubstr("try-again"))));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Part of the work for #8937 
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8947)
<!-- Reviewable:end -->
