### PR TITLE
refactor(bigtable): use variant<status, T> not StatusOr<optional<T>>

### DIFF
--- a/google/cloud/bigtable/internal/legacy_row_reader_impl.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader_impl.cc
@@ -105,17 +105,20 @@ bool LegacyRowReaderImpl::NextChunk() {
   return true;
 }
 
-StatusOr<RowReaderImpl::OptionalRow> LegacyRowReaderImpl::Advance() {
+absl::variant<Status, bigtable::Row> LegacyRowReaderImpl::Advance() {
   if (operation_cancelled_) {
     return Status(StatusCode::kCancelled, "Operation cancelled.");
   }
   while (true) {
-    OptionalRow row;
-    grpc::Status status = AdvanceOrFail(row);
-    if (status.ok()) {
-      return row;
+    auto variant = AdvanceOrFail();
+    if (absl::holds_alternative<bigtable::Row>(variant)) {
+      return absl::get<bigtable::Row>(std::move(variant));
     }
-    row.reset();
+
+    auto status = absl::get<Status>(std::move(variant));
+    if (status.ok()) {
+      return Status();
+    }
 
     // In the unlikely case when we have already reached the requested
     // number of rows and still receive an error (the parser can throw
@@ -123,7 +126,7 @@ StatusOr<RowReaderImpl::OptionalRow> LegacyRowReaderImpl::Advance() {
     // retry and we have no good value for rows_limit anyway.
     if (rows_limit_ != bigtable::RowReader::NO_ROWS_LIMIT &&
         rows_limit_ <= rows_count_) {
-      return row;
+      return Status();
     }
 
     if (!last_read_row_key_.empty()) {
@@ -135,11 +138,11 @@ StatusOr<RowReaderImpl::OptionalRow> LegacyRowReaderImpl::Advance() {
 
     // If we receive an error, but the retryable set is empty, stop.
     if (row_set_.IsEmpty()) {
-      return row;
+      return Status();
     }
 
     if (!retry_policy_->OnFailure(status)) {
-      return MakeStatusFromRpcError(status);
+      return status;
     }
 
     auto delay = backoff_policy_->OnCompletion(status);
@@ -150,8 +153,7 @@ StatusOr<RowReaderImpl::OptionalRow> LegacyRowReaderImpl::Advance() {
   }
 }
 
-grpc::Status LegacyRowReaderImpl::AdvanceOrFail(OptionalRow& row) {
-  row.reset();
+absl::variant<Status, bigtable::Row> LegacyRowReaderImpl::AdvanceOrFail() {
   grpc::Status status;
   if (!stream_) {
     MakeRequest();
@@ -162,7 +164,7 @@ grpc::Status LegacyRowReaderImpl::AdvanceOrFail(OptionalRow& row) {
           std::move(*(response_.mutable_chunks(processed_chunks_count_))),
           status);
       if (!status.ok()) {
-        return status;
+        return MakeStatusFromRpcError(status);
       }
       continue;
     }
@@ -173,22 +175,20 @@ grpc::Status LegacyRowReaderImpl::AdvanceOrFail(OptionalRow& row) {
     stream_is_open_ = false;
     status = stream_->Finish();
     if (!status.ok()) {
-      return status;
+      return MakeStatusFromRpcError(status);
     }
     parser_->HandleEndOfStream(status);
-    return status;
+    return MakeStatusFromRpcError(status);
   }
 
   // We have a complete row in the parser.
   bigtable::Row parsed_row = parser_->Next(status);
   if (!status.ok()) {
-    return status;
+    return MakeStatusFromRpcError(status);
   }
-  row.emplace(std::move(parsed_row));
   ++rows_count_;
-  last_read_row_key_ = std::string(row.value().row_key());
-
-  return status;
+  last_read_row_key_ = parsed_row.row_key();
+  return parsed_row;
 }
 
 void LegacyRowReaderImpl::Cancel() {

--- a/google/cloud/bigtable/internal/legacy_row_reader_impl.h
+++ b/google/cloud/bigtable/internal/legacy_row_reader_impl.h
@@ -25,8 +25,7 @@
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
-#include "google/cloud/optional.h"
-#include "absl/types/optional.h"
+#include "absl/types/variant.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <grpcpp/grpcpp.h>
 #include <cinttypes>
@@ -74,11 +73,11 @@ class LegacyRowReaderImpl : public RowReaderImpl {
    *
    * This call possibly blocks waiting for data until a full row is available.
    */
-  StatusOr<OptionalRow> Advance() override;
+  absl::variant<Status, bigtable::Row> Advance() override;
 
  private:
   /// Called by Advance(), does not handle retries.
-  grpc::Status AdvanceOrFail(OptionalRow& row);
+  absl::variant<Status, bigtable::Row> AdvanceOrFail();
 
   /**
    * Move the `processed_chunks_count_` index to the next chunk,

--- a/google/cloud/bigtable/internal/row_reader_impl.h
+++ b/google/cloud/bigtable/internal/row_reader_impl.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ROW_READER_IMPL_H
 
 #include "google/cloud/bigtable/row.h"
-#include "absl/types/optional.h"
+#include "absl/types/variant.h"
 
 namespace google {
 namespace cloud {
@@ -30,8 +30,7 @@ class RowReaderImpl {
 
   virtual void Cancel() = 0;
 
-  using OptionalRow = absl::optional<bigtable::Row>;
-  virtual StatusOr<OptionalRow> Advance() = 0;
+  virtual absl::variant<Status, bigtable::Row> Advance() = 0;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
refactor `RowReader` / `RowReaderIterator` to deal in `absl::variant<Status, Row>`s instead of `StatusOr<absl::optional<Row>>`s. This is more consistent with the interface `StreamRange` expects. In a subsequent PR I will probably implement RowReader in terms of a StreamRange (which will allow me to delete `bigtable/internal/rowreader_iterator.{h,cc}`)


 | previous type: `StatusOr<absl::optional<Row>>` | new type: `absl::variant<Status, Row>` |
|-|-|
| has `Row` | has `Row`|
| bad Status | has bad Status |
| has `absl::nullopt` | has OK Status|

<hr />

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8948)
<!-- Reviewable:end -->
