### PR TITLE
refactor(rest): leverage AuthorityOption to override Host header

### DIFF
--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -90,8 +90,9 @@ std::string CurlRestClient::HostHeader(Options const& options,
   // AuthorityOption.
   auto const& auth = options.get<AuthorityOption>();
   if (!auth.empty()) return absl::StrCat("Host: ", auth);
-  if (absl::StrContains(endpoint, "googleapis.com"))
+  if (absl::StrContains(endpoint, "googleapis.com")) {
     return absl::StrCat("Host: ", FormatHostHeaderValue(endpoint));
+  }
   return {};
 }
 

--- a/google/cloud/internal/curl_rest_client.cc
+++ b/google/cloud/internal/curl_rest_client.cc
@@ -79,19 +79,19 @@ std::string FormatHostHeaderValue(absl::string_view hostname) {
 }  // namespace
 
 std::string CurlRestClient::HostHeader(Options const& options,
-                                       std::string const& default_endpoint) {
+                                       std::string const& endpoint) {
   // If this function returns an empty string libcurl will fill out the `Host: `
   // header based on the URL. In most cases this is the correct value. The main
   // exception are applications using `VPC-SC`:
   //     https://cloud.google.com/vpc/docs/configure-private-google-access
   // In those cases the application would target a URL like
   // `https://restricted.googleapis.com`, or `https://private.googleapis.com`,
-  // or their own proxy, and need to provide the target's service host.
+  // or their own proxy, and need to provide the target's service host via the
+  // AuthorityOption.
   auto const& auth = options.get<AuthorityOption>();
   if (!auth.empty()) return absl::StrCat("Host: ", auth);
-  auto const& endpoint = options.get<RestEndpointOption>();
   if (absl::StrContains(endpoint, "googleapis.com"))
-    return absl::StrCat("Host: ", FormatHostHeaderValue(default_endpoint));
+    return absl::StrCat("Host: ", FormatHostHeaderValue(endpoint));
   return {};
 }
 

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -38,7 +38,7 @@ class CurlImpl;
 class CurlRestClient : public RestClient {
  public:
   static std::string HostHeader(Options const& options,
-                                std::string const& default_endpoint);
+                                std::string const& endpoint);
   ~CurlRestClient() override = default;
 
   CurlRestClient(CurlRestClient const&) = delete;

--- a/google/cloud/internal/curl_rest_client_test.cc
+++ b/google/cloud/internal/curl_rest_client_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/curl_rest_client.h"
+#include "google/cloud/common_options.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -21,38 +22,48 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::testing::Eq;
+TEST(CurlRestClientStandaloneFunctions, HostHeader) {
+  struct Test {
+    std::string endpoint;
+    std::string authority;
+    std::string expected;
+  } cases[] = {
+      {"https://storage.googleapis.com", "storage.googleapis.com",
+       "Host: storage.googleapis.com"},
+      {"https://storage.googleapis.com", "",
+       "Host: storage.googleapis.com"},
+      {"https://storage.googleapis.com", "auth", "Host: auth"},
+      {"https://storage.googleapis.com:443", "storage.googleapis.com",
+       "Host: storage.googleapis.com"},
+      {"https://restricted.googleapis.com", "storage.googleapis.com",
+       "Host: storage.googleapis.com"},
+      {"https://private.googleapis.com", "storage.googleapis.com",
+       "Host: storage.googleapis.com"},
+      {"https://restricted.googleapis.com", "iamcredentials.googleapis.com",
+       "Host: iamcredentials.googleapis.com"},
+      {"https://private.googleapis.com", "iamcredentials.googleapis.com",
+       "Host: iamcredentials.googleapis.com"},
+      {"http://localhost:8080", "", ""},
+      {"http://localhost:8080", "auth", "Host: auth"},
+      {"http://[::1]", "", ""},
+      {"http://[::1]/", "", ""},
+      {"http://[::1]/foo/bar", "", ""},
+      {"http://[::1]:8080/", "", ""},
+      {"http://[::1]:8080/foo/bar", "", ""},
+      {"http://localhost:8080", "", ""},
+      {"https://storage-download.127.0.0.1.nip.io/xmlapi/", "", ""},
+      {"https://gcs.127.0.0.1.nip.io/storage/v1/", "", ""},
+      {"https://gcs.127.0.0.1.nip.io:4443/upload/storage/v1/", "", ""},
+      {"https://gcs.127.0.0.1.nip.io:4443/upload/storage/v1/", "", ""},
+  };
 
-TEST(HostHeader, OptionNotSet) {
-  auto result = CurlRestClient::HostHeader({}, "endpoint.foo.com");
-  EXPECT_TRUE(result.empty());
-}
-
-TEST(HostHeader, OptionSetNotGoogleapis) {
-  auto result = CurlRestClient::HostHeader(
-      Options{}.set<RestEndpointOption>("private.foo.com"), "endpoint.foo.com");
-  EXPECT_TRUE(result.empty());
-}
-
-TEST(HostHeader, OptionSetGoogleapis) {
-  auto result = CurlRestClient::HostHeader(
-      Options{}.set<RestEndpointOption>("private.googleapis.com"),
-      "endpoint.googleapis.com");
-  EXPECT_THAT(result, Eq("Host: endpoint.googleapis.com"));
-}
-
-TEST(HostHeader, OptionSetGoogleapisMisformatted) {
-  auto result = CurlRestClient::HostHeader(
-      Options{}.set<RestEndpointOption>("private.googleapis.com"),
-      "https://endpoint.googleapis.com");
-  EXPECT_THAT(result, Eq("Host: endpoint.googleapis.com"));
-}
-
-TEST(HostHeader, OptionSetGoogleapisMisformattedAgain) {
-  auto result = CurlRestClient::HostHeader(
-      Options{}.set<RestEndpointOption>("private.googleapis.com"),
-      "https://endpoint.googleapis.com/v1/");
-  EXPECT_THAT(result, Eq("Host: endpoint.googleapis.com"));
+  for (auto const& test : cases) {
+    SCOPED_TRACE("Testing for " + test.endpoint + ", " + test.authority);
+    Options options;
+    if (!test.authority.empty()) options.set<AuthorityOption>(test.authority);
+    auto const actual = CurlRestClient::HostHeader(options, test.endpoint);
+    EXPECT_EQ(test.expected, actual);
+  }
 }
 
 }  // namespace

--- a/google/cloud/internal/curl_rest_client_test.cc
+++ b/google/cloud/internal/curl_rest_client_test.cc
@@ -30,8 +30,7 @@ TEST(CurlRestClientStandaloneFunctions, HostHeader) {
   } cases[] = {
       {"https://storage.googleapis.com", "storage.googleapis.com",
        "Host: storage.googleapis.com"},
-      {"https://storage.googleapis.com", "",
-       "Host: storage.googleapis.com"},
+      {"https://storage.googleapis.com", "", "Host: storage.googleapis.com"},
       {"https://storage.googleapis.com", "auth", "Host: auth"},
       {"https://storage.googleapis.com:443", "storage.googleapis.com",
        "Host: storage.googleapis.com"},


### PR DESCRIPTION
Simplify Host header population by using the AuthorityOption as an override. Otherwise, if the endpoint is a googleapis.com address, use it for the Host header. This adds the burden of correctly specifying the AuthorityOption to the library being built on top of the RestLibrary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8950)
<!-- Reviewable:end -->
