### PR TITLE
feat(generate): async streaming reads for `*Stub`

### DIFF
--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -79,6 +79,13 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::WriteObjectResponse>> WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::TailLogEntriesResponse>>
+  AsyncTailLogEntries(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<GoldenKitchenSinkStub> child_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -80,6 +80,13 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
    WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::TailLogEntriesResponse>>
+  AsyncTailLogEntries(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+
  private:
   std::shared_ptr<GoldenKitchenSinkStub> child_;
   TracingOptions tracing_options_;

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -108,6 +108,16 @@ GoldenKitchenSinkMetadata::WriteObject(
   return child_->WriteObject(std::move(context));
 }
 
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::TailLogEntriesResponse>>
+GoldenKitchenSinkMetadata::AsyncTailLogEntries(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+  SetMetadata(*context);
+  return child_->AsyncTailLogEntries(cq, std::move(context), request);
+}
+
 void GoldenKitchenSinkMetadata::SetMetadata(grpc::ClientContext& context,
                                         std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -76,6 +76,13 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
   WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::TailLogEntriesResponse>>
+  AsyncTailLogEntries(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -20,6 +20,7 @@
 #include "absl/memory/memory.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/async_read_write_stream_impl.h"
+#include "google/cloud/internal/async_streaming_read_rpc_impl.h"
 #include "google/cloud/status_or.h"
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
@@ -142,6 +143,19 @@ DefaultGoldenKitchenSinkStub::WriteObject(
   return absl::make_unique<::google::cloud::internal::StreamingWriteRpcImpl<
       google::test::admin::database::v1::WriteObjectRequest, google::test::admin::database::v1::WriteObjectResponse>>(
     std::move(context), std::move(response), std::move(stream));
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::test::admin::database::v1::TailLogEntriesResponse>>
+DefaultGoldenKitchenSinkStub::AsyncTailLogEntries(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::test::admin::database::v1::TailLogEntriesRequest const& request) {
+  return google::cloud::internal::MakeStreamingReadRpc<google::test::admin::database::v1::TailLogEntriesRequest, google::test::admin::database::v1::TailLogEntriesResponse>(
+    cq, std::move(context), request,
+    [this](grpc::ClientContext* context, google::test::admin::database::v1::TailLogEntriesRequest const& request, grpc::CompletionQueue* cq) {
+      return grpc_stub_->PrepareAsyncTailLogEntries(context, request, cq);
+    });
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -21,7 +21,6 @@
 
 #include "google/cloud/async_streaming_read_write_rpc.h"
 #include "google/cloud/completion_queue.h"
-#include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
 #include "google/cloud/internal/async_streaming_read_rpc.h"
 #include "google/cloud/internal/streaming_read_rpc.h"

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -21,6 +21,9 @@
 
 #include "google/cloud/async_streaming_read_write_rpc.h"
 #include "google/cloud/completion_queue.h"
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
+#include "google/cloud/internal/async_streaming_read_rpc.h"
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/internal/streaming_write_rpc.h"
 #include "google/cloud/status_or.h"
@@ -79,6 +82,13 @@ class GoldenKitchenSinkStub {
       google::test::admin::database::v1::WriteObjectResponse>>
   WriteObject(
       std::unique_ptr<grpc::ClientContext> context) = 0;
+
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::TailLogEntriesResponse>>
+  AsyncTailLogEntries(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::TailLogEntriesRequest const& request) = 0;
 };
 
 class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
@@ -134,6 +144,13 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::WriteObjectResponse>>
   WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::test::admin::database::v1::TailLogEntriesResponse>>
+  AsyncTailLogEntries(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::test::admin::database::v1::TailLogEntriesRequest const& request) override;
 
  private:
   std::unique_ptr<google::test::admin::database::v1::GoldenKitchenSink::StubInterface> grpc_stub_;

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -88,6 +88,15 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       WriteObject,
       (std::unique_ptr<grpc::ClientContext> context),
       (override));
+
+  MOCK_METHOD(
+    (std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+         ::google::test::admin::database::v1::TailLogEntriesResponse>>),
+    AsyncTailLogEntries,
+    (google::cloud::CompletionQueue const& cq,
+     std::unique_ptr<grpc::ClientContext> context,
+     ::google::test::admin::database::v1::TailLogEntriesRequest const&),
+    (override));
 };
 
 class MockTailLogEntriesStreamingReadRpc
@@ -106,6 +115,15 @@ public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(bool, Write, (::google::test::admin::database::v1::WriteObjectRequest const&, grpc::WriteOptions), (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::WriteObjectResponse>, Close, (), (override));
+};
+
+class MockTailLogEntriesAsyncStreamingReadRpc
+    : public google::cloud::internal::AsyncStreamingReadRpc<::google::test::admin::database::v1::TailLogEntriesResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<::google::test::admin::database::v1::TailLogEntriesResponse>>, Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden_config.textproto
+++ b/generator/integration_tests/golden_config.textproto
@@ -22,6 +22,6 @@ service {
   omitted_rpcs: ["Omitted1", "GoldenKitchenSink.Omitted2"]
   service_endpoint_env_var: "GOLDEN_KITCHEN_SINK_ENDPOINT"
   emulator_endpoint_env_var: "GOLDEN_KITCHEN_SINK_EMULATOR_HOST"
-  gen_async_rpcs: ["GetDatabase", "DropDatabase"]
+  gen_async_rpcs: ["GetDatabase", "DropDatabase", "TailLogEntries"]
   retryable_status_codes: ["GoldenKitchenSink.kInternal", "kUnavailable", "GoldenThingAdmin.kDeadlineExceeded"]
 }

--- a/generator/internal/auth_decorator_generator.cc
+++ b/generator/internal/auth_decorator_generator.cc
@@ -122,6 +122,18 @@ class $auth_class_name$ : public $stub_class_name$ {
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) {
+      auto constexpr kDeclaration = R"""(
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)""";
+      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      continue;
+    }
     HeaderPrintMethod(
         method,
         {MethodPattern({{IsResponseTypeEmpty,
@@ -183,6 +195,9 @@ Status AuthDecoratorGenerator::GenerateCc() {
       vars("auth_header_path"),
       HasBidirStreamingMethod()
           ? "google/cloud/internal/async_read_write_stream_auth.h"
+          : "",
+      HasAsynchronousStreamingReadMethod()
+          ? "google/cloud/internal/async_streaming_read_rpc_auth.h"
           : "",
   });
   CcSystemIncludes({vars("proto_grpc_header_path"), "memory"});
@@ -291,6 +306,28 @@ $auth_class_name$::$method_name$(
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) {
+      auto constexpr kDefinition = R"""(
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    $response_type$>>
+$auth_class_name$::Async$method_name$(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    $request_type$ const& request) {
+  using StreamAuth = google::cloud::internal::AsyncStreamingReadRpcAuth<
+    $response_type$>;
+
+  auto child = child_;
+  auto call = [child, cq, request](std::unique_ptr<grpc::ClientContext> ctx) {
+    return child->Async$method_name$(cq, std::move(ctx), request);
+  };
+  return absl::make_unique<StreamAuth>(
+    std::move(context), auth_, StreamAuth::StreamFactory(std::move(call)));
+}
+)""";
+      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+      continue;
+    }
     CcPrintMethod(
         method,
         {MethodPattern({{IsResponseTypeEmpty,

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -263,6 +263,7 @@ Status ClientGenerator::GenerateHeader() {
   }
 
   for (google::protobuf::MethodDescriptor const& method : async_methods()) {
+    if (IsStreamingRead(method)) continue;
     auto method_signature_extension =
         method.options().GetRepeatedExtension(google::api::method_signature);
     for (int i = 0; i < method_signature_extension.size(); ++i) {
@@ -558,6 +559,7 @@ $client_class_name$::Async$method_name$(ExperimentalTag tag, Options opts) {
   }
 
   for (google::protobuf::MethodDescriptor const& method : async_methods()) {
+    if (IsStreamingRead(method)) continue;
     auto method_signature_extension =
         method.options().GetRepeatedExtension(google::api::method_signature);
     for (int i = 0; i < method_signature_extension.size(); ++i) {

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -172,6 +172,7 @@ Status ConnectionGenerator::GenerateHeader() {
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) continue;
     HeaderPrintMethod(
         method,
         {MethodPattern(
@@ -333,6 +334,7 @@ $connection_class_name$::Async$method_name$(ExperimentalTag) {
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) continue;
     CcPrintMethod(
         method,
         {MethodPattern({{IsResponseTypeEmpty, R"""(

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -105,6 +105,7 @@ class $connection_class_name$Impl
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) continue;
     HeaderPrintMethod(method, __FILE__, __LINE__,
                       AsyncMethodDeclaration(method));
   }
@@ -215,6 +216,7 @@ $connection_class_name$Impl::$connection_class_name$Impl(
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) continue;
     CcPrintMethod(method, __FILE__, __LINE__, AsyncMethodDefinition(method));
   }
 

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -128,6 +128,13 @@ bool ServiceCodeGenerator::HasStreamingReadMethod() const {
                      });
 }
 
+bool ServiceCodeGenerator::HasAsynchronousStreamingReadMethod() const {
+  return std::any_of(async_methods_.begin(), async_methods_.end(),
+                     [](google::protobuf::MethodDescriptor const& m) {
+                       return IsStreamingRead(m);
+                     });
+}
+
 bool ServiceCodeGenerator::HasStreamingWriteMethod() const {
   return std::any_of(methods_.begin(), methods_.end(),
                      [](google::protobuf::MethodDescriptor const& m) {

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -122,6 +122,12 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool HasStreamingReadMethod() const;
 
   /**
+   * Determines if we need to generate at least one asynchronous streaming read
+   * RPC.
+   */
+  bool HasAsynchronousStreamingReadMethod() const;
+
+  /**
    * Determines if the service contains at least once rpc with a stream
    * request.
    */

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -57,6 +57,9 @@ Status StubGenerator::GenerateHeader() {
                                 : "",
        HasStreamingWriteMethod() ? "google/cloud/internal/streaming_write_rpc.h"
                                  : "",
+       HasAsynchronousStreamingReadMethod()
+           ? "google/cloud/internal/async_streaming_read_rpc.h"
+           : "",
        HasBidirStreamingMethod()
            ? "google/cloud/async_streaming_read_write_rpc.h"
            : "",
@@ -138,6 +141,18 @@ Status StubGenerator::GenerateHeader() {
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) {
+      auto constexpr kDeclaration = R"""(
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) = 0;
+)""";
+      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      continue;
+    }
     HeaderPrintMethod(
         method,
         {
@@ -255,6 +270,18 @@ Status StubGenerator::GenerateHeader() {
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) {
+      auto constexpr kDeclaration = R"""(
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      $response_type$>>
+  Async$method_name$(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      $request_type$ const& request) override;
+)""";
+      HeaderPrintMethod(method, __FILE__, __LINE__, kDeclaration);
+      continue;
+    }
     HeaderPrintMethod(
         method,
         {
@@ -322,6 +349,9 @@ Status StubGenerator::GenerateCc() {
   CcPrint("\n");
   CcLocalIncludes({vars("stub_header_path"),
                    HasStreamingReadMethod() ? "absl/memory/memory.h" : "",
+                   HasAsynchronousStreamingReadMethod()
+                       ? "google/cloud/internal/async_streaming_read_rpc_impl.h"
+                       : "",
                    HasBidirStreamingMethod()
                        ? "google/cloud/internal/async_read_write_stream_impl.h"
                        : "",
@@ -433,6 +463,24 @@ Default$stub_class_name$::Async$method_name$(
   }
 
   for (auto const& method : async_methods()) {
+    if (IsStreamingRead(method)) {
+      auto constexpr kDefinition = R"""(
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    $response_type$>>
+Default$stub_class_name$::Async$method_name$(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    $request_type$ const& request) {
+  return google::cloud::internal::MakeStreamingReadRpc<$request_type$, $response_type$>(
+    cq, std::move(context), request,
+    [this](grpc::ClientContext* context, $request_type$ const& request, grpc::CompletionQueue* cq) {
+      return grpc_stub_->PrepareAsync$method_name$(context, request, cq);
+    });
+}
+)""";
+      CcPrintMethod(method, __FILE__, __LINE__, kDefinition);
+      continue;
+    }
     CcPrintMethod(
         method,
         {MethodPattern(

--- a/generator/internal/stub_generator.cc
+++ b/generator/internal/stub_generator.cc
@@ -49,22 +49,22 @@ Status StubGenerator::GenerateHeader() {
 
   // includes
   HeaderPrint("\n");
+  auto const needs_completion_queue =
+      HasAsyncMethod() || HasBidirStreamingMethod();
   HeaderLocalIncludes(
-      {HasAsyncMethod() ? "google/cloud/completion_queue.h" : "",
+      {HasBidirStreamingMethod()
+           ? "google/cloud/async_streaming_read_write_rpc.h"
+           : "",
+       needs_completion_queue ? "google/cloud/completion_queue.h" : "",
        HasAsyncMethod() ? "google/cloud/future.h" : "",
-       "google/cloud/status_or.h",
+       HasAsynchronousStreamingReadMethod()
+           ? "google/cloud/internal/async_streaming_read_rpc.h"
+           : "",
        HasStreamingReadMethod() ? "google/cloud/internal/streaming_read_rpc.h"
                                 : "",
        HasStreamingWriteMethod() ? "google/cloud/internal/streaming_write_rpc.h"
                                  : "",
-       HasAsynchronousStreamingReadMethod()
-           ? "google/cloud/internal/async_streaming_read_rpc.h"
-           : "",
-       HasBidirStreamingMethod()
-           ? "google/cloud/async_streaming_read_write_rpc.h"
-           : "",
-       HasBidirStreamingMethod() ? "google/cloud/completion_queue.h" : "",
-       "google/cloud/version.h"});
+       "google/cloud/status_or.h", "google/cloud/version.h"});
   std::vector<std::string> additional_pb_header_paths =
       absl::StrSplit(vars("additional_pb_header_paths"), absl::ByChar(','));
   HeaderSystemIncludes(additional_pb_header_paths);


### PR DESCRIPTION
The generator can add asynchronous streaming reads in the `*Stub`
classes and their decorators.  No code is generated for the
`*Connection` or `*Client` classes.  We still don't know what is the
right API at that layer, and the services that need this have
hand-crafted `*Connection` and `*Client` layers at the moment.

Fixes #8937

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8951)
<!-- Reviewable:end -->
