### PR TITLE
ci: detect when generator creates new files

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -53,7 +53,7 @@ io::log_h2 "Highlight generated code differences"
 git diff --exit-code generator/integration_tests/golden/ google/ ci/
 
 io::log_h2 "Highlight new files"
-if [[ ! -z "$(git status --porcelain)" ]]; then
+if [[ -n "$(git status --porcelain)" ]]; then
   io::log_red "New unmanaged files created by generator"
   git status
   exit 1

--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -51,3 +51,10 @@ git ls-files -z | grep -zE '\.(cc|h)$' |
 # it's run while editing files in generator/...
 io::log_h2 "Highlight generated code differences"
 git diff --exit-code generator/integration_tests/golden/ google/ ci/
+
+io::log_h2 "Highlight new files"
+if [[ ! -z "$(git status --porcelain)" ]]; then
+  io::log_red "New unmanaged files created by generator"
+  git status
+  exit 1
+fi


### PR DESCRIPTION
If a new service is added to an existing proto file, the generator
creates new files. We want to detect these and add the new generated
files to the right library, or maybe omit the service if there are very
good reasons to do so.

Fixes #7584

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8952)
<!-- Reviewable:end -->
