### PR TITLE
feat(bigtable): default construct a RowReader

### DIFF
--- a/google/cloud/bigtable/internal/row_reader_impl.h
+++ b/google/cloud/bigtable/internal/row_reader_impl.h
@@ -33,6 +33,24 @@ class RowReaderImpl {
   virtual absl::variant<Status, bigtable::Row> Advance() = 0;
 };
 
+/**
+ * A simple `RowReader` implementation that returns a `Status`.
+ *
+ * An OK `StatusCode` represents a stream with no rows. Any other `StatusCode`
+ * represents a stream with an immediate failure.
+ */
+class StatusOnlyRowReader : public RowReaderImpl {
+ public:
+  explicit StatusOnlyRowReader(Status s) : status_(std::move(s)) {}
+
+  void Cancel() override{};
+
+  absl::variant<Status, bigtable::Row> Advance() override { return status_; }
+
+ private:
+  Status status_;
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal
 }  // namespace cloud

--- a/google/cloud/bigtable/row_reader.cc
+++ b/google/cloud/bigtable/row_reader.cc
@@ -62,6 +62,10 @@ static_assert(std::is_same<decltype(++std::declval<RowReader::iterator>()),
               "++it when it is of RowReader::iterator type must be a "
               "RowReader::iterator &>");
 
+RowReader::RowReader()
+    : RowReader(
+          std::make_shared<bigtable_internal::StatusOnlyRowReader>(Status{})) {}
+
 RowReader::RowReader(
     std::shared_ptr<DataClient> client, std::string table_name, RowSet row_set,
     std::int64_t rows_limit, Filter filter,

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -60,6 +60,9 @@ class RowReader {
   // NOLINTNEXTLINE(readability-identifier-naming)
   static std::int64_t constexpr NO_ROWS_LIMIT = 0;
 
+  /// Default constructs an empty RowReader.
+  RowReader();
+
   GOOGLE_CLOUD_CPP_BIGTABLE_ROW_READER_CTOR_DEPRECATED()
   RowReader(std::shared_ptr<DataClient> client, std::string table_name,
             RowSet row_set, std::int64_t rows_limit, Filter filter,

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -39,6 +39,7 @@ using ::google::cloud::bigtable::Row;
 using ::google::cloud::bigtable::testing::MockBackoffPolicy;
 using ::google::cloud::bigtable::testing::MockReadRowsReader;
 using ::google::cloud::bigtable::testing::MockRetryPolicy;
+using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::_;
 using ::testing::An;
@@ -843,6 +844,22 @@ TEST_F(RowReaderTest, FailedStreamRetryNewContext) {
   EXPECT_NE(it, reader.end());
   ASSERT_STATUS_OK(*it);
   EXPECT_EQ((*it)->row_key(), "r1");
+  EXPECT_EQ(++it, reader.end());
+}
+
+TEST(RowReader, DefaultConstructor) {
+  RowReader reader;
+  EXPECT_EQ(reader.begin(), reader.end());
+}
+
+TEST(RowReader, BadStatusOnly) {
+  auto impl = std::make_shared<bigtable_internal::StatusOnlyRowReader>(
+      Status(StatusCode::kUnimplemented, "unimplemented"));
+  auto reader = bigtable_internal::MakeRowReader(std::move(impl));
+
+  auto it = reader.begin();
+  EXPECT_NE(it, reader.end());
+  EXPECT_THAT(*it, StatusIs(StatusCode::kUnimplemented));
   EXPECT_EQ(++it, reader.end());
 }
 


### PR DESCRIPTION
Fixes #8892 

Let's just keep this simple. Adding a `StatusOnlyRowReader` will let me construct a default `RowReader`. It will also let me return an unimplemented `RowReader` (which I want for the default `DataConnection`). I will deal with mocking later.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8958)
<!-- Reviewable:end -->
