### PR TITLE
cleanup(storage): stop trying to uninstall Werkzeug

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -28,7 +28,7 @@ source module ci/cloudbuild/builds/lib/git.sh
 
 # To run the integration tests we need to install the dependencies for the storage emulator
 export PATH="${HOME}/.local/bin:${PATH}"
-python3 -m pip uninstall -y --quiet googleapis-storage-testbench Werkzeug
+python3 -m pip uninstall -y --quiet googleapis-storage-testbench
 python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
   "git+https://github.com/googleapis/storage-testbench@v0.20.0"
 


### PR DESCRIPTION
Now that we no longer pin Werkzeug (#8875), we also no longer need
to uninstall the default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8959)
<!-- Reviewable:end -->
