### PR TITLE
ci(generate-libraries): run update_libraries.sh

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -46,6 +46,9 @@ io::log_h2 "Formatting generated code"
 git ls-files -z | grep -zE '\.(cc|h)$' |
   xargs -P "$(nproc)" -n 1 -0 clang-format -i
 
+io::log_h2 "Updating protobuf lists/deps"
+external/googleapis/update_libraries.sh
+
 # This build should fail if any generated files differ from what was checked
 # in. We only look in the google/ directory so that the build doesn't fail if
 # it's run while editing files in generator/...


### PR DESCRIPTION
Update the protobuf lists/deps during the `generate-libraries` build.
Any edits or new files this produces will be cause the build to fail
due to the subsequent git diff/status checks.  Part of #7372.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8961)
<!-- Reviewable:end -->
