### PR TITLE
impl(bigtable): generate async streaming read rpcs in stubs

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -155,7 +155,10 @@ service {
   gen_async_rpcs: [
    "CheckAndMutateRow",
    "MutateRow",
-   "ReadModifyWriteRow"
+   "MutateRows",
+   "ReadModifyWriteRow",
+   "ReadRows",
+   "SampleRowKeys"
   ]
 }
 

--- a/google/cloud/bigtable/internal/bigtable_auth_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_auth_decorator.h
@@ -70,10 +70,30 @@ class BigtableAuth : public BigtableStub {
       grpc::ClientContext& context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.cc
@@ -71,12 +71,39 @@ BigtableChannelRefresh::ReadModifyWriteRow(
   return child_->ReadModifyWriteRow(client_context, request);
 }
 
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::ReadRowsResponse>>
+BigtableChannelRefresh::AsyncReadRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::ReadRowsRequest const& request) {
+  return child_->AsyncReadRows(cq, std::move(context), request);
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::SampleRowKeysResponse>>
+BigtableChannelRefresh::AsyncSampleRowKeys(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::SampleRowKeysRequest const& request) {
+  return child_->AsyncSampleRowKeys(cq, std::move(context), request);
+}
+
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableChannelRefresh::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::MutateRowRequest const& request) {
   return child_->AsyncMutateRow(cq, std::move(context), request);
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::MutateRowsResponse>>
+BigtableChannelRefresh::AsyncMutateRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::MutateRowsRequest const& request) {
+  return child_->AsyncMutateRows(cq, std::move(context), request);
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.h
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.h
@@ -74,10 +74,30 @@ class BigtableChannelRefresh : public BigtableStub {
       grpc::ClientContext& client_context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(

--- a/google/cloud/bigtable/internal/bigtable_logging_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_logging_decorator.h
@@ -70,10 +70,30 @@ class BigtableLogging : public BigtableStub {
       grpc::ClientContext& context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -91,6 +91,26 @@ BigtableMetadata::ReadModifyWriteRow(
   return child_->ReadModifyWriteRow(context, request);
 }
 
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::ReadRowsResponse>>
+BigtableMetadata::AsyncReadRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::ReadRowsRequest const& request) {
+  SetMetadata(*context, "table_name=" + request.table_name());
+  return child_->AsyncReadRows(cq, std::move(context), request);
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::SampleRowKeysResponse>>
+BigtableMetadata::AsyncSampleRowKeys(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::SampleRowKeysRequest const& request) {
+  SetMetadata(*context, "table_name=" + request.table_name());
+  return child_->AsyncSampleRowKeys(cq, std::move(context), request);
+}
+
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableMetadata::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
@@ -98,6 +118,16 @@ BigtableMetadata::AsyncMutateRow(
     google::bigtable::v2::MutateRowRequest const& request) {
   SetMetadata(*context, "table_name=" + request.table_name());
   return child_->AsyncMutateRow(cq, std::move(context), request);
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::MutateRowsResponse>>
+BigtableMetadata::AsyncMutateRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::MutateRowsRequest const& request) {
+  SetMetadata(*context, "table_name=" + request.table_name());
+  return child_->AsyncMutateRows(cq, std::move(context), request);
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.h
@@ -66,10 +66,30 @@ class BigtableMetadata : public BigtableStub {
       grpc::ClientContext& context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(

--- a/google/cloud/bigtable/internal/bigtable_round_robin.cc
+++ b/google/cloud/bigtable/internal/bigtable_round_robin.cc
@@ -70,6 +70,24 @@ BigtableRoundRobin::ReadModifyWriteRow(
   return Child()->ReadModifyWriteRow(client_context, request);
 }
 
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::ReadRowsResponse>>
+BigtableRoundRobin::AsyncReadRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::ReadRowsRequest const& request) {
+  return Child()->AsyncReadRows(cq, std::move(context), request);
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::SampleRowKeysResponse>>
+BigtableRoundRobin::AsyncSampleRowKeys(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::SampleRowKeysRequest const& request) {
+  return Child()->AsyncSampleRowKeys(cq, std::move(context), request);
+}
+
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 BigtableRoundRobin::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
@@ -78,6 +96,14 @@ BigtableRoundRobin::AsyncMutateRow(
   return Child()->AsyncMutateRow(cq, std::move(context), request);
 }
 
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::MutateRowsResponse>>
+BigtableRoundRobin::AsyncMutateRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::MutateRowsRequest const& request) {
+  return Child()->AsyncMutateRows(cq, std::move(context), request);
+}
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
 BigtableRoundRobin::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,

--- a/google/cloud/bigtable/internal/bigtable_round_robin.h
+++ b/google/cloud/bigtable/internal/bigtable_round_robin.h
@@ -64,10 +64,30 @@ class BigtableRoundRobin : public BigtableStub {
       grpc::ClientContext& client_context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(

--- a/google/cloud/bigtable/internal/bigtable_stub.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub.cc
@@ -18,6 +18,7 @@
 
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/async_streaming_read_rpc_impl.h"
 #include "google/cloud/status_or.h"
 #include "absl/memory/memory.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
@@ -113,6 +114,40 @@ DefaultBigtableStub::ReadModifyWriteRow(
   return response;
 }
 
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::ReadRowsResponse>>
+DefaultBigtableStub::AsyncReadRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::ReadRowsRequest const& request) {
+  return google::cloud::internal::MakeStreamingReadRpc<
+      google::bigtable::v2::ReadRowsRequest,
+      google::bigtable::v2::ReadRowsResponse>(
+      cq, std::move(context), request,
+      [this](grpc::ClientContext* context,
+             google::bigtable::v2::ReadRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncReadRows(context, request, cq);
+      });
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::SampleRowKeysResponse>>
+DefaultBigtableStub::AsyncSampleRowKeys(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::SampleRowKeysRequest const& request) {
+  return google::cloud::internal::MakeStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysRequest,
+      google::bigtable::v2::SampleRowKeysResponse>(
+      cq, std::move(context), request,
+      [this](grpc::ClientContext* context,
+             google::bigtable::v2::SampleRowKeysRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncSampleRowKeys(context, request, cq);
+      });
+}
+
 future<StatusOr<google::bigtable::v2::MutateRowResponse>>
 DefaultBigtableStub::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
@@ -125,6 +160,23 @@ DefaultBigtableStub::AsyncMutateRow(
         return grpc_stub_->AsyncMutateRow(context, request, cq);
       },
       request, std::move(context));
+}
+
+std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+    google::bigtable::v2::MutateRowsResponse>>
+DefaultBigtableStub::AsyncMutateRows(
+    google::cloud::CompletionQueue const& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::bigtable::v2::MutateRowsRequest const& request) {
+  return google::cloud::internal::MakeStreamingReadRpc<
+      google::bigtable::v2::MutateRowsRequest,
+      google::bigtable::v2::MutateRowsResponse>(
+      cq, std::move(context), request,
+      [this](grpc::ClientContext* context,
+             google::bigtable::v2::MutateRowsRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncMutateRows(context, request, cq);
+      });
 }
 
 future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>

--- a/google/cloud/bigtable/internal/bigtable_stub.h
+++ b/google/cloud/bigtable/internal/bigtable_stub.h
@@ -21,6 +21,7 @@
 
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
+#include "google/cloud/internal/async_streaming_read_rpc.h"
 #include "google/cloud/internal/streaming_read_rpc.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -69,10 +70,29 @@ class BigtableStub {
       grpc::ClientContext& context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) = 0;
 
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) = 0;
+
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) = 0;
+
   virtual future<StatusOr<google::bigtable::v2::MutateRowResponse>>
   AsyncMutateRow(google::cloud::CompletionQueue& cq,
                  std::unique_ptr<grpc::ClientContext> context,
                  google::bigtable::v2::MutateRowRequest const& request) = 0;
+
+  virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(google::cloud::CompletionQueue const& cq,
+                  std::unique_ptr<grpc::ClientContext> context,
+                  google::bigtable::v2::MutateRowsRequest const& request) = 0;
 
   virtual future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(
@@ -125,10 +145,30 @@ class DefaultBigtableStub : public BigtableStub {
       grpc::ClientContext& client_context,
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::ReadRowsResponse>>
+  AsyncReadRows(google::cloud::CompletionQueue const& cq,
+                std::unique_ptr<grpc::ClientContext> context,
+                google::bigtable::v2::ReadRowsRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::SampleRowKeysResponse>>
+  AsyncSampleRowKeys(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::SampleRowKeysRequest const& request) override;
+
   future<StatusOr<google::bigtable::v2::MutateRowResponse>> AsyncMutateRow(
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> context,
       google::bigtable::v2::MutateRowRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+      google::bigtable::v2::MutateRowsResponse>>
+  AsyncMutateRows(
+      google::cloud::CompletionQueue const& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::bigtable::v2::MutateRowsRequest const& request) override;
 
   future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>
   AsyncCheckAndMutateRow(

--- a/google/cloud/bigtable/testing/mock_bigtable_stub.h
+++ b/google/cloud/bigtable/testing/mock_bigtable_stub.h
@@ -61,11 +61,32 @@ class MockBigtableStub : public bigtable_internal::BigtableStub {
               (grpc::ClientContext&,
                google::bigtable::v2::ReadModifyWriteRowRequest const&),
               (override));
+  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                  google::bigtable::v2::ReadRowsResponse>>,
+              AsyncReadRows,
+              (google::cloud::CompletionQueue const&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::bigtable::v2::ReadRowsRequest const&),
+              (override));
+  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                  google::bigtable::v2::SampleRowKeysResponse>>,
+              AsyncSampleRowKeys,
+              (google::cloud::CompletionQueue const&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::bigtable::v2::SampleRowKeysRequest const&),
+              (override));
   MOCK_METHOD(future<StatusOr<google::bigtable::v2::MutateRowResponse>>,
               AsyncMutateRow,
               (google::cloud::CompletionQueue&,
                std::unique_ptr<grpc::ClientContext>,
                google::bigtable::v2::MutateRowRequest const&),
+              (override));
+  MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
+                  google::bigtable::v2::MutateRowsResponse>>,
+              AsyncMutateRows,
+              (google::cloud::CompletionQueue const&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::bigtable::v2::MutateRowsRequest const&),
               (override));
   MOCK_METHOD(future<StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>>,
               AsyncCheckAndMutateRow,
@@ -113,6 +134,40 @@ class MockSampleRowKeysStream
   MOCK_METHOD(SampleRowKeysResultType, Read, (), (override));
   MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
               (), (const, override));
+};
+
+class MockAsyncMutateRowsStream
+    : public google::cloud::internal::AsyncStreamingReadRpc<
+          google::bigtable::v2::MutateRowsResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<google::bigtable::v2::MutateRowsResponse>>,
+              Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+};
+
+class MockAsyncReadRowsStream
+    : public google::cloud::internal::AsyncStreamingReadRpc<
+          google::bigtable::v2::ReadRowsResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<google::bigtable::v2::ReadRowsResponse>>,
+              Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+};
+
+class MockAsyncSampleRowKeysStream
+    : public google::cloud::internal::AsyncStreamingReadRpc<
+          google::bigtable::v2::SampleRowKeysResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(
+      future<absl::optional<google::bigtable::v2::SampleRowKeysResponse>>, Read,
+      (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
 };
 
 }  // namespace testing


### PR DESCRIPTION
Part of the work for #8798 

I will need these things eventually. We might as well add them now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8964)
<!-- Reviewable:end -->
