### PR TITLE
doc: prefer absolute links in markdown

### DIFF
--- a/ci/etc/README.md
+++ b/ci/etc/README.md
@@ -27,4 +27,4 @@ cbt -project "${GOOGLE_CLOUD_PROJECT}" -instance test-instance \
 ## Storage
 
 The instructions for setting up storage resources are found in
-[doc/setup-test-resources.md](../../google/cloud/storage/doc/setup-test-resources.md).
+[doc/setup-test-resources.md](/google/cloud/storage/doc/setup-test-resources.md).

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -252,13 +252,13 @@ this library.
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');

--- a/google/cloud/README.md
+++ b/google/cloud/README.md
@@ -34,10 +34,10 @@ notice. These include `google/cloud/internal/`, and
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/accessapproval/README.md
+++ b/google/cloud/accessapproval/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/accesscontextmanager/README.md
+++ b/google/cloud/accesscontextmanager/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/apigateway/README.md
+++ b/google/cloud/apigateway/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/apigeeconnect/README.md
+++ b/google/cloud/apigeeconnect/README.md
@@ -85,10 +85,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/appengine/README.md
+++ b/google/cloud/appengine/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/artifactregistry/README.md
+++ b/google/cloud/artifactregistry/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/asset/README.md
+++ b/google/cloud/asset/README.md
@@ -82,10 +82,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/assuredworkloads/README.md
+++ b/google/cloud/assuredworkloads/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/automl/README.md
+++ b/google/cloud/automl/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/bigquery/README.md
+++ b/google/cloud/bigquery/README.md
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) try {
 
 ## Installation
 
-Please consult the [packaging guide](../../../doc/packaging.md) for detailed
+Please consult the [packaging guide](/doc/packaging.md) for detailed
 instructions to install the Google Cloud C++ client libraries.
 If your project uses [CMake](https://cmake.org) or [Bazel](https://bazel.build)
 check the [quickstart](quickstart/README.md) example for instructions to use
@@ -117,10 +117,10 @@ this library in your project.
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -97,10 +97,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/bigtable/examples/README.md
+++ b/google/cloud/bigtable/examples/README.md
@@ -28,7 +28,7 @@ Instance ID, and Table ID as you will need them below.
 These examples are compiled as part of the build for the Cloud Bigtable C++
 Client.  The instructions on how to compile the code are in the
 [top-level README](/README.md) file. The Bigtable client library
-[quickstart](../quickstart/README.md) may also be relevant.
+[quickstart](/google/cloud/bigtable/quickstart/README.md) may also be relevant.
 
 ### Configure Environment
 

--- a/google/cloud/billing/README.md
+++ b/google/cloud/billing/README.md
@@ -77,10 +77,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/binaryauthorization/README.md
+++ b/google/cloud/binaryauthorization/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/channel/README.md
+++ b/google/cloud/channel/README.md
@@ -82,10 +82,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/cloudbuild/README.md
+++ b/google/cloud/cloudbuild/README.md
@@ -77,10 +77,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/composer/README.md
+++ b/google/cloud/composer/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/contactcenterinsights/README.md
+++ b/google/cloud/contactcenterinsights/README.md
@@ -86,10 +86,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/container/README.md
+++ b/google/cloud/container/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/containeranalysis/README.md
+++ b/google/cloud/containeranalysis/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/datacatalog/README.md
+++ b/google/cloud/datacatalog/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/datamigration/README.md
+++ b/google/cloud/datamigration/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/dataplex/README.md
+++ b/google/cloud/dataplex/README.md
@@ -84,10 +84,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/dataproc/README.md
+++ b/google/cloud/dataproc/README.md
@@ -93,10 +93,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/debugger/README.md
+++ b/google/cloud/debugger/README.md
@@ -74,10 +74,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/dialogflow_cx/README.md
+++ b/google/cloud/dialogflow_cx/README.md
@@ -93,10 +93,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/dialogflow_es/README.md
+++ b/google/cloud/dialogflow_es/README.md
@@ -87,10 +87,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/dlp/README.md
+++ b/google/cloud/dlp/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/documentai/README.md
+++ b/google/cloud/documentai/README.md
@@ -104,10 +104,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/eventarc/README.md
+++ b/google/cloud/eventarc/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/filestore/README.md
+++ b/google/cloud/filestore/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/functions/README.md
+++ b/google/cloud/functions/README.md
@@ -82,10 +82,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/gameservices/README.md
+++ b/google/cloud/gameservices/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/gkehub/README.md
+++ b/google/cloud/gkehub/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/grafeas/README.md
+++ b/google/cloud/grafeas/README.md
@@ -28,10 +28,10 @@ Please note that the Google Cloud C++ client libraries do **not** follow
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/iam/README.md
+++ b/google/cloud/iam/README.md
@@ -80,7 +80,7 @@ int main(int argc, char* argv[]) try {
 
 ## Installation
 
-Please consult the [packaging guide](../../../doc/packaging.md) for detailed
+Please consult the [packaging guide](/doc/packaging.md) for detailed
 instructions to install the Google Cloud C++ client libraries.
 If your project uses [CMake](https://cmake.org) or [Bazel](https://bazel.build)
 check the [quickstart](quickstart/README.md) example for instructions to use
@@ -88,10 +88,10 @@ this library in your project.
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/iap/README.md
+++ b/google/cloud/iap/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/ids/README.md
+++ b/google/cloud/ids/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/iot/README.md
+++ b/google/cloud/iot/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/kms/README.md
+++ b/google/cloud/kms/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/language/README.md
+++ b/google/cloud/language/README.md
@@ -93,10 +93,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/managedidentities/README.md
+++ b/google/cloud/managedidentities/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/memcache/README.md
+++ b/google/cloud/memcache/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/monitoring/README.md
+++ b/google/cloud/monitoring/README.md
@@ -82,10 +82,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/networkmanagement/README.md
+++ b/google/cloud/networkmanagement/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/notebooks/README.md
+++ b/google/cloud/notebooks/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/orgpolicy/README.md
+++ b/google/cloud/orgpolicy/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/osconfig/README.md
+++ b/google/cloud/osconfig/README.md
@@ -85,10 +85,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/oslogin/README.md
+++ b/google/cloud/oslogin/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/policytroubleshooter/README.md
+++ b/google/cloud/policytroubleshooter/README.md
@@ -83,10 +83,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/privateca/README.md
+++ b/google/cloud/privateca/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/profiler/README.md
+++ b/google/cloud/profiler/README.md
@@ -94,10 +94,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/pubsub/README.md
+++ b/google/cloud/pubsub/README.md
@@ -82,7 +82,7 @@ int main(int argc, char* argv[]) try {
 
 ## Installation
 
-Please consult the [packaging guide](../../../doc/packaging.md) for detailed
+Please consult the [packaging guide](/doc/packaging.md) for detailed
 instructions to install the Google Cloud C++ client libraries.
 If your project uses [CMake](https://cmake.org) or [Bazel](https://bazel.build)
 check the [quickstart](quickstart/README.md) example for instructions to use
@@ -90,10 +90,10 @@ this library in your project.
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/pubsub/benchmarks/README.md
+++ b/google/cloud/pubsub/benchmarks/README.md
@@ -52,7 +52,7 @@ subscription while manual execution will use pre-existing Pub/Sub resources.
 The main audience for this guide are `google-cloud-cpp` developers who want to
 reproduce the benchmark results. This document assumes that you are familiar
 with the steps to compile the code in this repository, please check the
-top-level [README](../../../../README.md) if necessary.
+top-level [README](/README.md) if necessary.
 
 :warning: Running these benchmarks can easily exceed the free tier for Cloud
 Pub/Sub, generating hundreds of dollars in charges may take only a few minutes.

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -92,10 +92,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/recommender/README.md
+++ b/google/cloud/recommender/README.md
@@ -82,10 +82,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/redis/README.md
+++ b/google/cloud/redis/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/resourcemanager/README.md
+++ b/google/cloud/resourcemanager/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/resourcesettings/README.md
+++ b/google/cloud/resourcesettings/README.md
@@ -82,10 +82,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/retail/README.md
+++ b/google/cloud/retail/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/scheduler/README.md
+++ b/google/cloud/scheduler/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/secretmanager/README.md
+++ b/google/cloud/secretmanager/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/securitycenter/README.md
+++ b/google/cloud/securitycenter/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/servicecontrol/README.md
+++ b/google/cloud/servicecontrol/README.md
@@ -93,10 +93,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/servicedirectory/README.md
+++ b/google/cloud/servicedirectory/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/servicemanagement/README.md
+++ b/google/cloud/servicemanagement/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/serviceusage/README.md
+++ b/google/cloud/serviceusage/README.md
@@ -83,10 +83,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/shell/README.md
+++ b/google/cloud/shell/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/spanner/README.md
+++ b/google/cloud/spanner/README.md
@@ -81,10 +81,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/spanner/benchmarks/README.md
+++ b/google/cloud/spanner/benchmarks/README.md
@@ -34,7 +34,7 @@ configure the VM instance, and then install the development tools for whatever
 platform you chose. See [doc/packaging.md][packaging-doc-link] for install
 instructions for your platform.
 
-[packaging-doc-link]: ../../../../doc/packaging.md
+[packaging-doc-link]: /doc/packaging.md
 
 ### Compiling the library
 

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -87,10 +87,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/storage/README.md
+++ b/google/cloud/storage/README.md
@@ -96,10 +96,10 @@ int main(int argc, char* argv[]) {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/storage/examples/README.md
+++ b/google/cloud/storage/examples/README.md
@@ -7,7 +7,7 @@ Storage APIs.  These snippets are referenced from the Doxygen documentation.
 
 These examples are compiled as part of the build for the Google Cloud C++
 Libraries.  The instructions on how to compile the code are in the
-[top-level README](../../../../README.md) file.
+[top-level README](/README.md) file.
 
 ## Running the Samples
 

--- a/google/cloud/storagetransfer/README.md
+++ b/google/cloud/storagetransfer/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/talent/README.md
+++ b/google/cloud/talent/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/tasks/README.md
+++ b/google/cloud/tasks/README.md
@@ -77,10 +77,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/texttospeech/README.md
+++ b/google/cloud/texttospeech/README.md
@@ -94,10 +94,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/tpu/README.md
+++ b/google/cloud/tpu/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/trace/README.md
+++ b/google/cloud/trace/README.md
@@ -107,10 +107,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/translate/README.md
+++ b/google/cloud/translate/README.md
@@ -89,10 +89,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/videointelligence/README.md
+++ b/google/cloud/videointelligence/README.md
@@ -112,10 +112,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/vision/README.md
+++ b/google/cloud/vision/README.md
@@ -105,10 +105,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/vmmigration/README.md
+++ b/google/cloud/vmmigration/README.md
@@ -78,10 +78,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/vpcaccess/README.md
+++ b/google/cloud/vpcaccess/README.md
@@ -79,10 +79,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/webrisk/README.md
+++ b/google/cloud/webrisk/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/websecurityscanner/README.md
+++ b/google/cloud/websecurityscanner/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.

--- a/google/cloud/workflows/README.md
+++ b/google/cloud/workflows/README.md
@@ -80,10 +80,10 @@ int main(int argc, char* argv[]) try {
 
 ## Contributing changes
 
-See [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) for details on how to
+See [`CONTRIBUTING.md`](/CONTRIBUTING.md) for details on how to
 contribute to this project, including how to build and test your changes
 as well as how to properly format your code.
 
 ## Licensing
 
-Apache 2.0; see [`LICENSE`](../../../LICENSE) for details.
+Apache 2.0; see [`LICENSE`](/LICENSE) for details.


### PR DESCRIPTION
This makes it easier to re-target the links when importing the code to
Google.

Thanks to @dbolduc for the suggestion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8966)
<!-- Reviewable:end -->
