### PR TITLE
refactor(bigtable): move some definitions around

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -199,6 +199,7 @@ add_library(
     metadata_update_policy.h
     mutation_batcher.cc
     mutation_batcher.h
+    mutation_branch.h
     mutations.cc
     mutations.h
     options.h

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -93,6 +93,7 @@ google_cloud_cpp_bigtable_hdrs = [
     "internal/wait_for_consistency.h",
     "metadata_update_policy.h",
     "mutation_batcher.h",
+    "mutation_branch.h",
     "mutations.h",
     "options.h",
     "polling_policy.h",

--- a/google/cloud/bigtable/internal/data_connection.h
+++ b/google/cloud/bigtable/internal/data_connection.h
@@ -16,8 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_DATA_CONNECTION_H
 
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
-#include "google/cloud/bigtable/rpc_retry_policy.h"
-#include "google/cloud/backoff_policy.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/stream_range.h"
@@ -29,17 +27,6 @@ namespace cloud {
 // TODO(#8860) - Make this class public, when it is ready.
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-using DataRetryPolicy = ::google::cloud::internal::TraitBasedRetryPolicy<
-    bigtable::internal::SafeGrpcRetry>;
-
-using DataLimitedTimeRetryPolicy =
-    ::google::cloud::internal::LimitedTimeRetryPolicy<
-        bigtable::internal::SafeGrpcRetry>;
-
-using DataLimitedErrorCountRetryPolicy =
-    ::google::cloud::internal::LimitedErrorCountRetryPolicy<
-        bigtable::internal::SafeGrpcRetry>;
 
 /**
  * A connection to the Cloud Bigtable Data API.

--- a/google/cloud/bigtable/mutation_branch.h
+++ b/google/cloud/bigtable/mutation_branch.h
@@ -1,0 +1,40 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MUTATION_BRANCH_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MUTATION_BRANCH_H
+
+#include "google/cloud/bigtable/version.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// The branch taken by a Table::CheckAndMutateRow operation.
+enum class MutationBranch {
+  /// The predicate provided to CheckAndMutateRow did not match and the
+  /// `false_mutations` (if any) were applied.
+  kPredicateNotMatched,
+  /// The predicate provided to CheckAndMutateRow matched and the
+  /// `true_mutations` (if any) were applied.
+  kPredicateMatched,
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MUTATION_BRANCH_H

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -39,8 +39,9 @@
  */
 
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
-#include "google/cloud/bigtable/internal/data_connection.h"
+#include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/backoff_policy.h"
 #include "google/cloud/options.h"
 #include <chrono>
 #include <string>
@@ -106,6 +107,17 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 // TODO(#8860) - Make these options public.
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+using DataRetryPolicy = ::google::cloud::internal::TraitBasedRetryPolicy<
+    bigtable::internal::SafeGrpcRetry>;
+
+using DataLimitedTimeRetryPolicy =
+    ::google::cloud::internal::LimitedTimeRetryPolicy<
+        bigtable::internal::SafeGrpcRetry>;
+
+using DataLimitedErrorCountRetryPolicy =
+    ::google::cloud::internal::LimitedErrorCountRetryPolicy<
+        bigtable::internal::SafeGrpcRetry>;
 
 /// Option to use with `google::cloud::Options`.
 struct DataRetryPolicyOption {

--- a/google/cloud/bigtable/row_reader.h
+++ b/google/cloud/bigtable/row_reader.h
@@ -24,6 +24,7 @@
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
 #include "google/cloud/bigtable/version.h"
+#include "google/cloud/stream_range.h"
 
 namespace google {
 namespace cloud {

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/bigtable/idempotent_mutation_policy.h"
 #include "google/cloud/bigtable/internal/async_row_reader.h"
+#include "google/cloud/bigtable/mutation_branch.h"
 #include "google/cloud/bigtable/mutations.h"
 #include "google/cloud/bigtable/read_modify_write_rule.h"
 #include "google/cloud/bigtable/resource_names.h"
@@ -41,15 +42,6 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-/// The branch taken by a Table::CheckAndMutateRow operation.
-enum class MutationBranch {
-  /// The predicate provided to CheckAndMutateRow did not match and the
-  /// `false_mutations` (if any) were applied.
-  kPredicateNotMatched,
-  /// The predicate provided to CheckAndMutateRow matched and the
-  /// `true_mutations` (if any) were applied.
-  kPredicateMatched,
-};
 
 class MutationBatcher;
 


### PR DESCRIPTION
Move `MutationBranch` into its own file so I can include it from `DataConnection` and `Table`. I would rather do this than 1) add a public definition to a file in the `bigtable/internal/` directory 2) develop `DataConnection` in the `bigtable/` directory

Move the policy definitions out of `DataConnection`. (I am not sure why the generator defines things here...). If I don't do it, there would be a cyclic dependency: `data_connection.h` -> `row_reader.h` -> `data_client.h` -> `client_options.h` -> `options.h` -> `data_connection.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8967)
<!-- Reviewable:end -->
