### PR TITLE
fix(storage): avoid crashes when parsing `ErrorInfo`

### DIFF
--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -139,6 +139,24 @@ TEST(HttpResponseTest, ErrorInfoInvalidOnlyString) {
   EXPECT_EQ(AsStatus(HttpResponse{400, kJsonPayload, {}}), expected);
 }
 
+TEST(HttpResponseTest, ErrorInfoInvalidUnexpectedFormat) {
+  std::string cases[] = {
+      R"js({"error": "invalid_grant", "error_description": "Invalid grant: account not found"})js",
+      R"js({"error": ["invalid"], "error_description": "Invalid grant: account not found"})js",
+      R"js({"error": {"missing-message": "msg"}})js",
+      R"js({"error": {"message": "msg", "missing-details": {}}})js",
+      R"js({"error": {"message": ["not string"], "details": {}}}})js",
+      R"js({"error": {"message": "the error", "details": "not-an-array"}}})js",
+      R"js({"error": {"message": "the error", "details": {"@type": "invalid-@type"}}}})js",
+      R"js({"error": {"message": "the error", "details": ["not-an-object"]}}})js",
+      R"js({"error": {"message": "the error", "details": [{"@type": "invalid-@type"}]}}})js",
+  };
+  for (auto const& payload : cases) {
+    Status expected{StatusCode::kInvalidArgument, payload};
+    EXPECT_EQ(AsStatus(HttpResponse{400, payload, {}}), expected);
+  }
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Maybe unsurprisingly, the error payloads are less structured that we
expected. This PR performs additional validation to avoid crashes while
trying to parse these payloads as a `ErrorInfo`.  If we could reliably
use exceptions I would just parse the code and handle any exception in
a single line of code, alas, we cannot.

Fixes #8965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8968)
<!-- Reviewable:end -->
