### PR TITLE
test(storage): more test cases for `ErrorInfo` parser

### DIFF
--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -150,6 +150,8 @@ TEST(HttpResponseTest, ErrorInfoInvalidUnexpectedFormat) {
       R"js({"error": {"message": "the error", "details": {"@type": "invalid-@type"}}}})js",
       R"js({"error": {"message": "the error", "details": ["not-an-object"]}}})js",
       R"js({"error": {"message": "the error", "details": [{"@type": "invalid-@type"}]}}})js",
+      R"js(Service Unavailable)js",
+      R"js("Service Unavailable")js",
   };
   for (auto const& payload : cases) {
     Status expected{StatusCode::kInvalidArgument, payload};


### PR DESCRIPTION
Part of the work for #8965

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8970)
<!-- Reviewable:end -->
