### PR TITLE
refactor(spanner): use common RST_STREAM status helper

### DIFF
--- a/google/cloud/spanner/internal/connection_impl_test.cc
+++ b/google/cloud/spanner/internal/connection_impl_test.cc
@@ -2006,9 +2006,9 @@ TEST(ConnectionImplTest, ExecutePartitionedDmlRetryableInternalErrors) {
       .WillOnce(Return(ByMove(MakeReader(
           {}, {grpc::StatusCode::INTERNAL,
                "Received unexpected EOS on DATA frame from server"}))))
-      .WillOnce(
-          Return(ByMove(MakeReader({}, {grpc::StatusCode::INTERNAL,
-                                        "HTTP/2 error code: INTERNAL_ERROR"}))))
+      .WillOnce(Return(ByMove(MakeReader(
+          {}, {grpc::StatusCode::INTERNAL,
+               "HTTP/2 error code: INTERNAL_ERROR\nReceived Rst Stream"}))))
       .WillOnce(Return(ByMove(MakeReader({kTextResponse}))));
 
   auto result = conn->ExecutePartitionedDml(

--- a/google/cloud/spanner/retry_policy_test.cc
+++ b/google/cloud/spanner/retry_policy_test.cc
@@ -33,6 +33,8 @@ TEST(RetryPolicyTest, PermanentFailure) {
       Status(StatusCode::kAborted, "nothing done")));
   EXPECT_TRUE(spanner_internal::SafeGrpcRetry::IsPermanentFailure(
       Status(StatusCode::kPermissionDenied, "uh oh")));
+  EXPECT_TRUE(spanner_internal::SafeGrpcRetry::IsTransientFailure(
+      Status(StatusCode::kInternal, "RST_STREAM")));
 }
 
 TEST(TransactionRerunPolicyTest, PermanentFailure) {


### PR DESCRIPTION
Fixes #7394 (well, this is all I am going to do on it unless it becomes a bigger problem)

Refactor spanner to point to the [common helper](https://github.com/googleapis/google-cloud-cpp/blob/0ff878ea71ccea66e1e2c7cf74e703683ec7ad94/google/cloud/internal/retry_policy.cc#L24-L30).

Note that we drop the "Connection closed with unknown cause" case. It was fixed 4 years ago. Googlers can see: https://b.corp.google.com/issues/27794742#comment14

We also drop the "HTTP/2 error code: INTERNAL_ERROR" case. It is covered by matching on "Received Rst Stream". Googlers can see: https://b.corp.google.com/issues/33017979 for an example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8976)
<!-- Reviewable:end -->
