### PR TITLE
refactor(rest): remove RestEndpointOption from Rest library

### DIFF
--- a/google/cloud/common_options.h
+++ b/google/cloud/common_options.h
@@ -30,7 +30,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *
  * In almost all cases a suitable default will be chosen automatically.
  * Applications may need to be changed to (1) test against a fake or simulator,
- * or (2) use a beta or EAP version of the service.
+ * or (2) use a beta or EAP version of the service. When using a beta or EAP
+ * version of the service, the AuthorityOption should also be set to the usual
+ * hostname of the service.
  */
 struct EndpointOption {
   using Type = std::string;

--- a/google/cloud/internal/curl_rest_client.h
+++ b/google/cloud/internal/curl_rest_client.h
@@ -34,7 +34,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class CurlHandleFactory;
 class CurlImpl;
 
-// RestClient implementation using libcurl.
+// RestClient implementation using libcurl. In order to maximize the performance
+// of the connection that libcurl manages, the endpoint that the client connects
+// to cannot be changed after creation. If a service needs to communicate with
+// multiple endpoints, use a different CurlRestClient for each such endpoint.
 class CurlRestClient : public RestClient {
  public:
   static std::string HostHeader(Options const& options,

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -32,7 +32,7 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
-const char* const kIamCredentialsEndpoint =
+auto constexpr kIamCredentialsEndpoint =
     "https://iamcredentials.googleapis.com/v1/";
 }
 

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.cc
@@ -31,16 +31,20 @@ namespace google {
 namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+const char* const kIamCredentialsEndpoint =
+    "https://iamcredentials.googleapis.com/v1/";
+}
 
 MinimalIamCredentialsRestStub::MinimalIamCredentialsRestStub(
     std::shared_ptr<oauth2_internal::Credentials> credentials, Options options,
     std::shared_ptr<rest_internal::RestClient> rest_client)
-    : endpoint_(options.get<rest_internal::RestEndpointOption>()),
-      credentials_(std::move(credentials)),
+    : credentials_(std::move(credentials)),
       rest_client_(std::move(rest_client)),
       options_(std::move(options)) {
   if (!rest_client_) {
-    rest_client_ = rest_internal::MakeDefaultRestClient(endpoint_, options_);
+    rest_client_ =
+        rest_internal::MakeDefaultRestClient(kIamCredentialsEndpoint, options_);
   }
 }
 
@@ -117,10 +121,6 @@ MinimalIamCredentialsRestLogging::GenerateAccessToken(
 std::shared_ptr<MinimalIamCredentialsRest> MakeMinimalIamCredentialsRestStub(
     std::shared_ptr<oauth2_internal::Credentials> credentials,
     Options options) {
-  options = google::cloud::internal::MergeOptions(
-      Options{}.set<rest_internal::RestEndpointOption>(
-          "https://iamcredentials.googleapis.com/v1/"),
-      std::move(options));
   auto enable_logging =
       options.get<TracingComponentsOption>().count("rpc") != 0 ||
       options.get<TracingComponentsOption>().count("raw-client") != 0;

--- a/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
+++ b/google/cloud/internal/oauth2_minimal_iam_credentials_rest.h
@@ -72,7 +72,6 @@ class MinimalIamCredentialsRestStub : public MinimalIamCredentialsRest {
  private:
   static std::string MakeRequestPath(GenerateAccessTokenRequest const& request);
 
-  std::string endpoint_;
   std::shared_ptr<oauth2_internal::Credentials> credentials_;
   std::shared_ptr<rest_internal::RestClient> rest_client_;
   Options options_;

--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -38,25 +38,6 @@ struct UserIpOption {
 };
 
 /**
- * Configure the REST endpoint for the GCS client library.
- *
- * This endpoint must include the URL scheme (`http` or `https`) and `authority`
- * (host and port) used to access the GCS service, for example:
- *    https://storage.googleapis.com
- * When using emulators or testbench it can be of the form:
- *    http://localhost:8080/my-gcs-emulator-path
- *
- * @note The `Host` header is based on the `authority` component of the URL.
- *   Applications can override this default value using
- *   `google::cloud::AuthorityOption`
- *
- * @see https://en.wikipedia.org/wiki/Uniform_Resource_Identifier#URLs_and_URNs
- */
-struct RestEndpointOption {
-  using Type = std::string;
-};
-
-/**
  * Sets the transfer stall timeout.
  *
  * If a transfer (upload, download, or request) *stalls*, i.e., no bytes are
@@ -95,8 +76,7 @@ struct DownloadStallTimeoutOption {
 
 /// The complete list of options accepted by `CurlRestClient`
 using RestOptionList =
-    ::google::cloud::OptionList<UserIpOption, RestEndpointOption,
-                                TransferStallTimeoutOption,
+    ::google::cloud::OptionList<UserIpOption, TransferStallTimeoutOption,
                                 DownloadStallTimeoutOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
common_options.h already defines an `google::cloud::EndpointOption`, having an additional `google::cloud::rest_internal::RestEndpointOption` is unnecessary as the endpoint used to create the `RestClient` should be resolved by the library using the `RestClient`.

Additionally, add comments emphasizing the immutability of an endpoint in a `CurlRestClient` and add comments emphasizing the relationship between `EndpoinOption` and `AuthorityOption`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8977)
<!-- Reviewable:end -->
