### PR TITLE
feat(monitoring): generate async version of `CreateTimeSeries()`

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -834,6 +834,7 @@ service {
   service_proto_path: "google/monitoring/v3/metric_service.proto"
   product_path: "google/cloud/monitoring"
   initial_copyright_year: "2022"
+  gen_async_rpcs: ["CreateTimeSeries"]
   retryable_status_codes: ["kUnavailable"]
 }
 

--- a/google/cloud/monitoring/internal/metric_auth_decorator.h
+++ b/google/cloud/monitoring/internal/metric_auth_decorator.h
@@ -83,6 +83,11 @@ class MetricServiceAuth : public MetricServiceStub {
       grpc::ClientContext& context,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
+  future<Status> AsyncCreateTimeSeries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<MetricServiceStub> child_;

--- a/google/cloud/monitoring/internal/metric_connection_impl.h
+++ b/google/cloud/monitoring/internal/metric_connection_impl.h
@@ -82,6 +82,9 @@ class MetricServiceConnectionImpl : public monitoring::MetricServiceConnection {
   Status CreateServiceTimeSeries(
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
+  future<Status> AsyncCreateTimeSeries(
+      google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
+
  private:
   std::unique_ptr<monitoring::MetricServiceRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/google/cloud/monitoring/internal/metric_logging_decorator.cc
+++ b/google/cloud/monitoring/internal/metric_logging_decorator.cc
@@ -149,6 +149,19 @@ Status MetricServiceLogging::CreateServiceTimeSeries(
       context, request, __func__, tracing_options_);
 }
 
+future<Status> MetricServiceLogging::AsyncCreateTimeSeries(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+        return child_->AsyncCreateTimeSeries(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace monitoring_internal
 }  // namespace cloud

--- a/google/cloud/monitoring/internal/metric_logging_decorator.h
+++ b/google/cloud/monitoring/internal/metric_logging_decorator.h
@@ -83,6 +83,11 @@ class MetricServiceLogging : public MetricServiceStub {
       grpc::ClientContext& context,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
+  future<Status> AsyncCreateTimeSeries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
+
  private:
   std::shared_ptr<MetricServiceStub> child_;
   TracingOptions tracing_options_;

--- a/google/cloud/monitoring/internal/metric_metadata_decorator.cc
+++ b/google/cloud/monitoring/internal/metric_metadata_decorator.cc
@@ -105,6 +105,14 @@ Status MetricServiceMetadata::CreateServiceTimeSeries(
   return child_->CreateServiceTimeSeries(context, request);
 }
 
+future<Status> MetricServiceMetadata::AsyncCreateTimeSeries(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+  SetMetadata(*context, "name=" + request.name());
+  return child_->AsyncCreateTimeSeries(cq, std::move(context), request);
+}
+
 void MetricServiceMetadata::SetMetadata(grpc::ClientContext& context,
                                         std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/google/cloud/monitoring/internal/metric_metadata_decorator.h
+++ b/google/cloud/monitoring/internal/metric_metadata_decorator.h
@@ -79,6 +79,11 @@ class MetricServiceMetadata : public MetricServiceStub {
       grpc::ClientContext& context,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
+  future<Status> AsyncCreateTimeSeries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/google/cloud/monitoring/internal/metric_stub.cc
+++ b/google/cloud/monitoring/internal/metric_stub.cc
@@ -144,6 +144,23 @@ Status DefaultMetricServiceStub::CreateServiceTimeSeries(
   return google::cloud::Status();
 }
 
+future<Status> DefaultMetricServiceStub::AsyncCreateTimeSeries(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::monitoring::v3::CreateTimeSeriesRequest const& request) {
+  return cq
+      .MakeUnaryRpc(
+          [this](grpc::ClientContext* context,
+                 google::monitoring::v3::CreateTimeSeriesRequest const& request,
+                 grpc::CompletionQueue* cq) {
+            return grpc_stub_->AsyncCreateTimeSeries(context, request, cq);
+          },
+          request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        return f.get().status();
+      });
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace monitoring_internal
 }  // namespace cloud

--- a/google/cloud/monitoring/internal/metric_stub.h
+++ b/google/cloud/monitoring/internal/metric_stub.h
@@ -19,6 +19,8 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MONITORING_INTERNAL_METRIC_STUB_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_MONITORING_INTERNAL_METRIC_STUB_H
 
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <google/monitoring/v3/metric_service.grpc.pb.h>
@@ -75,6 +77,11 @@ class MetricServiceStub {
   virtual Status CreateServiceTimeSeries(
       grpc::ClientContext& context,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) = 0;
+
+  virtual future<Status> AsyncCreateTimeSeries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::monitoring::v3::CreateTimeSeriesRequest const& request) = 0;
 };
 
 class DefaultMetricServiceStub : public MetricServiceStub {
@@ -127,6 +134,11 @@ class DefaultMetricServiceStub : public MetricServiceStub {
 
   Status CreateServiceTimeSeries(
       grpc::ClientContext& client_context,
+      google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
+
+  future<Status> AsyncCreateTimeSeries(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
       google::monitoring::v3::CreateTimeSeriesRequest const& request) override;
 
  private:

--- a/google/cloud/monitoring/metric_client.cc
+++ b/google/cloud/monitoring/metric_client.cc
@@ -194,6 +194,24 @@ Status MetricServiceClient::CreateServiceTimeSeries(
   return connection_->CreateServiceTimeSeries(request);
 }
 
+future<Status> MetricServiceClient::AsyncCreateTimeSeries(
+    std::string const& name,
+    std::vector<google::monitoring::v3::TimeSeries> const& time_series,
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  google::monitoring::v3::CreateTimeSeriesRequest request;
+  request.set_name(name);
+  *request.mutable_time_series() = {time_series.begin(), time_series.end()};
+  return connection_->AsyncCreateTimeSeries(request);
+}
+
+future<Status> MetricServiceClient::AsyncCreateTimeSeries(
+    google::monitoring::v3::CreateTimeSeriesRequest const& request,
+    Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  return connection_->AsyncCreateTimeSeries(request);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace monitoring
 }  // namespace cloud

--- a/google/cloud/monitoring/metric_client.h
+++ b/google/cloud/monitoring/metric_client.h
@@ -500,6 +500,52 @@ class MetricServiceClient {
       google::monitoring::v3::CreateTimeSeriesRequest const& request,
       Options opts = {});
 
+  ///
+  /// Creates or adds data to one or more time series.
+  /// The response is empty if all time series in the request were written.
+  /// If any time series could not be written, a corresponding failure message
+  /// is included in the error response.
+  ///
+  /// @param name  Required. The
+  /// [project](https://cloud.google.com/monitoring/api/v3#project_name) on
+  ///  which to execute the request. The format is:
+  ///      projects/[PROJECT_ID_OR_NUMBER]
+  /// @param time_series  Required. The new data to be added to a list of time
+  /// series.
+  ///  Adds at most one data point to each of several time series.  The new data
+  ///  point must be more recent than any other point in its time series.  Each
+  ///  `TimeSeries` value must fully specify a unique time series by supplying
+  ///  all label values for the metric and the monitored resource.
+  ///  The maximum number of `TimeSeries` objects per `Create` request is 200.
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  ///
+  /// [google.monitoring.v3.CreateTimeSeriesRequest]:
+  /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L421}
+  ///
+  future<Status> AsyncCreateTimeSeries(
+      std::string const& name,
+      std::vector<google::monitoring::v3::TimeSeries> const& time_series,
+      Options opts = {});
+
+  ///
+  /// Creates or adds data to one or more time series.
+  /// The response is empty if all time series in the request were written.
+  /// If any time series could not be written, a corresponding failure message
+  /// is included in the error response.
+  ///
+  /// @param request
+  /// @googleapis_link{google::monitoring::v3::CreateTimeSeriesRequest,google/monitoring/v3/metric_service.proto#L421}
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  ///
+  /// [google.monitoring.v3.CreateTimeSeriesRequest]:
+  /// @googleapis_reference_link{google/monitoring/v3/metric_service.proto#L421}
+  ///
+  future<Status> AsyncCreateTimeSeries(
+      google::monitoring::v3::CreateTimeSeriesRequest const& request,
+      Options opts = {});
+
  private:
   std::shared_ptr<MetricServiceConnection> connection_;
   Options options_;

--- a/google/cloud/monitoring/metric_connection.cc
+++ b/google/cloud/monitoring/metric_connection.cc
@@ -91,6 +91,12 @@ Status MetricServiceConnection::CreateServiceTimeSeries(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
+future<Status> MetricServiceConnection::AsyncCreateTimeSeries(
+    google::monitoring::v3::CreateTimeSeriesRequest const&) {
+  return google::cloud::make_ready_future(
+      Status(StatusCode::kUnimplemented, "not implemented"));
+}
+
 std::shared_ptr<MetricServiceConnection> MakeMetricServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,

--- a/google/cloud/monitoring/metric_connection.h
+++ b/google/cloud/monitoring/metric_connection.h
@@ -81,6 +81,9 @@ class MetricServiceConnection {
 
   virtual Status CreateServiceTimeSeries(
       google::monitoring::v3::CreateTimeSeriesRequest const& request);
+
+  virtual future<Status> AsyncCreateTimeSeries(
+      google::monitoring::v3::CreateTimeSeriesRequest const& request);
 };
 
 std::shared_ptr<MetricServiceConnection> MakeMetricServiceConnection(

--- a/google/cloud/monitoring/mocks/mock_metric_connection.h
+++ b/google/cloud/monitoring/mocks/mock_metric_connection.h
@@ -74,6 +74,10 @@ class MockMetricServiceConnection : public monitoring::MetricServiceConnection {
   MOCK_METHOD(Status, CreateServiceTimeSeries,
               (google::monitoring::v3::CreateTimeSeriesRequest const& request),
               (override));
+
+  MOCK_METHOD(future<Status>, AsyncCreateTimeSeries,
+              (google::monitoring::v3::CreateTimeSeriesRequest const& request),
+              (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
At least one team is interested in using the asynchronous version of
this RPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8983)
<!-- Reviewable:end -->
