### PR TITLE
cleanup(GCS+gRPC): avoid excessive copies in `*BucketAcl()`

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -569,7 +569,7 @@ StatusOr<BucketAccessControl> GrpcClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
-  auto updater = [request](std::vector<BucketAccessControl> acl)
+  auto updater = [&request](std::vector<BucketAccessControl> acl)
       -> StatusOr<std::vector<BucketAccessControl>> {
     for (auto const& entry : acl) {
       if (entry.entity() == request.entity()) {
@@ -592,7 +592,7 @@ StatusOr<EmptyResponse> GrpcClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
-  auto updater = [request](std::vector<BucketAccessControl> acl)
+  auto updater = [&request](std::vector<BucketAccessControl> acl)
       -> StatusOr<std::vector<BucketAccessControl>> {
     auto i = std::remove_if(acl.begin(), acl.end(),
                             [&](BucketAccessControl const& entry) {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8987)
<!-- Reviewable:end -->
