### PR TITLE
fix(GCS+gRPC): use all tracing components from environment variable

### DIFF
--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -214,14 +214,9 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
   auto tracing =
       google::cloud::internal::GetEnv("CLOUD_STORAGE_ENABLE_TRACING");
   if (tracing.has_value()) {
-    std::set<std::string> const enabled = absl::StrSplit(*tracing, ',');
-    if (enabled.end() != enabled.find("http")) {
-      GCP_LOG(INFO) << "Enabling logging for http";
-      o.lookup<TracingComponentsOption>().insert("http");
-    }
-    if (enabled.end() != enabled.find("raw-client")) {
-      GCP_LOG(INFO) << "Enabling logging for RawClient functions";
-      o.lookup<TracingComponentsOption>().insert("raw-client");
+    for (auto c : absl::StrSplit(*tracing, ',')) {
+      GCP_LOG(INFO) << "Enabling logging for " << c;
+      o.lookup<TracingComponentsOption>().insert(std::string(c));
     }
   }
 


### PR DESCRIPTION
For historical reasons, the storage library uses
`CLOUD_STORAGE_TRACING_COMPONENTS`.  It was filtering the components
provided in this environment variable, which made it impossible to
enable logging for GCS+gRPC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8994)
<!-- Reviewable:end -->
