### PR TITLE
fix(GCS+gRPC): unused mutable Object fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ https://github.com/googleapis/google-cloud-cpp/issues/8234.
 
 ## v1.40.0 - TBD
 
+## v1.39.2 - 2022-05
+
+* fix(GCS+gRPC): unused mutable Object fields ([#8997](https://github.com/googleapis/google-cloud-cpp/pull/8997))
+
 ## v1.39.1 - 2022-04
 
 * Update Bazel builds, CI builds, and packaging instructions to use grpc-1.45.2

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -137,26 +137,31 @@ Status SetObjectMetadata(google::storage::v2::Object& resource,
   if (!metadata.content_type().empty()) {
     resource.set_content_type(metadata.content_type());
   }
-  if (metadata.event_based_hold()) {
-    resource.set_event_based_hold(metadata.event_based_hold());
-  }
-
+  resource.set_temporary_hold(metadata.temporary_hold());
   for (auto const& kv : metadata.metadata()) {
     (*resource.mutable_metadata())[kv.first] = kv.second;
   }
-
-  if (!metadata.storage_class().empty()) {
-    resource.set_storage_class(metadata.storage_class());
+  if (metadata.event_based_hold()) {
+    resource.set_event_based_hold(metadata.event_based_hold());
   }
-  resource.set_temporary_hold(metadata.temporary_hold());
-
-  if (metadata.has_customer_encryption()) {
-    auto encryption =
-        GrpcObjectMetadataParser::ToProto(metadata.customer_encryption());
-    if (!encryption) return std::move(encryption).status();
-    *resource.mutable_customer_encryption() = *std::move(encryption);
+  // The customer_encryption field is never set via the object resource, gRPC
+  // defines a separate message (`CommonObjectRequestParams`) and field in each
+  // request to include the encryption info.
+  // *resource.mutable_customer_encryption() = ...;
+  if (metadata.has_custom_time()) {
+    *resource.mutable_custom_time() =
+        google::cloud::internal::ToProtoTimestamp(metadata.custom_time());
   }
   return Status{};
+}
+
+// Only a few requests can set the storage class of the destination Object.
+template <typename StorageRequest>
+void SetStorageClass(google::storage::v2::Object& resource,
+                     StorageRequest const& req) {
+  if (!req.template HasOption<WithObjectMetadata>()) return;
+  auto metadata = req.template GetOption<WithObjectMetadata>().value();
+  resource.set_storage_class(metadata.storage_class());
 }
 
 }  // namespace
@@ -184,6 +189,7 @@ GrpcObjectRequestParser::ToProto(ComposeObjectRequest const& request) {
     destination.set_cache_control(metadata.cache_control());
     destination.set_content_language(metadata.content_language());
     destination.set_content_type(metadata.content_type());
+    destination.set_storage_class(metadata.storage_class());
     destination.set_temporary_hold(metadata.temporary_hold());
     destination.set_event_based_hold(metadata.event_based_hold());
     if (metadata.has_custom_time()) {
@@ -423,6 +429,7 @@ GrpcObjectRequestParser::ToProto(InsertObjectMediaRequest const& request) {
   SetResourceOptions(resource, request);
   auto status = SetObjectMetadata(resource, request);
   if (!status.ok()) return status;
+  SetStorageClass(resource, request);
   SetPredefinedAcl(object_spec, request);
   SetGenerationConditions(object_spec, request);
   SetMetagenerationConditions(object_spec, request);
@@ -535,27 +542,9 @@ GrpcObjectRequestParser::ToProto(RewriteObjectRequest const& request) {
     auto& destination = *result.mutable_destination();
     destination.set_kms_key(
         request.GetOption<DestinationKmsKeyName>().value_or(""));
-    // Only a few fields can be set as part of the metadata request.
-    auto m = request.GetOption<WithObjectMetadata>().value();
-    destination.set_storage_class(m.storage_class());
-    destination.set_content_encoding(m.content_encoding());
-    destination.set_content_disposition(m.content_disposition());
-    destination.set_cache_control(m.cache_control());
-    destination.set_content_language(m.content_language());
-    destination.set_content_type(m.content_type());
-    destination.set_temporary_hold(m.temporary_hold());
-    for (auto const& kv : m.metadata()) {
-      (*destination.mutable_metadata())[kv.first] = kv.second;
-    }
-    if (m.event_based_hold()) {
-      // The proto is an optional<bool>, avoid setting it to `false`, seems
-      // confusing.
-      destination.set_event_based_hold(m.event_based_hold());
-    }
-    if (m.has_custom_time()) {
-      *destination.mutable_custom_time() =
-          google::cloud::internal::ToProtoTimestamp(m.custom_time());
-    }
+    status = SetObjectMetadata(destination, request);
+    if (!status.ok()) return status;
+    SetStorageClass(destination, request);
   }
   result.set_source_bucket("projects/_/buckets/" + request.source_bucket());
   result.set_source_object(request.source_object());
@@ -634,27 +623,9 @@ GrpcObjectRequestParser::ToProto(CopyObjectRequest const& request) {
     auto& destination = *result.mutable_destination();
     destination.set_kms_key(
         request.GetOption<DestinationKmsKeyName>().value_or(""));
-    // Only a few fields can be set as part of the metadata request.
-    auto m = request.GetOption<WithObjectMetadata>().value();
-    destination.set_storage_class(m.storage_class());
-    destination.set_content_encoding(m.content_encoding());
-    destination.set_content_disposition(m.content_disposition());
-    destination.set_cache_control(m.cache_control());
-    destination.set_content_language(m.content_language());
-    destination.set_content_type(m.content_type());
-    destination.set_temporary_hold(m.temporary_hold());
-    for (auto const& kv : m.metadata()) {
-      (*destination.mutable_metadata())[kv.first] = kv.second;
-    }
-    if (m.event_based_hold()) {
-      // The proto is an optional<bool>, avoid setting it to `false`, seems
-      // confusing.
-      destination.set_event_based_hold(m.event_based_hold());
-    }
-    if (m.has_custom_time()) {
-      *destination.mutable_custom_time() =
-          google::cloud::internal::ToProtoTimestamp(m.custom_time());
-    }
+    status = SetObjectMetadata(destination, request);
+    if (!status.ok()) return status;
+    SetStorageClass(destination, request);
   }
   result.set_source_bucket("projects/_/buckets/" + request.source_bucket());
   result.set_source_object(request.source_object());
@@ -710,6 +681,7 @@ GrpcObjectRequestParser::ToProto(ResumableUploadRequest const& request) {
   SetResourceOptions(resource, request);
   status = SetObjectMetadata(resource, request);
   if (!status.ok()) return status;
+  SetStorageClass(resource, request);
   SetPredefinedAcl(object_spec, request);
   SetGenerationConditions(object_spec, request);
   SetMetagenerationConditions(object_spec, request);

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -32,6 +32,7 @@ namespace {
 namespace storage_proto = ::google::storage::v2;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
+using ::google::protobuf::TextFormat;
 using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
 
@@ -63,47 +64,103 @@ auto constexpr kText = "The quick brown fox jumps over the lazy dog";
 //     MD5         : 4ad12fa3657faa80c2b9a92d652c3721
 auto constexpr kAlt = "How vexingly quick daft zebras jump!";
 
+// Many of the tests need to verify that all fields can be set when creating
+// or updating objects. The next two functions provide most of the values for
+// such objects. There are a few edge conditions:
+// - Some fields, like `storage_class`, an only be set in create operations,
+//   we leave those undefined here, and explicitly set them in each test
+// - Some fields, like the object name and bucket, are required in some gRPC
+//   requests, but not others. We also leave those undefined here.
+// - Some fields, like `kms_key`, can be set via an option or via the object
+//   metadata. We leave those undefined here too.
+google::storage::v2::Object ExpectedFullObjectMetadata() {
+  // The fields are sorted as they appear in the .proto file.
+  auto constexpr kProto = R"pb(
+    # storage_class: "REGIONAL" ## set only where applicable
+    content_encoding: "test-content-encoding"
+    content_disposition: "test-content-disposition"
+    cache_control: "test-cache-control"
+    acl: { role: "test-role1" entity: "test-entity1" }
+    acl: { role: "test-role2" entity: "test-entity2" }
+    content_language: "test-content-language"
+    content_type: "test-content-type"
+    temporary_hold: true
+    metadata: { key: "test-metadata-key1" value: "test-value1" }
+    metadata: { key: "test-metadata-key2" value: "test-value2" }
+    event_based_hold: true
+    custom_time { seconds: 1643126687 nanos: 123000000 }
+  )pb";
+  google::storage::v2::Object proto;
+  if (TextFormat::ParseFromString(kProto, &proto)) return proto;
+  ADD_FAILURE() << "Parsing text proto for " << __func__ << " failed";
+  return proto;
+}
+
+ObjectMetadata FullObjectMetadata() {
+  return ObjectMetadata{}
+      .set_content_encoding("test-content-encoding")
+      .set_content_disposition("test-content-disposition")
+      .set_cache_control("test-cache-control")
+      .set_acl({ObjectAccessControl()
+                    .set_role("test-role1")
+                    .set_entity("test-entity1"),
+                ObjectAccessControl()
+                    .set_role("test-role2")
+                    .set_entity("test-entity2")})
+      .set_content_language("test-content-language")
+      .set_content_type("test-content-type")
+      .set_temporary_hold(true)
+      .upsert_metadata("test-metadata-key1", "test-value1")
+      .upsert_metadata("test-metadata-key2", "test-value2")
+      .set_event_based_hold(true)
+      .set_custom_time(std::chrono::system_clock::time_point{} +
+                       std::chrono::seconds(1643126687) +
+                       std::chrono::milliseconds(123));
+}
+
+google::storage::v2::CommonObjectRequestParams
+ExpectedCommonObjectRequestParams() {
+  // To get the magic values use:
+  //  /bin/echo -n "01234567" | sha256sum
+  auto constexpr kProto = R"pb(
+    encryption_algorithm: "AES256"
+    encryption_key_bytes: "01234567"
+    encryption_key_sha256_bytes: "\x92\x45\x92\xb9\xb1\x03\xf1\x4f\x83\x3f\xaa\xfb\x67\xf4\x80\x69\x1f\x01\x98\x8a\xa4\x57\xc0\x06\x17\x69\xf5\x8c\xd4\x73\x11\xbc"
+  )pb";
+  google::storage::v2::CommonObjectRequestParams proto;
+  if (TextFormat::ParseFromString(kProto, &proto)) return proto;
+  ADD_FAILURE() << "Parsing text proto for " << __func__ << " failed";
+  return proto;
+}
+
 TEST(GrpcObjectRequestParser, ComposeObjectRequestAllOptions) {
+  auto constexpr kTextProto = R"pb(
+    source_objects { name: "source-object-1" }
+    source_objects {
+      name: "source-object-2"
+      generation: 27
+      object_preconditions { if_generation_match: 28 }
+    }
+    source_objects { name: "source-object-3" generation: 37 }
+    source_objects {
+      name: "source-object-4"
+      object_preconditions { if_generation_match: 48 }
+    }
+    destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+    if_generation_match: 1
+    if_metageneration_match: 3
+    kms_key: "test-only-kms-key"
+    common_request_params: { user_project: "test-user-project" }
+  )pb";
   google::storage::v2::ComposeObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        destination {
-          bucket: "projects/_/buckets/bucket-name"
-          name: "object-name"
-          acl { entity: "allUsers" role: "READER" }
-          content_encoding: "test-only-content-encoding"
-          content_disposition: "test-only-content-disposition"
-          cache_control: "test-only-cache-control"
-          content_language: "test-only-content-language"
-          content_type: "test-only-content-type"
-          temporary_hold: true
-          metadata { key: "key0" value: "value0" }
-          event_based_hold: true
-          custom_time { seconds: 1643126687 nanos: 123000000 }
-        }
-        source_objects { name: "source-object-1" }
-        source_objects {
-          name: "source-object-2"
-          generation: 27
-          object_preconditions { if_generation_match: 28 }
-        }
-        source_objects { name: "source-object-3" generation: 37 }
-        source_objects {
-          name: "source-object-4"
-          object_preconditions { if_generation_match: 48 }
-        }
-        destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
-        if_generation_match: 1
-        if_metageneration_match: 3
-        kms_key: "test-only-kms-key"
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
-        common_request_params: { user_project: "test-user-project" }
-      )pb",
-      &expected));
+  ASSERT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  auto& destination = *expected.mutable_destination();
+  destination = ExpectedFullObjectMetadata();
+  destination.set_bucket("projects/_/buckets/bucket-name");
+  destination.set_name("object-name");
+  destination.set_storage_class("STANDARD");
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   ComposeObjectRequest req(
       "bucket-name",
@@ -119,22 +176,7 @@ TEST(GrpcObjectRequestParser, ComposeObjectRequestAllOptions) {
       DestinationPredefinedAcl("projectPrivate"),
       KmsKeyName("test-only-kms-key"), IfGenerationMatch(1),
       IfMetagenerationMatch(3), UserProject("test-user-project"),
-      WithObjectMetadata(
-          ObjectMetadata{}
-              .set_acl({ObjectAccessControl{}
-                            .set_entity("allUsers")
-                            .set_role("READER")})
-              .set_content_encoding("test-only-content-encoding")
-              .set_content_disposition("test-only-content-disposition")
-              .set_cache_control("test-only-cache-control")
-              .set_content_language("test-only-content-language")
-              .set_content_type("test-only-content-type")
-              .upsert_metadata("key0", "value0")
-              .set_temporary_hold(true)
-              .set_event_based_hold(true)
-              .set_custom_time(std::chrono::system_clock::time_point{} +
-                               std::chrono::seconds(1643126687) +
-                               std::chrono::milliseconds(123))),
+      WithObjectMetadata(FullObjectMetadata().set_storage_class("STANDARD")),
       QuotaUser("test-quota-user"), UserIp("test-user-ip"));
 
   auto actual = GrpcObjectRequestParser::ToProto(req);
@@ -144,7 +186,7 @@ TEST(GrpcObjectRequestParser, ComposeObjectRequestAllOptions) {
 
 TEST(GrpcObjectRequestParser, DeleteObjectAllFields) {
   google::storage::v2::DeleteObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         bucket: "projects/_/buckets/test-bucket"
         object: "test-object"
@@ -170,7 +212,7 @@ TEST(GrpcObjectRequestParser, DeleteObjectAllFields) {
 
 TEST(GrpcObjectRequestParser, GetObjectMetadataAllFields) {
   google::storage::v2::GetObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         bucket: "projects/_/buckets/test-bucket"
         object: "test-object"
@@ -197,7 +239,7 @@ TEST(GrpcObjectRequestParser, GetObjectMetadataAllFields) {
 
 TEST(GrpcObjectRequestParser, ReadObjectRangeRequestSimple) {
   google::storage::v2::ReadObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         bucket: "projects/_/buckets/test-bucket" object: "test-object"
       )pb",
@@ -211,7 +253,7 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestSimple) {
 
 TEST(GrpcObjectRequestParser, ReadObjectRangeRequestAllFields) {
   google::storage::v2::ReadObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         bucket: "projects/_/buckets/test-bucket"
         object: "test-object"
@@ -223,17 +265,10 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestAllFields) {
         if_metageneration_match: 3
         if_metageneration_not_match: 4
         common_request_params: { user_project: "test-user-project" }
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          # to get the key value use:
-          #   /bin/echo -n "01234567"
-          # to get the key hash use (note this command goes over two lines):
-          #   /bin/echo -n "01234567" | sha256sum
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\x92\x45\x92\xb9\xb1\x03\xf1\x4f\x83\x3f\xaa\xfb\x67\xf4\x80\x69\x1f\x01\x98\x8a\xa4\x57\xc0\x06\x17\x69\xf5\x8c\xd4\x73\x11\xbc"
-        }
       )pb",
       &expected));
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   ReadObjectRangeRequest req("test-bucket", "test-object");
   req.set_multiple_options(
@@ -249,7 +284,7 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestAllFields) {
 
 TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLast) {
   google::storage::v2::ReadObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         bucket: "projects/_/buckets/test-bucket"
         object: "test-object"
@@ -266,7 +301,7 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLast) {
 
 TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLastZero) {
   google::storage::v2::ReadObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         bucket: "projects/_/buckets/test-bucket" object: "test-object"
       )pb",
@@ -287,52 +322,44 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLastZero) {
 }
 
 TEST(GrpcObjectRequestParser, PatchObjectRequestAllOptions) {
+  auto constexpr kTextProto = R"pb(
+    predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+    if_generation_match: 1
+    if_generation_not_match: 2
+    if_metageneration_match: 3
+    if_metageneration_not_match: 4
+    common_request_params: { user_project: "test-user-project" }
+    update_mask {}
+  )pb";
   google::storage::v2::UpdateObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        object {
-          bucket: "projects/_/buckets/bucket-name"
-          name: "object-name"
-          generation: 7
-          acl { entity: "allUsers" role: "READER" }
-          content_encoding: "test-only-content-encoding"
-          content_disposition: "test-only-content-disposition"
-          cache_control: "test-only-cache-control"
-          content_language: "test-only-content-language"
-          content_type: "test-only-content-type"
-          temporary_hold: true
-          metadata { key: "key0" value: "value0" }
-          event_based_hold: true
-          custom_time { seconds: 1643126687 nanos: 123000000 }
-        }
-        predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
-        if_generation_match: 1
-        if_generation_not_match: 2
-        if_metageneration_match: 3
-        if_metageneration_not_match: 4
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
-        common_request_params: { user_project: "test-user-project" }
-        update_mask {}
-      )pb",
-      &expected));
+  ASSERT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  auto& object = *expected.mutable_object();
+  object = ExpectedFullObjectMetadata();
+  object.set_name("object-name");
+  object.set_bucket("projects/_/buckets/bucket-name");
+  object.set_generation(7);
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   PatchObjectRequest req(
       "bucket-name", "object-name",
       ObjectMetadataPatchBuilder{}
-          .SetAcl(
-              {ObjectAccessControl{}.set_entity("allUsers").set_role("READER")})
-          .SetContentEncoding("test-only-content-encoding")
-          .SetContentDisposition("test-only-content-disposition")
-          .SetCacheControl("test-only-cache-control")
-          .SetContentLanguage("test-only-content-language")
-          .SetContentType("test-only-content-type")
-          .SetMetadata("key0", "value0")
-          .SetContentType("test-only-content-type")
+          .SetContentEncoding("test-content-encoding")
+          .SetContentDisposition("test-content-disposition")
+          .SetCacheControl("test-cache-control")
+          .SetContentLanguage("test-content-language")
+          .SetContentType("test-content-type")
+          .SetMetadata("test-metadata-key1", "test-value1")
+          .SetMetadata("test-metadata-key2", "test-value2")
           .SetTemporaryHold(true)
+          .SetAcl({
+              ObjectAccessControl{}
+                  .set_entity("test-entity1")
+                  .set_role("test-role1"),
+              ObjectAccessControl{}
+                  .set_entity("test-entity2")
+                  .set_role("test-role2"),
+          })
           .SetEventBasedHold(true)
           .SetCustomTime(std::chrono::system_clock::time_point{} +
                          std::chrono::seconds(1643126687) +
@@ -360,55 +387,26 @@ TEST(GrpcObjectRequestParser, PatchObjectRequestAllOptions) {
 }
 
 TEST(GrpcObjectRequestParser, UpdateObjectRequestAllOptions) {
+  auto constexpr kTextProto = R"pb(
+    predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+    if_generation_match: 1
+    if_generation_not_match: 2
+    if_metageneration_match: 3
+    if_metageneration_not_match: 4
+    common_request_params: { user_project: "test-user-project" }
+    update_mask {}
+  )pb";
   google::storage::v2::UpdateObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        object {
-          bucket: "projects/_/buckets/bucket-name"
-          name: "object-name"
-          generation: 7
-          acl { entity: "allUsers" role: "READER" }
-          content_encoding: "test-only-content-encoding"
-          content_disposition: "test-only-content-disposition"
-          cache_control: "test-only-cache-control"
-          content_language: "test-only-content-language"
-          content_type: "test-only-content-type"
-          temporary_hold: true
-          metadata { key: "key0" value: "value0" }
-          event_based_hold: true
-          custom_time { seconds: 1643126687 nanos: 123000000 }
-        }
-        predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
-        if_generation_match: 1
-        if_generation_not_match: 2
-        if_metageneration_match: 3
-        if_metageneration_not_match: 4
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
-        common_request_params: { user_project: "test-user-project" }
-        update_mask {}
-      )pb",
-      &expected));
+  ASSERT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  auto& object = *expected.mutable_object();
+  object = ExpectedFullObjectMetadata();
+  object.set_bucket("projects/_/buckets/bucket-name");
+  object.set_name("object-name");
+  object.set_generation(7);
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
-  UpdateObjectRequest req(
-      "bucket-name", "object-name",
-      ObjectMetadata{}
-          .set_acl(
-              {ObjectAccessControl{}.set_entity("allUsers").set_role("READER")})
-          .set_content_encoding("test-only-content-encoding")
-          .set_content_disposition("test-only-content-disposition")
-          .set_cache_control("test-only-cache-control")
-          .set_content_language("test-only-content-language")
-          .set_content_type("test-only-content-type")
-          .upsert_metadata("key0", "value0")
-          .set_temporary_hold(true)
-          .set_event_based_hold(true)
-          .set_custom_time(std::chrono::system_clock::time_point{} +
-                           std::chrono::seconds(1643126687) +
-                           std::chrono::milliseconds(123)));
+  UpdateObjectRequest req("bucket-name", "object-name", FullObjectMetadata());
   req.set_multiple_options(
       Generation(7), IfGenerationMatch(1), IfGenerationNotMatch(2),
       IfMetagenerationMatch(3), IfMetagenerationNotMatch(4),
@@ -433,7 +431,7 @@ TEST(GrpcObjectRequestParser, UpdateObjectRequestAllOptions) {
 
 TEST(GrpcObjectRequestParser, InsertObjectMediaRequestSimple) {
   storage_proto::WriteObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         write_object_spec: {
           resource: {
@@ -551,8 +549,8 @@ TEST(GrpcObjectRequestParser, InsertObjectMediaRequestHashOptions) {
   for (auto const& test : cases) {
     SCOPED_TRACE("Expected outcome " + test.expected_checksums);
     storage_proto::ObjectChecksums expected;
-    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-        test.expected_checksums, &expected));
+    ASSERT_TRUE(
+        TextFormat::ParseFromString(test.expected_checksums, &expected));
 
     InsertObjectMediaRequest request("test-bucket-name", "test-object-name",
                                      kAlt);
@@ -564,44 +562,36 @@ TEST(GrpcObjectRequestParser, InsertObjectMediaRequestHashOptions) {
 }
 
 TEST(GrpcObjectRequestParser, InsertObjectMediaRequestAllOptions) {
-  storage_proto::WriteObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  auto constexpr kTextProto =
       R"pb(
-        write_object_spec: {
-          resource: {
-            bucket: "projects/_/buckets/test-bucket-name"
-            name: "test-object-name"
-            content_type: "test-content-type"
-            content_encoding: "test-content-encoding"
-            # Should not be set, the proto file says these values should
-            # not be included in the upload
-            #     crc32c:
-            #     md5_hash:
-            kms_key: "test-kms-key-name"
-          }
-          predefined_acl: OBJECT_ACL_PRIVATE
-          if_generation_match: 0
-          if_generation_not_match: 7
-          if_metageneration_match: 42
-          if_metageneration_not_match: 84
-        }
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          # to get the key value use:
-          #   /bin/echo -n "01234567"
-          # to get the key hash use (note this command goes over two lines):
-          #   /bin/echo -n "01234567" | sha256sum
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\x92\x45\x92\xb9\xb1\x03\xf1\x4f\x83\x3f\xaa\xfb\x67\xf4\x80\x69\x1f\x01\x98\x8a\xa4\x57\xc0\x06\x17\x69\xf5\x8c\xd4\x73\x11\xbc"
-        }
-        common_request_params: { user_project: "test-user-project" }
-        object_checksums: {
-          # See top-of-file comments for details on the magic numbers
-          crc32c: 0x22620404
-          md5_hash: "\x9e\x10\x7d\x9d\x37\x2b\xb6\x82\x6b\xd8\x1d\x35\x42\xa4\x19\xd6"
-        }
-      )pb",
-      &expected));
+    write_object_spec: {
+      resource: {
+        bucket: "projects/_/buckets/test-bucket-name"
+        name: "test-object-name"
+        content_type: "test-content-type"
+        content_encoding: "test-content-encoding"
+        # Should not be set, the proto file says these values should
+        # not be included in the upload
+        #     crc32c:
+        #     md5_hash:
+        kms_key: "test-kms-key-name"
+      }
+      predefined_acl: OBJECT_ACL_PRIVATE
+      if_generation_match: 0
+      if_generation_not_match: 7
+      if_metageneration_match: 42
+      if_metageneration_not_match: 84
+    }
+    common_request_params: { user_project: "test-user-project" }
+    object_checksums: {
+      # See top-of-file comments for details on the magic numbers
+      crc32c: 0x22620404
+      md5_hash: "\x9e\x10\x7d\x9d\x37\x2b\xb6\x82\x6b\xd8\x1d\x35\x42\xa4\x19\xd6"
+    })pb";
+  storage_proto::WriteObjectRequest expected;
+  EXPECT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   auto constexpr kContents = "The quick brown fox jumps over the lazy dog";
 
@@ -623,53 +613,24 @@ TEST(GrpcObjectRequestParser, InsertObjectMediaRequestAllOptions) {
 }
 
 TEST(GrpcObjectRequestParser, InsertObjectMediaRequestWithObjectMetadata) {
+  auto constexpr kTextProto = R"pb(
+    # See top-of-file comments for details on the magic numbers
+    object_checksums: { crc32c: 0x22620404 }
+  )pb";
   storage_proto::WriteObjectRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        write_object_spec: {
-          resource: {
-            bucket: "projects/_/buckets/test-bucket-name"
-            name: "test-object-name"
-            acl: { role: "test-role1" entity: "test-entity1" }
-            acl: { role: "test-role2" entity: "test-entity2" }
-            cache_control: "test-cache-control"
-            content_disposition: "test-content-disposition"
-            content_encoding: "test-content-encoding"
-            content_language: "test-content-language"
-            content_type: "test-content-type"
-            event_based_hold: true
-            metadata: { key: "test-key-1" value: "test-value-1" }
-            metadata: { key: "test-key-2" value: "test-value-2" }
-            storage_class: "test-storage-class"
-            temporary_hold: true
-          }
-        }
-        # See top-of-file comments for details on the magic numbers
-        object_checksums: { crc32c: 0x22620404 }
-      )pb",
-      &expected));
+  EXPECT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  auto& resource = *expected.mutable_write_object_spec()->mutable_resource();
+  resource = ExpectedFullObjectMetadata();
+  resource.set_bucket("projects/_/buckets/test-bucket-name");
+  resource.set_name("test-object-name");
+  resource.set_storage_class("STANDARD");
 
   auto constexpr kContents = "The quick brown fox jumps over the lazy dog";
 
-  std::vector<ObjectAccessControl> acls{
-      ObjectAccessControl().set_role("test-role1").set_entity("test-entity1"),
-      ObjectAccessControl().set_role("test-role2").set_entity("test-entity2")};
-
   InsertObjectMediaRequest request("test-bucket-name", "test-object-name",
                                    kContents);
-  request.set_multiple_options(WithObjectMetadata(
-      ObjectMetadata()
-          .set_acl(acls)
-          .set_cache_control("test-cache-control")
-          .set_content_disposition("test-content-disposition")
-          .set_content_encoding("test-content-encoding")
-          .set_content_language("test-content-language")
-          .set_content_type("test-content-type")
-          .set_event_based_hold(true)
-          .upsert_metadata("test-key-1", "test-value-1")
-          .upsert_metadata("test-key-2", "test-value-2")
-          .set_storage_class("test-storage-class")
-          .set_temporary_hold(true)));
+  request.set_multiple_options(
+      WithObjectMetadata(FullObjectMetadata().set_storage_class("STANDARD")));
 
   auto actual = GrpcObjectRequestParser::ToProto(request).value();
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -677,7 +638,7 @@ TEST(GrpcObjectRequestParser, InsertObjectMediaRequestWithObjectMetadata) {
 
 TEST(GrpcObjectRequestParser, WriteObjectResponseSimple) {
   google::storage::v2::WriteObjectResponse input;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         persisted_size: 123456
       )pb",
@@ -691,7 +652,7 @@ TEST(GrpcObjectRequestParser, WriteObjectResponseSimple) {
 
 TEST(GrpcObjectRequestParser, WriteObjectResponseWithResource) {
   google::storage::v2::WriteObjectResponse input;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         resource {
           name: "test-object-name"
@@ -711,7 +672,7 @@ TEST(GrpcObjectRequestParser, WriteObjectResponseWithResource) {
 
 TEST(GrpcObjectRequestParser, ListObjectsRequestAllFields) {
   google::storage::v2::ListObjectsRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         parent: "projects/_/buckets/test-bucket"
         page_size: 10
@@ -740,7 +701,7 @@ TEST(GrpcObjectRequestParser, ListObjectsRequestAllFields) {
 
 TEST(GrpcObjectRequestParser, ListObjectsResponse) {
   google::storage::v2::ListObjectsResponse response;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         objects { bucket: "projects/_/buckets/test-bucket" name: "object1" }
         objects { bucket: "projects/_/buckets/test-bucket" name: "object2" }
@@ -762,55 +723,44 @@ TEST(GrpcObjectRequestParser, ListObjectsResponse) {
 }
 
 TEST(GrpcObjectRequestParser, RewriteObjectRequestAllOptions) {
+  auto constexpr kTextProto = R"pb(
+    destination_bucket: "projects/_/buckets/destination-bucket"
+    destination_name: "destination-object"
+    source_bucket: "projects/_/buckets/source-bucket"
+    source_object: "source-object"
+    source_generation: 7
+    rewrite_token: "test-only-rewrite-token"
+    destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+    if_generation_match: 1
+    if_generation_not_match: 2
+    if_metageneration_match: 3
+    if_metageneration_not_match: 4
+    if_source_generation_match: 5
+    if_source_generation_not_match: 6
+    if_source_metageneration_match: 7
+    if_source_metageneration_not_match: 8
+    max_bytes_rewritten_per_call: 123456
+    copy_source_encryption_algorithm: "AES256"
+    copy_source_encryption_key_bytes: "ABCDEFGH"
+    # Used `/bin/echo -n "ABCDEFGH" | sha256sum` to create this magic string
+    copy_source_encryption_key_sha256_bytes: "\x9a\xc2\x19\x7d\x92\x58\x25\x7b\x1a\xe8\x46\x3e\x42\x14\xe4\xcd\x0a\x57\x8b\xc1\x51\x7f\x24\x15\x92\x8b\x91\xbe\x42\x83\xfc\x48"
+    common_request_params: { user_project: "test-user-project" }
+  )pb";
   google::storage::v2::RewriteObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        destination_bucket: "projects/_/buckets/destination-bucket"
-        destination_name: "destination-object"
-        destination {
-          storage_class: "STANDARD"
-          content_encoding: "test-only-content-encoding"
-          content_disposition: "test-only-content-disposition"
-          cache_control: "test-only-cache-control"
-          content_language: "test-only-content-language"
-          content_type: "test-only-content-type"
-          kms_key: "test-only-destination-kms-key-name"
-          temporary_hold: true
-          metadata { key: "key0" value: "value0" }
-          event_based_hold: true
-          custom_time { seconds: 1643126687 nanos: 123000000 }
-        }
-        source_bucket: "projects/_/buckets/source-bucket"
-        source_object: "source-object"
-        source_generation: 7
-        rewrite_token: "test-only-rewrite-token"
-        destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
-        if_generation_match: 1
-        if_generation_not_match: 2
-        if_metageneration_match: 3
-        if_metageneration_not_match: 4
-        if_source_generation_match: 5
-        if_source_generation_not_match: 6
-        if_source_metageneration_match: 7
-        if_source_metageneration_not_match: 8
-        max_bytes_rewritten_per_call: 123456
-        copy_source_encryption_algorithm: "AES256"
-        copy_source_encryption_key_bytes: "ABCDEFGH"
-        copy_source_encryption_key_sha256_bytes: "\232\302\031}\222X%{\032\350F>B\024\344\315\nW\213\301Q\177$\025\222\213\221\276B\203\374H"
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
-        common_request_params: { user_project: "test-user-project" }
-      )pb",
-      &expected));
+  ASSERT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  auto& destination = *expected.mutable_destination();
+  destination = ExpectedFullObjectMetadata();
+  // Set via the `DestinationKmsKeyName()` option.
+  destination.set_kms_key("test-kms-key-name-from-option");
+  destination.set_storage_class("STANDARD");
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   RewriteObjectRequest req("source-bucket", "source-object",
                            "destination-bucket", "destination-object",
                            "test-only-rewrite-token");
   req.set_multiple_options(
-      DestinationKmsKeyName("test-only-destination-kms-key-name"),
+      DestinationKmsKeyName("test-kms-key-name-from-option"),
       DestinationPredefinedAcl("projectPrivate"),
       EncryptionKey::FromBinaryKey("01234567"), IfGenerationMatch(1),
       IfGenerationNotMatch(2), IfMetagenerationMatch(3),
@@ -820,20 +770,7 @@ TEST(GrpcObjectRequestParser, RewriteObjectRequestAllOptions) {
       Projection("full"), SourceEncryptionKey::FromBinaryKey("ABCDEFGH"),
       SourceGeneration(7), UserProject("test-user-project"),
       QuotaUser("test-quota-user"), UserIp("test-user-ip"),
-      WithObjectMetadata(
-          ObjectMetadata()
-              .set_storage_class("STANDARD")
-              .set_content_encoding("test-only-content-encoding")
-              .set_content_disposition("test-only-content-disposition")
-              .set_cache_control("test-only-cache-control")
-              .set_content_language("test-only-content-language")
-              .upsert_metadata("key0", "value0")
-              .set_content_type("test-only-content-type")
-              .set_temporary_hold(true)
-              .set_event_based_hold(true)
-              .set_custom_time(std::chrono::system_clock::time_point{} +
-                               std::chrono::seconds(1643126687) +
-                               std::chrono::milliseconds(123))));
+      WithObjectMetadata(FullObjectMetadata().set_storage_class("STANDARD")));
 
   auto const actual = GrpcObjectRequestParser::ToProto(req);
   ASSERT_STATUS_OK(actual);
@@ -842,7 +779,7 @@ TEST(GrpcObjectRequestParser, RewriteObjectRequestAllOptions) {
 
 TEST(GrpcObjectRequestParser, RewriteObjectRequestNoDestination) {
   google::storage::v2::RewriteObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         destination_bucket: "projects/_/buckets/destination-bucket"
         destination_name: "destination-object"
@@ -862,15 +799,13 @@ TEST(GrpcObjectRequestParser, RewriteObjectRequestNoDestination) {
         max_bytes_rewritten_per_call: 123456
         copy_source_encryption_algorithm: "AES256"
         copy_source_encryption_key_bytes: "ABCDEFGH"
-        copy_source_encryption_key_sha256_bytes: "\232\302\031}\222X%{\032\350F>B\024\344\315\nW\213\301Q\177$\025\222\213\221\276B\203\374H"
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
+        # Used `/bin/echo -n "ABCDEFGH" | sha256sum` to create this magic string
+        copy_source_encryption_key_sha256_bytes: "\x9a\xc2\x19\x7d\x92\x58\x25\x7b\x1a\xe8\x46\x3e\x42\x14\xe4\xcd\x0a\x57\x8b\xc1\x51\x7f\x24\x15\x92\x8b\x91\xbe\x42\x83\xfc\x48"
         common_request_params: { user_project: "test-user-project" }
       )pb",
       &expected));
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   RewriteObjectRequest req("source-bucket", "source-object",
                            "destination-bucket", "destination-object",
@@ -893,7 +828,7 @@ TEST(GrpcObjectRequestParser, RewriteObjectRequestNoDestination) {
 
 TEST(GrpcObjectRequestParser, RewriteObjectResponse) {
   google::storage::v2::RewriteResponse input;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         total_bytes_rewritten: 123456
         object_size: 1234560
@@ -916,52 +851,40 @@ TEST(GrpcObjectRequestParser, RewriteObjectResponse) {
 }
 
 TEST(GrpcObjectRequestParser, CopyObjectRequestAllOptions) {
+  auto constexpr kTextProto = R"pb(
+    destination_bucket: "projects/_/buckets/destination-bucket"
+    destination_name: "destination-object"
+    source_bucket: "projects/_/buckets/source-bucket"
+    source_object: "source-object"
+    source_generation: 7
+    destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
+    if_generation_match: 1
+    if_generation_not_match: 2
+    if_metageneration_match: 3
+    if_metageneration_not_match: 4
+    if_source_generation_match: 5
+    if_source_generation_not_match: 6
+    if_source_metageneration_match: 7
+    if_source_metageneration_not_match: 8
+    copy_source_encryption_algorithm: "AES256"
+    copy_source_encryption_key_bytes: "ABCDEFGH"
+    # Used `/bin/echo -n "ABCDEFGH" | sha256sum` to create this magic string
+    copy_source_encryption_key_sha256_bytes: "\x9a\xc2\x19\x7d\x92\x58\x25\x7b\x1a\xe8\x46\x3e\x42\x14\xe4\xcd\x0a\x57\x8b\xc1\x51\x7f\x24\x15\x92\x8b\x91\xbe\x42\x83\xfc\x48"
+    common_request_params { user_project: "test-user-project" }
+  )pb";
   google::storage::v2::RewriteObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
-      R"pb(
-        destination_bucket: "projects/_/buckets/destination-bucket"
-        destination_name: "destination-object"
-        destination {
-          storage_class: "STANDARD"
-          content_encoding: "test-only-content-encoding"
-          content_disposition: "test-only-content-disposition"
-          cache_control: "test-only-cache-control"
-          content_language: "test-only-content-language"
-          content_type: "test-only-content-type"
-          kms_key: "test-only-destination-kms-key-name"
-          temporary_hold: true
-          metadata { key: "key0" value: "value0" }
-          event_based_hold: true
-          custom_time { seconds: 1643126687 nanos: 123000000 }
-        }
-        source_bucket: "projects/_/buckets/source-bucket"
-        source_object: "source-object"
-        source_generation: 7
-        destination_predefined_acl: OBJECT_ACL_PROJECT_PRIVATE
-        if_generation_match: 1
-        if_generation_not_match: 2
-        if_metageneration_match: 3
-        if_metageneration_not_match: 4
-        if_source_generation_match: 5
-        if_source_generation_not_match: 6
-        if_source_metageneration_match: 7
-        if_source_metageneration_not_match: 8
-        copy_source_encryption_algorithm: "AES256"
-        copy_source_encryption_key_bytes: "ABCDEFGH"
-        copy_source_encryption_key_sha256_bytes: "\232\302\031}\222X%{\032\350F>B\024\344\315\nW\213\301Q\177$\025\222\213\221\276B\203\374H"
-        common_object_request_params {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
-        common_request_params { user_project: "test-user-project" }
-      )pb",
-      &expected));
+  ASSERT_TRUE(TextFormat::ParseFromString(kTextProto, &expected));
+  auto& destination = *expected.mutable_destination();
+  destination = ExpectedFullObjectMetadata();
+  destination.set_kms_key("test-kms-key-name-from-option");
+  destination.set_storage_class("STANDARD");
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   CopyObjectRequest req("source-bucket", "source-object", "destination-bucket",
                         "destination-object");
   req.set_multiple_options(
-      DestinationKmsKeyName("test-only-destination-kms-key-name"),
+      DestinationKmsKeyName("test-kms-key-name-from-option"),
       DestinationPredefinedAcl("projectPrivate"),
       EncryptionKey::FromBinaryKey("01234567"), IfGenerationMatch(1),
       IfGenerationNotMatch(2), IfMetagenerationMatch(3),
@@ -971,20 +894,7 @@ TEST(GrpcObjectRequestParser, CopyObjectRequestAllOptions) {
       SourceEncryptionKey::FromBinaryKey("ABCDEFGH"), SourceGeneration(7),
       UserProject("test-user-project"), QuotaUser("test-quota-user"),
       UserIp("test-user-ip"),
-      WithObjectMetadata(
-          ObjectMetadata()
-              .set_storage_class("STANDARD")
-              .set_content_encoding("test-only-content-encoding")
-              .set_content_disposition("test-only-content-disposition")
-              .set_cache_control("test-only-cache-control")
-              .set_content_language("test-only-content-language")
-              .upsert_metadata("key0", "value0")
-              .set_content_type("test-only-content-type")
-              .set_temporary_hold(true)
-              .set_event_based_hold(true)
-              .set_custom_time(std::chrono::system_clock::time_point{} +
-                               std::chrono::seconds(1643126687) +
-                               std::chrono::milliseconds(123))));
+      WithObjectMetadata(FullObjectMetadata().set_storage_class("STANDARD")));
 
   auto const actual = GrpcObjectRequestParser::ToProto(req);
   ASSERT_STATUS_OK(actual);
@@ -993,7 +903,7 @@ TEST(GrpcObjectRequestParser, CopyObjectRequestAllOptions) {
 
 TEST(GrpcObjectRequestParser, CopyObjectRequestNoDestination) {
   google::storage::v2::RewriteObjectRequest expected;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         destination_bucket: "projects/_/buckets/destination-bucket"
         destination_name: "destination-object"
@@ -1011,15 +921,13 @@ TEST(GrpcObjectRequestParser, CopyObjectRequestNoDestination) {
         if_source_metageneration_not_match: 8
         copy_source_encryption_algorithm: "AES256"
         copy_source_encryption_key_bytes: "ABCDEFGH"
-        copy_source_encryption_key_sha256_bytes: "\232\302\031}\222X%{\032\350F>B\024\344\315\nW\213\301Q\177$\025\222\213\221\276B\203\374H"
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\222E\222\271\261\003\361O\203?\252\373g\364\200i\037\001\230\212\244W\300\006\027i\365\214\324s\021\274"
-        }
+        # Used `/bin/echo -n "ABCDEFGH" | sha256sum` to create this magic string
+        copy_source_encryption_key_sha256_bytes: "\x9a\xc2\x19\x7d\x92\x58\x25\x7b\x1a\xe8\x46\x3e\x42\x14\xe4\xcd\x0a\x57\x8b\xc1\x51\x7f\x24\x15\x92\x8b\x91\xbe\x42\x83\xfc\x48"
         common_request_params: { user_project: "test-user-project" }
       )pb",
       &expected));
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   CopyObjectRequest req("source-bucket", "source-object", "destination-bucket",
                         "destination-object");
@@ -1041,14 +949,14 @@ TEST(GrpcObjectRequestParser, CopyObjectRequestNoDestination) {
 
 TEST(GrpcObjectRequestParser, ResumableUploadRequestSimple) {
   google::storage::v2::StartResumableWriteRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
+  EXPECT_TRUE(TextFormat::ParseFromString(R"""(
       write_object_spec: {
           resource: {
             name: "test-object"
             bucket: "projects/_/buckets/test-bucket"
           }
       })""",
-                                                            &expected));
+                                          &expected));
 
   ResumableUploadRequest req("test-bucket", "test-object");
 
@@ -1058,7 +966,7 @@ TEST(GrpcObjectRequestParser, ResumableUploadRequestSimple) {
 
 TEST(GrpcObjectRequestParser, ResumableUploadRequestAllFields) {
   google::storage::v2::StartResumableWriteRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         write_object_spec: {
           resource: {
@@ -1079,17 +987,10 @@ TEST(GrpcObjectRequestParser, ResumableUploadRequestAllFields) {
           if_metageneration_not_match: 84
         }
         common_request_params: { user_project: "test-user-project" }
-
-        common_object_request_params: {
-          encryption_algorithm: "AES256"
-          # to get the key value use:
-          #   /bin/echo -n "01234567"
-          # to get the key hash use (note this command goes over two lines):
-          #   /bin/echo -n "01234567" | sha256sum
-          encryption_key_bytes: "01234567"
-          encryption_key_sha256_bytes: "\x92\x45\x92\xb9\xb1\x03\xf1\x4f\x83\x3f\xaa\xfb\x67\xf4\x80\x69\x1f\x01\x98\x8a\xa4\x57\xc0\x06\x17\x69\xf5\x8c\xd4\x73\x11\xbc"
-        })pb",
+      )pb",
       &expected));
+  *expected.mutable_common_object_request_params() =
+      ExpectedCommonObjectRequestParams();
 
   ResumableUploadRequest req("test-bucket", "test-object");
   req.set_multiple_options(
@@ -1112,45 +1013,17 @@ TEST(GrpcObjectRequestParser, ResumableUploadRequestAllFields) {
 
 TEST(GrpcObjectRequestParser, ResumableUploadRequestWithObjectMetadataFields) {
   google::storage::v2::StartResumableWriteRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
-      write_object_spec: {
-          resource: {
-            name: "test-object"
-            bucket: "projects/_/buckets/test-bucket"
-            content_encoding: "test-content-encoding"
-            content_disposition: "test-content-disposition"
-            cache_control: "test-cache-control"
-            content_language: "test-content-language"
-            content_type: "test-content-type"
-            storage_class: "REGIONAL"
-            event_based_hold: true
-            metadata: { key: "test-metadata-key1" value: "test-value1" }
-            metadata: { key: "test-metadata-key2" value: "test-value2" }
-            temporary_hold: true
-            acl: { role: "test-role1" entity: "test-entity1" }
-            acl: { role: "test-role2" entity: "test-entity2" }
-          }
-      })""",
-                                                            &expected));
+  auto& resource = *expected.mutable_write_object_spec()->mutable_resource();
+  resource = ExpectedFullObjectMetadata();
+  // In this particular case, the object name and bucket are part of the
+  // metadata
+  resource.set_name("test-object");
+  resource.set_bucket("projects/_/buckets/test-bucket");
+  resource.set_storage_class("STANDARD");
 
   ResumableUploadRequest req("test-bucket", "test-object");
-  std::vector<ObjectAccessControl> acls{
-      ObjectAccessControl().set_role("test-role1").set_entity("test-entity1"),
-      ObjectAccessControl().set_role("test-role2").set_entity("test-entity2")};
-  req.set_multiple_options(WithObjectMetadata(
-      ObjectMetadata()
-          .set_storage_class(storage_class::Regional())
-          .set_content_encoding("test-content-encoding")
-          .set_content_disposition("test-content-disposition")
-          .set_cache_control("test-cache-control")
-          .set_content_language("test-content-language")
-          .set_content_type("test-content-type")
-          .set_event_based_hold(true)
-          .upsert_metadata("test-metadata-key1", "test-value1")
-          .upsert_metadata("test-metadata-key2", "test-value2")
-          .set_storage_class(storage_class::Regional())
-          .set_temporary_hold(true)
-          .set_acl(std::move(acls))));
+  req.set_multiple_options(
+      WithObjectMetadata(FullObjectMetadata().set_storage_class("STANDARD")));
 
   auto actual = GrpcObjectRequestParser::ToProto(req).value();
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -1158,7 +1031,7 @@ TEST(GrpcObjectRequestParser, ResumableUploadRequestWithObjectMetadataFields) {
 
 TEST(GrpcObjectRequestParser, QueryResumableUploadRequestSimple) {
   google::storage::v2::QueryWriteStatusRequest expected;
-  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  EXPECT_TRUE(TextFormat::ParseFromString(
       R"pb(
         upload_id: "test-upload-id"
       )pb",
@@ -1172,7 +1045,7 @@ TEST(GrpcObjectRequestParser, QueryResumableUploadRequestSimple) {
 
 TEST(GrpcObjectRequestParser, QueryResumableUploadResponseSimple) {
   google::storage::v2::QueryWriteStatusResponse input;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         persisted_size: 123456
       )pb",
@@ -1186,7 +1059,7 @@ TEST(GrpcObjectRequestParser, QueryResumableUploadResponseSimple) {
 
 TEST(GrpcObjectRequestParser, QueryResumableUploadResponseWithResource) {
   google::storage::v2::QueryWriteStatusResponse input;
-  ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
+  ASSERT_TRUE(TextFormat::ParseFromString(
       R"pb(
         resource {
           name: "test-object-name"

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -824,7 +824,6 @@ TEST_F(ObjectIntegrationTest, DeleteResumableUpload) {
 }
 
 TEST_F(ObjectIntegrationTest, InsertWithCustomTime) {
-  if (UsingGrpc()) GTEST_SKIP();  // TODO(#4893) - no support in GCS+gRPC
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 
@@ -847,7 +846,6 @@ TEST_F(ObjectIntegrationTest, InsertWithCustomTime) {
 }
 
 TEST_F(ObjectIntegrationTest, WriteWithCustomTime) {
-  if (UsingGrpc()) GTEST_SKIP();  // TODO(#4893) - no support in GCS+gRPC
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 


### PR DESCRIPTION
A few fields in the `WithObjectMetadata()` option were not used. Notably
`custom_time()` and `acl()`.  I changed the unit test to make it easier
to inspect that all fields are tested, the expectation is created via
`ExpectedFullObjectMetadata()`.  A few fields are complicated, because
they only setable in requests that create new objects.

To fix the problem I refactored the code to copy mutable fields from the
`storage::*Request` classes to the `google.storage.v2.Object` proto.

See #8990 for the motivation, note that this backports the fixes to the v1.39.x series.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/8997)
<!-- Reviewable:end -->
