### PR TITLE
fix(generator): scaffold support absolute CMAKE_INSTALL_*DIR

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -239,3 +239,52 @@ function (google_cloud_cpp_add_executable target prefix source)
         "${target_name}"
         PARENT_SCOPE)
 endfunction ()
+
+# We do not use macros a lot, so this deserves a comment. Unlike functions,
+# macros do not introduce a scope. This is an advantage when trying to set
+# global variables, as we do here.  It is obviously a disadvantage if you need
+# local variables.
+macro (google_cloud_cpp_set_pkgconfig_paths)
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_BINDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_EXEC_PREFIX "${CMAKE_INSTALL_BINDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_EXEC_PREFIX
+            "\${prefix}/${CMAKE_INSTALL_BINDIR}")
+    endif ()
+
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_LIBDIR "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif ()
+
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR
+            "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif ()
+endmacro ()
+
+#
+# Create the pkgconfig configuration file (aka *.pc file) and the rules to
+# install it.
+#
+# * library: the name of the library, such as `storage`, or `spanner`
+# * ARGN: the names of any pkgconfig modules the generated module depends on
+#
+function (google_cloud_cpp_add_pkgconfig library name description)
+    set(GOOGLE_CLOUD_CPP_PC_NAME "${name}")
+    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
+    google_cloud_cpp_set_pkgconfig_paths()
+
+    # Create and install the pkg-config files.
+    configure_file("${CMAKE_CURRENT_SOURCE_DIR}/config.pc.in"
+                   "google_cloud_cpp_${library}.pc" @ONLY)
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        COMPONENT google_cloud_cpp_development)
+endfunction ()

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -177,16 +177,16 @@ void GenerateConfigPcIn(std::ostream& os,
 # limitations under the License.
 
 prefix=$${pcfiledir}/../..
-exec_prefix=$${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=$${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=$${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=@GOOGLE_CLOUD_CPP_PC_EXEC_PREFIX@
+libdir=@GOOGLE_CLOUD_CPP_PC_LIBDIR@
+includedir=@GOOGLE_CLOUD_CPP_PC_INCLUDEDIR@
 
-Name: @GOOGLE_CLOUD_PC_NAME@
-Description: @GOOGLE_CLOUD_PC_DESCRIPTION@
-Requires: @GOOGLE_CLOUD_PC_REQUIRES@
+Name: @GOOGLE_CLOUD_CPP_PC_NAME@
+Description: @GOOGLE_CLOUD_CPP_PC_DESCRIPTION@
+Requires: @GOOGLE_CLOUD_CPP_PC_REQUIRES@
 Version: @DOXYGEN_PROJECT_NUMBER@
 
-Libs: -L$${libdir} @GOOGLE_CLOUD_PC_LIBS@
+Libs: -L$${libdir} @GOOGLE_CLOUD_CPP_PC_LIBS@
 Cflags: -I$${includedir}
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
@@ -495,22 +495,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_$library$_mocks"
                                  "include/google/cloud/$library$")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR $${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR $${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH $${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The $title$ C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the $title$.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_$library$")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_$library$_protos")
-
-# Create and install the pkg-config files.
-configure_file("$${PROJECT_SOURCE_DIR}/google/cloud/$library$/config.pc.in"
-               "google_cloud_cpp_$library$.pc" @ONLY)
-install(
-    FILES "$${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_$library$.pc"
-    DESTINATION "$${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    $library$
+    "The $title$ API C++ Client Library"
+    "Provides C++ APIs to use the $title$."
+    "google_cloud_cpp_$library$_protos"
+    " google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -171,25 +171,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_baremetalsolution_mocks"
                                  "include/google/cloud/baremetalsolution")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
-set(GOOGLE_CLOUD_PC_NAME "The Bare Metal Solution API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
-    "Provides C++ APIs to use the Bare Metal Solution API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_baremetalsolution")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_baremetalsolution_protos")
-
-# Create and install the pkg-config files.
-configure_file(
-    "${PROJECT_SOURCE_DIR}/google/cloud/baremetalsolution/config.pc.in"
-    "google_cloud_cpp_baremetalsolution.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_baremetalsolution.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    baremetalsolution
+    "The Bare Metal Solution API C++ Client Library"
+    "Provides C++ APIs to use the Bare Metal Solution API."
+    "google_cloud_cpp_baremetalsolution_protos"
+    " google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/baremetalsolution/config.pc.in
+++ b/google/cloud/baremetalsolution/config.pc.in
@@ -13,14 +13,14 @@
 # limitations under the License.
 
 prefix=${pcfiledir}/../..
-exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+exec_prefix=@GOOGLE_CLOUD_CPP_PC_EXEC_PREFIX@
+libdir=@GOOGLE_CLOUD_CPP_PC_LIBDIR@
+includedir=@GOOGLE_CLOUD_CPP_PC_INCLUDEDIR@
 
-Name: @GOOGLE_CLOUD_PC_NAME@
-Description: @GOOGLE_CLOUD_PC_DESCRIPTION@
-Requires: @GOOGLE_CLOUD_PC_REQUIRES@
+Name: @GOOGLE_CLOUD_CPP_PC_NAME@
+Description: @GOOGLE_CLOUD_CPP_PC_DESCRIPTION@
+Requires: @GOOGLE_CLOUD_CPP_PC_REQUIRES@
 Version: @DOXYGEN_PROJECT_NUMBER@
 
-Libs: -L${libdir} @GOOGLE_CLOUD_PC_LIBS@
+Libs: -L${libdir} @GOOGLE_CLOUD_CPP_PC_LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
Change the scaffold generator to support absolute CMAKE_INSTALL_*DIR
directories.  Just to test this code I also changed the
`baremetalsolution` library.  I am planning to update the existing
libraries in separate PRs.

Part of the work for #8992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9009)
<!-- Reviewable:end -->
