### PR TITLE
cleanup: remove unused CMake variables

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -495,9 +495,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_$library$_mocks"
                                  "include/google/cloud/$library$")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR $${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR $${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH $${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The $title$ C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the $title$.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_$library$")

--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -165,9 +165,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accessapproval_mocks"
                                  "include/google/cloud/accessapproval")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Access Approval API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Access Approval API.")

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -171,9 +171,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accesscontextmanager_mocks"
                                  "include/google/cloud/accesscontextmanager")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Access Context Manager API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Access Context Manager API.")

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigateway_mocks"
                                  "include/google/cloud/apigateway")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The API Gateway API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the API Gateway API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_apigateway")

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -165,9 +165,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigeeconnect_mocks"
                                  "include/google/cloud/apigeeconnect")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Apigee Connect API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Apigee Connect API.")

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_appengine_mocks"
                                  "include/google/cloud/appengine")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The App Engine Admin API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the App Engine Admin API.")

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -167,9 +167,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_artifactregistry_mocks"
                                  "include/google/cloud/artifactregistry")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Artifact Registry API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Artifact Registry API.")

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -173,9 +173,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_asset_mocks"
                                  "include/google/cloud/asset")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Asset API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Asset API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_asset")

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -181,9 +181,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_assuredworkloads_mocks"
                                  "include/google/cloud/assuredworkloads")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Assured Workloads API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Assured Workloads API.")

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_automl_mocks"
                                  "include/google/cloud/automl")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud AutoML API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud AutoML API.")

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -171,9 +171,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_baremetalsolution_mocks"
                                  "include/google/cloud/baremetalsolution")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Bare Metal Solution API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Bare Metal Solution API.")

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -275,9 +275,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_mocks"
                                  "include/google/cloud/bigquery")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Google Cloud BigQuery C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud BigQuery.")

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_billing_mocks"
                                  "include/google/cloud/billing")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Billing Budget API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Billing Budget API.")

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -173,9 +173,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_binaryauthorization_mocks"
                                  "include/google/cloud/binaryauthorization")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Binary Authorization API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Binary Authorization API.")

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -151,9 +151,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_channel_mocks"
                                  "include/google/cloud/channel")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Channel API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Channel API.")

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_cloudbuild_mocks"
                                  "include/google/cloud/cloudbuild")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Build API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Build API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_cloudbuild")

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_composer_mocks"
                                  "include/google/cloud/composer")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Composer API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Composer API.")

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -172,9 +172,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_contactcenterinsights_mocks"
                                  "include/google/cloud/contactcenterinsights")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Contact Center AI Insights API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_container_mocks"
                                  "include/google/cloud/container")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Kubernetes Engine API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Kubernetes Engine API.")

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -169,9 +169,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_containeranalysis_mocks"
                                  "include/google/cloud/containeranalysis")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Container Analysis API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Container Analysis API.")

--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -162,9 +162,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datacatalog_mocks"
                                  "include/google/cloud/datacatalog")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Google Cloud Data Catalog API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Google Cloud Data Catalog API.")

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -163,9 +163,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datamigration_mocks"
                                  "include/google/cloud/datamigration")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Database Migration API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Database Migration API.")

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -162,9 +162,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dataplex_mocks"
                                  "include/google/cloud/dataplex")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Dataplex API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Dataplex API.")

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -148,9 +148,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dataproc_mocks"
                                  "include/google/cloud/dataproc")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Dataproc API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Dataproc API.")

--- a/google/cloud/debugger/CMakeLists.txt
+++ b/google/cloud/debugger/CMakeLists.txt
@@ -159,9 +159,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_debugger_mocks"
                                  "include/google/cloud/debugger")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Stackdriver Debugger API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Stackdriver Debugger API.")

--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -163,9 +163,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_cx_mocks"
                                  "include/google/cloud/dialogflow_cx")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Dialogflow API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Dialogflow API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_cx")

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -154,9 +154,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_es_mocks"
                                  "include/google/cloud/dialogflow_es")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Dialogflow API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Dialogflow API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_es")

--- a/google/cloud/dlp/CMakeLists.txt
+++ b/google/cloud/dlp/CMakeLists.txt
@@ -157,9 +157,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dlp_mocks"
                                  "include/google/cloud/dlp")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Cloud Data Loss Prevention (DLP) API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -162,9 +162,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_documentai_mocks"
                                  "include/google/cloud/documentai")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Document AI API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Document AI API.")

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_eventarc_mocks"
                                  "include/google/cloud/eventarc")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Eventarc API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Eventarc API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_eventarc")

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_filestore_mocks"
                                  "include/google/cloud/filestore")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Filestore API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Filestore API.")

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_functions_mocks"
                                  "include/google/cloud/functions")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Functions API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Functions API.")

--- a/google/cloud/gameservices/CMakeLists.txt
+++ b/google/cloud/gameservices/CMakeLists.txt
@@ -162,9 +162,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_gameservices_mocks"
                                  "include/google/cloud/gameservices")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Game Services API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Game Services API.")

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -156,9 +156,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_gkehub_mocks"
                                  "include/google/cloud/gkehub")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The GKE Hub C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the GKE Hub.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_gkehub")

--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -84,9 +84,6 @@ google_cloud_cpp_install_proto_library_headers(
     "google_cloud_cpp_grafeas_protos")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -199,9 +199,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iam_mocks"
                                  "include/google/cloud/iam")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Google Cloud IAM C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Google Cloud IAM.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_iam")

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -153,9 +153,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iap_mocks"
                                  "include/google/cloud/iap")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Cloud Identity-Aware Proxy API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -152,9 +152,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_ids_mocks"
                                  "include/google/cloud/ids")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud IDS API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud IDS API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_ids")

--- a/google/cloud/iot/CMakeLists.txt
+++ b/google/cloud/iot/CMakeLists.txt
@@ -154,9 +154,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iot_mocks"
                                  "include/google/cloud/iot")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud IoT API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud IoT API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_iot")

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -155,9 +155,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_kms_mocks"
                                  "include/google/cloud/kms")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Cloud Key Management Service (KMS) API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -161,9 +161,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_language_mocks"
                                  "include/google/cloud/language")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Natural Language API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Natural Language API.")

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -154,9 +154,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_logging_mocks"
                                  "include/google/cloud/logging")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Google Cloud Logging C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Logging.")

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -170,9 +170,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_managedidentities_mocks"
                                  "include/google/cloud/managedidentities")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Managed Service for Microsoft Active Directory API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -159,9 +159,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_memcache_mocks"
                                  "include/google/cloud/memcache")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Cloud Memorystore for Memcached API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -140,9 +140,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_monitoring_mocks"
                                  "include/google/cloud/monitoring")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Monitoring API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Monitoring API.")

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -167,9 +167,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_networkmanagement_mocks"
                                  "include/google/cloud/networkmanagement")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Network Management API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Network Management API.")

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_notebooks_mocks"
                                  "include/google/cloud/notebooks")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Notebooks API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Notebooks API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_notebooks")

--- a/google/cloud/orgpolicy/CMakeLists.txt
+++ b/google/cloud/orgpolicy/CMakeLists.txt
@@ -161,9 +161,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_orgpolicy_mocks"
                                  "include/google/cloud/orgpolicy")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Organization Policy API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Organization Policy API.")

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_osconfig_mocks"
                                  "include/google/cloud/osconfig")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The OS Config API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the OS Config API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_osconfig")

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -159,9 +159,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_oslogin_mocks"
                                  "include/google/cloud/oslogin")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud OS Login API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud OS Login API.")

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -155,9 +155,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_policytroubleshooter_mocks"
                                  "include/google/cloud/policytroubleshooter")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Policy Troubleshooter API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Policy Troubleshooter API.")

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -161,9 +161,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_privateca_mocks"
                                  "include/google/cloud/privateca")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Certificate Authority API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Certificate Authority API.")

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_profiler_mocks"
                                  "include/google/cloud/profiler")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Profiler API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Profiler API.")

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -376,9 +376,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsub_mocks"
                                  "include/google/cloud/pubsub")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Google Cloud Pubsub C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Pubsub.")

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -363,9 +363,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite_mocks"
                                  "include/google/cloud/pubsublite")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Pub/Sub Lite API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Pub/Sub Lite API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_pubsublite")

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -164,9 +164,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_recommender_mocks"
                                  "include/google/cloud/recommender")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Recommender API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Recommender API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_recommender")

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -156,9 +156,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_redis_mocks"
                                  "include/google/cloud/redis")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME
     "The Google Cloud Memorystore for Redis API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -166,9 +166,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcemanager_mocks"
                                  "include/google/cloud/resourcemanager")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Resource Manager API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Resource Manager API.")

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -169,9 +169,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcesettings_mocks"
                                  "include/google/cloud/resourcesettings")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Resource Settings API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Resource Settings API.")

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_retail_mocks"
                                  "include/google/cloud/retail")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Retail API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Retail API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_retail")

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_scheduler_mocks"
                                  "include/google/cloud/scheduler")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Scheduler API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Scheduler API.")

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -161,9 +161,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_secretmanager_mocks"
                                  "include/google/cloud/secretmanager")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Secret Manager API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Secret Manager API.")

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -167,9 +167,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_securitycenter_mocks"
                                  "include/google/cloud/securitycenter")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Security Command Center API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Security Command Center API.")

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -165,9 +165,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicecontrol_mocks"
                                  "include/google/cloud/servicecontrol")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Service Control API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Control API.")

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -167,9 +167,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicedirectory_mocks"
                                  "include/google/cloud/servicedirectory")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Service Directory API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Directory API.")

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -167,9 +167,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicemanagement_mocks"
                                  "include/google/cloud/servicemanagement")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Service Management API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Management API.")

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -159,9 +159,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_serviceusage_mocks"
                                  "include/google/cloud/serviceusage")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Service Usage API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Usage API.")

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -157,9 +157,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_shell_mocks"
                                  "include/google/cloud/shell")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Shell API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Shell API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_shell")

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_speech_mocks"
                                  "include/google/cloud/speech")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Speech-to-Text API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Speech-to-Text API.")

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -173,9 +173,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_storagetransfer_mocks"
                                  "include/google/cloud/storagetransfer")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Storage Transfer API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Storage Transfer API.")

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_talent_mocks"
                                  "include/google/cloud/talent")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Talent Solution API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Talent Solution API.")

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -157,9 +157,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tasks_mocks"
                                  "include/google/cloud/tasks")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Tasks API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Tasks API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_tasks")

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -162,9 +162,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_texttospeech_mocks"
                                  "include/google/cloud/texttospeech")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Text-to-Speech API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Text-to-Speech API.")

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -152,9 +152,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tpu_mocks"
                                  "include/google/cloud/tpu")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud TPU API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud TPU API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_tpu")

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -155,9 +155,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_trace_mocks"
                                  "include/google/cloud/trace")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Stackdriver Trace API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Stackdriver Trace API.")

--- a/google/cloud/translate/CMakeLists.txt
+++ b/google/cloud/translate/CMakeLists.txt
@@ -160,9 +160,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_translate_mocks"
                                  "include/google/cloud/translate")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Translation API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Translation API.")

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -169,9 +169,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_videointelligence_mocks"
                                  "include/google/cloud/videointelligence")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Video Intelligence API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Video Intelligence API.")

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -158,9 +158,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vision_mocks"
                                  "include/google/cloud/vision")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Cloud Vision API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Vision API.")

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -159,9 +159,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vmmigration_mocks"
                                  "include/google/cloud/vmmigration")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The VM Migration API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the VM Migration API.")

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -161,9 +161,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vpcaccess_mocks"
                                  "include/google/cloud/vpcaccess")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Serverless VPC Access API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Serverless VPC Access API.")

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -159,9 +159,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_webrisk_mocks"
                                  "include/google/cloud/webrisk")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Web Risk API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Web Risk API.")
 set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_webrisk")

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -170,9 +170,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_websecurityscanner_mocks"
                                  "include/google/cloud/websecurityscanner")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Web Security Scanner API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Web Security Scanner API.")

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -161,9 +161,6 @@ google_cloud_cpp_install_headers("google_cloud_cpp_workflows_mocks"
                                  "include/google/cloud/workflows")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CONFIG_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_MINOR ${PROJECT_VERSION_MINOR})
-set(GOOGLE_CLOUD_CONFIG_VERSION_PATCH ${PROJECT_VERSION_PATCH})
 set(GOOGLE_CLOUD_PC_NAME "The Workflow Executions API C++ Client Library")
 set(GOOGLE_CLOUD_PC_DESCRIPTION
     "Provides C++ APIs to use the Workflow Executions API.")


### PR DESCRIPTION
Just noticed these were unused, easy enough to clean up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9013)
<!-- Reviewable:end -->
