### PR TITLE
cleanup: consistent names for `config.pc.in` template variables

### DIFF
--- a/cmake/templates/config.pc.in
+++ b/cmake/templates/config.pc.in
@@ -17,10 +17,10 @@ exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: @GOOGLE_CLOUD_PC_NAME@
-Description: @GOOGLE_CLOUD_PC_DESCRIPTION@
-Requires: @GOOGLE_CLOUD_PC_REQUIRES@
+Name: @GOOGLE_CLOUD_CPP_PC_NAME@
+Description: @GOOGLE_CLOUD_CPP_PC_DESCRIPTION@
+Requires: @GOOGLE_CLOUD_CPP_PC_REQUIRES@
 Version: @DOXYGEN_PROJECT_NUMBER@
 
-Libs: -L${libdir} @GOOGLE_CLOUD_PC_LIBS@
+Libs: -L${libdir} @GOOGLE_CLOUD_CPP_PC_LIBS@
 Cflags: -I${includedir}

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -181,12 +181,12 @@ exec_prefix=$${prefix}/@CMAKE_INSTALL_BINDIR@
 libdir=$${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=$${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: @GOOGLE_CLOUD_PC_NAME@
-Description: @GOOGLE_CLOUD_PC_DESCRIPTION@
-Requires: @GOOGLE_CLOUD_PC_REQUIRES@
+Name: @GOOGLE_CLOUD_CPP_PC_NAME@
+Description: @GOOGLE_CLOUD_CPP_PC_DESCRIPTION@
+Requires: @GOOGLE_CLOUD_CPP_PC_REQUIRES@
 Version: @DOXYGEN_PROJECT_NUMBER@
 
-Libs: -L$${libdir} @GOOGLE_CLOUD_PC_LIBS@
+Libs: -L$${libdir} @GOOGLE_CLOUD_CPP_PC_LIBS@
 Cflags: -I$${includedir}
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
@@ -495,10 +495,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_$library$_mocks"
                                  "include/google/cloud/$library$")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The $title$ C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the $title$.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_$library$")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The $title$ C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Provides C++ APIs to use the $title$.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_$library$")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_$library$_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -165,11 +165,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accessapproval_mocks"
                                  "include/google/cloud/accessapproval")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Access Approval API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Access Approval API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Access Approval API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_accessapproval")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_accessapproval")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_accessapproval_protos")
 

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -171,11 +171,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accesscontextmanager_mocks"
                                  "include/google/cloud/accesscontextmanager")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Access Context Manager API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME
+    "The Access Context Manager API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Access Context Manager API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_accesscontextmanager")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_accesscontextmanager")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_accesscontextmanager_protos")
 

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -160,10 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigateway_mocks"
                                  "include/google/cloud/apigateway")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The API Gateway API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the API Gateway API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_apigateway")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The API Gateway API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the API Gateway API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_apigateway")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_apigateway_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -165,11 +165,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigeeconnect_mocks"
                                  "include/google/cloud/apigeeconnect")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Apigee Connect API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Apigee Connect API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Apigee Connect API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_apigeeconnect")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_apigeeconnect")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_apigeeconnect_protos")
 

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -158,11 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_appengine_mocks"
                                  "include/google/cloud/appengine")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The App Engine Admin API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The App Engine Admin API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the App Engine Admin API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_appengine")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_appengine")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_appengine_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -167,11 +167,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_artifactregistry_mocks"
                                  "include/google/cloud/artifactregistry")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Artifact Registry API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Artifact Registry API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Artifact Registry API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_artifactregistry")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_artifactregistry")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_artifactregistry_protos")
 

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -173,10 +173,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_asset_mocks"
                                  "include/google/cloud/asset")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Asset API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Asset API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_asset")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Asset API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud Asset API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_asset")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_asset_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -181,11 +181,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_assuredworkloads_mocks"
                                  "include/google/cloud/assuredworkloads")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Assured Workloads API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Assured Workloads API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Assured Workloads API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_assuredworkloads")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_assuredworkloads")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_assuredworkloads_protos")
 

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_automl_mocks"
                                  "include/google/cloud/automl")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud AutoML API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud AutoML API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud AutoML API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_automl")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_automl")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_automl_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -171,11 +171,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_baremetalsolution_mocks"
                                  "include/google/cloud/baremetalsolution")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Bare Metal Solution API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Bare Metal Solution API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Bare Metal Solution API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_baremetalsolution")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_baremetalsolution")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_baremetalsolution_protos")
 

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -275,11 +275,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_mocks"
                                  "include/google/cloud/bigquery")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Google Cloud BigQuery C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud BigQuery C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud BigQuery.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_bigquery")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_bigquery")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_cloud_bigquery_protos")
 

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -158,11 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_billing_mocks"
                                  "include/google/cloud/billing")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Billing Budget API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Billing Budget API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Billing Budget API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_billing")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_billing")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_billing_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -173,12 +173,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_binaryauthorization_mocks"
                                  "include/google/cloud/binaryauthorization")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Binary Authorization API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Binary Authorization API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Binary Authorization API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_binaryauthorization")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_binaryauthorization")
 string(
-    CONCAT GOOGLE_CLOUD_PC_REQUIRES
+    CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
            "google_cloud_cpp_grpc_utils"
            " google_cloud_cpp_common"
            " google_cloud_cpp_binaryauthorization_protos"

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -151,11 +151,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_channel_mocks"
                                  "include/google/cloud/channel")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Channel API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Channel API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Channel API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_channel")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_channel")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_channel_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -158,10 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_cloudbuild_mocks"
                                  "include/google/cloud/cloudbuild")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Build API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Build API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_cloudbuild")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Build API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud Build API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_cloudbuild")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_cloudbuild_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_composer_mocks"
                                  "include/google/cloud/composer")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Composer API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Composer API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Composer API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_composer")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_composer")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_composer_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -172,12 +172,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_contactcenterinsights_mocks"
                                  "include/google/cloud/contactcenterinsights")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Contact Center AI Insights API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Contact Center AI Insights API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_contactcenterinsights")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_contactcenterinsights")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_contactcenterinsights_protos")
 

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_container_mocks"
                                  "include/google/cloud/container")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Kubernetes Engine API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Kubernetes Engine API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Kubernetes Engine API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_container")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_container")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_container_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -169,11 +169,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_containeranalysis_mocks"
                                  "include/google/cloud/containeranalysis")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Container Analysis API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Container Analysis API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Container Analysis API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_containeranalysis")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_containeranalysis")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_containeranalysis_protos")
 

--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -162,11 +162,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datacatalog_mocks"
                                  "include/google/cloud/datacatalog")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Google Cloud Data Catalog API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME
+    "The Google Cloud Data Catalog API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Google Cloud Data Catalog API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_datacatalog")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_datacatalog")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_datacatalog_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -163,11 +163,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datamigration_mocks"
                                  "include/google/cloud/datamigration")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Database Migration API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Database Migration API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Database Migration API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_datamigration")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_datamigration")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_datamigration_protos")
 

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -162,11 +162,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dataplex_mocks"
                                  "include/google/cloud/dataplex")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Dataplex API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Dataplex API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Dataplex API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dataplex")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dataplex")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_dataplex_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -148,11 +148,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dataproc_mocks"
                                  "include/google/cloud/dataproc")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Dataproc API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Dataproc API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Dataproc API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dataproc")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dataproc")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_dataproc_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/debugger/CMakeLists.txt
+++ b/google/cloud/debugger/CMakeLists.txt
@@ -159,11 +159,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_debugger_mocks"
                                  "include/google/cloud/debugger")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Stackdriver Debugger API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Stackdriver Debugger API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Stackdriver Debugger API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_debugger")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_debugger")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_debugger_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -163,10 +163,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_cx_mocks"
                                  "include/google/cloud/dialogflow_cx")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Dialogflow API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Dialogflow API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_cx")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Dialogflow API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Dialogflow API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_cx")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_dialogflow_cx_protos")
 

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -154,10 +154,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_es_mocks"
                                  "include/google/cloud/dialogflow_es")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Dialogflow API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Dialogflow API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_es")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Dialogflow API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Dialogflow API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_es")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_dialogflow_es_protos")
 

--- a/google/cloud/dlp/CMakeLists.txt
+++ b/google/cloud/dlp/CMakeLists.txt
@@ -157,12 +157,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dlp_mocks"
                                  "include/google/cloud/dlp")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Cloud Data Loss Prevention (DLP) API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Data Loss Prevention (DLP) API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_dlp")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dlp")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_dlp_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -162,11 +162,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_documentai_mocks"
                                  "include/google/cloud/documentai")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Document AI API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Document AI API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Document AI API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_documentai")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_documentai")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_documentai_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -160,10 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_eventarc_mocks"
                                  "include/google/cloud/eventarc")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Eventarc API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Eventarc API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_eventarc")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Eventarc API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Eventarc API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_eventarc")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_eventarc_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -158,11 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_filestore_mocks"
                                  "include/google/cloud/filestore")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Filestore API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Filestore API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Filestore API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_filestore")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_filestore")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_filestore_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -158,11 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_functions_mocks"
                                  "include/google/cloud/functions")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Functions API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Functions API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Functions API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_functions")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_functions")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_functions_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/gameservices/CMakeLists.txt
+++ b/google/cloud/gameservices/CMakeLists.txt
@@ -162,11 +162,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_gameservices_mocks"
                                  "include/google/cloud/gameservices")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Game Services API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Game Services API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Game Services API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_gameservices")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_gameservices")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_gameservices_protos")
 

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -156,10 +156,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_gkehub_mocks"
                                  "include/google/cloud/gkehub")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The GKE Hub C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the GKE Hub.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_gkehub")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The GKE Hub C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Provides C++ APIs to use the GKE Hub.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_gkehub")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_gkehub_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -199,10 +199,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iam_mocks"
                                  "include/google/cloud/iam")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Google Cloud IAM C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Google Cloud IAM.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_iam")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud IAM C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to access Google Cloud IAM.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_iam")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_iam_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -153,12 +153,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iap_mocks"
                                  "include/google/cloud/iap")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Cloud Identity-Aware Proxy API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Identity-Aware Proxy API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_iap")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_iap")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_iap_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -152,10 +152,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_ids_mocks"
                                  "include/google/cloud/ids")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud IDS API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud IDS API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_ids")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud IDS API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud IDS API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_ids")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_ids_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/iot/CMakeLists.txt
+++ b/google/cloud/iot/CMakeLists.txt
@@ -154,10 +154,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iot_mocks"
                                  "include/google/cloud/iot")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud IoT API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud IoT API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_iot")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud IoT API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud IoT API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_iot")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_iot_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -155,12 +155,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_kms_mocks"
                                  "include/google/cloud/kms")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Cloud Key Management Service (KMS) API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Key Management Service (KMS) API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_kms")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_kms")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_kms_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -161,11 +161,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_language_mocks"
                                  "include/google/cloud/language")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Natural Language API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME
+    "The Cloud Natural Language API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Natural Language API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_language")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_language")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_language_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -154,11 +154,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_logging_mocks"
                                  "include/google/cloud/logging")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Google Cloud Logging C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Logging C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Logging.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_logging")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_logging")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_logging_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -170,13 +170,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_managedidentities_mocks"
                                  "include/google/cloud/managedidentities")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Managed Service for Microsoft Active Directory API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Managed Service for Microsoft Active Directory API."
 )
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_managedidentities")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_managedidentities")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_managedidentities_protos")
 

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -159,12 +159,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_memcache_mocks"
                                  "include/google/cloud/memcache")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Cloud Memorystore for Memcached API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Memorystore for Memcached API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_memcache")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_memcache")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_memcache_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -140,11 +140,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_monitoring_mocks"
                                  "include/google/cloud/monitoring")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Monitoring API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Monitoring API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Monitoring API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_monitoring")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_monitoring")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_monitoring_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -167,11 +167,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_networkmanagement_mocks"
                                  "include/google/cloud/networkmanagement")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Network Management API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Network Management API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Network Management API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_networkmanagement")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_networkmanagement")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_networkmanagement_protos")
 

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -160,10 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_notebooks_mocks"
                                  "include/google/cloud/notebooks")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Notebooks API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Notebooks API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_notebooks")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Notebooks API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Notebooks API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_notebooks")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_notebooks_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/orgpolicy/CMakeLists.txt
+++ b/google/cloud/orgpolicy/CMakeLists.txt
@@ -161,11 +161,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_orgpolicy_mocks"
                                  "include/google/cloud/orgpolicy")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Organization Policy API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Organization Policy API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Organization Policy API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_orgpolicy")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_orgpolicy")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_orgpolicy_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -160,10 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_osconfig_mocks"
                                  "include/google/cloud/osconfig")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The OS Config API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the OS Config API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_osconfig")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The OS Config API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the OS Config API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_osconfig")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_osconfig_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -159,11 +159,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_oslogin_mocks"
                                  "include/google/cloud/oslogin")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud OS Login API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud OS Login API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud OS Login API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_oslogin")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_oslogin")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_oslogin_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -155,11 +155,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_policytroubleshooter_mocks"
                                  "include/google/cloud/policytroubleshooter")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Policy Troubleshooter API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Policy Troubleshooter API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Policy Troubleshooter API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_policytroubleshooter")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_policytroubleshooter")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_policytroubleshooter_protos")
 

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -161,11 +161,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_privateca_mocks"
                                  "include/google/cloud/privateca")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Certificate Authority API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Certificate Authority API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Certificate Authority API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_privateca")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_privateca")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_privateca_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -158,11 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_profiler_mocks"
                                  "include/google/cloud/profiler")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Profiler API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Profiler API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Profiler API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_profiler")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_profiler")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_profiler_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -376,11 +376,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsub_mocks"
                                  "include/google/cloud/pubsub")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Google Cloud Pubsub C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Pubsub C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Pubsub.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_pubsub")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_pubsub")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_pubsub_protos"
               " absl_str_format")
 

--- a/google/cloud/pubsub/config.pc.in
+++ b/google/cloud/pubsub/config.pc.in
@@ -17,10 +17,10 @@ exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
-Name: @GOOGLE_CLOUD_PC_NAME@
-Description: @GOOGLE_CLOUD_PC_DESCRIPTION@
-Requires: @GOOGLE_CLOUD_PC_REQUIRES@
+Name: @GOOGLE_CLOUD_CPP_PC_NAME@
+Description: @GOOGLE_CLOUD_CPP_PC_DESCRIPTION@
+Requires: @GOOGLE_CLOUD_CPP_PC_REQUIRES@
 Version: @DOXYGEN_PROJECT_NUMBER@
 
-Libs: -L${libdir} @GOOGLE_CLOUD_PC_LIBS@
+Libs: -L${libdir} @GOOGLE_CLOUD_CPP_PC_LIBS@
 Cflags: -I${includedir}

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -363,10 +363,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite_mocks"
                                  "include/google/cloud/pubsublite")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Pub/Sub Lite API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to access Pub/Sub Lite API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_pubsublite")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Pub/Sub Lite API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to access Pub/Sub Lite API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_pubsublite")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_pubsublite_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -164,10 +164,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_recommender_mocks"
                                  "include/google/cloud/recommender")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Recommender API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Recommender API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_recommender")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Recommender API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Recommender API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_recommender")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_recommender_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -156,12 +156,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_redis_mocks"
                                  "include/google/cloud/redis")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME
+set(GOOGLE_CLOUD_CPP_PC_NAME
     "The Google Cloud Memorystore for Redis API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Google Cloud Memorystore for Redis API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_redis")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_redis")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_redis_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -166,11 +166,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcemanager_mocks"
                                  "include/google/cloud/resourcemanager")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Resource Manager API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME
+    "The Cloud Resource Manager API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Resource Manager API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_resourcemanager")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_resourcemanager")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_resourcemanager_protos")
 

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -169,11 +169,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcesettings_mocks"
                                  "include/google/cloud/resourcesettings")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Resource Settings API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Resource Settings API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Resource Settings API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_resourcesettings")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_resourcesettings")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_resourcesettings_protos")
 

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -158,10 +158,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_retail_mocks"
                                  "include/google/cloud/retail")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Retail API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Retail API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_retail")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Retail API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Provides C++ APIs to use the Retail API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_retail")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_retail_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_scheduler_mocks"
                                  "include/google/cloud/scheduler")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Scheduler API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Scheduler API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Scheduler API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_scheduler")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_scheduler")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_scheduler_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -161,11 +161,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_secretmanager_mocks"
                                  "include/google/cloud/secretmanager")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Secret Manager API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Secret Manager API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Secret Manager API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_secretmanager")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_secretmanager")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_secretmanager_protos")
 

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -167,11 +167,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_securitycenter_mocks"
                                  "include/google/cloud/securitycenter")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Security Command Center API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME
+    "The Security Command Center API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Security Command Center API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_securitycenter")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_securitycenter")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_securitycenter_protos")
 

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -165,11 +165,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicecontrol_mocks"
                                  "include/google/cloud/servicecontrol")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Service Control API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Control API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Control API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_servicecontrol")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_servicecontrol")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_servicecontrol_protos")
 

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -167,11 +167,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicedirectory_mocks"
                                  "include/google/cloud/servicedirectory")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Service Directory API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Directory API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Directory API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_servicedirectory")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_servicedirectory")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_servicedirectory_protos")
 

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -167,11 +167,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicemanagement_mocks"
                                  "include/google/cloud/servicemanagement")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Service Management API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Management API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Management API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_servicemanagement")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_servicemanagement")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_servicemanagement_protos")
 

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -159,11 +159,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_serviceusage_mocks"
                                  "include/google/cloud/serviceusage")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Service Usage API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Usage API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Service Usage API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_serviceusage")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_serviceusage")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_serviceusage_protos")
 

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -157,10 +157,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_shell_mocks"
                                  "include/google/cloud/shell")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Shell API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Shell API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_shell")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Shell API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud Shell API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_shell")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_shell_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_speech_mocks"
                                  "include/google/cloud/speech")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Speech-to-Text API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Speech-to-Text API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Speech-to-Text API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_speech")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_speech")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_speech_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -173,11 +173,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_storagetransfer_mocks"
                                  "include/google/cloud/storagetransfer")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Storage Transfer API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Storage Transfer API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Storage Transfer API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_storagetransfer")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_storagetransfer")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_storagetransfer_protos")
 

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_talent_mocks"
                                  "include/google/cloud/talent")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Talent Solution API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Talent Solution API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Talent Solution API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_talent")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_talent")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_talent_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -157,10 +157,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tasks_mocks"
                                  "include/google/cloud/tasks")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Tasks API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud Tasks API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_tasks")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Tasks API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud Tasks API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_tasks")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_tasks_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -162,11 +162,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_texttospeech_mocks"
                                  "include/google/cloud/texttospeech")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Text-to-Speech API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Text-to-Speech API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Text-to-Speech API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_texttospeech")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_texttospeech")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_texttospeech_protos")
 

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -152,10 +152,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tpu_mocks"
                                  "include/google/cloud/tpu")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud TPU API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Cloud TPU API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_tpu")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud TPU API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Cloud TPU API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_tpu")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_tpu_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -155,11 +155,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_trace_mocks"
                                  "include/google/cloud/trace")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Stackdriver Trace API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Stackdriver Trace API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Stackdriver Trace API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_trace")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_trace")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_trace_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/translate/CMakeLists.txt
+++ b/google/cloud/translate/CMakeLists.txt
@@ -160,11 +160,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_translate_mocks"
                                  "include/google/cloud/translate")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Translation API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Translation API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Translation API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_translate")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_translate")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_translate_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -169,11 +169,12 @@ google_cloud_cpp_install_headers("google_cloud_cpp_videointelligence_mocks"
                                  "include/google/cloud/videointelligence")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Video Intelligence API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME
+    "The Cloud Video Intelligence API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Video Intelligence API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_videointelligence")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_videointelligence")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_videointelligence_protos")
 

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -158,11 +158,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vision_mocks"
                                  "include/google/cloud/vision")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Cloud Vision API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Vision API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Cloud Vision API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_vision")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_vision")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_vision_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -159,11 +159,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vmmigration_mocks"
                                  "include/google/cloud/vmmigration")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The VM Migration API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The VM Migration API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the VM Migration API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_vmmigration")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_vmmigration")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_vmmigration_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -161,11 +161,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vpcaccess_mocks"
                                  "include/google/cloud/vpcaccess")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Serverless VPC Access API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Serverless VPC Access API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Serverless VPC Access API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_vpcaccess")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_vpcaccess")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_vpcaccess_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -159,10 +159,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_webrisk_mocks"
                                  "include/google/cloud/webrisk")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Web Risk API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION "Provides C++ APIs to use the Web Risk API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_webrisk")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Web Risk API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+    "Provides C++ APIs to use the Web Risk API.")
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_webrisk")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_webrisk_protos")
 
 # Create and install the pkg-config files.

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -170,11 +170,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_websecurityscanner_mocks"
                                  "include/google/cloud/websecurityscanner")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Web Security Scanner API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Web Security Scanner API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Web Security Scanner API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_websecurityscanner")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_websecurityscanner")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common"
               " google_cloud_cpp_websecurityscanner_protos")
 

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -161,11 +161,11 @@ google_cloud_cpp_install_headers("google_cloud_cpp_workflows_mocks"
                                  "include/google/cloud/workflows")
 
 # Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_PC_NAME "The Workflow Executions API C++ Client Library")
-set(GOOGLE_CLOUD_PC_DESCRIPTION
+set(GOOGLE_CLOUD_CPP_PC_NAME "The Workflow Executions API C++ Client Library")
+set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to use the Workflow Executions API.")
-set(GOOGLE_CLOUD_PC_LIBS "-lgoogle_cloud_cpp_workflows")
-string(CONCAT GOOGLE_CLOUD_PC_REQUIRES "google_cloud_cpp_grpc_utils"
+set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_workflows")
+string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
               " google_cloud_cpp_common" " google_cloud_cpp_workflows_protos")
 
 # Create and install the pkg-config files.


### PR DESCRIPTION
This command expands the values of some CMake variables, we could not
consolidate all the `config.pc.in` template files because they used
different CMake variables.  This PR just normalizes the variables, I
will consolidate the handful of remaining files in a followup PR.

Motivated by #8992 