### PR TITLE
refactor(common): encapsulate googleapis updates in a script

### DIFF
--- a/doc/contributor/howto-guide-update-googleapis-sha.md
+++ b/doc/contributor/howto-guide-update-googleapis-sha.md
@@ -27,29 +27,13 @@ git checkout main
 git checkout -b chore-update-googleapis-sha-circa-$(date +%Y-%m-%d)
 ```
 
-## Find out the commit SHA you want to use
-
-Use your browser to find out a recent commit SHA for `googleapis`.  In this
-document we will use `134d8be4b58b2bfc373374f71ec52a0df59af664` as an example.
-That was a recent SHA circa 2022-05-18.
-
-Find the SHA256 of the repository tarball at that commit:
+## Run the "renovate.sh" script to update the Bazel/CMake dependencies
 
 ```shell
-SHA=134d8be4b58b2bfc373374f71ec52a0df59af664
-curl -sSL https://github.com/googleapis/googleapis/archive/${SHA}.tar.gz | sha256sum -
-# Output: bf45ef870b4d36de2c7a9eebdd887cd8f9c6c016b65561c93a1f135bb577571a  -
+external/googleapis/renovate.sh
 ```
 
-Make a note of the download SHA256.
-
-## Edit the code
-
-You need to edit `cmake/GoogleapisConfig.cmake`
-and `bazel/google_cloud_cpp_deps.bzl`.  You can see sample patches in the
-[appendix](#appendix-sample-patches) at the end of this document.
-
-Commit your edits:
+Commit those edits:
 
 ```shell
 git commit -m"chore: update googleapis SHA circa $(date +%Y-%m-%d)" bazel cmake
@@ -89,53 +73,5 @@ git push --set-upstream origin "$(git branch --show-current)"
 ```
 
 Then use your favorite workflow to create the PR.
-
-## Appendix: Sample Patches
-
-For `bazel/google_cloud_cpp_deps.bzl`:
-
-```diff
-diff --git a/bazel/google_cloud_cpp_deps.bzl b/bazel/google_cloud_cpp_deps.bzl
-index 0f1f3abb9..890875c86 100644
---- a/bazel/google_cloud_cpp_deps.bzl
-+++ b/bazel/google_cloud_cpp_deps.bzl
-@@ -85,10 +85,10 @@ def google_cloud_cpp_deps():
-         http_archive(
-             name = "com_google_googleapis",
-             urls = [
--                "https://github.com/googleapis/googleapis/archive/cf88418a2dea51a1007792ad19739d53d4ee510e.tar.gz",
-+                "https://github.com/googleapis/googleapis/archive/134d8be4b58b2bfc373374f71ec52a0df59af664.tar.gz",
-             ],
--            strip_prefix = "googleapis-cf88418a2dea51a1007792ad19739d53d4ee510e",
--            sha256 = "17c34d62592df2c684c19102079c4146faaafdba8244f517d2a52848a3e6b8b7",
-+            strip_prefix = "googleapis-134d8be4b58b2bfc373374f71ec52a0df59af664",
-+            sha256 = "bf45ef870b4d36de2c7a9eebdd887cd8f9c6c016b65561c93a1f135bb577571a",
-             build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
-             # Scaffolding for patching googleapis after download. For example:
-             #   patches = ["googleapis.patch"]
-```
-
-For `cmake/GoogleapisConfig.cmake`:
-
-```diff
-diff --git a/cmake/GoogleapisConfig.cmake b/cmake/GoogleapisConfig.cmake
-index e3f6f2424..fdc1ca901 100644
---- a/cmake/GoogleapisConfig.cmake
-+++ b/cmake/GoogleapisConfig.cmake
-@@ -17,11 +17,11 @@
- # Give application developers a hook to configure the version and hash
- # downloaded from GitHub.
- set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA
--    "cf88418a2dea51a1007792ad19739d53d4ee510e"
-+    "134d8be4b58b2bfc373374f71ec52a0df59af664"
-     CACHE STRING "Configure the commit SHA (or tag) for the googleapis protos.")
- mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA)
- set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
--    "17c34d62592df2c684c19102079c4146faaafdba8244f517d2a52848a3e6b8b7"
-+    "bf45ef870b4d36de2c7a9eebdd887cd8f9c6c016b65561c93a1f135bb577571a"
-     CACHE STRING "Configure the SHA256 checksum of the googleapis tarball.")
- mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256)
-
-```
 
 [googleapis-repo]: https://github.com/googleapis/googleapis.git

--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# Determine the googleapis HEAD commit and the checksum of its tarball.
+REPO="googleapis/googleapis"
+BRANCH="master"
+COMMIT=$(curl -sSL -H "Accept: application/vnd.github.VERSION.sha" \
+  "https://api.github.com/repos/${REPO}/commits/${BRANCH}")
+SHA256=$(curl -sSL "https://github.com/${REPO}/archive/${COMMIT}.tar.gz" |
+  sha256sum | sed "s/ .*//")
+
+# Update the Bazel dependency.
+sed -i -f - bazel/google_cloud_cpp_deps.bzl <<EOT
+  /name = "com_google_googleapis",/,/sha256 = "/ {
+    s;/${REPO}/archive/.*.tar.gz",;/${REPO}/archive/${COMMIT}.tar.gz",;
+    s/strip_prefix = "googleapis-.*",/strip_prefix = "googleapis-${COMMIT}",/
+    s/sha256 = ".*",/sha256 = "${SHA256}",/
+  }
+EOT
+
+# Update the CMake dependency.
+sed -i -f - cmake/GoogleapisConfig.cmake <<EOT
+  /^set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA$/ {
+    n
+    s/".*"/"${COMMIT}"/
+  }
+  /^set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256$/ {
+    n
+    s/".*"/"${SHA256}"/
+  }
+EOT


### PR DESCRIPTION
Add a script to update the googleapis Bazel/CMake dependencies, much
like the renovate-bot would do if it was enabled.  Update the how-to
doc to use the script.

Part of #7372.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9017)
<!-- Reviewable:end -->
