### PR TITLE
refactor: use a CMake function to create pkg-config files

### DIFF
--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -239,3 +239,25 @@ function (google_cloud_cpp_add_executable target prefix source)
         "${target_name}"
         PARENT_SCOPE)
 endfunction ()
+
+#
+# Create the pkgconfig configuration file (aka *.pc file) and the rules to
+# install it.
+#
+# * library: the name of the library, such as `storage`, or `spanner`
+# * ARGN: the names of any pkgconfig modules the generated module depends on
+#
+function (google_cloud_cpp_add_pkgconfig library name description)
+    set(GOOGLE_CLOUD_CPP_PC_NAME "${name}")
+    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
+
+    # Create and install the pkg-config files.
+    configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
+                   "google_cloud_cpp_${library}.pc" @ONLY)
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        COMPONENT google_cloud_cpp_development)
+endfunction ()

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -494,20 +494,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_$library$"
 google_cloud_cpp_install_headers("google_cloud_cpp_$library$_mocks"
                                  "include/google/cloud/$library$")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The $title$ C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Provides C++ APIs to use the $title$.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_$library$")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_$library$_protos")
-
-# Create and install the pkg-config files.
-configure_file("$${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_$library$.pc" @ONLY)
-install(
-    FILES "$${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_$library$.pc"
-    DESTINATION "$${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    $library$
+    "The $title$ C++ Client Library"
+    "Provides C++ APIs to use the $title$."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_$library$_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/accessapproval/CMakeLists.txt
+++ b/google/cloud/accessapproval/CMakeLists.txt
@@ -164,22 +164,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accessapproval"
 google_cloud_cpp_install_headers("google_cloud_cpp_accessapproval_mocks"
                                  "include/google/cloud/accessapproval")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Access Approval API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Access Approval API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_accessapproval")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_accessapproval_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_accessapproval.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_accessapproval.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    accessapproval
+    "The Access Approval API C++ Client Library"
+    "Provides C++ APIs to use the Access Approval API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_accessapproval_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -170,23 +170,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_accesscontextmanager"
 google_cloud_cpp_install_headers("google_cloud_cpp_accesscontextmanager_mocks"
                                  "include/google/cloud/accesscontextmanager")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Access Context Manager API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Access Context Manager API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_accesscontextmanager")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_accesscontextmanager_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_accesscontextmanager.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_accesscontextmanager.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    accesscontextmanager
+    "The Access Context Manager API C++ Client Library"
+    "Provides C++ APIs to use the Access Context Manager API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_accesscontextmanager_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/apigateway/CMakeLists.txt
+++ b/google/cloud/apigateway/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigateway"
 google_cloud_cpp_install_headers("google_cloud_cpp_apigateway_mocks"
                                  "include/google/cloud/apigateway")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The API Gateway API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the API Gateway API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_apigateway")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_apigateway_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_apigateway.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_apigateway.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    apigateway
+    "The API Gateway API C++ Client Library"
+    "Provides C++ APIs to use the API Gateway API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_apigateway_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -164,22 +164,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_apigeeconnect"
 google_cloud_cpp_install_headers("google_cloud_cpp_apigeeconnect_mocks"
                                  "include/google/cloud/apigeeconnect")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Apigee Connect API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Apigee Connect API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_apigeeconnect")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_apigeeconnect_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_apigeeconnect.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_apigeeconnect.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    apigeeconnect
+    "The Apigee Connect API C++ Client Library"
+    "Provides C++ APIs to use the Apigee Connect API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_apigeeconnect_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/appengine/CMakeLists.txt
+++ b/google/cloud/appengine/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_appengine"
 google_cloud_cpp_install_headers("google_cloud_cpp_appengine_mocks"
                                  "include/google/cloud/appengine")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The App Engine Admin API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the App Engine Admin API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_appengine")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_appengine_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_appengine.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_appengine.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    appengine
+    "The App Engine Admin API C++ Client Library"
+    "Provides C++ APIs to use the App Engine Admin API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_appengine_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/artifactregistry/CMakeLists.txt
+++ b/google/cloud/artifactregistry/CMakeLists.txt
@@ -166,22 +166,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_artifactregistry"
 google_cloud_cpp_install_headers("google_cloud_cpp_artifactregistry_mocks"
                                  "include/google/cloud/artifactregistry")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Artifact Registry API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Artifact Registry API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_artifactregistry")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_artifactregistry_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_artifactregistry.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_artifactregistry.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    artifactregistry
+    "The Artifact Registry API C++ Client Library"
+    "Provides C++ APIs to use the Artifact Registry API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_artifactregistry_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/asset/CMakeLists.txt
+++ b/google/cloud/asset/CMakeLists.txt
@@ -172,21 +172,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_asset"
 google_cloud_cpp_install_headers("google_cloud_cpp_asset_mocks"
                                  "include/google/cloud/asset")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Asset API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Asset API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_asset")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_asset_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_asset.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_asset.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    asset
+    "The Cloud Asset API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Asset API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_asset_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -180,22 +180,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_assuredworkloads"
 google_cloud_cpp_install_headers("google_cloud_cpp_assuredworkloads_mocks"
                                  "include/google/cloud/assuredworkloads")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Assured Workloads API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Assured Workloads API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_assuredworkloads")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_assuredworkloads_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_assuredworkloads.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_assuredworkloads.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    assuredworkloads
+    "The Assured Workloads API C++ Client Library"
+    "Provides C++ APIs to use the Assured Workloads API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_assuredworkloads_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/automl/CMakeLists.txt
+++ b/google/cloud/automl/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_automl"
 google_cloud_cpp_install_headers("google_cloud_cpp_automl_mocks"
                                  "include/google/cloud/automl")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud AutoML API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud AutoML API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_automl")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_automl_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_automl.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_automl.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    automl
+    "The Cloud AutoML API C++ Client Library"
+    "Provides C++ APIs to use the Cloud AutoML API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_automl_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/baremetalsolution/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/CMakeLists.txt
@@ -170,22 +170,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_baremetalsolution"
 google_cloud_cpp_install_headers("google_cloud_cpp_baremetalsolution_mocks"
                                  "include/google/cloud/baremetalsolution")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Bare Metal Solution API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Bare Metal Solution API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_baremetalsolution")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_baremetalsolution_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_baremetalsolution.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_baremetalsolution.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    baremetalsolution
+    "The Bare Metal Solution API C++ Client Library"
+    "Provides C++ APIs to use the Bare Metal Solution API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_baremetalsolution_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/bigquery/CMakeLists.txt
+++ b/google/cloud/bigquery/CMakeLists.txt
@@ -274,22 +274,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_bigquery"
 google_cloud_cpp_install_headers("google_cloud_cpp_bigquery_mocks"
                                  "include/google/cloud/bigquery")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud BigQuery C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud BigQuery.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_bigquery")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_cloud_bigquery_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_bigquery.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigquery.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    bigquery
+    "The Google Cloud BigQuery C++ Client Library"
+    "Provides C++ APIs to access Google Cloud BigQuery."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_cloud_bigquery_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -462,22 +462,14 @@ google_cloud_cpp_install_headers("google_cloud_cpp_bigtable"
 google_cloud_cpp_install_headers("google_cloud_cpp_bigtable_mocks"
                                  "include/google/cloud/bigtable")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Bigtable C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud Bigtable.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_bigtable")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_bigtable_protos"
-              " absl_memory")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_bigtable.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_bigtable.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    bigtable
+    "The Google Cloud Bigtable C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Bigtable."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_bigtable_protos"
+    " absl_memory")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/billing/CMakeLists.txt
+++ b/google/cloud/billing/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_billing"
 google_cloud_cpp_install_headers("google_cloud_cpp_billing_mocks"
                                  "include/google/cloud/billing")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Billing Budget API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Billing Budget API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_billing")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_billing_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_billing.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_billing.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    billing
+    "The Cloud Billing Budget API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Billing Budget API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_billing_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/binaryauthorization/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/CMakeLists.txt
@@ -172,25 +172,14 @@ google_cloud_cpp_install_headers("google_cloud_cpp_binaryauthorization"
 google_cloud_cpp_install_headers("google_cloud_cpp_binaryauthorization_mocks"
                                  "include/google/cloud/binaryauthorization")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Binary Authorization API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Binary Authorization API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_binaryauthorization")
-string(
-    CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_grpc_utils"
-           " google_cloud_cpp_common"
-           " google_cloud_cpp_binaryauthorization_protos"
-           " google_cloud_cpp_grafeas_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_binaryauthorization.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_binaryauthorization.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    binaryauthorization
+    "The Binary Authorization API C++ Client Library"
+    "Provides C++ APIs to use the Binary Authorization API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_binaryauthorization_protos"
+    " google_cloud_cpp_grafeas_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/channel/CMakeLists.txt
+++ b/google/cloud/channel/CMakeLists.txt
@@ -150,21 +150,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_channel"
 google_cloud_cpp_install_headers("google_cloud_cpp_channel_mocks"
                                  "include/google/cloud/channel")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Channel API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Channel API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_channel")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_channel_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_channel.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_channel.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    channel
+    "The Cloud Channel API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Channel API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_channel_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/cloudbuild/CMakeLists.txt
+++ b/google/cloud/cloudbuild/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_cloudbuild"
 google_cloud_cpp_install_headers("google_cloud_cpp_cloudbuild_mocks"
                                  "include/google/cloud/cloudbuild")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Build API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Build API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_cloudbuild")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_cloudbuild_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_cloudbuild.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_cloudbuild.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    cloudbuild
+    "The Cloud Build API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Build API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_cloudbuild_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/composer/CMakeLists.txt
+++ b/google/cloud/composer/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_composer"
 google_cloud_cpp_install_headers("google_cloud_cpp_composer_mocks"
                                  "include/google/cloud/composer")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Composer API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Composer API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_composer")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_composer_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_composer.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_composer.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    composer
+    "The Cloud Composer API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Composer API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_composer_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/contactcenterinsights/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/CMakeLists.txt
@@ -171,24 +171,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_contactcenterinsights"
 google_cloud_cpp_install_headers("google_cloud_cpp_contactcenterinsights_mocks"
                                  "include/google/cloud/contactcenterinsights")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Contact Center AI Insights API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Contact Center AI Insights API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_contactcenterinsights")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_contactcenterinsights_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_contactcenterinsights.pc" @ONLY)
-install(
-    FILES
-        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_contactcenterinsights.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    contactcenterinsights
+    "The Contact Center AI Insights API C++ Client Library"
+    "Provides C++ APIs to use the Contact Center AI Insights API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_contactcenterinsights_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/container/CMakeLists.txt
+++ b/google/cloud/container/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_container"
 google_cloud_cpp_install_headers("google_cloud_cpp_container_mocks"
                                  "include/google/cloud/container")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Kubernetes Engine API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Kubernetes Engine API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_container")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_container_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_container.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_container.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    container
+    "The Kubernetes Engine API C++ Client Library"
+    "Provides C++ APIs to use the Kubernetes Engine API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_container_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/containeranalysis/CMakeLists.txt
+++ b/google/cloud/containeranalysis/CMakeLists.txt
@@ -168,22 +168,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_containeranalysis"
 google_cloud_cpp_install_headers("google_cloud_cpp_containeranalysis_mocks"
                                  "include/google/cloud/containeranalysis")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Container Analysis API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Container Analysis API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_containeranalysis")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_containeranalysis_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_containeranalysis.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_containeranalysis.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    containeranalysis
+    "The Container Analysis API C++ Client Library"
+    "Provides C++ APIs to use the Container Analysis API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_containeranalysis_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/datacatalog/CMakeLists.txt
+++ b/google/cloud/datacatalog/CMakeLists.txt
@@ -161,22 +161,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datacatalog"
 google_cloud_cpp_install_headers("google_cloud_cpp_datacatalog_mocks"
                                  "include/google/cloud/datacatalog")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Google Cloud Data Catalog API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Google Cloud Data Catalog API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_datacatalog")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_datacatalog_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_datacatalog.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_datacatalog.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    datacatalog
+    "The Google Cloud Data Catalog API C++ Client Library"
+    "Provides C++ APIs to use the Google Cloud Data Catalog API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_datacatalog_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/datamigration/CMakeLists.txt
+++ b/google/cloud/datamigration/CMakeLists.txt
@@ -162,22 +162,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_datamigration"
 google_cloud_cpp_install_headers("google_cloud_cpp_datamigration_mocks"
                                  "include/google/cloud/datamigration")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Database Migration API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Database Migration API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_datamigration")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_datamigration_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_datamigration.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_datamigration.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    datamigration
+    "The Database Migration API C++ Client Library"
+    "Provides C++ APIs to use the Database Migration API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_datamigration_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/dataplex/CMakeLists.txt
+++ b/google/cloud/dataplex/CMakeLists.txt
@@ -161,21 +161,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dataplex"
 google_cloud_cpp_install_headers("google_cloud_cpp_dataplex_mocks"
                                  "include/google/cloud/dataplex")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Dataplex API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Dataplex API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dataplex")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_dataplex_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_dataplex.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dataplex.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    dataplex
+    "The Cloud Dataplex API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Dataplex API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_dataplex_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/dataproc/CMakeLists.txt
+++ b/google/cloud/dataproc/CMakeLists.txt
@@ -147,21 +147,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dataproc"
 google_cloud_cpp_install_headers("google_cloud_cpp_dataproc_mocks"
                                  "include/google/cloud/dataproc")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Dataproc API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Dataproc API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dataproc")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_dataproc_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_dataproc.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dataproc.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    dataproc
+    "The Cloud Dataproc API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Dataproc API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_dataproc_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/debugger/CMakeLists.txt
+++ b/google/cloud/debugger/CMakeLists.txt
@@ -158,21 +158,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_debugger"
 google_cloud_cpp_install_headers("google_cloud_cpp_debugger_mocks"
                                  "include/google/cloud/debugger")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Stackdriver Debugger API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Stackdriver Debugger API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_debugger")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_debugger_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_debugger.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_debugger.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    debugger
+    "The Stackdriver Debugger API C++ Client Library"
+    "Provides C++ APIs to use the Stackdriver Debugger API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_debugger_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/dialogflow_cx/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/CMakeLists.txt
@@ -162,22 +162,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_cx"
 google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_cx_mocks"
                                  "include/google/cloud/dialogflow_cx")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Dialogflow API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Dialogflow API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_cx")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_dialogflow_cx_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_dialogflow_cx.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dialogflow_cx.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    dialogflow_cx
+    "The Dialogflow API C++ Client Library"
+    "Provides C++ APIs to use the Dialogflow API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_dialogflow_cx_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/dialogflow_es/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/CMakeLists.txt
@@ -153,22 +153,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_es"
 google_cloud_cpp_install_headers("google_cloud_cpp_dialogflow_es_mocks"
                                  "include/google/cloud/dialogflow_es")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Dialogflow API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Dialogflow API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dialogflow_es")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_dialogflow_es_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_dialogflow_es.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dialogflow_es.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    dialogflow_es
+    "The Dialogflow API C++ Client Library"
+    "Provides C++ APIs to use the Dialogflow API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_dialogflow_es_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/dlp/CMakeLists.txt
+++ b/google/cloud/dlp/CMakeLists.txt
@@ -156,22 +156,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_dlp"
 google_cloud_cpp_install_headers("google_cloud_cpp_dlp_mocks"
                                  "include/google/cloud/dlp")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Data Loss Prevention (DLP) API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Data Loss Prevention (DLP) API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_dlp")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_dlp_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_dlp.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_dlp.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    dlp
+    "The Cloud Data Loss Prevention (DLP) API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Data Loss Prevention (DLP) API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_dlp_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/documentai/CMakeLists.txt
+++ b/google/cloud/documentai/CMakeLists.txt
@@ -161,21 +161,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_documentai"
 google_cloud_cpp_install_headers("google_cloud_cpp_documentai_mocks"
                                  "include/google/cloud/documentai")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Document AI API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Document AI API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_documentai")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_documentai_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_documentai.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_documentai.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    documentai
+    "The Cloud Document AI API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Document AI API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_documentai_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/eventarc/CMakeLists.txt
+++ b/google/cloud/eventarc/CMakeLists.txt
@@ -159,21 +159,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_eventarc"
 google_cloud_cpp_install_headers("google_cloud_cpp_eventarc_mocks"
                                  "include/google/cloud/eventarc")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Eventarc API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Eventarc API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_eventarc")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_eventarc_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_eventarc.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_eventarc.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    eventarc "The Eventarc API C++ Client Library"
+    "Provides C++ APIs to use the Eventarc API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_eventarc_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/filestore/CMakeLists.txt
+++ b/google/cloud/filestore/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_filestore"
 google_cloud_cpp_install_headers("google_cloud_cpp_filestore_mocks"
                                  "include/google/cloud/filestore")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Filestore API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Filestore API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_filestore")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_filestore_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_filestore.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_filestore.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    filestore
+    "The Cloud Filestore API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Filestore API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_filestore_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/functions/CMakeLists.txt
+++ b/google/cloud/functions/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_functions"
 google_cloud_cpp_install_headers("google_cloud_cpp_functions_mocks"
                                  "include/google/cloud/functions")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Functions API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Functions API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_functions")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_functions_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_functions.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_functions.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    functions
+    "The Cloud Functions API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Functions API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_functions_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/gameservices/CMakeLists.txt
+++ b/google/cloud/gameservices/CMakeLists.txt
@@ -161,22 +161,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_gameservices"
 google_cloud_cpp_install_headers("google_cloud_cpp_gameservices_mocks"
                                  "include/google/cloud/gameservices")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Game Services API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Game Services API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_gameservices")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_gameservices_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_gameservices.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_gameservices.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    gameservices
+    "The Game Services API C++ Client Library"
+    "Provides C++ APIs to use the Game Services API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_gameservices_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/gkehub/CMakeLists.txt
+++ b/google/cloud/gkehub/CMakeLists.txt
@@ -155,20 +155,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_gkehub"
 google_cloud_cpp_install_headers("google_cloud_cpp_gkehub_mocks"
                                  "include/google/cloud/gkehub")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The GKE Hub C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Provides C++ APIs to use the GKE Hub.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_gkehub")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_gkehub_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_gkehub.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_gkehub.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    gkehub "The GKE Hub C++ Client Library"
+    "Provides C++ APIs to use the GKE Hub." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_gkehub_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -186,22 +186,14 @@ install(
 
 google_cloud_cpp_install_headers(google_cloud_cpp_common include/google/cloud)
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "Google Cloud C++ Client Library Common Components")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Common Components used by the Google Cloud C++ Client Libraries.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_common")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "absl_memory" " absl_optional"
-              " absl_time" " openssl")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_common.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_common.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    "common"
+    "Google Cloud C++ Client Library Common Components"
+    "Common Components used by the Google Cloud C++ Client Libraries."
+    "absl_memory"
+    " absl_optional"
+    " absl_time"
+    " openssl")
 
 # Create and install the CMake configuration files.
 configure_file("config.cmake.in" "google_cloud_cpp_common-config.cmake" @ONLY)

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -157,27 +157,15 @@ install(
 google_cloud_cpp_install_headers(google_cloud_cpp_grpc_utils
                                  include/google/cloud)
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "gRPC Utilities for the Google Cloud C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides gRPC Utilities for the Google Cloud C++ Client Library.")
-string(
-    CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_common"
-           " google_cloud_cpp_iam_protos"
-           " google_cloud_cpp_longrunning_operations_protos"
-           " google_cloud_cpp_rpc_status_protos"
-           " openssl")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_grpc_utils")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_grpc_utils.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_grpc_utils.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    grpc_utils
+    "gRPC Utilities for the Google Cloud C++ Client Library"
+    "Provides gRPC Utilities for the Google Cloud C++ Client Library."
+    "google_cloud_cpp_common"
+    " google_cloud_cpp_iam_protos"
+    " google_cloud_cpp_longrunning_operations_protos"
+    " google_cloud_cpp_rpc_status_protos"
+    " openssl")
 
 # Create and install the CMake configuration files.
 configure_file("grpc_utils/config.cmake.in"

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -125,21 +125,10 @@ install(
 google_cloud_cpp_install_headers(google_cloud_cpp_rest_internal
                                  include/google/cloud)
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "REST library for the Google Cloud C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides REST Transport for the Google Cloud C++ Client Library.")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_common")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_rest_internal")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_rest_internal.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_rest_internal.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    rest_internal "REST library for the Google Cloud C++ Client Library"
+    "Provides REST Transport for the Google Cloud C++ Client Library."
+    "google_cloud_cpp_common" " libcurl" " openssl")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -83,7 +83,6 @@ google_cloud_cpp_install_proto_library_protos("google_cloud_cpp_grafeas_protos"
 google_cloud_cpp_install_proto_library_headers(
     "google_cloud_cpp_grafeas_protos")
 
-# Setup global variables used in the following *.in files.
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/grafeas/CMakeLists.txt
+++ b/google/cloud/grafeas/CMakeLists.txt
@@ -83,7 +83,6 @@ google_cloud_cpp_install_proto_library_protos("google_cloud_cpp_grafeas_protos"
 google_cloud_cpp_install_proto_library_headers(
     "google_cloud_cpp_grafeas_protos")
 
-
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)
 configure_file("config.cmake.in" "google_cloud_cpp_grafeas-config.cmake" @ONLY)

--- a/google/cloud/iam/CMakeLists.txt
+++ b/google/cloud/iam/CMakeLists.txt
@@ -198,21 +198,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iam"
 google_cloud_cpp_install_headers("google_cloud_cpp_iam_mocks"
                                  "include/google/cloud/iam")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud IAM C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud IAM.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_iam")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_iam_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_iam.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_iam.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    iam
+    "The Google Cloud IAM C++ Client Library"
+    "Provides C++ APIs to access Google Cloud IAM."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_iam_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/iap/CMakeLists.txt
+++ b/google/cloud/iap/CMakeLists.txt
@@ -152,22 +152,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iap"
 google_cloud_cpp_install_headers("google_cloud_cpp_iap_mocks"
                                  "include/google/cloud/iap")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Identity-Aware Proxy API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Identity-Aware Proxy API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_iap")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_iap_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_iap.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_iap.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    iap
+    "The Cloud Identity-Aware Proxy API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Identity-Aware Proxy API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_iap_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/ids/CMakeLists.txt
+++ b/google/cloud/ids/CMakeLists.txt
@@ -151,21 +151,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_ids"
 google_cloud_cpp_install_headers("google_cloud_cpp_ids_mocks"
                                  "include/google/cloud/ids")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud IDS API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud IDS API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_ids")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_ids_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_ids.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_ids.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    ids "The Cloud IDS API C++ Client Library"
+    "Provides C++ APIs to use the Cloud IDS API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_ids_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/iot/CMakeLists.txt
+++ b/google/cloud/iot/CMakeLists.txt
@@ -153,21 +153,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_iot"
 google_cloud_cpp_install_headers("google_cloud_cpp_iot_mocks"
                                  "include/google/cloud/iot")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud IoT API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud IoT API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_iot")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_iot_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_iot.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_iot.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    iot "The Cloud IoT API C++ Client Library"
+    "Provides C++ APIs to use the Cloud IoT API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_iot_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/kms/CMakeLists.txt
+++ b/google/cloud/kms/CMakeLists.txt
@@ -154,22 +154,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_kms"
 google_cloud_cpp_install_headers("google_cloud_cpp_kms_mocks"
                                  "include/google/cloud/kms")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Key Management Service (KMS) API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Key Management Service (KMS) API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_kms")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_kms_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_kms.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_kms.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    kms
+    "The Cloud Key Management Service (KMS) API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Key Management Service (KMS) API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_kms_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/language/CMakeLists.txt
+++ b/google/cloud/language/CMakeLists.txt
@@ -160,22 +160,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_language"
 google_cloud_cpp_install_headers("google_cloud_cpp_language_mocks"
                                  "include/google/cloud/language")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Natural Language API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Natural Language API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_language")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_language_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_language.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_language.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    language
+    "The Cloud Natural Language API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Natural Language API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_language_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/logging/CMakeLists.txt
+++ b/google/cloud/logging/CMakeLists.txt
@@ -153,21 +153,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_logging"
 google_cloud_cpp_install_headers("google_cloud_cpp_logging_mocks"
                                  "include/google/cloud/logging")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Logging C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud Logging.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_logging")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_logging_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_logging.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_logging.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    logging
+    "The Google Cloud Logging C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Logging."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_logging_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/managedidentities/CMakeLists.txt
+++ b/google/cloud/managedidentities/CMakeLists.txt
@@ -169,24 +169,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_managedidentities"
 google_cloud_cpp_install_headers("google_cloud_cpp_managedidentities_mocks"
                                  "include/google/cloud/managedidentities")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Managed Service for Microsoft Active Directory API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
+google_cloud_cpp_add_pkgconfig(
+    managedidentities
+    "The Managed Service for Microsoft Active Directory API C++ Client Library"
     "Provides C++ APIs to use the Managed Service for Microsoft Active Directory API."
-)
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_managedidentities")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_managedidentities_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_managedidentities.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_managedidentities.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_managedidentities_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/memcache/CMakeLists.txt
+++ b/google/cloud/memcache/CMakeLists.txt
@@ -158,22 +158,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_memcache"
 google_cloud_cpp_install_headers("google_cloud_cpp_memcache_mocks"
                                  "include/google/cloud/memcache")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Memorystore for Memcached API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Memorystore for Memcached API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_memcache")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_memcache_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_memcache.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_memcache.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    memcache
+    "The Cloud Memorystore for Memcached API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Memorystore for Memcached API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_memcache_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/monitoring/CMakeLists.txt
+++ b/google/cloud/monitoring/CMakeLists.txt
@@ -139,21 +139,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_monitoring"
 google_cloud_cpp_install_headers("google_cloud_cpp_monitoring_mocks"
                                  "include/google/cloud/monitoring")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Monitoring API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Monitoring API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_monitoring")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_monitoring_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_monitoring.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_monitoring.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    monitoring
+    "The Cloud Monitoring API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Monitoring API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_monitoring_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/networkmanagement/CMakeLists.txt
+++ b/google/cloud/networkmanagement/CMakeLists.txt
@@ -166,22 +166,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_networkmanagement"
 google_cloud_cpp_install_headers("google_cloud_cpp_networkmanagement_mocks"
                                  "include/google/cloud/networkmanagement")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Network Management API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Network Management API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_networkmanagement")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_networkmanagement_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_networkmanagement.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_networkmanagement.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    networkmanagement
+    "The Network Management API C++ Client Library"
+    "Provides C++ APIs to use the Network Management API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_networkmanagement_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/notebooks/CMakeLists.txt
+++ b/google/cloud/notebooks/CMakeLists.txt
@@ -159,21 +159,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_notebooks"
 google_cloud_cpp_install_headers("google_cloud_cpp_notebooks_mocks"
                                  "include/google/cloud/notebooks")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Notebooks API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Notebooks API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_notebooks")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_notebooks_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_notebooks.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_notebooks.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    notebooks "The Notebooks API C++ Client Library"
+    "Provides C++ APIs to use the Notebooks API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_notebooks_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/orgpolicy/CMakeLists.txt
+++ b/google/cloud/orgpolicy/CMakeLists.txt
@@ -160,21 +160,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_orgpolicy"
 google_cloud_cpp_install_headers("google_cloud_cpp_orgpolicy_mocks"
                                  "include/google/cloud/orgpolicy")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Organization Policy API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Organization Policy API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_orgpolicy")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_orgpolicy_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_orgpolicy.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_orgpolicy.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    orgpolicy
+    "The Organization Policy API C++ Client Library"
+    "Provides C++ APIs to use the Organization Policy API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_orgpolicy_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -159,21 +159,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_osconfig"
 google_cloud_cpp_install_headers("google_cloud_cpp_osconfig_mocks"
                                  "include/google/cloud/osconfig")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The OS Config API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the OS Config API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_osconfig")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_osconfig_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_osconfig.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_osconfig.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    osconfig "The OS Config API C++ Client Library"
+    "Provides C++ APIs to use the OS Config API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_osconfig_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -158,21 +158,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_oslogin"
 google_cloud_cpp_install_headers("google_cloud_cpp_oslogin_mocks"
                                  "include/google/cloud/oslogin")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud OS Login API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud OS Login API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_oslogin")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_oslogin_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_oslogin.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_oslogin.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    oslogin
+    "The Cloud OS Login API C++ Client Library"
+    "Provides C++ APIs to use the Cloud OS Login API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_oslogin_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/policytroubleshooter/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/CMakeLists.txt
@@ -154,22 +154,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_policytroubleshooter"
 google_cloud_cpp_install_headers("google_cloud_cpp_policytroubleshooter_mocks"
                                  "include/google/cloud/policytroubleshooter")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Policy Troubleshooter API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Policy Troubleshooter API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_policytroubleshooter")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_policytroubleshooter_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_policytroubleshooter.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_policytroubleshooter.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    policytroubleshooter
+    "The Policy Troubleshooter API C++ Client Library"
+    "Provides C++ APIs to use the Policy Troubleshooter API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_policytroubleshooter_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/privateca/CMakeLists.txt
+++ b/google/cloud/privateca/CMakeLists.txt
@@ -160,21 +160,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_privateca"
 google_cloud_cpp_install_headers("google_cloud_cpp_privateca_mocks"
                                  "include/google/cloud/privateca")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Certificate Authority API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Certificate Authority API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_privateca")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_privateca_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_privateca.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_privateca.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    privateca
+    "The Certificate Authority API C++ Client Library"
+    "Provides C++ APIs to use the Certificate Authority API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_privateca_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/profiler/CMakeLists.txt
+++ b/google/cloud/profiler/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_profiler"
 google_cloud_cpp_install_headers("google_cloud_cpp_profiler_mocks"
                                  "include/google/cloud/profiler")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Profiler API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Profiler API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_profiler")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_profiler_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_profiler.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_profiler.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    profiler
+    "The Cloud Profiler API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Profiler API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_profiler_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -375,22 +375,14 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsub"
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsub_mocks"
                                  "include/google/cloud/pubsub")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Pubsub C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud Pubsub.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_pubsub")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_pubsub_protos"
-              " absl_str_format")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_pubsub.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    pubsub
+    "The Google Cloud Pubsub C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Pubsub."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_pubsub_protos"
+    " absl_str_format")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/pubsublite/CMakeLists.txt
+++ b/google/cloud/pubsublite/CMakeLists.txt
@@ -362,21 +362,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite"
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsublite_mocks"
                                  "include/google/cloud/pubsublite")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Pub/Sub Lite API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Pub/Sub Lite API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_pubsublite")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_pubsublite_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_pubsublite.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsublite.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    pubsublite
+    "The Pub/Sub Lite API C++ Client Library"
+    "Provides C++ APIs to access Pub/Sub Lite API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_pubsublite_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/recommender/CMakeLists.txt
+++ b/google/cloud/recommender/CMakeLists.txt
@@ -163,21 +163,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_recommender"
 google_cloud_cpp_install_headers("google_cloud_cpp_recommender_mocks"
                                  "include/google/cloud/recommender")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Recommender API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Recommender API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_recommender")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_recommender_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_recommender.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_recommender.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    recommender
+    "The Recommender API C++ Client Library"
+    "Provides C++ APIs to use the Recommender API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_recommender_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/redis/CMakeLists.txt
+++ b/google/cloud/redis/CMakeLists.txt
@@ -155,22 +155,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_redis"
 google_cloud_cpp_install_headers("google_cloud_cpp_redis_mocks"
                                  "include/google/cloud/redis")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Google Cloud Memorystore for Redis API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Google Cloud Memorystore for Redis API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_redis")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_redis_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_redis.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_redis.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    redis
+    "The Google Cloud Memorystore for Redis API C++ Client Library"
+    "Provides C++ APIs to use the Google Cloud Memorystore for Redis API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_redis_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/resourcemanager/CMakeLists.txt
+++ b/google/cloud/resourcemanager/CMakeLists.txt
@@ -165,23 +165,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcemanager"
 google_cloud_cpp_install_headers("google_cloud_cpp_resourcemanager_mocks"
                                  "include/google/cloud/resourcemanager")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Resource Manager API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Resource Manager API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_resourcemanager")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_resourcemanager_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_resourcemanager.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_resourcemanager.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    resourcemanager
+    "The Cloud Resource Manager API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Resource Manager API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_resourcemanager_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/resourcesettings/CMakeLists.txt
+++ b/google/cloud/resourcesettings/CMakeLists.txt
@@ -168,22 +168,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_resourcesettings"
 google_cloud_cpp_install_headers("google_cloud_cpp_resourcesettings_mocks"
                                  "include/google/cloud/resourcesettings")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Resource Settings API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Resource Settings API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_resourcesettings")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_resourcesettings_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_resourcesettings.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_resourcesettings.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    resourcesettings
+    "The Resource Settings API C++ Client Library"
+    "Provides C++ APIs to use the Resource Settings API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_resourcesettings_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/retail/CMakeLists.txt
+++ b/google/cloud/retail/CMakeLists.txt
@@ -157,20 +157,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_retail"
 google_cloud_cpp_install_headers("google_cloud_cpp_retail_mocks"
                                  "include/google/cloud/retail")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Retail API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "Provides C++ APIs to use the Retail API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_retail")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_retail_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_retail.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_retail.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    retail "The Retail API C++ Client Library"
+    "Provides C++ APIs to use the Retail API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_retail_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/scheduler/CMakeLists.txt
+++ b/google/cloud/scheduler/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_scheduler"
 google_cloud_cpp_install_headers("google_cloud_cpp_scheduler_mocks"
                                  "include/google/cloud/scheduler")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Scheduler API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Scheduler API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_scheduler")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_scheduler_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_scheduler.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_scheduler.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    scheduler
+    "The Cloud Scheduler API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Scheduler API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_scheduler_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/secretmanager/CMakeLists.txt
+++ b/google/cloud/secretmanager/CMakeLists.txt
@@ -160,22 +160,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_secretmanager"
 google_cloud_cpp_install_headers("google_cloud_cpp_secretmanager_mocks"
                                  "include/google/cloud/secretmanager")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Secret Manager API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Secret Manager API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_secretmanager")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_secretmanager_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_secretmanager.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_secretmanager.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    secretmanager
+    "The Secret Manager API C++ Client Library"
+    "Provides C++ APIs to use the Secret Manager API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_secretmanager_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/securitycenter/CMakeLists.txt
+++ b/google/cloud/securitycenter/CMakeLists.txt
@@ -166,23 +166,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_securitycenter"
 google_cloud_cpp_install_headers("google_cloud_cpp_securitycenter_mocks"
                                  "include/google/cloud/securitycenter")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Security Command Center API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Security Command Center API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_securitycenter")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_securitycenter_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_securitycenter.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_securitycenter.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    securitycenter
+    "The Security Command Center API C++ Client Library"
+    "Provides C++ APIs to use the Security Command Center API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_securitycenter_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -164,22 +164,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicecontrol"
 google_cloud_cpp_install_headers("google_cloud_cpp_servicecontrol_mocks"
                                  "include/google/cloud/servicecontrol")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Control API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Service Control API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_servicecontrol")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_servicecontrol_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_servicecontrol.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_servicecontrol.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    servicecontrol
+    "The Service Control API C++ Client Library"
+    "Provides C++ APIs to use the Service Control API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_servicecontrol_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/servicedirectory/CMakeLists.txt
+++ b/google/cloud/servicedirectory/CMakeLists.txt
@@ -166,22 +166,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicedirectory"
 google_cloud_cpp_install_headers("google_cloud_cpp_servicedirectory_mocks"
                                  "include/google/cloud/servicedirectory")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Directory API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Service Directory API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_servicedirectory")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_servicedirectory_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_servicedirectory.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_servicedirectory.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    servicedirectory
+    "The Service Directory API C++ Client Library"
+    "Provides C++ APIs to use the Service Directory API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_servicedirectory_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/servicemanagement/CMakeLists.txt
+++ b/google/cloud/servicemanagement/CMakeLists.txt
@@ -166,22 +166,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_servicemanagement"
 google_cloud_cpp_install_headers("google_cloud_cpp_servicemanagement_mocks"
                                  "include/google/cloud/servicemanagement")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Management API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Service Management API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_servicemanagement")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_servicemanagement_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_servicemanagement.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_servicemanagement.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    servicemanagement
+    "The Service Management API C++ Client Library"
+    "Provides C++ APIs to use the Service Management API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_servicemanagement_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/serviceusage/CMakeLists.txt
+++ b/google/cloud/serviceusage/CMakeLists.txt
@@ -158,22 +158,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_serviceusage"
 google_cloud_cpp_install_headers("google_cloud_cpp_serviceusage_mocks"
                                  "include/google/cloud/serviceusage")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Service Usage API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Service Usage API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_serviceusage")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_serviceusage_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_serviceusage.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_serviceusage.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    serviceusage
+    "The Service Usage API C++ Client Library"
+    "Provides C++ APIs to use the Service Usage API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_serviceusage_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/shell/CMakeLists.txt
+++ b/google/cloud/shell/CMakeLists.txt
@@ -156,21 +156,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_shell"
 google_cloud_cpp_install_headers("google_cloud_cpp_shell_mocks"
                                  "include/google/cloud/shell")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Shell API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Shell API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_shell")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_shell_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_shell.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_shell.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    shell
+    "The Cloud Shell API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Shell API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_shell_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -484,28 +484,17 @@ google_cloud_cpp_install_headers("google_cloud_cpp_spanner"
 google_cloud_cpp_install_headers("google_cloud_cpp_spanner_mocks"
                                  "include/google/cloud/spanner")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Spanner C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to access Google Cloud Spanner.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_spanner")
-string(
-    CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_grpc_utils"
-           " google_cloud_cpp_common"
-           " google_cloud_cpp_spanner_protos"
-           " absl_memory"
-           " absl_numeric"
-           " absl_strings"
-           " absl_time")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_spanner.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_spanner.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    spanner
+    "The Google Cloud Spanner C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Spanner."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_spanner_protos"
+    " absl_memory"
+    " absl_numeric"
+    " absl_strings"
+    " absl_time")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/speech/CMakeLists.txt
+++ b/google/cloud/speech/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_speech"
 google_cloud_cpp_install_headers("google_cloud_cpp_speech_mocks"
                                  "include/google/cloud/speech")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Speech-to-Text API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Speech-to-Text API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_speech")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_speech_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_speech.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_speech.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    speech
+    "The Cloud Speech-to-Text API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Speech-to-Text API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_speech_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -304,7 +304,10 @@ install(
 google_cloud_cpp_install_headers(google_cloud_cpp_storage
                                  include/google/cloud/storage)
 
-# Setup global variables used in the following *.in files.
+# Cannot use google_cloud_cpp_add_pkgconfig() for this library. There is a
+# horrible hack here, adding -lcrc32c to the 'Libs:` entry. We should be adding
+# this library to the `Requires:` line, but it does not create pkg-config
+# modules.
 set(GOOGLE_CLOUD_CPP_PC_NAME "The Google Cloud Storage C++ Client Library")
 set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
     "Provides C++ APIs to access Google Cloud Storage.")

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -106,29 +106,18 @@ else ()
     create_bazel_config(google_cloud_cpp_storage_grpc)
 endif ()
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The GCS (Google Cloud Storage) gRPC plugin")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "An extension to the GCS C++ client library using gRPC for transport.")
-string(
-    CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES
-           "google_cloud_cpp_storage"
-           " google_cloud_cpp_grpc_utils"
-           " google_cloud_cpp_storage_protos"
-           " google_cloud_cpp_rpc_status_protos"
-           " google_cloud_cpp_rpc_error_details_protos"
-           " google_cloud_cpp_common"
-           " libcurl"
-           " openssl")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_storage_grpc")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_storage_grpc.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storage_grpc.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    storage_grpc
+    "The GCS (Google Cloud Storage) gRPC plugin"
+    "An extension to the GCS C++ client library using gRPC for transport."
+    "google_cloud_cpp_storage"
+    " google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_storage_protos"
+    " google_cloud_cpp_rpc_status_protos"
+    " google_cloud_cpp_rpc_error_details_protos"
+    " google_cloud_cpp_common"
+    " libcurl"
+    " openssl")
 
 install(
     TARGETS google_cloud_cpp_storage_grpc

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -172,22 +172,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_storagetransfer"
 google_cloud_cpp_install_headers("google_cloud_cpp_storagetransfer_mocks"
                                  "include/google/cloud/storagetransfer")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Storage Transfer API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Storage Transfer API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_storagetransfer")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_storagetransfer_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_storagetransfer.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_storagetransfer.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    storagetransfer
+    "The Storage Transfer API C++ Client Library"
+    "Provides C++ APIs to use the Storage Transfer API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_storagetransfer_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/talent/CMakeLists.txt
+++ b/google/cloud/talent/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_talent"
 google_cloud_cpp_install_headers("google_cloud_cpp_talent_mocks"
                                  "include/google/cloud/talent")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Talent Solution API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Talent Solution API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_talent")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_talent_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_talent.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_talent.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    talent
+    "The Cloud Talent Solution API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Talent Solution API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_talent_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/tasks/CMakeLists.txt
+++ b/google/cloud/tasks/CMakeLists.txt
@@ -156,21 +156,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tasks"
 google_cloud_cpp_install_headers("google_cloud_cpp_tasks_mocks"
                                  "include/google/cloud/tasks")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Tasks API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Tasks API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_tasks")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_tasks_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_tasks.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_tasks.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    tasks
+    "The Cloud Tasks API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Tasks API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_tasks_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/texttospeech/CMakeLists.txt
+++ b/google/cloud/texttospeech/CMakeLists.txt
@@ -161,22 +161,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_texttospeech"
 google_cloud_cpp_install_headers("google_cloud_cpp_texttospeech_mocks"
                                  "include/google/cloud/texttospeech")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Text-to-Speech API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Text-to-Speech API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_texttospeech")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_texttospeech_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_texttospeech.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_texttospeech.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    texttospeech
+    "The Cloud Text-to-Speech API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Text-to-Speech API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_texttospeech_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/tpu/CMakeLists.txt
+++ b/google/cloud/tpu/CMakeLists.txt
@@ -151,21 +151,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_tpu"
 google_cloud_cpp_install_headers("google_cloud_cpp_tpu_mocks"
                                  "include/google/cloud/tpu")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud TPU API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud TPU API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_tpu")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_tpu_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_tpu.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_tpu.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    tpu "The Cloud TPU API C++ Client Library"
+    "Provides C++ APIs to use the Cloud TPU API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_tpu_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/trace/CMakeLists.txt
+++ b/google/cloud/trace/CMakeLists.txt
@@ -154,21 +154,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_trace"
 google_cloud_cpp_install_headers("google_cloud_cpp_trace_mocks"
                                  "include/google/cloud/trace")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Stackdriver Trace API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Stackdriver Trace API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_trace")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_trace_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_trace.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_trace.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    trace
+    "The Stackdriver Trace API C++ Client Library"
+    "Provides C++ APIs to use the Stackdriver Trace API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_trace_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/translate/CMakeLists.txt
+++ b/google/cloud/translate/CMakeLists.txt
@@ -159,21 +159,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_translate"
 google_cloud_cpp_install_headers("google_cloud_cpp_translate_mocks"
                                  "include/google/cloud/translate")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Translation API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Translation API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_translate")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_translate_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_translate.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_translate.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    translate
+    "The Cloud Translation API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Translation API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_translate_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/videointelligence/CMakeLists.txt
+++ b/google/cloud/videointelligence/CMakeLists.txt
@@ -168,23 +168,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_videointelligence"
 google_cloud_cpp_install_headers("google_cloud_cpp_videointelligence_mocks"
                                  "include/google/cloud/videointelligence")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME
-    "The Cloud Video Intelligence API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Video Intelligence API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_videointelligence")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_videointelligence_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_videointelligence.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_videointelligence.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    videointelligence
+    "The Cloud Video Intelligence API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Video Intelligence API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_videointelligence_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/vision/CMakeLists.txt
+++ b/google/cloud/vision/CMakeLists.txt
@@ -157,21 +157,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vision"
 google_cloud_cpp_install_headers("google_cloud_cpp_vision_mocks"
                                  "include/google/cloud/vision")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Cloud Vision API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Cloud Vision API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_vision")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_vision_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_vision.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_vision.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    vision
+    "The Cloud Vision API C++ Client Library"
+    "Provides C++ APIs to use the Cloud Vision API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_vision_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/vmmigration/CMakeLists.txt
+++ b/google/cloud/vmmigration/CMakeLists.txt
@@ -158,21 +158,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vmmigration"
 google_cloud_cpp_install_headers("google_cloud_cpp_vmmigration_mocks"
                                  "include/google/cloud/vmmigration")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The VM Migration API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the VM Migration API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_vmmigration")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_vmmigration_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_vmmigration.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_vmmigration.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    vmmigration
+    "The VM Migration API C++ Client Library"
+    "Provides C++ APIs to use the VM Migration API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_vmmigration_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/vpcaccess/CMakeLists.txt
+++ b/google/cloud/vpcaccess/CMakeLists.txt
@@ -160,21 +160,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_vpcaccess"
 google_cloud_cpp_install_headers("google_cloud_cpp_vpcaccess_mocks"
                                  "include/google/cloud/vpcaccess")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Serverless VPC Access API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Serverless VPC Access API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_vpcaccess")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_vpcaccess_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_vpcaccess.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_vpcaccess.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    vpcaccess
+    "The Serverless VPC Access API C++ Client Library"
+    "Provides C++ APIs to use the Serverless VPC Access API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_vpcaccess_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/webrisk/CMakeLists.txt
+++ b/google/cloud/webrisk/CMakeLists.txt
@@ -158,21 +158,10 @@ google_cloud_cpp_install_headers("google_cloud_cpp_webrisk"
 google_cloud_cpp_install_headers("google_cloud_cpp_webrisk_mocks"
                                  "include/google/cloud/webrisk")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Web Risk API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Web Risk API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_webrisk")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_webrisk_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_webrisk.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_webrisk.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    webrisk "The Web Risk API C++ Client Library"
+    "Provides C++ APIs to use the Web Risk API." "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common" " google_cloud_cpp_webrisk_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/websecurityscanner/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/CMakeLists.txt
@@ -169,22 +169,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_websecurityscanner"
 google_cloud_cpp_install_headers("google_cloud_cpp_websecurityscanner_mocks"
                                  "include/google/cloud/websecurityscanner")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Web Security Scanner API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Web Security Scanner API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_websecurityscanner")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common"
-              " google_cloud_cpp_websecurityscanner_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_websecurityscanner.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_websecurityscanner.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    websecurityscanner
+    "The Web Security Scanner API C++ Client Library"
+    "Provides C++ APIs to use the Web Security Scanner API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_websecurityscanner_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)

--- a/google/cloud/workflows/CMakeLists.txt
+++ b/google/cloud/workflows/CMakeLists.txt
@@ -160,21 +160,13 @@ google_cloud_cpp_install_headers("google_cloud_cpp_workflows"
 google_cloud_cpp_install_headers("google_cloud_cpp_workflows_mocks"
                                  "include/google/cloud/workflows")
 
-# Setup global variables used in the following *.in files.
-set(GOOGLE_CLOUD_CPP_PC_NAME "The Workflow Executions API C++ Client Library")
-set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION
-    "Provides C++ APIs to use the Workflow Executions API.")
-set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_workflows")
-string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES "google_cloud_cpp_grpc_utils"
-              " google_cloud_cpp_common" " google_cloud_cpp_workflows_protos")
-
-# Create and install the pkg-config files.
-configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-               "google_cloud_cpp_workflows.pc" @ONLY)
-install(
-    FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_workflows.pc"
-    DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-    COMPONENT google_cloud_cpp_development)
+google_cloud_cpp_add_pkgconfig(
+    workflows
+    "The Workflow Executions API C++ Client Library"
+    "Provides C++ APIs to use the Workflow Executions API."
+    "google_cloud_cpp_grpc_utils"
+    " google_cloud_cpp_common"
+    " google_cloud_cpp_workflows_protos")
 
 # Create and install the CMake configuration files.
 include(CMakePackageConfigHelpers)


### PR DESCRIPTION
All generated files, and most hand-crafted files, use
a common function to create and install the `pkg-config(1)` files.

Part of the work for #8992 

The PR is broken down in several commits to (I hope) ease the review.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9018)
<!-- Reviewable:end -->
