### PR TITLE
fix: use correct paths in `pkg-config` files

### DIFF
--- a/cmake/templates/config.pc.in
+++ b/cmake/templates/config.pc.in
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 prefix=${pcfiledir}/../..
-exec_prefix=${prefix}/@CMAKE_INSTALL_BINDIR@
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
 includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: @GOOGLE_CLOUD_CPP_PC_NAME@


### PR DESCRIPTION
The definition of `exec_prefix` was wrong, but probably harmless, as we
also defined `libdir` incorrectly.  These are the correct definitions
according to:

https://people.freedesktop.org/~dbn/pkg-config-guide.html#concepts

If I read the documentation incorrectly: at least we just need to fix
one place.

Part of the work for #8992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9019)
<!-- Reviewable:end -->
