### PR TITLE
feat(common): add functions for url encoding and decoding

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -82,6 +82,7 @@ google_cloud_cpp_common_hdrs = [
     "stream_range.h",
     "terminate_handler.h",
     "tracing_options.h",
+    "url_encoded.h",
     "version.h",
 ]
 
@@ -114,5 +115,6 @@ google_cloud_cpp_common_srcs = [
     "status.cc",
     "terminate_handler.cc",
     "tracing_options.cc",
+    "url_encoded.cc",
     "version.cc",
 ]

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -122,6 +122,8 @@ add_library(
     terminate_handler.h
     tracing_options.cc
     tracing_options.h
+    url_encoded.cc
+    url_encoded.h
     version.cc
     version.h)
 target_link_libraries(
@@ -263,7 +265,8 @@ if (BUILD_TESTING)
         status_test.cc
         stream_range_test.cc
         terminate_handler_test.cc
-        tracing_options_test.cc)
+        tracing_options_test.cc
+        url_encoded_test.cc)
 
     # Export the list of unit tests so the Bazel BUILD file can pick it up.
     export_list_to_bazel("google_cloud_cpp_common_unit_tests.bzl"

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -59,4 +59,5 @@ google_cloud_cpp_common_unit_tests = [
     "stream_range_test.cc",
     "terminate_handler_test.cc",
     "tracing_options_test.cc",
+    "url_encoded_test.cc",
 ]

--- a/google/cloud/url_encoded.cc
+++ b/google/cloud/url_encoded.cc
@@ -33,7 +33,6 @@ std::array<const char[4], 95> constexpr kEncode = {
 }  // namespace
 
 std::string UrlEncode(std::string const& input) {
-  if (input.empty()) return {};
   std::stringstream encoded;
   for (auto const& c : input) {
     encoded << kEncode[c - 0x20];
@@ -42,7 +41,6 @@ std::string UrlEncode(std::string const& input) {
 }
 
 std::string UrlDecode(std::string const& input) {
-  if (input.empty()) return {};
   std::stringstream decoded;
   for (std::size_t i = 0; i < input.size(); ++i) {
     if (input[i] == '%') {

--- a/google/cloud/url_encoded.cc
+++ b/google/cloud/url_encoded.cc
@@ -1,0 +1,61 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/url_encoded.h"
+#include <array>
+#include <sstream>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+std::array<const char[4], 95> constexpr kEncode = {
+    "%20", "%21", "%22", "%23", "%24", "%25", "%26", "%27", "%28", "%29", "%2A",
+    "%2B", "%2C", "-",   ".",   "%2F", "0",   "1",   "2",   "3",   "4",   "5",
+    "6",   "7",   "8",   "9",   "%3A", "%3B", "%3C", "%3D", "%3E", "%3F", "%40",
+    "A",   "B",   "C",   "D",   "E",   "F",   "G",   "H",   "I",   "J",   "K",
+    "L",   "M",   "N",   "O",   "P",   "Q",   "R",   "S",   "T",   "U",   "V",
+    "W",   "X",   "Y",   "Z",   "%5B", "%5C", "%5D", "%5E", "_",   "%60", "a",
+    "b",   "c",   "d",   "e",   "f",   "g",   "h",   "i",   "j",   "k",   "l",
+    "m",   "n",   "o",   "p",   "q",   "r",   "s",   "t",   "u",   "v",   "w",
+    "x",   "y",   "z",   "%7B", "%7C", "%7D", "~"};
+}  // namespace
+
+std::string UrlEncode(std::string const& input) {
+  if (input.empty()) return {};
+  std::stringstream encoded;
+  for (auto const& c : input) {
+    encoded << kEncode[c - 0x20];
+  }
+  return encoded.str();
+}
+
+std::string UrlDecode(std::string const& input) {
+  if (input.empty()) return {};
+  std::stringstream decoded;
+  for (std::size_t i = 0; i < input.size(); ++i) {
+    if (input[i] == '%') {
+      decoded << static_cast<char>(
+          std::stoi(input.substr(i + 1, 2), nullptr, 16));
+      i += 2;
+    } else {
+      decoded << input[i];
+    }
+  }
+  return decoded.str();
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/url_encoded.h
+++ b/google/cloud/url_encoded.h
@@ -25,10 +25,13 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 // Encodes the given string and returns a new string such that all input
 // characters that are not in [a-zA-z-._~] are converted to their "URL escaped"
 // version "%NN" where NN is the ASCII hex value.
+// Non-printable ASCII characters in input results in undefined behavior.
 std::string UrlEncode(std::string const& input);
 
 // Decodes the given string, interpreting any "%NN" sequence as an "URL escaped"
 // character and substitutes the ASCII character corresponding to hex value NN.
+// Malformed escaped sequences in input could result in non-printable characters
+// in the result or possibly thrown exceptions.
 std::string UrlDecode(std::string const& input);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/url_encoded.h
+++ b/google/cloud/url_encoded.h
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_URL_ENCODED_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_URL_ENCODED_H
+
+#include "google/cloud/version.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// Encodes the given string and returns a new string such that all input
+// characters that are not in [a-zA-z-._~] are converted to their "URL escaped"
+// version "%NN" where NN is the ASCII hex value.
+std::string UrlEncode(std::string const& input);
+
+// Decodes the given string, interpreting any "%NN" sequence as an "URL escaped"
+// character and substitutes the ASCII character corresponding to hex value NN.
+std::string UrlDecode(std::string const& input);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_URL_ENCODED_H

--- a/google/cloud/url_encoded_test.cc
+++ b/google/cloud/url_encoded_test.cc
@@ -1,0 +1,76 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/url_encoded.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::IsEmpty;
+
+TEST(UrlEncodeString, AllPrintableAsciiCharacters) {
+  std::string escaped_printable_ascii_chars =
+      R"(%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~)";
+  std::string printable_ascii_chars =
+      R"( !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~)";
+  auto result = UrlEncode(printable_ascii_chars);
+  EXPECT_EQ(result, escaped_printable_ascii_chars);
+}
+
+TEST(UrlEncodeString, EmptyString) {
+  auto result = UrlEncode({});
+  EXPECT_THAT(result, IsEmpty());
+}
+
+TEST(UrlEncodeString, OneUnreservedCharacter) {
+  auto result = UrlEncode("T");
+  EXPECT_EQ(result, "T");
+}
+
+TEST(UrlEncodeString, OneReservedCharacter) {
+  auto result = UrlEncode("%");
+  EXPECT_EQ(result, "%25");
+}
+
+TEST(UrlDecodeString, AllPrintableAsciiCharacters) {
+  std::string escaped_printable_ascii_chars =
+      R"(%20%21%22%23%24%25%26%27%28%29%2A%2B%2C-.%2F0123456789%3A%3B%3C%3D%3E%3F%40ABCDEFGHIJKLMNOPQRSTUVWXYZ%5B%5C%5D%5E_%60abcdefghijklmnopqrstuvwxyz%7B%7C%7D~)";
+  std::string printable_ascii_chars =
+      R"( !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~)";
+  auto result = UrlDecode(escaped_printable_ascii_chars);
+  EXPECT_EQ(result, printable_ascii_chars);
+}
+
+TEST(UrlDecodeString, EmptyString) {
+  auto result = UrlDecode({});
+  EXPECT_THAT(result, IsEmpty());
+}
+
+TEST(UrlDecodeString, OneUnreservedCharacter) {
+  auto result = UrlDecode("T");
+  EXPECT_EQ(result, "T");
+}
+
+TEST(UrlDecodeString, OneReservedCharacter) {
+  auto result = UrlDecode("%25");
+  EXPECT_EQ(result, "%");
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/url_encoded_test.cc
+++ b/google/cloud/url_encoded_test.cc
@@ -70,6 +70,13 @@ TEST(UrlDecodeString, OneReservedCharacter) {
   EXPECT_EQ(result, "%");
 }
 
+TEST(UrlEncoding, RoundTrip) {
+  std::string printable_ascii_chars =
+      R"( !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~)";
+  auto result = UrlDecode(UrlEncode(printable_ascii_chars));
+  EXPECT_EQ(printable_ascii_chars, result);
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud


### PR DESCRIPTION
This functionality exists in libcurl, but requires creating a curl handle, which we're trying to better encapsulate. I've put off rolling my own prior to this, but in order to url encode object names for storage it's necessary. This implementation matches that of curl_easy_escape which escapes all printable ASCII characters except for [a-zA-Z0-9-_.~].

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9021)
<!-- Reviewable:end -->
