### PR TITLE
fix: support absolute paths for `CMAKE_INSTALL_*DIR`

### DIFF
--- a/ci/cloudbuild/builds/cmake-single-feature.sh
+++ b/ci/cloudbuild/builds/cmake-single-feature.sh
@@ -21,9 +21,45 @@ source module ci/lib/io.sh
 source module ci/cloudbuild/builds/lib/features.sh
 
 mapfile -t features < <(features::list_full)
+
+check_pkgconfig_relative() {
+  local binary_dir="${1}"
+  # shellcheck disable=SC2016
+  mapfile -t unmatched < <(find "${binary_dir}" -name '*.pc' -print0 | xargs -0 grep -L 'includedir=${prefix}/')
+  if [[ ${#unmatched[@]} -ne 0 ]]; then
+    io::log_red "Found ${#unmatched} pkg-config module files with incorrect paths: " "$(printf "%s\n" "${unmatched[@]}")"
+    return 1
+  fi
+  # shellcheck disable=SC2016
+  mapfile -t unmatched < <(find "${binary_dir}" -name '*.pc' -print0 | xargs -0 grep -L 'libdir=${exec_prefix}/')
+  if [[ ${#unmatched[@]} -ne 0 ]]; then
+    io::log_red "Found ${#unmatched} pkg-config module files with incorrect paths: " "$(printf "%s\n" "${unmatched[@]}")"
+    return 1
+  fi
+}
+
+check_pkgconfig_absolute() {
+  local binary_dir="${1}"
+  mapfile -t unmatched < <(find "${binary_dir}" -name '*.pc' -print0 | xargs -0 grep -L includedir=/test-only/include)
+  if [[ ${#unmatched[@]} -ne 0 ]]; then
+    io::log_red "Found ${#unmatched} pkg-config module files with incorrect paths: " "$(printf "%s\n" "${unmatched[@]}")"
+    return 1
+  fi
+  mapfile -t unmatched < <(find "${binary_dir}" -name '*.pc' -print0 | xargs -0 grep -L libdir=/test-only/lib)
+  if [[ ${#unmatched[@]} -ne 0 ]]; then
+    io::log_red "Found ${#unmatched} pkg-config module files with incorrect paths: " "$(printf "%s\n" "${unmatched[@]}")"
+    return 1
+  fi
+}
+
 for feature in "${features[@]}"; do
-  io::log_h2 cmake -S . -B cmake-out/test-only-"${feature}" \
+  io::run cmake -S . -B cmake-out/test-only-"${feature}" \
     -DGOOGLE_CLOUD_CPP_ENABLE="${feature}"
-  cmake -S . -B cmake-out/test-only-"${feature}" \
-    -DGOOGLE_CLOUD_CPP_ENABLE="${feature}"
+  io::run check_pkgconfig_relative cmake-out/test-only-"${feature}"
+
+  io::run cmake -S . -B cmake-out/test-only-"${feature}"-absolute-cmake-install \
+    -DGOOGLE_CLOUD_CPP_ENABLE="${feature}" \
+    -DCMAKE_INSTALL_INCLUDEDIR=/test-only/include \
+    -DCMAKE_INSTALL_LIBDIR=/test-only/lib
+  io::run check_pkgconfig_absolute cmake-out/test-only-"${feature}"-absolute-cmake-install
 done

--- a/cmake/AddPkgConfig.cmake
+++ b/cmake/AddPkgConfig.cmake
@@ -14,7 +14,6 @@
 # limitations under the License.
 # ~~~
 
-
 # We do not use macros a lot, so this deserves a comment. Unlike functions,
 # macros do not introduce a scope. This is an advantage when trying to set
 # global variables, as we do here.  It is obviously a disadvantage if you need
@@ -24,14 +23,14 @@ macro (google_cloud_cpp_set_pkgconfig_paths)
         set(GOOGLE_CLOUD_CPP_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
     else ()
         set(GOOGLE_CLOUD_CPP_PC_LIBDIR
-                "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+            "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
     endif ()
 
     if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
         set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
     else ()
         set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR
-                "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+            "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
     endif ()
 endmacro ()
 
@@ -51,9 +50,9 @@ function (google_cloud_cpp_add_pkgconfig library name description)
 
     # Create and install the pkg-config files.
     configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-            "google_cloud_cpp_${library}.pc" @ONLY)
+                   "google_cloud_cpp_${library}.pc" @ONLY)
     install(
-            FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
-            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-            COMPONENT google_cloud_cpp_development)
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+        COMPONENT google_cloud_cpp_development)
 endfunction ()

--- a/cmake/AddPkgConfig.cmake
+++ b/cmake/AddPkgConfig.cmake
@@ -1,0 +1,59 @@
+# ~~~
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ~~~
+
+
+# We do not use macros a lot, so this deserves a comment. Unlike functions,
+# macros do not introduce a scope. This is an advantage when trying to set
+# global variables, as we do here.  It is obviously a disadvantage if you need
+# local variables.
+macro (google_cloud_cpp_set_pkgconfig_paths)
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_LIBDIR
+                "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif ()
+
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR
+                "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif ()
+endmacro ()
+
+#
+# Create the pkgconfig configuration file (aka *.pc file) and the rules to
+# install it.
+#
+# * library: the name of the library, such as `storage`, or `spanner`
+# * ARGN: the names of any pkgconfig modules the generated module depends on
+#
+function (google_cloud_cpp_add_pkgconfig library name description)
+    set(GOOGLE_CLOUD_CPP_PC_NAME "${name}")
+    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
+    string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
+    google_cloud_cpp_set_pkgconfig_paths()
+
+    # Create and install the pkg-config files.
+    configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
+            "google_cloud_cpp_${library}.pc" @ONLY)
+    install(
+            FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+            COMPONENT google_cloud_cpp_development)
+endfunction ()

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -452,7 +452,7 @@ macro (external_googleapis_install_pc_common target)
     endif ()
 endmacro ()
 
-include(GoogleCloudCppCommon)
+include(AddPkgConfig)
 
 # Use a function to create a scope for the variables.
 function (external_googleapis_install_pc target)

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -452,9 +452,12 @@ macro (external_googleapis_install_pc_common target)
     endif ()
 endmacro ()
 
+include(GoogleCloudCppCommon)
+
 # Use a function to create a scope for the variables.
 function (external_googleapis_install_pc target)
     external_googleapis_install_pc_common("${target}")
+    google_cloud_cpp_set_pkgconfig_paths()
     configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
                    "${target}.pc" @ONLY)
     install(

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -27,6 +27,9 @@ include(SelectMSVCRuntime)
 # Enable Werror
 include(EnableWerror)
 
+# Helper functions to create pkg-config(1) module files.
+include(AddPkgConfig)
+
 if (${CMAKE_VERSION} VERSION_LESS "3.12")
     # Old versions of CMake have really poor support for Doxygen generation.
     message(STATUS "Doxygen generation only enabled for cmake 3.9 and higher")
@@ -238,47 +241,4 @@ function (google_cloud_cpp_add_executable target prefix source)
     set("${target}"
         "${target_name}"
         PARENT_SCOPE)
-endfunction ()
-
-# We do not use macros a lot, so this deserves a comment. Unlike functions,
-# macros do not introduce a scope. This is an advantage when trying to set
-# global variables, as we do here.  It is obviously a disadvantage if you need
-# local variables.
-macro (google_cloud_cpp_set_pkgconfig_paths)
-    if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
-        set(GOOGLE_CLOUD_CPP_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
-    else ()
-        set(GOOGLE_CLOUD_CPP_PC_LIBDIR
-            "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
-    endif ()
-
-    if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
-        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
-    else ()
-        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR
-            "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
-    endif ()
-endmacro ()
-
-#
-# Create the pkgconfig configuration file (aka *.pc file) and the rules to
-# install it.
-#
-# * library: the name of the library, such as `storage`, or `spanner`
-# * ARGN: the names of any pkgconfig modules the generated module depends on
-#
-function (google_cloud_cpp_add_pkgconfig library name description)
-    set(GOOGLE_CLOUD_CPP_PC_NAME "${name}")
-    set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
-    string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
-    google_cloud_cpp_set_pkgconfig_paths()
-
-    # Create and install the pkg-config files.
-    configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
-                   "google_cloud_cpp_${library}.pc" @ONLY)
-    install(
-        FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
-        COMPONENT google_cloud_cpp_development)
 endfunction ()

--- a/cmake/GoogleCloudCppCommon.cmake
+++ b/cmake/GoogleCloudCppCommon.cmake
@@ -240,6 +240,26 @@ function (google_cloud_cpp_add_executable target prefix source)
         PARENT_SCOPE)
 endfunction ()
 
+# We do not use macros a lot, so this deserves a comment. Unlike functions,
+# macros do not introduce a scope. This is an advantage when trying to set
+# global variables, as we do here.  It is obviously a disadvantage if you need
+# local variables.
+macro (google_cloud_cpp_set_pkgconfig_paths)
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_LIBDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_LIBDIR "${CMAKE_INSTALL_LIBDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_LIBDIR
+            "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+    endif ()
+
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_INCLUDEDIR}")
+        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}")
+    else ()
+        set(GOOGLE_CLOUD_CPP_PC_INCLUDEDIR
+            "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+    endif ()
+endmacro ()
+
 #
 # Create the pkgconfig configuration file (aka *.pc file) and the rules to
 # install it.
@@ -252,6 +272,7 @@ function (google_cloud_cpp_add_pkgconfig library name description)
     set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
     set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
     string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
+    google_cloud_cpp_set_pkgconfig_paths()
 
     # Create and install the pkg-config files.
     configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"

--- a/cmake/templates/config.pc.in
+++ b/cmake/templates/config.pc.in
@@ -14,8 +14,8 @@
 
 prefix=${pcfiledir}/../..
 exec_prefix=${prefix}
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@GOOGLE_CLOUD_CPP_PC_LIBDIR@
+includedir=@GOOGLE_CLOUD_CPP_PC_INCLUDEDIR@
 
 Name: @GOOGLE_CLOUD_CPP_PC_NAME@
 Description: @GOOGLE_CLOUD_CPP_PC_DESCRIPTION@

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -494,6 +494,7 @@ endforeach ()
 
 external_googleapis_install_pc_common(google_cloud_cpp_logging_type_protos)
 set(GOOGLE_CLOUD_CPP_PC_LIBS "")
+google_cloud_cpp_set_pkgconfig_paths()
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
                "google_cloud_cpp_logging_type_protos.pc" @ONLY)
 install(
@@ -538,6 +539,7 @@ string(
            " zlib"
            " libcares")
 set(GOOGLE_CLOUD_CPP_PC_LIBS "")
+google_cloud_cpp_set_pkgconfig_paths()
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
                "googleapis.pc" @ONLY)
 install(

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -324,6 +324,7 @@ string(
            " absl_variant")
 
 # Create and install the pkg-config files.
+google_cloud_cpp_set_pkgconfig_paths()
 configure_file("${PROJECT_SOURCE_DIR}/cmake/templates/config.pc.in"
                "google_cloud_cpp_storage.pc" @ONLY)
 install(


### PR DESCRIPTION
Change the `config.pc.in` template to use our own variables
(`GOOGLE_CLOUD_CPP_PC_{LIB,INCLUDE}DIR`) for the `libdir=` and
`includedir=` values. A new helper CMake macro sets these variables to
`CMAKE_INSTALL_{LIB,INCLUDE}DIR` when these are absolute paths,
otherwise it adds the right prefix.

I changed `cmake-single-feature.sh` to test for this new behavior. Maybe
abusing the build.

Fixes #8992

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9022)
<!-- Reviewable:end -->
