### PR TITLE
test(spanner): remove database_dialect workaround for CreateDatabase

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -111,13 +111,6 @@ TEST_F(BackupIntegrationTest, BackupRestore) {
                       .get();
   ASSERT_STATUS_OK(database);
   EXPECT_EQ(database->name(), db.FullName());
-  if (database->database_dialect() ==
-      google::spanner::admin::database::v1::DatabaseDialect::
-          DATABASE_DIALECT_UNSPECIFIED) {
-    // TODO(#8573): Remove when CreateDatabase() returns correct dialect.
-    database->set_database_dialect(google::spanner::admin::database::v1::
-                                       DatabaseDialect::GOOGLE_STANDARD_SQL);
-  }
   EXPECT_EQ(database->database_dialect(),
             google::spanner::admin::database::v1::DatabaseDialect::
                 GOOGLE_STANDARD_SQL);

--- a/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
@@ -134,13 +134,6 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
               google::spanner::admin::database::v1::DatabaseDialect::
                   DATABASE_DIALECT_UNSPECIFIED);
   } else {
-    if (database->database_dialect() ==
-        google::spanner::admin::database::v1::DatabaseDialect::
-            DATABASE_DIALECT_UNSPECIFIED) {
-      // TODO(#8573): Remove when CreateDatabase() returns correct dialect.
-      database->set_database_dialect(google::spanner::admin::database::v1::
-                                         DatabaseDialect::GOOGLE_STANDARD_SQL);
-    }
     EXPECT_EQ(database->database_dialect(),
               google::spanner::admin::database::v1::DatabaseDialect::
                   GOOGLE_STANDARD_SQL);


### PR DESCRIPTION
Setting of `database_dialect` in the `CreateDatabase()` result has
been fixed.  `RestoreDatabase()`, however, remains an issue.

Part of #8573.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9029)
<!-- Reviewable:end -->
