### PR TITLE
feat(storage): implement suffix and prefix OLM rules

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/bucket_metadata.h"
 #include "google/cloud/storage/internal/bucket_acl_requests.h"
+#include "google/cloud/storage/internal/bucket_metadata_parser.h"
 #include "google/cloud/storage/internal/bucket_requests.h"
 #include "google/cloud/storage/internal/metadata_parser.h"
 #include "google/cloud/storage/internal/object_acl_requests.h"
@@ -394,17 +395,21 @@ BucketMetadataPatchBuilder& BucketMetadataPatchBuilder::SetLifecycle(
       condition["daysSinceNoncurrentTime"] = *c.days_since_noncurrent_time;
     }
     if (c.noncurrent_time_before.has_value()) {
-      condition["noncurrentTimeBefore"] = absl::StrFormat(
-          "%04d-%02d-%02d", c.noncurrent_time_before->year(),
-          c.noncurrent_time_before->month(), c.noncurrent_time_before->day());
+      condition["noncurrentTimeBefore"] =
+          internal::ToJsonString(*c.noncurrent_time_before);
     }
     if (c.days_since_custom_time.has_value()) {
       condition["daysSinceCustomTime"] = *c.days_since_custom_time;
     }
     if (c.custom_time_before.has_value()) {
-      condition["customTimeBefore"] = absl::StrFormat(
-          "%04d-%02d-%02d", c.custom_time_before->year(),
-          c.custom_time_before->month(), c.custom_time_before->day());
+      condition["customTimeBefore"] =
+          internal::ToJsonString(*c.custom_time_before);
+    }
+    if (c.matches_prefix.has_value()) {
+      condition["matchesPrefix"] = *c.matches_prefix;
+    }
+    if (c.matches_suffix.has_value()) {
+      condition["matchesSuffix"] = *c.matches_suffix;
     }
     nlohmann::json action;
     if (!a.action().type.empty()) {

--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -336,9 +336,7 @@ void ToJsonLifecycle(nlohmann::json& json, BucketMetadata const& meta) {
       condition["age"] = *c.age;
     }
     if (c.created_before.has_value()) {
-      condition["createdBefore"] =
-          absl::StrFormat("%04d-%02d-%02d", c.created_before->year(),
-                          c.created_before->month(), c.created_before->day());
+      condition["createdBefore"] = ToJsonString(*c.created_before);
     }
     if (c.is_live) {
       condition["isLive"] = *c.is_live;
@@ -349,7 +347,19 @@ void ToJsonLifecycle(nlohmann::json& json, BucketMetadata const& meta) {
     if (c.num_newer_versions) {
       condition["numNewerVersions"] = *c.num_newer_versions;
     }
+    if (c.days_since_custom_time) {
+      condition["daysSinceCustomTime"] = *c.days_since_custom_time;
+    }
+    if (c.custom_time_before) {
+      condition["customTimeBefore"] = ToJsonString(*c.custom_time_before);
+    }
+    if (c.matches_prefix) condition["matchesPrefix"] = *c.matches_prefix;
+    if (c.matches_suffix) condition["matchesSuffix"] = *c.matches_suffix;
+
     nlohmann::json action{{"type", v.action().type}};
+    if (!v.action().storage_class.empty()) {
+      action["storageClass"] = v.action().storage_class;
+    }
     if (!v.action().storage_class.empty()) {
       action["storageClass"] = v.action().storage_class;
     }
@@ -488,6 +498,11 @@ StatusOr<BucketMetadata> BucketMetadataParser::FromString(
     std::string const& payload) {
   auto json = nlohmann::json::parse(payload, nullptr, false);
   return FromJson(json);
+}
+
+std::string ToJsonString(absl::CivilDay date) {
+  return absl::StrFormat("%04d-%02d-%02d", date.year(), date.month(),
+                         date.day());
 }
 
 std::string BucketMetadataToJsonString(BucketMetadata const& meta) {

--- a/google/cloud/storage/internal/bucket_metadata_parser.h
+++ b/google/cloud/storage/internal/bucket_metadata_parser.h
@@ -30,6 +30,7 @@ struct BucketMetadataParser {
   static StatusOr<BucketMetadata> FromString(std::string const& payload);
 };
 
+std::string ToJsonString(absl::CivilDay date);
 std::string BucketMetadataToJsonString(BucketMetadata const& meta);
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -307,6 +307,16 @@ GrpcBucketMetadataParser::ToProto(LifecycleRuleCondition rhs) {
   if (rhs.custom_time_before.has_value()) {
     *result.mutable_custom_time_before() = ToProtoDate(*rhs.custom_time_before);
   }
+  if (rhs.matches_prefix.has_value()) {
+    for (auto& v : *rhs.matches_prefix) {
+      *result.add_matches_prefix() = std::move(v);
+    }
+  }
+  if (rhs.matches_suffix.has_value()) {
+    for (auto& v : *rhs.matches_suffix) {
+      *result.add_matches_suffix() = std::move(v);
+    }
+  }
   return result;
 }
 
@@ -343,6 +353,20 @@ LifecycleRuleCondition GrpcBucketMetadataParser::FromProto(
   }
   if (rhs.has_custom_time_before()) {
     result.custom_time_before = ToCivilDay(rhs.custom_time_before());
+  }
+  if (rhs.matches_prefix_size() != 0) {
+    std::vector<std::string> tmp;
+    for (auto& v : *rhs.mutable_matches_prefix()) {
+      tmp.push_back(std::move(v));
+    }
+    result.matches_prefix = std::move(tmp);
+  }
+  if (rhs.matches_suffix_size() != 0) {
+    std::vector<std::string> tmp;
+    for (auto& v : *rhs.mutable_matches_suffix()) {
+      tmp.push_back(std::move(v));
+    }
+    result.matches_suffix = std::move(tmp);
   }
   return result;
 }

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
@@ -314,6 +314,10 @@ TEST(GrpcBucketMetadataParser, LifecycleRuleConditionRoundtrip) {
     custom_time_before { year: 2022 month: 2 day: 15 }
     days_since_noncurrent_time: 5
     noncurrent_time_before { year: 2022 month: 1 day: 2 }
+    matches_prefix: "p1/"
+    matches_prefix: "p2/"
+    matches_suffix: ".txt"
+    matches_suffix: ".html"
   )pb";
   google::storage::v2::Bucket::Lifecycle::Rule::Condition start;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &start));
@@ -325,7 +329,9 @@ TEST(GrpcBucketMetadataParser, LifecycleRuleConditionRoundtrip) {
       LifecycleRule::DaysSinceCustomTime(4),
       LifecycleRule::CustomTimeBefore(absl::CivilDay(2022, 2, 15)),
       LifecycleRule::DaysSinceNoncurrentTime(5),
-      LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2022, 1, 2)));
+      LifecycleRule::NoncurrentTimeBefore(absl::CivilDay(2022, 1, 2)),
+      LifecycleRule::MatchesPrefixes({"p1/", "p2/"}),
+      LifecycleRule::MatchesSuffixes({".txt", ".html"}));
   auto const middle = GrpcBucketMetadataParser::FromProto(start);
   EXPECT_EQ(middle, expected);
   auto const end = GrpcBucketMetadataParser::ToProto(middle);
@@ -342,6 +348,10 @@ TEST(GrpcBucketMetadataParser, LifecycleRuleRoundtrip) {
       num_newer_versions: 3
       matches_storage_class: "STANDARD"
       matches_storage_class: "NEARLINE"
+      matches_prefix: "p1/"
+      matches_prefix: "p2/"
+      matches_suffix: ".txt"
+      matches_suffix: ".html"
     }
   )pb";
   google::storage::v2::Bucket::Lifecycle::Rule start;
@@ -351,7 +361,9 @@ TEST(GrpcBucketMetadataParser, LifecycleRuleRoundtrip) {
           LifecycleRule::MaxAge(7),
           LifecycleRule::CreatedBefore(absl::CivilDay(2021, 12, 20)),
           LifecycleRule::IsLive(true), LifecycleRule::NumNewerVersions(3),
-          LifecycleRule::MatchesStorageClasses({"STANDARD", "NEARLINE"})),
+          LifecycleRule::MatchesStorageClasses({"STANDARD", "NEARLINE"}),
+          LifecycleRule::MatchesPrefixes({"p1/", "p2/"}),
+          LifecycleRule::MatchesSuffixes({".txt", ".html"})),
       LifecycleRule::Delete());
   auto const middle = GrpcBucketMetadataParser::FromProto(start);
   EXPECT_EQ(middle, expected);

--- a/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
@@ -98,6 +98,8 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
                 age_days: 90
                 is_live: false
                 matches_storage_class: "NEARLINE"
+                matches_prefix: "p1/"
+                matches_suffix: ".txt"
               }
             }
           }
@@ -150,7 +152,9 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
           .set_lifecycle(BucketLifecycle{{LifecycleRule(
               LifecycleRule::ConditionConjunction(
                   LifecycleRule::MaxAge(90), LifecycleRule::IsLive(false),
-                  LifecycleRule::MatchesStorageClassNearline()),
+                  LifecycleRule::MatchesStorageClassNearline(),
+                  LifecycleRule::MatchesPrefix("p1/"),
+                  LifecycleRule::MatchesSuffix(".txt")),
               LifecycleRule::Delete())}})
           .set_logging(
               BucketLogging{/*.log_bucket=*/"test-log-bucket",
@@ -386,6 +390,9 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
                 days_since_custom_time: 42
                 days_since_noncurrent_time: 84
                 noncurrent_time_before { year: 2022 month: 2 day: 15 }
+                matches_prefix: "p1/"
+                matches_prefix: "p2/"
+                matches_suffix: ".html"
               }
             }
           }
@@ -449,7 +456,9 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
                   LifecycleRule::DaysSinceCustomTime(42),
                   LifecycleRule::DaysSinceNoncurrentTime(84),
                   LifecycleRule::NoncurrentTimeBefore(
-                      absl::CivilDay(2022, 2, 15))),
+                      absl::CivilDay(2022, 2, 15)),
+                  LifecycleRule::MatchesPrefixes({"p1/", "p2/"}),
+                  LifecycleRule::MatchesSuffix(".html")),
               LifecycleRule::Delete())}})
           .SetCors({
               CorsEntry{

--- a/google/cloud/storage/lifecycle_rule.h
+++ b/google/cloud/storage/lifecycle_rule.h
@@ -87,31 +87,15 @@ struct LifecycleRuleCondition {
   absl::optional<absl::CivilDay> noncurrent_time_before;
   absl::optional<std::int32_t> days_since_custom_time;
   absl::optional<absl::CivilDay> custom_time_before;
+  absl::optional<std::vector<std::string>> matches_prefix;
+  absl::optional<std::vector<std::string>> matches_suffix;
 };
 
-inline bool operator==(LifecycleRuleCondition const& lhs,
-                       LifecycleRuleCondition const& rhs) {
-  return lhs.age == rhs.age && lhs.created_before == rhs.created_before &&
-         lhs.is_live == rhs.is_live &&
-         lhs.matches_storage_class == rhs.matches_storage_class &&
-         lhs.num_newer_versions == rhs.num_newer_versions &&
-         lhs.days_since_noncurrent_time == rhs.days_since_noncurrent_time &&
-         lhs.noncurrent_time_before == rhs.noncurrent_time_before &&
-         lhs.days_since_custom_time == rhs.days_since_custom_time &&
-         lhs.custom_time_before == rhs.custom_time_before;
-}
+bool operator==(LifecycleRuleCondition const& lhs,
+                LifecycleRuleCondition const& rhs);
 
-inline bool operator<(LifecycleRuleCondition const& lhs,
-                      LifecycleRuleCondition const& rhs) {
-  return std::tie(lhs.age, lhs.created_before, lhs.is_live,
-                  lhs.matches_storage_class, lhs.num_newer_versions,
-                  lhs.days_since_noncurrent_time, lhs.noncurrent_time_before,
-                  lhs.days_since_custom_time, lhs.custom_time_before) <
-         std::tie(rhs.age, rhs.created_before, rhs.is_live,
-                  rhs.matches_storage_class, rhs.num_newer_versions,
-                  rhs.days_since_noncurrent_time, rhs.noncurrent_time_before,
-                  rhs.days_since_custom_time, rhs.custom_time_before);
-}
+bool operator<(LifecycleRuleCondition const& lhs,
+               LifecycleRuleCondition const& rhs);
 
 inline bool operator!=(LifecycleRuleCondition const& lhs,
                        LifecycleRuleCondition const& rhs) {
@@ -272,6 +256,38 @@ class LifecycleRule {
   static LifecycleRuleCondition CustomTimeBefore(absl::CivilDay date) {
     LifecycleRuleCondition result;
     result.custom_time_before = date;
+    return result;
+  }
+
+  static LifecycleRuleCondition MatchesPrefix(std::string prefix) {
+    std::vector<std::string> value;
+    value.emplace_back(std::move(prefix));
+    LifecycleRuleCondition result;
+    result.matches_prefix.emplace(std::move(value));
+    return result;
+  }
+
+  static LifecycleRuleCondition MatchesPrefixes(
+      std::initializer_list<std::string> list) {
+    std::vector<std::string> classes(std::move(list));
+    LifecycleRuleCondition result;
+    result.matches_prefix.emplace(std::move(classes));
+    return result;
+  }
+
+  static LifecycleRuleCondition MatchesSuffix(std::string suffix) {
+    std::vector<std::string> value;
+    value.emplace_back(std::move(suffix));
+    LifecycleRuleCondition result;
+    result.matches_suffix.emplace(std::move(value));
+    return result;
+  }
+
+  static LifecycleRuleCondition MatchesSuffixes(
+      std::initializer_list<std::string> list) {
+    std::vector<std::string> classes(std::move(list));
+    LifecycleRuleCondition result;
+    result.matches_suffix.emplace(std::move(classes));
     return result;
   }
   ///@}


### PR DESCRIPTION
GCS is adding additional Object Lifecycle Management rules. This PR
introduces support for the rules in REST and gRPC.

Part of the work for #8968

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9030)
<!-- Reviewable:end -->
