### PR TITLE
fix(common)!: adjust env/option/default override order for endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,16 @@ to grant, change, and revoke access to all
 [resource-types-with-policies]: https://cloud.google.com/iam/docs/resource-types-with-policies
 [iam-policy-link]: https://cloud.google.com/iam/docs/manage-access-other-resources
 
+### [Common Libraries](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/README.md)
+
+**BREAKING CHANGES**
+
+* We have changed the preference order for determining the service endpoint from
+  (1) `${emulator_env}`, (2) `EndpointOption`, (3) `${endpoint_env}`, and (4)
+  default value, to (1) `${emulator_env}`, (2) `${endpoint_env}`, (3)
+  `EndpointOption`, and (4) default value. That is, the more dynamic
+  `${endpoint_env}` is now preferred over any `EndpointOption` set in the code.
+
 ### New Libraries
 
 We are introducing a new client library: [Bare Metal Solution]. While we do not

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_option_defaults_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_option_defaults_test.cc
@@ -39,13 +39,12 @@ TEST(GoldenKitchenSinkDefaultOptions, EnvVarEndpoint) {
   auto env =
       ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
+  options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);
   EXPECT_EQ("foo.googleapis.com", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenKitchenSinkDefaultOptions, OptionEndpoint) {
-  auto env =
-      ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenKitchenSinkDefaultOptions(options);

--- a/generator/integration_tests/golden/tests/golden_thing_admin_option_defaults_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_option_defaults_test.cc
@@ -15,7 +15,7 @@
 #include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
-#include "google/cloud/testing_util/setenv.h"
+#include "google/cloud/testing_util/scoped_environment.h"
 #include <gtest/gtest.h>
 #include <memory>
 
@@ -25,6 +25,8 @@ namespace golden_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::ScopedEnvironment;
+
 TEST(GoldenThingAdminDefaultOptions, DefaultEndpoint) {
   Options options;
   auto updated_options = GoldenThingAdminDefaultOptions(options);
@@ -32,14 +34,15 @@ TEST(GoldenThingAdminDefaultOptions, DefaultEndpoint) {
 }
 
 TEST(GoldenThingAdminDefaultOptions, EnvVarEndpoint) {
-  testing_util::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
+  auto env =
+      ScopedEnvironment("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
+  options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenThingAdminDefaultOptions(options);
   EXPECT_EQ("foo.googleapis.com", updated_options.get<EndpointOption>());
 }
 
 TEST(GoldenThingAdminDefaultOptions, OptionEndpoint) {
-  testing_util::SetEnv("GOLDEN_KITCHEN_SINK_ENDPOINT", "foo.googleapis.com");
   Options options;
   options.set<EndpointOption>("bar.googleapis.com");
   auto updated_options = GoldenThingAdminDefaultOptions(options);

--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -26,28 +26,31 @@ namespace internal {
 Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
                               std::string const& emulator_env_var,
                               std::string default_endpoint) {
-  if (!emulator_env_var.empty()) {
-    auto e = internal::GetEnv(emulator_env_var.c_str());
-    if (e && !e->empty()) {
-      opts.set<EndpointOption>(*std::move(e));
-    }
-  }
   if (!opts.has<EndpointOption>()) {
-    auto e = internal::GetEnv(endpoint_env_var.c_str());
-    if (e && !e->empty()) {
-      opts.set<EndpointOption>(*std::move(e));
-    } else {
-      opts.set<EndpointOption>(default_endpoint);
-    }
+    opts.set<EndpointOption>(default_endpoint);
   }
+  auto ep = internal::GetEnv(endpoint_env_var.c_str());
+  if (ep && !ep->empty()) {
+    opts.set<EndpointOption>(*std::move(ep));
+  }
+  auto em = internal::GetEnv(emulator_env_var.c_str());
+  if (em && !em->empty()) {
+    opts.set<EndpointOption>(*std::move(em));
+  }
+
   if (!opts.has<AuthorityOption>()) {
     opts.set<AuthorityOption>(std::move(default_endpoint));
   }
+
   auto e = GetEnv("GOOGLE_CLOUD_CPP_USER_PROJECT");
-  if (e && !e->empty()) opts.set<UserProjectOption>(*std::move(e));
+  if (e && !e->empty()) {
+    opts.set<UserProjectOption>(*std::move(e));
+  }
+
   if (!opts.has<TracingComponentsOption>()) {
     opts.set<TracingComponentsOption>(internal::DefaultTracingComponents());
   }
+
   auto& products = opts.lookup<UserAgentProductsOption>();
   products.insert(products.begin(), UserAgentPrefix());
 

--- a/google/cloud/internal/populate_common_options_test.cc
+++ b/google/cloud/internal/populate_common_options_test.cc
@@ -71,8 +71,8 @@ TEST(PopulateCommonOptions, Endpoint) {
       {"with-ep-3", with_ep, "", absl::nullopt, "with-ep"},
       {"with-ep-4", with_ep, "", "", "with-ep"},
       {"with-ep-5", with_ep, "", "emulator", "emulator"},
-      {"with-ep-6", with_ep, "env", absl::nullopt, "with-ep"},
-      {"with-ep-7", with_ep, "env", "", "with-ep"},
+      {"with-ep-6", with_ep, "env", absl::nullopt, "env"},
+      {"with-ep-7", with_ep, "env", "", "env"},
       {"with-ep-8", with_ep, "env", "emulator", "emulator"},
   };
 

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -185,10 +185,10 @@ TEST(Options, PassThroughUnknown) {
 
 TEST(Options, OverrideEndpoint) {
   testing_util::ScopedEnvironment endpoint_env(
-      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", "no.thank.you");
+      "GOOGLE_CLOUD_CPP_SPANNER_DEFAULT_ENDPOINT", "foo.bar.baz");
   testing_util::ScopedEnvironment emulator_env("SPANNER_EMULATOR_HOST",
                                                absl::nullopt);
-  auto opts = Options{}.set<EndpointOption>("foo.bar.baz");
+  auto opts = Options{}.set<EndpointOption>("no.thank.you");
   opts = spanner_internal::DefaultOptions(std::move(opts));
   EXPECT_EQ("foo.bar.baz", opts.get<EndpointOption>());
 }


### PR DESCRIPTION
Make the preference order be (1) `${emulator_env}`, (2) `${endpoint_env}`,
(3) `EndpointOption`, and (4) default value.

The changes to the tests are good indications that the new ordering is more
logical.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9032)
<!-- Reviewable:end -->
