### PR TITLE
impl(bigtable): add unimplemented Connection API

### DIFF
--- a/google/cloud/bigtable/internal/data_connection.cc
+++ b/google/cloud/bigtable/internal/data_connection.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/bigtable/internal/bigtable_stub_factory.h"
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
 #include "google/cloud/bigtable/internal/defaults.h"
+#include "google/cloud/bigtable/internal/row_reader_impl.h"
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
@@ -26,8 +27,121 @@ namespace google {
 namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+std::vector<bigtable::FailedMutation> MakeUnimplementedFailedMutations(
+    std::size_t n) {
+  std::vector<bigtable::FailedMutation> mutations;
+  mutations.reserve(n);
+  for (int i = 0; i != static_cast<int>(n); ++i) {
+    mutations.emplace_back(bigtable::FailedMutation(
+        Status(StatusCode::kUnimplemented, "not implemented"), i));
+  }
+  return mutations;
+}
+
+}  // namespace
 
 DataConnection::~DataConnection() = default;
+
+Status DataConnection::Apply(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, bigtable::SingleRowMutation) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+future<Status> DataConnection::AsyncApply(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, bigtable::SingleRowMutation) {
+  return make_ready_future(
+      Status(StatusCode::kUnimplemented, "not implemented"));
+}
+
+std::vector<bigtable::FailedMutation> DataConnection::BulkApply(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, bigtable::BulkMutation mut) {
+  return MakeUnimplementedFailedMutations(mut.size());
+}
+
+future<std::vector<bigtable::FailedMutation>> DataConnection::AsyncBulkApply(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, bigtable::BulkMutation mut) {
+  return make_ready_future(MakeUnimplementedFailedMutations(mut.size()));
+}
+
+bigtable::RowReader DataConnection::ReadRows(
+    std::string const&, std::string const&,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    bigtable::RowSet, std::int64_t, bigtable::Filter) {
+  return MakeRowReader(std::make_shared<StatusOnlyRowReader>(
+      Status(StatusCode::kUnimplemented, "not implemented")));
+}
+
+StatusOr<std::pair<bool, bigtable::Row>> DataConnection::ReadRow(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, std::string, bigtable::Filter) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+StatusOr<bigtable::MutationBranch> DataConnection::CheckAndMutateRow(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, std::string, bigtable::Filter,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::vector<bigtable::Mutation>, std::vector<bigtable::Mutation>) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+future<StatusOr<bigtable::MutationBranch>>
+DataConnection::AsyncCheckAndMutateRow(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, std::string, bigtable::Filter,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::vector<bigtable::Mutation>, std::vector<bigtable::Mutation>) {
+  return make_ready_future<StatusOr<bigtable::MutationBranch>>(
+      Status(StatusCode::kUnimplemented, "not implemented"));
+}
+
+StatusOr<std::vector<bigtable::RowKeySample>> DataConnection::SampleRows(
+    std::string const&, std::string const&) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+future<StatusOr<std::vector<bigtable::RowKeySample>>>
+DataConnection::AsyncSampleRows(std::string const&, std::string const&) {
+  return make_ready_future<StatusOr<std::vector<bigtable::RowKeySample>>>(
+      Status(StatusCode::kUnimplemented, "not implemented"));
+}
+
+StatusOr<bigtable::Row> DataConnection::ReadModifyWriteRow(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::bigtable::v2::MutateRowRequest) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+future<StatusOr<bigtable::Row>> DataConnection::AsyncReadModifyWriteRow(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    google::bigtable::v2::MutateRowRequest) {
+  return make_ready_future<StatusOr<bigtable::Row>>(
+      Status(StatusCode::kUnimplemented, "not implemented"));
+}
+
+void DataConnection::AsyncReadRows(
+    std::string const&, std::string const&,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::function<future<bool>(bigtable::Row)>,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::function<void(Status)> on_finish, bigtable::RowSet, std::int64_t,
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    bigtable::Filter) {
+  on_finish(Status(StatusCode::kUnimplemented, "not implemented"));
+}
+
+future<StatusOr<std::pair<bool, bigtable::Row>>> DataConnection::AsyncReadRow(
+    // NOLINTNEXTLINE(performance-unnecessary-value-param)
+    std::string const&, std::string const&, std::string, bigtable::Filter) {
+  return make_ready_future<StatusOr<std::pair<bool, bigtable::Row>>>(
+      Status(StatusCode::kUnimplemented, "not implemented"));
+}
 
 std::shared_ptr<DataConnection> MakeDataConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,


### PR DESCRIPTION
Part of the work for #8798 

Add the DataConnection API as defined in this (internal) [document](https://docs.google.com/document/d/1NjGK7_1gfkxavxFxIHcKoDyxPWGITnYL5JBH18ZNG6A/edit?resourcekey=0-A9nSevk5ZyWVGzhxtXE93Q).

The one difference is that I forgot about resources (app profile id + table name) in the document. We do not want to store resources in the Connection. So the Table must pass the resource names with each request.

I tried my best to minimize the `NOLINT` eye sore. `NOLINTBEGIN`/`NOLINTEND` [is a thing](https://clang.llvm.org/extra/clang-tidy/), but not until clang-tidy 15.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9033)
<!-- Reviewable:end -->
