### PR TITLE
doc(pubsub): fix typos Pub/Sub vs. Pubsub

### DIFF
--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -377,8 +377,8 @@ google_cloud_cpp_install_headers("google_cloud_cpp_pubsub_mocks"
 
 google_cloud_cpp_add_pkgconfig(
     pubsub
-    "The Google Cloud Pubsub C++ Client Library"
-    "Provides C++ APIs to access Google Cloud Pubsub."
+    "The Google Cloud Pub/Sub C++ Client Library"
+    "Provides C++ APIs to access Google Cloud Pub/Sub."
     "google_cloud_cpp_grpc_utils"
     " google_cloud_cpp_common"
     " google_cloud_cpp_pubsub_protos"

--- a/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
+++ b/google/cloud/pubsub/ci/lib/pubsub_emulator.sh
@@ -22,7 +22,7 @@ fi # include guard
 
 source module /ci/lib/io.sh
 
-# Global variable that holds the PID of the Pubsub emulator. This will be set
+# Global variable that holds the PID of the Pub/Sub emulator. This will be set
 # when the emulator is started, and it will be used to kill the emulator.
 PUBSUB_EMULATOR_PID=0
 

--- a/google/cloud/pubsub/message.h
+++ b/google/cloud/pubsub/message.h
@@ -54,14 +54,14 @@ class MessageBuilder;
  * type to automatically detect what is the representation for this field and
  * use the correct mapping.
  *
- * External users of the Cloud Pubsub C++ client library should treat this as
+ * External users of the Cloud Pub/Sub C++ client library should treat this as
  * a complicated `typedef` for `std::string`. We have no plans to change the
  * type in the external version of the C++ client library for the foreseeable
  * future. In the eventuality that we do decide to change the type, this would
  * be a reason update the library major version number, and we would give users
  * time to migrate.
  *
- * In other words, external users of the Cloud Pubsub C++ client should simply
+ * In other words, external users of the Cloud Pub/Sub C++ client should simply
  * write `std::string` where this type appears. For Google projects that must
  * compile both inside and outside Google, this alias may be convenient.
  */

--- a/google/cloud/pubsub/mocks/mock_ack_handler.h
+++ b/google/cloud/pubsub/mocks/mock_ack_handler.h
@@ -24,9 +24,9 @@ namespace cloud {
 /// A namespace for googlemock-based Cloud Pub/Sub C++ client mocks.
 namespace pubsub_mocks {
 /**
- * The inlined, versioned namespace for the Cloud Pubsub C++ client APIs.
+ * The inlined, versioned namespace for the Cloud Pub/Sub C++ client APIs.
  *
- * Applications may need to link multiple versions of the Cloud pubsub C++
+ * Applications may need to link multiple versions of the Cloud Pub/Sub C++
  * client, for example, if they link a library that uses an older version of
  * the client than they do.  This namespace is inlined, so applications can use
  * `pubsub::Foo` in their source, but the symbols are versioned, i.e., the

--- a/google/cloud/pubsub/quickstart/Makefile
+++ b/google/cloud/pubsub/quickstart/Makefile
@@ -31,6 +31,6 @@ PUBSUB_CXXFLAGS   := $(shell pkg-config $(PUBSUB_DEPS) --cflags)
 PUBSUB_CXXLDFLAGS := $(shell pkg-config $(PUBSUB_DEPS) --libs-only-L)
 PUBSUB_LIBS       := $(shell pkg-config $(PUBSUB_DEPS) --libs-only-l)
 
-# A target using the Cloud Pubsub C++ client library.
+# A target using the Cloud Pub/Sub C++ client library.
 $(BIN)/quickstart: quickstart.cc
 	$(CXXLD) $(CXXFLAGS) $(PUBSUB_CXXFLAGS) $(PUBSUB_CXXLDFLAGS) -o $@ $^ $(PUBSUB_LIBS)

--- a/google/cloud/pubsub/version.h
+++ b/google/cloud/pubsub/version.h
@@ -29,7 +29,7 @@ namespace google {
  */
 namespace cloud {
 /**
- * Contains all the Cloud Pubsub C++ client types and functions.
+ * Contains all the Cloud Pub/Sub C++ client types and functions.
  */
 namespace pubsub {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN


### PR DESCRIPTION
The name of the service is Cloud Pub/Sub, fixed it in a number of
places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9034)
<!-- Reviewable:end -->
