### PR TITLE
impl(bigtable): add mock data connection

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -62,6 +62,7 @@ expected_dirs+=(
   ./include/google/cloud/bigquery/logging
   ./include/google/cloud/bigquery/logging/v1
   ./include/google/cloud/bigtable/admin/mocks
+  ./include/google/cloud/bigtable/mocks
   # no RPC services in google/cloud/clouddms
   ./include/google/cloud/clouddms/logging
   ./include/google/cloud/clouddms/logging/v1

--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -45,7 +45,7 @@ target_sources(
     INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/admin/mocks/mock_bigtable_instance_admin_connection.h
         ${CMAKE_CURRENT_SOURCE_DIR}/admin/mocks/mock_bigtable_table_admin_connection.h
-)
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_data_connection.h)
 target_link_libraries(
     google_cloud_cpp_bigtable_mocks
     INTERFACE google-cloud-cpp::bigtable GTest::gmock_main GTest::gmock

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable_mocks.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable_mocks.bzl
@@ -19,6 +19,7 @@
 google_cloud_cpp_bigtable_mocks_hdrs = [
     "admin/mocks/mock_bigtable_instance_admin_connection.h",
     "admin/mocks/mock_bigtable_table_admin_connection.h",
+    "mocks/mock_data_connection.h",
 ]
 
 google_cloud_cpp_bigtable_mocks_srcs = [

--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -63,7 +63,7 @@ class MockDataConnection : public bigtable_internal::DataConnection {
                bigtable::Filter filter),
               (override));
 
-  MOCK_METHOD(StatusOr<std::pair<bool, , bigtable::Row>> ReadRow,
+  MOCK_METHOD((StatusOr<std::pair<bool, bigtable::Row>>), ReadRow,
               (std::string const& app_profile_id, std::string const& table_name,
                std::string row_key, bigtable::Filter filter),
               (override));
@@ -107,7 +107,7 @@ class MockDataConnection : public bigtable_internal::DataConnection {
                std::int64_t rows_limit, bigtable::Filter filter),
               (override));
 
-  MOCK_METHOD(future<StatusOr<std::pair<bool, , bigtable::Row>>> AsyncReadRow,
+  MOCK_METHOD((future<StatusOr<std::pair<bool, bigtable::Row>>>), AsyncReadRow,
               (std::string const& app_profile_id, std::string const& table_name,
                std::string row_key, bigtable::Filter filter),
               (override));

--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -1,0 +1,121 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MOCKS_MOCK_DATA_CONNECTION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MOCKS_MOCK_DATA_CONNECTION_H
+
+#include "google/cloud/bigtable/internal/data_connection.h"
+#include "google/cloud/version.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+// TODO(#8860) - Move this mock class into bigtable_mocks.
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * A class to mock `google::cloud::bigtable::DataConnection`.
+ *
+ * Application developers may want to test their code with simulated responses,
+ * including errors from a `bigtable::Table`. To do so, construct a
+ * `bigtable::Table` with an instance of this class. Then use the Google Test
+ * framework functions to program the behavior of this mock.
+ */
+class MockDataConnection : public bigtable_internal::DataConnection {
+ public:
+  MOCK_METHOD(Options, options, (), (override));
+
+  MOCK_METHOD(Status, Apply,
+              (std::string const& app_profile_id, std::string const& table_name,
+               bigtable::SingleRowMutation mut),
+              (override));
+
+  MOCK_METHOD(future<Status>, AsyncApply,
+              (std::string const& app_profile_id, std::string const& table_name,
+               bigtable::SingleRowMutation mut),
+              (override));
+
+  MOCK_METHOD(std::vector<bigtable::FailedMutation>, BulkApply,
+              (std::string const& app_profile_id, std::string const& table_name,
+               bigtable::BulkMutation mut),
+              (override));
+
+  MOCK_METHOD(future<std::vector<bigtable::FailedMutation>>, AsyncBulkApply,
+              (std::string const& app_profile_id, std::string const& table_name,
+               bigtable::BulkMutation mut),
+              (override));
+
+  MOCK_METHOD(bigtable::RowReader, ReadRows,
+              (std::string const& app_profile_id, std::string const& table_name,
+               bigtable::RowSet row_set, std::int64_t rows_limit,
+               bigtable::Filter filter),
+              (override));
+
+  MOCK_METHOD(StatusOr<std::pair<bool, , bigtable::Row>> ReadRow,
+              (std::string const& app_profile_id, std::string const& table_name,
+               std::string row_key, bigtable::Filter filter),
+              (override));
+
+  MOCK_METHOD(StatusOr<bigtable::MutationBranch>, CheckAndMutateRow,
+              (std::string const& app_profile_id, std::string const& table_name,
+               std::string row_key, bigtable::Filter filter,
+               std::vector<bigtable::Mutation> true_mutations,
+               std::vector<bigtable::Mutation> false_mutations),
+              (override));
+
+  MOCK_METHOD(future<StatusOr<bigtable::MutationBranch>>,
+              AsyncCheckAndMutateRow,
+              (std::string const& app_profile_id, std::string const& table_name,
+               std::string row_key, bigtable::Filter filter,
+               std::vector<bigtable::Mutation> true_mutations,
+               std::vector<bigtable::Mutation> false_mutations),
+              (override));
+
+  MOCK_METHOD(StatusOr<std::vector<bigtable::RowKeySample>>, SampleRows,
+              (std::string const& app_profile_id,
+               std::string const& table_name),
+              (override));
+
+  MOCK_METHOD(future<StatusOr<std::vector<bigtable::RowKeySample>>>,
+              AsyncSampleRows,
+              (std::string const& app_profile_id,
+               std::string const& table_name),
+              (override));
+
+  MOCK_METHOD(StatusOr<bigtable::Row>, ReadModifyWriteRow,
+              (google::bigtable::v2::MutateRowRequest request), (override));
+
+  MOCK_METHOD(future<StatusOr<bigtable::Row>>, AsyncReadModifyWriteRow,
+              (google::bigtable::v2::MutateRowRequest request), (override));
+
+  MOCK_METHOD(void, AsyncReadRows,
+              (std::string const& app_profile_id, std::string const& table_name,
+               std::function<future<bool>(bigtable::Row)> on_row,
+               std::function<void(Status)> on_finish, bigtable::RowSet row_set,
+               std::int64_t rows_limit, bigtable::Filter filter),
+              (override));
+
+  MOCK_METHOD(future<StatusOr<std::pair<bool, , bigtable::Row>>> AsyncReadRow,
+              (std::string const& app_profile_id, std::string const& table_name,
+               std::string row_key, bigtable::Filter filter),
+              (override));
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MOCKS_MOCK_DATA_CONNECTION_H


### PR DESCRIPTION
Part of the work for #8798 

`bigtable_mocks` is a public namespace. So we develop in `bigtable_internal` instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9035)
<!-- Reviewable:end -->
