### PR TITLE
impl(common): do not lookup empty environment-variable names

### DIFF
--- a/google/cloud/internal/populate_common_options.cc
+++ b/google/cloud/internal/populate_common_options.cc
@@ -29,13 +29,17 @@ Options PopulateCommonOptions(Options opts, std::string const& endpoint_env_var,
   if (!opts.has<EndpointOption>()) {
     opts.set<EndpointOption>(default_endpoint);
   }
-  auto ep = internal::GetEnv(endpoint_env_var.c_str());
-  if (ep && !ep->empty()) {
-    opts.set<EndpointOption>(*std::move(ep));
+  if (!endpoint_env_var.empty()) {
+    auto e = internal::GetEnv(endpoint_env_var.c_str());
+    if (e && !e->empty()) {
+      opts.set<EndpointOption>(*std::move(e));
+    }
   }
-  auto em = internal::GetEnv(emulator_env_var.c_str());
-  if (em && !em->empty()) {
-    opts.set<EndpointOption>(*std::move(em));
+  if (!emulator_env_var.empty()) {
+    auto e = internal::GetEnv(emulator_env_var.c_str());
+    if (e && !e->empty()) {
+      opts.set<EndpointOption>(*std::move(e));
+    }
   }
 
   if (!opts.has<AuthorityOption>()) {

--- a/google/cloud/internal/populate_common_options.h
+++ b/google/cloud/internal/populate_common_options.h
@@ -27,23 +27,25 @@ namespace internal {
 /**
  * Modify @p opts to have default values for common options.
  *
- * Add default values for common options, including
- * `EndpointOption`,`UserAgentProductsOption`, `TracingComponentsOption`, and
- * `UserProjectOption`.
+ * Add default values for common options, including:
+ *  - `AuthorityOption`
+ *  - `EndpointOption`
+ *  - `TracingComponentsOption`
+ *  - `UserAgentProductsOption`
+ *  - `UserProjectOption`
  *
  * @param opts the current options. Any values already present in this
  *     collection are not modified.
- * @param endpoint_env_var an environment variable name to override the
+ * @param endpoint_env_var an environment variable name used to override the
  *     default endpoint. If no `EndpointOption` is set in `opts`, **and** this
  *     environment variable is set, **and** its value is not the empty string,
  *     use the environment variable value for `EndpointOption`. This parameter
- *     is ignored if empty. This is useful on libraries that do not have an
- *     environment variable to override the endpoint value.
+ *     is ignored if empty, which is useful when a service does not need an
+ *     override.
  * @param emulator_env_var an environment variable name to override the endpoint
  *     and the default credentials. If this environment variable is set, use its
- *     value for `EndpointOption`. Not all services have emulators, in this
- *     case, the library can provide an empty value for this environment
- *     variable.
+ *     value for `EndpointOption`. This parameter is ignored if empty, which is
+ *     useful when a service does not have an emulator.
  * @param default_endpoint the default value for `EndpointOption`, if none of
  *     the other mechanisms has set a value.
  *


### PR DESCRIPTION
Follow the `PopulateCommonOptions()` specification and actually ignore
empty environment-variable names, rather than assuming that `${}` never
has a value (or that the `std::getenv()` implementation will never
return a value for an empty name).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9042)
<!-- Reviewable:end -->
