### PR TITLE
impl(bigtable): add RowReader factory for testing

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -45,7 +45,9 @@ target_sources(
     INTERFACE
         ${CMAKE_CURRENT_SOURCE_DIR}/admin/mocks/mock_bigtable_instance_admin_connection.h
         ${CMAKE_CURRENT_SOURCE_DIR}/admin/mocks/mock_bigtable_table_admin_connection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_data_connection.h)
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_data_connection.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_row_reader.cc
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_row_reader.h)
 target_link_libraries(
     google_cloud_cpp_bigtable_mocks
     INTERFACE google-cloud-cpp::bigtable GTest::gmock_main GTest::gmock
@@ -339,6 +341,7 @@ if (BUILD_TESTING)
         internal/prefix_range_end_test.cc
         internal/wait_for_consistency_test.cc
         metadata_update_policy_test.cc
+        mocks/mock_row_reader_test.cc
         mutation_batcher_test.cc
         mutations_test.cc
         polling_policy_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -53,6 +53,7 @@ bigtable_client_unit_tests = [
     "internal/prefix_range_end_test.cc",
     "internal/wait_for_consistency_test.cc",
     "metadata_update_policy_test.cc",
+    "mocks/mock_row_reader_test.cc",
     "mutation_batcher_test.cc",
     "mutations_test.cc",
     "polling_policy_test.cc",

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable_mocks.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable_mocks.bzl
@@ -20,6 +20,7 @@ google_cloud_cpp_bigtable_mocks_hdrs = [
     "admin/mocks/mock_bigtable_instance_admin_connection.h",
     "admin/mocks/mock_bigtable_table_admin_connection.h",
     "mocks/mock_data_connection.h",
+    "mocks/mock_row_reader.h",
 ]
 
 google_cloud_cpp_bigtable_mocks_srcs = [

--- a/google/cloud/bigtable/mocks/mock_row_reader.cc
+++ b/google/cloud/bigtable/mocks/mock_row_reader.cc
@@ -1,0 +1,60 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/mocks/mock_row_reader.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable_mocks {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+// TODO(#8860) - Remove internal namespace.
+namespace internal {
+
+bigtable::RowReader MakeTestRowReader(std::vector<bigtable::Row> rows,
+                                      Status final_status) {
+  class ConvenientRowReader : public bigtable_internal::RowReaderImpl {
+   public:
+    explicit ConvenientRowReader(std::vector<bigtable::Row> rows,
+                                 Status final_status)
+        : final_status_(std::move(final_status)),
+          rows_(std::move(rows)),
+          iter_(rows_.cbegin()) {}
+
+    ~ConvenientRowReader() override = default;
+
+    /// Skips remaining rows and invalidates current iterator.
+    void Cancel() override { iter_ = rows_.cend(); };
+
+    absl::variant<Status, bigtable::Row> Advance() override {
+      if (iter_ == rows_.cend()) return final_status_;
+      return *iter_++;
+    }
+
+   private:
+    Status final_status_;
+    std::vector<bigtable::Row> const rows_;
+    std::vector<bigtable::Row>::const_iterator iter_;
+  };
+
+  auto impl = std::make_shared<ConvenientRowReader>(std::move(rows),
+                                                    std::move(final_status));
+  return bigtable_internal::MakeRowReader(std::move(impl));
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_mocks
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/mocks/mock_row_reader.h
+++ b/google/cloud/bigtable/mocks/mock_row_reader.h
@@ -1,0 +1,70 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MOCKS_MOCK_ROW_READER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MOCKS_MOCK_ROW_READER_H
+
+#include "google/cloud/bigtable/row_reader.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable_mocks {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+// TODO(#8860) - Remove internal namespace.
+namespace internal {
+
+/**
+ * Returns a `RowReader` with a fixed output stream.
+ *
+ * This factory function is offered for customers to mock the output of
+ * `Table::ReadRows(...)` in their tests.
+ *
+ * @note If `Cancel()` is called on the `RowReader`, the stream will terminate
+ *     and return `final_status`.
+ *
+ * @param rows a vector containing the `Row`s returned by iterating over the
+ *     `RowReader`.
+ *
+ * @param final_status the final Status of the stream. Defaults to OK.
+ *
+ * @code
+ * TEST(ReadRowsTest, Success) {
+ *   using ::google::cloud::StatusOr;
+ *   using cbt = ::google::cloud::bigtable;
+ *   using cbtm = ::google::cloud::bigtable_mocks;
+ *
+ *   std::vector<cbt::Row> rows = {cbt::Row("r1", {}), cbt::Row("r2", {})};
+ *
+ *   auto mock = std::shared_ptr<cbtm::MockDataConnection>();
+ *   EXPECT_CALL(*mock, ReadRows)
+ *       .WillOnce(Return(cbtm::MakeTestRowReader(rows)));
+ *
+ *   auto table = cbt::Table(mock);
+ *   auto reader = table.ReadRows(...);
+ *
+ *   // Verify your code works when reading rows: {"r1", "r2"}
+ * }
+ * @endcode
+ */
+bigtable::RowReader MakeTestRowReader(std::vector<bigtable::Row> rows,
+                                      Status final_status = {});
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_mocks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_MOCKS_MOCK_ROW_READER_H

--- a/google/cloud/bigtable/mocks/mock_row_reader_test.cc
+++ b/google/cloud/bigtable/mocks/mock_row_reader_test.cc
@@ -1,0 +1,148 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/mocks/mock_row_reader.h"
+#include "google/cloud/bigtable/row_reader.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+#include <algorithm>
+
+namespace google {
+namespace cloud {
+namespace bigtable_mocks {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::bigtable::Row;
+using ::google::cloud::testing_util::StatusIs;
+
+struct Result {
+  explicit Result(std::vector<Row> const& in_rows, Status in_final_status)
+      : final_status(std::move(in_final_status)) {
+    rows.reserve(in_rows.size());
+    for (auto const& r : in_rows) rows.emplace_back(r.row_key());
+  }
+
+  explicit Result(bigtable::RowReader reader) {
+    for (auto const& sor : reader) {
+      if (!sor) {
+        final_status = std::move(sor).status();
+      } else {
+        rows.emplace_back((*std::move(sor)).row_key());
+      }
+    }
+  }
+
+  std::vector<std::string> rows;
+  Status final_status;
+};
+
+TEST(MakeTestRowReader, Empty) {
+  std::vector<Row> rows;
+  Status final_status;
+
+  auto reader = MakeTestRowReader(rows);
+
+  auto actual = Result(std::move(reader));
+  auto expected = Result(rows, final_status);
+  EXPECT_EQ(actual.rows, expected.rows);
+  EXPECT_EQ(actual.final_status, expected.final_status);
+}
+
+TEST(MakeTestRowReader, Rows) {
+  std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
+  Status final_status;
+
+  auto reader = MakeTestRowReader(rows);
+
+  auto actual = Result(std::move(reader));
+  auto expected = Result(rows, final_status);
+  EXPECT_EQ(actual.rows, expected.rows);
+  EXPECT_EQ(actual.final_status, expected.final_status);
+}
+
+TEST(MakeTestRowReader, StatusOnly) {
+  std::vector<Row> rows;
+  auto final_status = Status(StatusCode::kPermissionDenied, "fail");
+
+  auto reader = MakeTestRowReader(rows, final_status);
+
+  auto actual = Result(std::move(reader));
+  auto expected = Result(rows, final_status);
+  EXPECT_EQ(actual.rows, expected.rows);
+  EXPECT_EQ(actual.final_status, expected.final_status);
+}
+
+TEST(MakeTestRowReader, RowsThenStatus) {
+  std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
+  auto final_status = Status(StatusCode::kPermissionDenied, "fail");
+
+  auto reader = MakeTestRowReader(rows, final_status);
+
+  auto actual = Result(std::move(reader));
+  auto expected = Result(rows, final_status);
+  EXPECT_EQ(actual.rows, expected.rows);
+  EXPECT_EQ(actual.final_status, expected.final_status);
+}
+
+TEST(MakeTestRowReader, CancelEndsGoodStream) {
+  std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
+  Status final_status;
+
+  auto reader = MakeTestRowReader(rows);
+
+  auto it = reader.begin();
+  ASSERT_STATUS_OK(*it);
+  EXPECT_EQ((*it)->row_key(), "r1");
+
+  // Cancel the reader
+  reader.Cancel();
+
+  // Verify that the next iterator points to `end()` instead of "r2"
+  EXPECT_EQ(++it, reader.end());
+
+  // Verify that new iterators point to `end()`
+  EXPECT_EQ(reader.begin(), reader.end());
+}
+
+TEST(MakeTestRowReader, CancelEndsBadStream) {
+  std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
+  auto final_status = Status(StatusCode::kCancelled, "cancelled");
+
+  auto reader = MakeTestRowReader(rows, final_status);
+
+  auto it = reader.begin();
+  ASSERT_STATUS_OK(*it);
+  EXPECT_EQ((*it)->row_key(), "r1");
+
+  // Cancel the reader
+  reader.Cancel();
+
+  // Verify that the next iterator points to `final_status` instead of "r2"
+  EXPECT_THAT(*++it, StatusIs(StatusCode::kCancelled));
+
+  // Verify that the next iterator points to `end()`
+  EXPECT_EQ(++it, reader.end());
+
+  // Verify that new iterators return the `final_status`
+  EXPECT_THAT(*reader.begin(), StatusIs(StatusCode::kCancelled));
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_mocks
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Fixes #8797 

Similar to what we decided for `StreamRange`'s, add a simple factory function to construct a `RowReader` that accepts a vector of rows + a final status. We are not adding a google mock object that extends `RowReaderImpl` at this time.

I kept `google_cloud_cpp_bigtable_mocks` as an INTERFACE library because cmake is hard.