### PR TITLE
doc: update generated endpoint documentation during generate-libraries

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -66,8 +66,9 @@ for dox in google/cloud/*/doc/main.dox; do
     endpoint=$(grep -Pom1 "${endpoint_re}" "${option_defaults_cc}")
     make_connection_re='Make.*?Connection()'
     make_connection=$(grep -Pom1 "${make_connection_re}" "${connection_h}")
-    env_vars+=("- \`${variable}=...\` changes the default \`EndpointOption\`,")
-    env_vars+=("  ${endpoint}, used by \`${make_connection}()\`.")
+    env_vars+=("- \`${variable}=...\` overrides the")
+    env_vars+=("  \`EndpointOption\` (which defaults to ${endpoint})")
+    env_vars+=("  used by \`${make_connection}()\`.")
     env_vars+=("")
   done
   sed -i -f - "${dox}" <<EOT

--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -49,6 +49,35 @@ git ls-files -z | grep -zE '\.(cc|h)$' |
 io::log_h2 "Updating protobuf lists/deps"
 external/googleapis/update_libraries.sh
 
+io::log_h2 "Updating generated documentation"
+# Update the service's endpoint environment variables.
+for dox in google/cloud/*/doc/main.dox; do
+  lib="${dox%/doc/main.dox}"
+  inject_start="<!-- inject-endpoint-env-vars-start -->"
+  inject_end="<!-- inject-endpoint-env-vars-end -->"
+  env_vars=("")
+  for option_defaults_cc in "${lib}"/internal/*_option_defaults.cc; do
+    service="$(basename "${option_defaults_cc}" _option_defaults.cc)"
+    connection_h="${lib}/${service}_connection.h"
+    # Should we generate documentation for GOOGLE_CLOUD_CPP_.*_AUTHORITY too?
+    variable_re='GOOGLE_CLOUD_CPP_.*_ENDPOINT'
+    variable=$(grep -om1 "${variable_re}" "${option_defaults_cc}")
+    endpoint_re='"[^"]*?\.googleapis\.com"'
+    endpoint=$(grep -Pom1 "${endpoint_re}" "${option_defaults_cc}")
+    make_connection_re='Make.*?Connection()'
+    make_connection=$(grep -Pom1 "${make_connection_re}" "${connection_h}")
+    env_vars+=("- \`${variable}=...\` changes the default \`EndpointOption\`,")
+    env_vars+=("  ${endpoint}, used by \`${make_connection}()\`.")
+    env_vars+=("")
+  done
+  sed -i -f - "${dox}" <<EOT
+/${inject_start}/,/${inject_end}/c \\
+${inject_start}\\
+$(printf '%s\\\n' "${env_vars[@]}")
+${inject_end}
+EOT
+done
+
 # This build should fail if any generated files differ from what was checked
 # in. We only look in the google/ directory so that the build doesn't fail if
 # it's run while editing files in generator/...

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -41,8 +41,8 @@ which should give you a taste of the Bare Metal Solution API C++ client library 
 
 <!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_BARE_METAL_SOLUTION_ENDPOINT=...` changes the default endpoint
-  (baremetalsolution.googleapis.com) used by `BareMetalSolutionConnection`.
+- `GOOGLE_CLOUD_CPP_BARE_METAL_SOLUTION_ENDPOINT=...` changes the default `EndpointOption`,
+  "baremetalsolution.googleapis.com", used by `MakeBareMetalSolutionConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->
 

--- a/google/cloud/baremetalsolution/doc/main.dox
+++ b/google/cloud/baremetalsolution/doc/main.dox
@@ -41,8 +41,9 @@ which should give you a taste of the Bare Metal Solution API C++ client library 
 
 <!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_BARE_METAL_SOLUTION_ENDPOINT=...` changes the default `EndpointOption`,
-  "baremetalsolution.googleapis.com", used by `MakeBareMetalSolutionConnection()`.
+- `GOOGLE_CLOUD_CPP_BARE_METAL_SOLUTION_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "baremetalsolution.googleapis.com")
+  used by `MakeBareMetalSolutionConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->
 


### PR DESCRIPTION
Teach the `generate-libraries` build how to update the generated endpoint
documentation.

Run it to update the `baremetalsolution` doc, which is the only one that
still has the required injection markers.  A followup PR will re-add these
markers to all the other `main.dox` files.

This, and the recent addition of `external/googleapis/update_libraries.sh`
to the `generate-libraries` build, means the the "How-to Guide" for adding
a generated library can be simplified, but that remains a TODO for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9056)
<!-- Reviewable:end -->
