### PR TITLE
impl(bigtable): add Table ctor that accepts a DataConnection

### DIFF
--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -21,9 +21,10 @@
 
 namespace google {
 namespace cloud {
-// TODO(#8860) - Move this mock class into bigtable_mocks.
-namespace bigtable_internal {
+namespace bigtable_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+// TODO(#8860) - Remove the internal namespace
+namespace internal {
 
 /**
  * A class to mock `google::cloud::bigtable::DataConnection`.
@@ -113,8 +114,9 @@ class MockDataConnection : public bigtable_internal::DataConnection {
               (override));
 };
 
+}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_internal
+}  // namespace bigtable_mocks
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/table.h"
+#include "google/cloud/bigtable/mocks/mock_data_connection.h"
 #include "google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h"
 #include "google/cloud/bigtable/testing/table_test_fixture.h"
 #include "google/cloud/internal/background_threads_impl.h"
@@ -155,6 +156,18 @@ TEST_F(TableTest, ConstructorWithAppProfileAndPolicies) {
               AlwaysRetryMutationPolicy(), LimitedErrorCountRetryPolicy(42));
   EXPECT_EQ("test-profile-id", table.app_profile_id());
   EXPECT_THAT(table.table_name(), HasSubstr("some-table"));
+}
+
+TEST_F(TableTest, ConnectionConstructor) {
+  auto conn = std::make_shared<bigtable_mocks::internal::MockDataConnection>();
+  auto table = bigtable_internal::MakeTable(conn, "the-project", "the-instance",
+                                            "the-profile", "the-table");
+  EXPECT_EQ("the-profile", table.app_profile_id());
+  EXPECT_EQ("the-project", table.project_id());
+  EXPECT_EQ("the-instance", table.instance_id());
+  EXPECT_EQ("the-table", table.table_id());
+  EXPECT_EQ("projects/the-project/instances/the-instance/tables/the-table",
+            table.table_name());
 }
 
 std::string const kProjectId = "the-project";


### PR DESCRIPTION
Part of the work for #8798 

I see that the test defines global `std::string`s. This is not the PR to deal with those.

Also, move `MockDataConnection` from `bigtable_internal` -> `bigtable_mocks::internal`. I think that is a better idea.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9059)
<!-- Reviewable:end -->
