### PR TITLE
ci: enable GCS+gRPC production integration tests

### DIFF
--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -33,7 +33,6 @@ mapfile -t args < <(bazel::common_args)
 # Run as many of the integration tests as possible using production and gRPC:
 # "media" says to use the hybrid gRPC/REST client. For more details see
 # https://github.com/googleapis/google-cloud-cpp/issues/6268
-# TODO(#7257) - restore production tests
-#    readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media
+readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media
 mapfile -t integration_args < <(integration::bazel_args)
 bazel test "${args[@]}" "${integration_args[@]}" -- //google/cloud/storage/... "${excluded_rules[@]}"

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -149,6 +149,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
 
     set(storage_client_grpc_unit_tests
         # cmake-format: sort
+        grpc_plugin_test.cc
         internal/grpc_bucket_access_control_parser_test.cc
         internal/grpc_bucket_metadata_parser_test.cc
         internal/grpc_bucket_request_parser_test.cc

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/grpc_plugin.h"
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/hybrid_client.h"
+#include "google/cloud/internal/getenv.h"
 
 namespace google {
 namespace cloud {
@@ -22,12 +23,15 @@ namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 google::cloud::storage::Client DefaultGrpcClient(Options opts) {
-  opts = google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
-  auto config = opts.get<GrpcPluginOption>();
+  using ::google::cloud::internal::GetEnv;
+  auto const config = GetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG")
+                          .value_or(opts.get<GrpcPluginOption>());
   if (config == "none" || config.empty()) {
     return google::cloud::storage::Client(std::move(opts));
   }
   if (config == "metadata") {
+    opts =
+        google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
     return storage::internal::ClientImplDetails::CreateClient(
         storage::internal::GrpcClient::Create(opts));
   }

--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/grpc_plugin.h"
+#include "google/cloud/storage/internal/curl_client.h"
+#include "google/cloud/storage/internal/grpc_client.h"
+#include "google/cloud/storage/internal/hybrid_client.h"
+#include "google/cloud/storage/internal/retry_client.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_experimental {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::storage::internal::ClientImplDetails;
+using ::google::cloud::storage::internal::CurlClient;
+using ::google::cloud::storage::internal::GrpcClient;
+using ::google::cloud::storage::internal::HybridClient;
+using ::google::cloud::storage::internal::RetryClient;
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::IsNull;
+using ::testing::NotNull;
+
+TEST(GrpcPluginTest, MetadataConfigCreatesGrpc) {
+  // Disable the RestClient, while this is not the default, it is enabled in
+  // some of our CI builds.
+  auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
+                                absl::nullopt);
+  // Disable logging, also enabled in most of our CI builds
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  auto client = DefaultGrpcClient(Options{}.set<GrpcPluginOption>("metadata"));
+  auto const* const retry =
+      dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
+  ASSERT_THAT(retry, NotNull());
+  auto const* const grpc =
+      dynamic_cast<GrpcClient const*>(retry->client().get());
+  ASSERT_THAT(grpc, NotNull());
+}
+
+TEST(GrpcPluginTest, EnvironmentOverrides) {
+  // Disable the RestClient, while this is not the default, it is enabled in
+  // some of our CI builds.
+  auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
+                                absl::nullopt);
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", "none");
+  auto client = DefaultGrpcClient(Options{}.set<GrpcPluginOption>("metadata"));
+  auto const* const retry =
+      dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
+  ASSERT_THAT(retry, NotNull());
+  auto const* const grpc = dynamic_cast<GrpcClient*>(retry->client().get());
+  ASSERT_THAT(grpc, IsNull());
+}
+
+TEST(GrpcPluginTest, UnsetConfigCreatesCurl) {
+  // Disable the RestClient, while this is not the default, it is enabled in
+  // some of our CI builds.
+  auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
+                                absl::nullopt);
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  auto client = DefaultGrpcClient(Options{});
+  auto const* const retry =
+      dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
+  ASSERT_THAT(retry, NotNull());
+  auto const* const curl = dynamic_cast<CurlClient*>(retry->client().get());
+  ASSERT_THAT(curl, NotNull());
+}
+
+TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
+  // Disable the RestClient, while this is not the default, it is enabled in
+  // some of our CI builds.
+  auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
+                                absl::nullopt);
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  auto client = DefaultGrpcClient(Options{}.set<GrpcPluginOption>("none"));
+  auto const* const retry =
+      dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
+  ASSERT_THAT(retry, NotNull());
+  auto const* const curl = dynamic_cast<CurlClient*>(retry->client().get());
+  ASSERT_THAT(curl, NotNull());
+}
+
+TEST(GrpcPluginTest, MediaConfigCreatesHybrid) {
+  // Disable the RestClient, while this is not the default, it is enabled in
+  // some of our CI builds.
+  auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
+                                absl::nullopt);
+  auto logging =
+      ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
+  auto config =
+      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
+  auto client = DefaultGrpcClient(Options{}.set<GrpcPluginOption>("media"));
+  auto const* const retry =
+      dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
+  ASSERT_THAT(retry, NotNull());
+  auto const* const hybrid = dynamic_cast<HybridClient*>(retry->client().get());
+  ASSERT_THAT(hybrid, NotNull());
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_experimental
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -36,11 +36,10 @@ using ::testing::IsNull;
 using ::testing::NotNull;
 
 TEST(GrpcPluginTest, MetadataConfigCreatesGrpc) {
-  // Disable the RestClient, while this is not the default, it is enabled in
-  // some of our CI builds.
+  // Explicitly disable the RestClient, which may be enabled by our CI builds.
   auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
                                 absl::nullopt);
-  // Disable logging, also enabled in most of our CI builds
+  // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
@@ -55,10 +54,10 @@ TEST(GrpcPluginTest, MetadataConfigCreatesGrpc) {
 }
 
 TEST(GrpcPluginTest, EnvironmentOverrides) {
-  // Disable the RestClient, while this is not the default, it is enabled in
-  // some of our CI builds.
+  // Explicitly disable the RestClient, which may be enabled by our CI builds.
   auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
                                 absl::nullopt);
+  // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
@@ -72,10 +71,10 @@ TEST(GrpcPluginTest, EnvironmentOverrides) {
 }
 
 TEST(GrpcPluginTest, UnsetConfigCreatesCurl) {
-  // Disable the RestClient, while this is not the default, it is enabled in
-  // some of our CI builds.
+  // Explicitly disable the RestClient, which may be enabled by our CI builds.
   auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
                                 absl::nullopt);
+  // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
@@ -89,10 +88,10 @@ TEST(GrpcPluginTest, UnsetConfigCreatesCurl) {
 }
 
 TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
-  // Disable the RestClient, while this is not the default, it is enabled in
-  // some of our CI builds.
+  // Explicitly disable the RestClient, which may be enabled by our CI builds.
   auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
                                 absl::nullopt);
+  // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =
@@ -106,10 +105,10 @@ TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
 }
 
 TEST(GrpcPluginTest, MediaConfigCreatesHybrid) {
-  // Disable the RestClient, while this is not the default, it is enabled in
-  // some of our CI builds.
+  // Explicitly disable the RestClient, which may be enabled by our CI builds.
   auto rest = ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT",
                                 absl::nullopt);
+  // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
   auto config =

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/grpc_client.h"
-#include "google/cloud/storage/grpc_plugin.h"
 #include "google/cloud/storage/internal/grpc_bucket_access_control_parser.h"
 #include "google/cloud/storage/internal/grpc_bucket_metadata_parser.h"
 #include "google/cloud/storage/internal/grpc_bucket_request_parser.h"
@@ -91,7 +90,6 @@ int DefaultGrpcNumChannels(std::string const& endpoint) {
 
 Options DefaultOptionsGrpc(Options options) {
   using ::google::cloud::internal::GetEnv;
-  using ::google::cloud::storage_experimental::GrpcPluginOption;
 
   options = DefaultOptionsWithCredentials(std::move(options));
   if (!options.has<UnifiedCredentialsOption>() &&
@@ -105,10 +103,6 @@ Options DefaultOptionsGrpc(Options options) {
   }
   if (!options.has<AuthorityOption>()) {
     options.set<AuthorityOption>("storage.googleapis.com");
-  }
-  if (!options.has<GrpcPluginOption>()) {
-    options.set<GrpcPluginOption>(
-        GetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG").value_or("none"));
   }
   if (GetEnv("CLOUD_STORAGE_EMULATOR_ENDPOINT")) {
     // The emulator does not support HTTPS or authentication, use insecure

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -19,7 +19,6 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
-#include "google/cloud/testing_util/scoped_environment.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "google/cloud/testing_util/validate_metadata.h"
 #include <google/protobuf/text_format.h>
@@ -34,9 +33,7 @@ namespace {
 
 namespace v2 = ::google::storage::v2;
 using ::google::cloud::internal::CurrentOptions;
-using ::google::cloud::storage_experimental::GrpcPluginOption;
 using ::google::cloud::testing_util::IsProtoEqual;
-using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::google::protobuf::TextFormat;
@@ -180,24 +177,6 @@ google::cloud::Options TestOptions() {
 std::shared_ptr<GrpcClient> CreateTestClient(
     std::shared_ptr<storage_internal::StorageStub> stub) {
   return GrpcClient::CreateMock(std::move(stub), TestOptions());
-}
-
-TEST_F(GrpcClientTest, DefaultOptionsGrpcNoEnv) {
-  auto grpc_config =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", absl::nullopt);
-  auto opts = DefaultOptionsGrpc(TestOptions());
-  EXPECT_EQ(opts.get<GrpcPluginOption>(), "none");
-  opts = DefaultOptionsGrpc(Options{}.set<GrpcPluginOption>("configured"));
-  EXPECT_EQ(opts.get<GrpcPluginOption>(), "configured");
-}
-
-TEST_F(GrpcClientTest, DefaultOptionsGrpcWithEnv) {
-  auto grpc_config =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG", "env");
-  auto opts = DefaultOptionsGrpc(TestOptions());
-  EXPECT_EQ(opts.get<GrpcPluginOption>(), "env");
-  opts = DefaultOptionsGrpc(Options{}.set<GrpcPluginOption>("configured"));
-  EXPECT_EQ(opts.get<GrpcPluginOption>(), "configured");
 }
 
 TEST_F(GrpcClientTest, DefaultOptionsGrpcChannelCount) {

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -26,7 +26,8 @@ std::shared_ptr<RawClient> HybridClient::Create(Options const& options) {
 }
 
 HybridClient::HybridClient(Options const& options)
-    : grpc_(GrpcClient::Create(options)), curl_(CurlClient::Create(options)) {}
+    : grpc_(GrpcClient::Create(DefaultOptionsGrpc(std::move(options)))),
+      curl_(CurlClient::Create(DefaultOptionsWithCredentials(options))) {}
 
 ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -17,6 +17,7 @@
 """Automatically generated unit tests list - DO NOT EDIT."""
 
 storage_client_grpc_unit_tests = [
+    "grpc_plugin_test.cc",
     "internal/grpc_bucket_access_control_parser_test.cc",
     "internal/grpc_bucket_metadata_parser_test.cc",
     "internal/grpc_bucket_request_parser_test.cc",

--- a/google/cloud/storage/tests/grpc_bucket_acl_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_acl_integration_test.cc
@@ -45,7 +45,7 @@ class GrpcBucketAclIntegrationTest
 TEST_F(GrpcBucketAclIntegrationTest, AclCRUD) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#7257) - restore gRPC integration tests against production
+  // TODO(#5673) - restore gRPC integration tests against production
   if (!UsingEmulator()) GTEST_SKIP();
 
   auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");

--- a/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
@@ -48,7 +48,7 @@ class GrpcBucketMetadataIntegrationTest
 TEST_F(GrpcBucketMetadataIntegrationTest, ObjectMetadataCRUD) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#7257) - restore gRPC integration tests against production
+  // TODO(#5673) - restore gRPC integration tests against production
   if (!UsingEmulator()) GTEST_SKIP();
 
   auto const project_name = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");

--- a/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
@@ -38,7 +38,7 @@ class GrpcHmacKeyMetadataIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(GrpcHmacKeyMetadataIntegrationTest, HmacKeyCRUD) {
-  // TODO(#7257) - restore gRPC integration tests against production, even then
+  // TODO(#5673) - restore gRPC integration tests against production, even then
   //     generally we do not create HMAC keys in production because they are
   //     an extremely limited resource.
   if (!UsingEmulator()) GTEST_SKIP();

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -251,9 +251,7 @@ TEST_P(GrpcIntegrationTest, FieldFilter) {
 }
 
 INSTANTIATE_TEST_SUITE_P(GrpcIntegrationMediaTest, GrpcIntegrationTest,
-                         // TODO(#7257) - restore production tests
-                         //     ::testing::Values("media"));
-                         ::testing::Values("none"));
+                         ::testing::Values("media"));
 
 }  // namespace
 }  // namespace internal

--- a/google/cloud/storage/tests/grpc_object_acl_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_acl_integration_test.cc
@@ -44,7 +44,7 @@ class GrpcObjectAclIntegrationTest
 TEST_F(GrpcObjectAclIntegrationTest, AclCRUD) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#7257) - restore gRPC integration tests against production
+  // TODO(#5673) - restore gRPC integration tests against production
   if (!UsingEmulator()) GTEST_SKIP();
 
   auto const bucket_name =

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -43,7 +43,7 @@ class GrpcObjectMetadataIntegrationTest
 TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#7257) - restore gRPC integration tests against production
+  // TODO(#5673) - restore gRPC integration tests against production
   if (!UsingEmulator()) GTEST_SKIP();
 
   auto const bucket_name =

--- a/google/cloud/storage/tests/grpc_service_account_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_service_account_integration_test.cc
@@ -38,7 +38,7 @@ class GrpcServiceAccountIntegrationTest
 TEST_F(GrpcServiceAccountIntegrationTest, GetServiceAccount) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#7257) - restore gRPC integration tests against production
+  // TODO(#5673) - restore gRPC integration tests against production
   if (!UsingEmulator()) GTEST_SKIP();
 
   auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");

--- a/google/cloud/storage/tests/object_read_range_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_range_integration_test.cc
@@ -189,6 +189,8 @@ TEST_F(ObjectReadRangeIntegrationTest, ReadLast) {
   EXPECT_THAT(contents.size(), insert->size());
 
   for (auto const& test : cases) {
+    // TODO(#9058) - disable this workaround
+    if (test.count > kObjectSize && UsingGrpc()) continue;
     SCOPED_TRACE("Testing last " + std::to_string(test.count));
     auto reader =
         client->ReadObject(bucket_name(), object_name, ReadLast(test.count));

--- a/google/cloud/storage/tests/signed_url_integration_test.cc
+++ b/google/cloud/storage/tests/signed_url_integration_test.cc
@@ -32,6 +32,8 @@ class SignedUrlIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {
  protected:
   void SetUp() override {
+    // TODO(#4206) - gRPC does not implement SignBlob
+    if (UsingGrpc()) GTEST_SKIP();
     bucket_name_ = google::cloud::internal::GetEnv(
                        "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME")
                        .value_or("");


### PR DESCRIPTION
The integration tests against production were disabled while the protos
stabilized. There are no anticipated breaking changes at this point.

We cannot pass the options created for a `GrpcClient` to a `CurlClient`.
The latter has a very subtle interpretation of `AuthorityOption` as it
supports two separate services: `iamcredentials.googleapis.com` is
used to sign blobs.

A number of tests remain disabled because they use metadata operations
in gRPC, which are not ready in production. Changed their TODO entries
to point to the right bug.

Fixes #7257

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9060)
<!-- Reviewable:end -->
