### PR TITLE
doc: update generated endpoint documentation

### DIFF
--- a/google/cloud/accessapproval/doc/main.dox
+++ b/google/cloud/accessapproval/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Access Approval API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ACCESS_APPROVAL_ENDPOINT=...` changes the default endpoint
-  (accessapproval.googleapis.com) used by `AccessApprovalConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_ACCESS_APPROVAL_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "accessapproval.googleapis.com")
+  used by `MakeAccessApprovalConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/accesscontextmanager/doc/main.dox
+++ b/google/cloud/accesscontextmanager/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Access Context Manager API C++ client libra
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ACCESS_CONTEXT_MANAGER_ENDPOINT=...` changes the default endpoint
-  (accesscontextmanager.googleapis.com) used by `AccessContextManagerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_ACCESS_CONTEXT_MANAGER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "accesscontextmanager.googleapis.com")
+  used by `MakeAccessContextManagerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/apigateway/doc/main.dox
+++ b/google/cloud/apigateway/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the API Gateway API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_API_GATEWAY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (apigateway.googleapis.com) used by `ApiGatewayServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_API_GATEWAY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "apigateway.googleapis.com")
+  used by `MakeApiGatewayServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/apigeeconnect/doc/main.dox
+++ b/google/cloud/apigeeconnect/doc/main.dox
@@ -42,8 +42,13 @@ which should give you a taste of the Apigee Connect API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_APIGEE_CONNECTION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (apigeeconnect.googleapis.com) used by `ConnectionServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_APIGEE_CONNECTION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "apigeeconnect.googleapis.com")
+  used by `MakeConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/appengine/doc/main.dox
+++ b/google/cloud/appengine/doc/main.dox
@@ -38,29 +38,41 @@ which should give you a taste of the App Engine Admin API C++ client library API
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_APPLICATIONS_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `ApplicationsConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_AUTHORIZED_CERTIFICATES_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `AuthorizedCertificatesConnection`.
+- `GOOGLE_CLOUD_CPP_APPLICATIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeApplicationsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_AUTHORIZED_DOMAINS_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `AuthorizedDomainsConnection`.
+- `GOOGLE_CLOUD_CPP_AUTHORIZED_CERTIFICATES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeAuthorizedCertificatesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DOMAIN_MAPPINGS_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `DomainMappingsConnection`.
+- `GOOGLE_CLOUD_CPP_AUTHORIZED_DOMAINS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeAuthorizedDomainsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_FIREWALL_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `FirewallConnection`.
+- `GOOGLE_CLOUD_CPP_DOMAIN_MAPPINGS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeDomainMappingsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_INSTANCES_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `InstancesConnection`.
+- `GOOGLE_CLOUD_CPP_FIREWALL_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeFirewallConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SERVICES_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `ServicesConnection`.
+- `GOOGLE_CLOUD_CPP_INSTANCES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeInstancesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_VERSIONS_ENDPOINT=...` changes the default endpoint
-  (appengine.googleapis.com) used by `VersionsConnection`.
+- `GOOGLE_CLOUD_CPP_SERVICES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeServicesConnection()`.
+
+- `GOOGLE_CLOUD_CPP_VERSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "appengine.googleapis.com")
+  used by `MakeVersionsConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/artifactregistry/doc/main.dox
+++ b/google/cloud/artifactregistry/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Artifact Registry API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ARTIFACT_REGISTRY_ENDPOINT=...` changes the default endpoint
-  (artifactregistry.googleapis.com) used by `ArtifactRegistryConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_ARTIFACT_REGISTRY_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "artifactregistry.googleapis.com")
+  used by `MakeArtifactRegistryConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/asset/doc/main.dox
+++ b/google/cloud/asset/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud Asset API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ASSET_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudasset.googleapis.com) used by `AssetServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_ASSET_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudasset.googleapis.com")
+  used by `MakeAssetServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/assuredworkloads/doc/main.dox
+++ b/google/cloud/assuredworkloads/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Assured Workloads API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ASSURED_WORKLOADS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (assuredworkloads.googleapis.com) used by `AssuredWorkloadsServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_ASSURED_WORKLOADS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "assuredworkloads.googleapis.com")
+  used by `MakeAssuredWorkloadsServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/automl/doc/main.dox
+++ b/google/cloud/automl/doc/main.dox
@@ -39,11 +39,17 @@ which should give you a taste of the Cloud AutoML API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_AUTO_ML_ENDPOINT=...` changes the default endpoint
-  (automl.googleapis.com) used by `AutoMlConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_AUTOML_PREDICTION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (automl.googleapis.com) used by `PredictionServiceConnection`.
+- `GOOGLE_CLOUD_CPP_AUTO_ML_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "automl.googleapis.com")
+  used by `MakeAutoMlConnection()`.
+
+- `GOOGLE_CLOUD_CPP_AUTOML_PREDICTION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "automl.googleapis.com")
+  used by `MakePredictionServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/billing/doc/main.dox
+++ b/google/cloud/billing/doc/main.dox
@@ -40,14 +40,21 @@ which should give you a taste of the Cloud Billing Budget API C++ client library
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_BUDGET_SERVICE_ENDPOINT=...` changes the default endpoint
-  (billingbudgets.googleapis.com) used by `BudgetServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_CLOUD_BILLING_ENDPOINT=...` changes the default endpoint
-  (cloudbilling.googleapis.com) used by `CloudBillingConnection`.
+- `GOOGLE_CLOUD_CPP_BUDGET_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "billingbudgets.googleapis.com")
+  used by `MakeBudgetServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CLOUD_CATALOG_ENDPOINT=...` changes the default endpoint
-  (cloudbilling.googleapis.com) used by `CloudCatalogConnection`.
+- `GOOGLE_CLOUD_CPP_CLOUD_BILLING_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudbilling.googleapis.com")
+  used by `MakeCloudBillingConnection()`.
+
+- `GOOGLE_CLOUD_CPP_CLOUD_CATALOG_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudbilling.googleapis.com")
+  used by `MakeCloudCatalogConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/binaryauthorization/doc/main.dox
+++ b/google/cloud/binaryauthorization/doc/main.dox
@@ -39,14 +39,21 @@ which should give you a taste of the Binary Authorization API C++ client library
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_BINAUTHZ_MANAGEMENT_SERVICE_V1_ENDPOINT=...` changes the default endpoint
-  (binaryauthorization.googleapis.com) used by `BinauthzManagementServiceV1Connection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_SYSTEM_POLICY_V1_ENDPOINT=...` changes the default endpoint
-  (binaryauthorization.googleapis.com) used by `SystemPolicyV1Connection`.
+- `GOOGLE_CLOUD_CPP_BINAUTHZ_MANAGEMENT_SERVICE_V1_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "binaryauthorization.googleapis.com")
+  used by `MakeBinauthzManagementServiceV1Connection()`.
 
-- `GOOGLE_CLOUD_CPP_VALIDATION_HELPER_V1_ENDPOINT=...` changes the default endpoint
-  (binaryauthorization.googleapis.com) used by `ValidationHelperV1Connection`.
+- `GOOGLE_CLOUD_CPP_SYSTEM_POLICY_V1_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "binaryauthorization.googleapis.com")
+  used by `MakeSystemPolicyV1Connection()`.
+
+- `GOOGLE_CLOUD_CPP_VALIDATION_HELPER_V1_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "binaryauthorization.googleapis.com")
+  used by `MakeValidationHelperV1Connection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/channel/doc/main.dox
+++ b/google/cloud/channel/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Cloud Channel API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_CHANNEL_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudchannel.googleapis.com) used by `CloudChannelServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_CHANNEL_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudchannel.googleapis.com")
+  used by `MakeCloudChannelServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/cloudbuild/doc/main.dox
+++ b/google/cloud/cloudbuild/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Cloud Build API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_BUILD_ENDPOINT=...` changes the default endpoint
-  (cloudbuild.googleapis.com) used by `CloudBuildConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_BUILD_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudbuild.googleapis.com")
+  used by `MakeCloudBuildConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/composer/doc/main.dox
+++ b/google/cloud/composer/doc/main.dox
@@ -38,11 +38,17 @@ which should give you a taste of the Cloud Composer C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ENVIRONMENTS_ENDPOINT=...` changes the default endpoint
-  (composer.googleapis.com) used by `EnvironmentsConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_IMAGE_VERSIONS_ENDPOINT=...` changes the default endpoint
-  (composer.googleapis.com) used by `ImageVersionsConnection`.
+- `GOOGLE_CLOUD_CPP_ENVIRONMENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "composer.googleapis.com")
+  used by `MakeEnvironmentsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_IMAGE_VERSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "composer.googleapis.com")
+  used by `MakeImageVersionsConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/contactcenterinsights/doc/main.dox
+++ b/google/cloud/contactcenterinsights/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Contact Center AI Insights API C++ client l
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CONTACT_CENTER_INSIGHTS_ENDPOINT=...` changes the default endpoint
-  (contactcenterinsights.googleapis.com) used by `ContactCenterInsightsConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CONTACT_CENTER_INSIGHTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "contactcenterinsights.googleapis.com")
+  used by `MakeContactCenterInsightsConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/container/doc/main.dox
+++ b/google/cloud/container/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Kubernetes Engine API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLUSTER_MANAGER_ENDPOINT=...` changes the default endpoint
-  (container.googleapis.com) used by `ClusterManagerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLUSTER_MANAGER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "container.googleapis.com")
+  used by `MakeClusterManagerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/containeranalysis/doc/main.dox
+++ b/google/cloud/containeranalysis/doc/main.dox
@@ -40,11 +40,17 @@ which should give you a taste of the Container Analysis API C++ client library A
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CONTAINER_ANALYSIS_ENDPOINT=...` changes the default endpoint
-  (containeranalysis.googleapis.com) used by `ContainerAnalysisConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_GRAFEAS_ENDPOINT=...` changes the default endpoint
-  (containeranalysis.googleapis.com) used by `GrafeasConnection`.
+- `GOOGLE_CLOUD_CPP_CONTAINER_ANALYSIS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "containeranalysis.googleapis.com")
+  used by `MakeContainerAnalysisConnection()`.
+
+- `GOOGLE_CLOUD_CPP_GRAFEAS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "containeranalysis.googleapis.com")
+  used by `MakeGrafeasConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/datacatalog/doc/main.dox
+++ b/google/cloud/datacatalog/doc/main.dox
@@ -38,14 +38,21 @@ which should give you a taste of the Google Cloud Data Catalog API C++ client li
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_DATA_CATALOG_ENDPOINT=...` changes the default endpoint
-  (datacatalog.googleapis.com) used by `DataCatalogConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_POLICY_TAG_MANAGER_ENDPOINT=...` changes the default endpoint
-  (datacatalog.googleapis.com) used by `PolicyTagManagerConnection`.
+- `GOOGLE_CLOUD_CPP_DATA_CATALOG_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "datacatalog.googleapis.com")
+  used by `MakeDataCatalogConnection()`.
 
-- `GOOGLE_CLOUD_CPP_POLICY_TAG_MANAGER_SERIALIZATION_ENDPOINT=...` changes the default endpoint
-  (datacatalog.googleapis.com) used by `PolicyTagManagerSerializationConnection`.
+- `GOOGLE_CLOUD_CPP_POLICY_TAG_MANAGER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "datacatalog.googleapis.com")
+  used by `MakePolicyTagManagerConnection()`.
+
+- `GOOGLE_CLOUD_CPP_POLICY_TAG_MANAGER_SERIALIZATION_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "datacatalog.googleapis.com")
+  used by `MakePolicyTagManagerSerializationConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/datamigration/doc/main.dox
+++ b/google/cloud/datamigration/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Database Migration API C++ client library A
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_DATA_MIGRATION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (datamigration.googleapis.com) used by `DataMigrationServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_DATA_MIGRATION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "datamigration.googleapis.com")
+  used by `MakeDataMigrationServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dataplex/doc/main.dox
+++ b/google/cloud/dataplex/doc/main.dox
@@ -39,14 +39,21 @@ which should give you a taste of the Cloud Dataplex API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CONTENT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dataplex.googleapis.com) used by `ContentServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_DATAPLEX_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dataplex.googleapis.com) used by `DataplexServiceConnection`.
+- `GOOGLE_CLOUD_CPP_CONTENT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataplex.googleapis.com")
+  used by `MakeContentServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_METADATA_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dataplex.googleapis.com) used by `MetadataServiceConnection`.
+- `GOOGLE_CLOUD_CPP_DATAPLEX_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataplex.googleapis.com")
+  used by `MakeDataplexServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_METADATA_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataplex.googleapis.com")
+  used by `MakeMetadataServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -41,20 +41,29 @@ which should give you a taste of the Cloud Dataproc API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_AUTOSCALING_POLICY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dataproc.googleapis.com) used by `AutoscalingPolicyServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_ENDPOINT=...` changes the default endpoint
-  (dataproc.googleapis.com) used by `BatchControllerConnection`.
+- `GOOGLE_CLOUD_CPP_AUTOSCALING_POLICY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  used by `MakeAutoscalingPolicyServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CLUSTER_CONTROLLER_ENDPOINT=...` changes the default endpoint
-  (dataproc.googleapis.com) used by `ClusterControllerConnection`.
+- `GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  used by `MakeBatchControllerConnection()`.
 
-- `GOOGLE_CLOUD_CPP_JOB_CONTROLLER_ENDPOINT=...` changes the default endpoint
-  (dataproc.googleapis.com) used by `JobControllerConnection`.
+- `GOOGLE_CLOUD_CPP_CLUSTER_CONTROLLER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  used by `MakeClusterControllerConnection()`.
 
-- `GOOGLE_CLOUD_CPP_WORKFLOW_TEMPLATE_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dataproc.googleapis.com) used by `WorkflowTemplateServiceConnection`.
+- `GOOGLE_CLOUD_CPP_JOB_CONTROLLER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  used by `MakeJobControllerConnection()`.
+
+- `GOOGLE_CLOUD_CPP_WORKFLOW_TEMPLATE_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  used by `MakeWorkflowTemplateServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/debugger/doc/main.dox
+++ b/google/cloud/debugger/doc/main.dox
@@ -39,11 +39,17 @@ which should give you a taste of the Stackdriver Debugger API C++ client library
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CONTROLLER2_ENDPOINT=...` changes the default endpoint
-  (clouddebugger.googleapis.com) used by `Controller2Connection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_DEBUGGER2_ENDPOINT=...` changes the default endpoint
-  (clouddebugger.googleapis.com) used by `Debugger2Connection`.
+- `GOOGLE_CLOUD_CPP_CONTROLLER2_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "clouddebugger.googleapis.com")
+  used by `MakeController2Connection()`.
+
+- `GOOGLE_CLOUD_CPP_DEBUGGER2_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "clouddebugger.googleapis.com")
+  used by `MakeDebugger2Connection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -41,53 +41,73 @@ which should give you a taste of the Dialogflow API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `AgentsConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_CHANGELOGS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ChangelogsConnection`.
+- `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeAgentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DEPLOYMENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `DeploymentsConnection`.
+- `GOOGLE_CLOUD_CPP_CHANGELOGS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeChangelogsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `EntityTypesConnection`.
+- `GOOGLE_CLOUD_CPP_DEPLOYMENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeDeploymentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `EnvironmentsConnection`.
+- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeEntityTypesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_EXPERIMENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ExperimentsConnection`.
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeEnvironmentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_FLOWS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `FlowsConnection`.
+- `GOOGLE_CLOUD_CPP_EXPERIMENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeExperimentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `IntentsConnection`.
+- `GOOGLE_CLOUD_CPP_FLOWS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeFlowsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_PAGES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `PagesConnection`.
+- `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeIntentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SECURITY_SETTINGS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `SecuritySettingsServiceConnection`.
+- `GOOGLE_CLOUD_CPP_PAGES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakePagesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `SessionEntityTypesConnection`.
+- `GOOGLE_CLOUD_CPP_SECURITY_SETTINGS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeSecuritySettingsServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `SessionsConnection`.
+- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeSessionEntityTypesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_TEST_CASES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `TestCasesConnection`.
+- `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeSessionsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `TransitionRouteGroupsConnection`.
+- `GOOGLE_CLOUD_CPP_TEST_CASES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeTestCasesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `VersionsConnection`.
+- `GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeTransitionRouteGroupsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_WEBHOOKS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `WebhooksConnection`.
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeVersionsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_WEBHOOKS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeWebhooksConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -41,56 +41,77 @@ which should give you a taste of the Dialogflow API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `AgentsConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_ANSWER_RECORDS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `AnswerRecordsConnection`.
+- `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeAgentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CONTEXTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ContextsConnection`.
+- `GOOGLE_CLOUD_CPP_ANSWER_RECORDS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeAnswerRecordsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ConversationDatasetsConnection`.
+- `GOOGLE_CLOUD_CPP_CONTEXTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeContextsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CONVERSATION_MODELS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ConversationModelsConnection`.
+- `GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeConversationDatasetsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CONVERSATION_PROFILES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ConversationProfilesConnection`.
+- `GOOGLE_CLOUD_CPP_CONVERSATION_MODELS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeConversationModelsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ConversationsConnection`.
+- `GOOGLE_CLOUD_CPP_CONVERSATION_PROFILES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeConversationProfilesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DOCUMENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `DocumentsConnection`.
+- `GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeConversationsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `EntityTypesConnection`.
+- `GOOGLE_CLOUD_CPP_DOCUMENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeDocumentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `EnvironmentsConnection`.
+- `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeEntityTypesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_FULFILLMENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `FulfillmentsConnection`.
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeEnvironmentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `IntentsConnection`.
+- `GOOGLE_CLOUD_CPP_FULFILLMENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeFulfillmentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_KNOWLEDGE_BASES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `KnowledgeBasesConnection`.
+- `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeIntentsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_PARTICIPANTS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `ParticipantsConnection`.
+- `GOOGLE_CLOUD_CPP_KNOWLEDGE_BASES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeKnowledgeBasesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `SessionEntityTypesConnection`.
+- `GOOGLE_CLOUD_CPP_PARTICIPANTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeParticipantsConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `SessionsConnection`.
+- `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeSessionEntityTypesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` changes the default endpoint
-  (dialogflow.googleapis.com) used by `VersionsConnection`.
+- `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeSessionsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  used by `MakeVersionsConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/dlp/doc/main.dox
+++ b/google/cloud/dlp/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Cloud Data Loss Prevention (DLP) API C++ cl
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_DLP_SERVICE_ENDPOINT=...` changes the default endpoint
-  (dlp.googleapis.com) used by `DlpServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_DLP_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "dlp.googleapis.com")
+  used by `MakeDlpServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud Document AI API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_DOCUMENT_PROCESSOR_SERVICE_ENDPOINT=...` changes the default endpoint
-  (documentai.googleapis.com) used by `DocumentProcessorServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_DOCUMENT_PROCESSOR_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "documentai.googleapis.com")
+  used by `MakeDocumentProcessorServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/eventarc/doc/main.dox
+++ b/google/cloud/eventarc/doc/main.dox
@@ -38,11 +38,17 @@ which should give you a taste of the Eventarc API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_EVENTARC_ENDPOINT=...` changes the default endpoint
-  (eventarc.googleapis.com) used by `EventarcConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_PUBLISHER_ENDPOINT=...` changes the default endpoint
-  (eventarcpublishing.googleapis.com) used by `PublisherConnection`.
+- `GOOGLE_CLOUD_CPP_EVENTARC_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "eventarc.googleapis.com")
+  used by `MakeEventarcConnection()`.
+
+- `GOOGLE_CLOUD_CPP_PUBLISHER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "eventarcpublishing.googleapis.com")
+  used by `MakePublisherConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/filestore/doc/main.dox
+++ b/google/cloud/filestore/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Cloud Filestore API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_FILESTORE_MANAGER_ENDPOINT=...` changes the default endpoint
-  (file.googleapis.com) used by `CloudFilestoreManagerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_FILESTORE_MANAGER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "file.googleapis.com")
+  used by `MakeCloudFilestoreManagerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/functions/doc/main.dox
+++ b/google/cloud/functions/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Cloud Functions API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_FUNCTIONS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudfunctions.googleapis.com) used by `CloudFunctionsServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_FUNCTIONS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudfunctions.googleapis.com")
+  used by `MakeCloudFunctionsServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/gameservices/doc/main.dox
+++ b/google/cloud/gameservices/doc/main.dox
@@ -39,17 +39,25 @@ which should give you a taste of the Game Services API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_GAME_SERVER_CLUSTERS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (gameservices.googleapis.com) used by `GameServerClustersServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_GAME_SERVER_CONFIGS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (gameservices.googleapis.com) used by `GameServerConfigsServiceConnection`.
+- `GOOGLE_CLOUD_CPP_GAME_SERVER_CLUSTERS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "gameservices.googleapis.com")
+  used by `MakeGameServerClustersServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_GAME_SERVER_DEPLOYMENTS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (gameservices.googleapis.com) used by `GameServerDeploymentsServiceConnection`.
+- `GOOGLE_CLOUD_CPP_GAME_SERVER_CONFIGS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "gameservices.googleapis.com")
+  used by `MakeGameServerConfigsServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_REALMS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (gameservices.googleapis.com) used by `RealmsServiceConnection`.
+- `GOOGLE_CLOUD_CPP_GAME_SERVER_DEPLOYMENTS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "gameservices.googleapis.com")
+  used by `MakeGameServerDeploymentsServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_REALMS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "gameservices.googleapis.com")
+  used by `MakeRealmsServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/gkehub/doc/main.dox
+++ b/google/cloud/gkehub/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the GKE Hub C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_GKE_HUB_ENDPOINT=...` changes the default endpoint
-  (gkehub.googleapis.com) used by `GkeHubConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_GKE_HUB_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "gkehub.googleapis.com")
+  used by `MakeGkeHubConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/iap/doc/main.dox
+++ b/google/cloud/iap/doc/main.dox
@@ -38,11 +38,17 @@ which should give you a taste of the Cloud Identity-Aware Proxy API C++ client l
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_IDENTITY_AWARE_PROXY_ADMIN_SERVICE_ENDPOINT=...` changes the default endpoint
-  (iap.googleapis.com) used by `IdentityAwareProxyAdminServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_IDENTITY_AWARE_PROXY_O_AUTH_SERVICE_ENDPOINT=...` changes the default endpoint
-  (iap.googleapis.com) used by `IdentityAwareProxyOAuthServiceConnection`.
+- `GOOGLE_CLOUD_CPP_IDENTITY_AWARE_PROXY_ADMIN_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "iap.googleapis.com")
+  used by `MakeIdentityAwareProxyAdminServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_IDENTITY_AWARE_PROXY_O_AUTH_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "iap.googleapis.com")
+  used by `MakeIdentityAwareProxyOAuthServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/ids/doc/main.dox
+++ b/google/cloud/ids/doc/main.dox
@@ -43,8 +43,13 @@ which should give you a taste of the Cloud IDS API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_IDS_ENDPOINT=...` changes the default endpoint
-  (ids.googleapis.com) used by `IDSConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_IDS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "ids.googleapis.com")
+  used by `MakeIDSConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/iot/doc/main.dox
+++ b/google/cloud/iot/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud IoT API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_DEVICE_MANAGER_ENDPOINT=...` changes the default endpoint
-  (cloudiot.googleapis.com) used by `DeviceManagerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_DEVICE_MANAGER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudiot.googleapis.com")
+  used by `MakeDeviceManagerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/kms/doc/main.dox
+++ b/google/cloud/kms/doc/main.dox
@@ -41,11 +41,17 @@ which should give you a taste of the KMS C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_EKM_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudkms.googleapis.com) used by `EkmServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_KEY_MANAGEMENT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudkms.googleapis.com) used by `KeyManagementServiceConnection`.
+- `GOOGLE_CLOUD_CPP_EKM_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudkms.googleapis.com")
+  used by `MakeEkmServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_KEY_MANAGEMENT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudkms.googleapis.com")
+  used by `MakeKeyManagementServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/language/doc/main.dox
+++ b/google/cloud/language/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Cloud Natural Language API C++ client libra
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_LANGUAGE_SERVICE_ENDPOINT=...` changes the default endpoint
-  (language.googleapis.com) used by `LanguageServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_LANGUAGE_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "language.googleapis.com")
+  used by `MakeLanguageServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/logging/doc/main.dox
+++ b/google/cloud/logging/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Cloud Logging API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_LOGGING_SERVICE_V2_ENDPOINT=...` changes the default endpoint
-  (logging.googleapis.com) used by `LoggingServiceV2Connection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_LOGGING_SERVICE_V2_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "logging.googleapis.com")
+  used by `MakeLoggingServiceV2Connection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/managedidentities/doc/main.dox
+++ b/google/cloud/managedidentities/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Managed Service for Microsoft Active Direct
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_MANAGED_IDENTITIES_SERVICE_ENDPOINT=...` changes the default endpoint
-  (managedidentities.googleapis.com) used by `ManagedIdentitiesServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_MANAGED_IDENTITIES_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "managedidentities.googleapis.com")
+  used by `MakeManagedIdentitiesServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/memcache/doc/main.dox
+++ b/google/cloud/memcache/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud Memorystore for Memcached API C++ cli
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_MEMCACHE_ENDPOINT=...` changes the default endpoint
-  (memcache.googleapis.com) used by `CloudMemcacheConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_MEMCACHE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "memcache.googleapis.com")
+  used by `MakeCloudMemcacheConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/monitoring/doc/main.dox
+++ b/google/cloud/monitoring/doc/main.dox
@@ -41,32 +41,45 @@ which should give you a taste of the Cloud Monitoring API C++ client library API
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ALERT_POLICY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `AlertPolicyServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_DASHBOARDS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `DashboardsServiceConnection`.
+- `GOOGLE_CLOUD_CPP_ALERT_POLICY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeAlertPolicyServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_GROUP_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `GroupServiceConnection`.
+- `GOOGLE_CLOUD_CPP_DASHBOARDS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeDashboardsServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `MetricServiceConnection`.
+- `GOOGLE_CLOUD_CPP_GROUP_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeGroupServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_METRICS_SCOPES_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `MetricsScopesConnection`.
+- `GOOGLE_CLOUD_CPP_METRIC_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeMetricServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_NOTIFICATION_CHANNEL_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `NotificationChannelServiceConnection`.
+- `GOOGLE_CLOUD_CPP_METRICS_SCOPES_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeMetricsScopesConnection()`.
 
-- `GOOGLE_CLOUD_CPP_QUERY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `QueryServiceConnection`.
+- `GOOGLE_CLOUD_CPP_NOTIFICATION_CHANNEL_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeNotificationChannelServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SERVICE_MONITORING_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `ServiceMonitoringServiceConnection`.
+- `GOOGLE_CLOUD_CPP_QUERY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeQueryServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_UPTIME_CHECK_SERVICE_ENDPOINT=...` changes the default endpoint
-  (monitoring.googleapis.com) used by `UptimeCheckServiceConnection`.
+- `GOOGLE_CLOUD_CPP_SERVICE_MONITORING_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeServiceMonitoringServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_UPTIME_CHECK_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "monitoring.googleapis.com")
+  used by `MakeUptimeCheckServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/networkmanagement/doc/main.dox
+++ b/google/cloud/networkmanagement/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Network Management API C++ client library A
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_REACHABILITY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (networkmanagement.googleapis.com) used by `ReachabilityServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_REACHABILITY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "networkmanagement.googleapis.com")
+  used by `MakeReachabilityServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/notebooks/doc/main.dox
+++ b/google/cloud/notebooks/doc/main.dox
@@ -39,11 +39,17 @@ which should give you a taste of the Notebooks API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_MANAGED_NOTEBOOK_SERVICE_ENDPOINT=...` changes the default endpoint
-  (notebooks.googleapis.com) used by `ManagedNotebookServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_NOTEBOOK_SERVICE_ENDPOINT=...` changes the default endpoint
-  (notebooks.googleapis.com) used by `NotebookServiceConnection`.
+- `GOOGLE_CLOUD_CPP_MANAGED_NOTEBOOK_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "notebooks.googleapis.com")
+  used by `MakeManagedNotebookServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_NOTEBOOK_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "notebooks.googleapis.com")
+  used by `MakeNotebookServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/orgpolicy/doc/main.dox
+++ b/google/cloud/orgpolicy/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Organization Policy API C++ client library 
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ORG_POLICY_ENDPOINT=...` changes the default endpoint
-  (orgpolicy.googleapis.com) used by `OrgPolicyConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_ORG_POLICY_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "orgpolicy.googleapis.com")
+  used by `MakeOrgPolicyConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -39,11 +39,17 @@ which should give you a taste of the OS Config API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_AGENT_ENDPOINT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (osconfig.googleapis.com) used by `AgentEndpointServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_OS_CONFIG_SERVICE_ENDPOINT=...` changes the default endpoint
-  (osconfig.googleapis.com) used by `OsConfigServiceConnection`.
+- `GOOGLE_CLOUD_CPP_AGENT_ENDPOINT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "osconfig.googleapis.com")
+  used by `MakeAgentEndpointServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_OS_CONFIG_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "osconfig.googleapis.com")
+  used by `MakeOsConfigServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/oslogin/doc/main.dox
+++ b/google/cloud/oslogin/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud OS Login API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_OS_LOGIN_SERVICE_ENDPOINT=...` changes the default endpoint
-  (oslogin.googleapis.com) used by `OsLoginServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_OS_LOGIN_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "oslogin.googleapis.com")
+  used by `MakeOsLoginServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/policytroubleshooter/doc/main.dox
+++ b/google/cloud/policytroubleshooter/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Policy Troubleshooter API C++ client librar
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_IAM_CHECKER_ENDPOINT=...` changes the default endpoint
-  (policytroubleshooter.googleapis.com) used by `IamCheckerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_IAM_CHECKER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "policytroubleshooter.googleapis.com")
+  used by `MakeIamCheckerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/privateca/doc/main.dox
+++ b/google/cloud/privateca/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Certificate Authority API C++ client librar
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CERTIFICATE_AUTHORITY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (privateca.googleapis.com) used by `CertificateAuthorityServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CERTIFICATE_AUTHORITY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "privateca.googleapis.com")
+  used by `MakeCertificateAuthorityServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/profiler/doc/main.dox
+++ b/google/cloud/profiler/doc/main.dox
@@ -46,8 +46,13 @@ which should give you a taste of the Cloud Profiler API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_PROFILER_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudprofiler.googleapis.com) used by `ProfilerServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_PROFILER_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudprofiler.googleapis.com")
+  used by `MakeProfilerServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/pubsublite/doc/main.dox
+++ b/google/cloud/pubsublite/doc/main.dox
@@ -41,11 +41,17 @@ which should give you a taste of the Pub/Sub Lite API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_ADMIN_SERVICE_ENDPOINT=...` changes the default endpoint
-  (pubsublite.googleapis.com) used by `AdminServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_TOPIC_STATS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (pubsublite.googleapis.com) used by `TopicStatsServiceConnection`.
+- `GOOGLE_CLOUD_CPP_ADMIN_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "pubsublite.googleapis.com")
+  used by `MakeAdminServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_TOPIC_STATS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "pubsublite.googleapis.com")
+  used by `MakeTopicStatsServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/recommender/doc/main.dox
+++ b/google/cloud/recommender/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Recommender C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_RECOMMENDER_ENDPOINT=...` changes the default endpoint
-  (recommender.googleapis.com) used by `RecommenderConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_RECOMMENDER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "recommender.googleapis.com")
+  used by `MakeRecommenderConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/redis/doc/main.dox
+++ b/google/cloud/redis/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Google Cloud Memorystore for Redis API C++ 
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_REDIS_ENDPOINT=...` changes the default endpoint
-  (redis.googleapis.com) used by `CloudRedisConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_REDIS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "redis.googleapis.com")
+  used by `MakeCloudRedisConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/resourcemanager/doc/main.dox
+++ b/google/cloud/resourcemanager/doc/main.dox
@@ -39,14 +39,21 @@ which should give you a taste of the Cloud Resource Manager API C++ client libra
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_FOLDERS_ENDPOINT=...` changes the default endpoint
-  (cloudresourcemanager.googleapis.com) used by `FoldersConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_ORGANIZATIONS_ENDPOINT=...` changes the default endpoint
-  (cloudresourcemanager.googleapis.com) used by `OrganizationsConnection`.
+- `GOOGLE_CLOUD_CPP_FOLDERS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudresourcemanager.googleapis.com")
+  used by `MakeFoldersConnection()`.
 
-- `GOOGLE_CLOUD_CPP_PROJECTS_ENDPOINT=...` changes the default endpoint
-  (cloudresourcemanager.googleapis.com) used by `ProjectsConnection`.
+- `GOOGLE_CLOUD_CPP_ORGANIZATIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudresourcemanager.googleapis.com")
+  used by `MakeOrganizationsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_PROJECTS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudresourcemanager.googleapis.com")
+  used by `MakeProjectsConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/resourcesettings/doc/main.dox
+++ b/google/cloud/resourcesettings/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Resource Settings API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_RESOURCE_SETTINGS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (resourcesettings.googleapis.com) used by `ResourceSettingsServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_RESOURCE_SETTINGS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "resourcesettings.googleapis.com")
+  used by `MakeResourceSettingsServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/retail/doc/main.dox
+++ b/google/cloud/retail/doc/main.dox
@@ -40,23 +40,33 @@ which should give you a taste of the Retail API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CATALOG_SERVICE_ENDPOINT=...` changes the default endpoint
-  (retail.googleapis.com) used by `CatalogServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_COMPLETION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (retail.googleapis.com) used by `CompletionServiceConnection`.
+- `GOOGLE_CLOUD_CPP_CATALOG_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakeCatalogServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_RETAIL_PREDICTION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (retail.googleapis.com) used by `PredictionServiceConnection`.
+- `GOOGLE_CLOUD_CPP_COMPLETION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakeCompletionServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_PRODUCT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (retail.googleapis.com) used by `ProductServiceConnection`.
+- `GOOGLE_CLOUD_CPP_RETAIL_PREDICTION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakePredictionServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_SEARCH_SERVICE_ENDPOINT=...` changes the default endpoint
-  (retail.googleapis.com) used by `SearchServiceConnection`.
+- `GOOGLE_CLOUD_CPP_PRODUCT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakeProductServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_USER_EVENT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (retail.googleapis.com) used by `UserEventServiceConnection`.
+- `GOOGLE_CLOUD_CPP_SEARCH_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakeSearchServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_USER_EVENT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "retail.googleapis.com")
+  used by `MakeUserEventServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/scheduler/doc/main.dox
+++ b/google/cloud/scheduler/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Cloud Scheduler API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_SCHEDULER_ENDPOINT=...` changes the default endpoint
-  (cloudscheduler.googleapis.com) used by `CloudSchedulerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_SCHEDULER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudscheduler.googleapis.com")
+  used by `MakeCloudSchedulerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/secretmanager/doc/main.dox
+++ b/google/cloud/secretmanager/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Secret Manager API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_SECRET_MANAGER_SERVICE_ENDPOINT=...` changes the default endpoint
-  (secretmanager.googleapis.com) used by `SecretManagerServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_SECRET_MANAGER_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "secretmanager.googleapis.com")
+  used by `MakeSecretManagerServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/securitycenter/doc/main.dox
+++ b/google/cloud/securitycenter/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Security Command Center API C++ client libr
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_SECURITY_CENTER_ENDPOINT=...` changes the default endpoint
-  (securitycenter.googleapis.com) used by `SecurityCenterConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_SECURITY_CENTER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "securitycenter.googleapis.com")
+  used by `MakeSecurityCenterConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/servicecontrol/doc/main.dox
+++ b/google/cloud/servicecontrol/doc/main.dox
@@ -39,11 +39,17 @@ which should give you a taste of the Service Control API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_QUOTA_CONTROLLER_ENDPOINT=...` changes the default endpoint
-  (servicecontrol.googleapis.com) used by `QuotaControllerConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_SERVICE_CONTROLLER_ENDPOINT=...` changes the default endpoint
-  (servicecontrol.googleapis.com) used by `ServiceControllerConnection`.
+- `GOOGLE_CLOUD_CPP_QUOTA_CONTROLLER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "servicecontrol.googleapis.com")
+  used by `MakeQuotaControllerConnection()`.
+
+- `GOOGLE_CLOUD_CPP_SERVICE_CONTROLLER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "servicecontrol.googleapis.com")
+  used by `MakeServiceControllerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/servicedirectory/doc/main.dox
+++ b/google/cloud/servicedirectory/doc/main.dox
@@ -39,11 +39,17 @@ which should give you a taste of the Service Directory API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_LOOKUP_SERVICE_ENDPOINT=...` changes the default endpoint
-  (servicedirectory.googleapis.com) used by `LookupServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_REGISTRATION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (servicedirectory.googleapis.com) used by `RegistrationServiceConnection`.
+- `GOOGLE_CLOUD_CPP_LOOKUP_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "servicedirectory.googleapis.com")
+  used by `MakeLookupServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_REGISTRATION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "servicedirectory.googleapis.com")
+  used by `MakeRegistrationServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/servicemanagement/doc/main.dox
+++ b/google/cloud/servicemanagement/doc/main.dox
@@ -37,8 +37,13 @@ which should give you a taste of the Service Management API C++ client library A
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_SERVICE_MANAGER_ENDPOINT=...` changes the default endpoint
-  (servicemanagement.googleapis.com) used by `ServiceManagerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_SERVICE_MANAGER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "servicemanagement.googleapis.com")
+  used by `MakeServiceManagerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/serviceusage/doc/main.dox
+++ b/google/cloud/serviceusage/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Service Usage API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_SERVICE_USAGE_ENDPOINT=...` changes the default endpoint
-  (serviceusage.googleapis.com) used by `ServiceUsageConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_SERVICE_USAGE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "serviceusage.googleapis.com")
+  used by `MakeServiceUsageConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/shell/doc/main.dox
+++ b/google/cloud/shell/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud Shell API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_SHELL_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudshell.googleapis.com) used by `CloudShellServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_SHELL_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudshell.googleapis.com")
+  used by `MakeCloudShellServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/speech/doc/main.dox
+++ b/google/cloud/speech/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Cloud Speech-to-Text API C++ client library
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` changes the default endpoint
-  (speech.googleapis.com) used by `SpeechConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_SPEECH_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "speech.googleapis.com")
+  used by `MakeSpeechConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/storagetransfer/doc/main.dox
+++ b/google/cloud/storagetransfer/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Storage Transfer API C++ client library API
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_STORAGE_TRANSFER_SERVICE_ENDPOINT=...` changes the default endpoint
-  (storagetransfer.googleapis.com) used by `StorageTransferServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_STORAGE_TRANSFER_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "storagetransfer.googleapis.com")
+  used by `MakeStorageTransferServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/talent/doc/main.dox
+++ b/google/cloud/talent/doc/main.dox
@@ -39,20 +39,29 @@ which should give you a taste of the Cloud Talent Solution C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_COMPANY_SERVICE_ENDPOINT=...` changes the default endpoint
-  (jobs.googleapis.com) used by `CompanyServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_COMPLETION_ENDPOINT=...` changes the default endpoint
-  (jobs.googleapis.com) used by `CompletionConnection`.
+- `GOOGLE_CLOUD_CPP_COMPANY_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "jobs.googleapis.com")
+  used by `MakeCompanyServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_EVENT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (jobs.googleapis.com) used by `EventServiceConnection`.
+- `GOOGLE_CLOUD_CPP_COMPLETION_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "jobs.googleapis.com")
+  used by `MakeCompletionConnection()`.
 
-- `GOOGLE_CLOUD_CPP_JOB_SERVICE_ENDPOINT=...` changes the default endpoint
-  (jobs.googleapis.com) used by `JobServiceConnection`.
+- `GOOGLE_CLOUD_CPP_EVENT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "jobs.googleapis.com")
+  used by `MakeEventServiceConnection()`.
 
-- `GOOGLE_CLOUD_CPP_TENANT_SERVICE_ENDPOINT=...` changes the default endpoint
-  (jobs.googleapis.com) used by `TenantServiceConnection`.
+- `GOOGLE_CLOUD_CPP_JOB_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "jobs.googleapis.com")
+  used by `MakeJobServiceConnection()`.
+
+- `GOOGLE_CLOUD_CPP_TENANT_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "jobs.googleapis.com")
+  used by `MakeTenantServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/tasks/doc/main.dox
+++ b/google/cloud/tasks/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Cloud Tasks API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_CLOUD_TASKS_ENDPOINT=...` changes the default endpoint
-  (cloudtasks.googleapis.com) used by `CloudTasksConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_CLOUD_TASKS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudtasks.googleapis.com")
+  used by `MakeCloudTasksConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/texttospeech/doc/main.dox
+++ b/google/cloud/texttospeech/doc/main.dox
@@ -39,8 +39,13 @@ which should give you a taste of the Cloud Text-to-Speech API C++ client library
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_TEXT_TO_SPEECH_ENDPOINT=...` changes the default endpoint
-  (texttospeech.googleapis.com) used by `TextToSpeechConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_TEXT_TO_SPEECH_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "texttospeech.googleapis.com")
+  used by `MakeTextToSpeechConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/tpu/doc/main.dox
+++ b/google/cloud/tpu/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Cloud TPU API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_TPU_ENDPOINT=...` changes the default endpoint
-  (tpu.googleapis.com) used by `TpuConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_TPU_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "tpu.googleapis.com")
+  used by `MakeTpuConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/trace/doc/main.dox
+++ b/google/cloud/trace/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Stackdriver Trace API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_TRACE_SERVICE_ENDPOINT=...` changes the default endpoint
-  (cloudtrace.googleapis.com) used by `TraceServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_TRACE_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "cloudtrace.googleapis.com")
+  used by `MakeTraceServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/translate/doc/main.dox
+++ b/google/cloud/translate/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Cloud Translation API C++ client library AP
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_TRANSLATION_SERVICE_ENDPOINT=...` changes the default endpoint
-  (translate.googleapis.com) used by `TranslationServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_TRANSLATION_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "translate.googleapis.com")
+  used by `MakeTranslationServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/videointelligence/doc/main.dox
+++ b/google/cloud/videointelligence/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Cloud Video Intelligence API C++ client lib
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_VIDEO_INTELLIGENCE_SERVICE_ENDPOINT=...` changes the default endpoint
-  (videointelligence.googleapis.com) used by `VideoIntelligenceServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_VIDEO_INTELLIGENCE_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "videointelligence.googleapis.com")
+  used by `MakeVideoIntelligenceServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vision/doc/main.dox
+++ b/google/cloud/vision/doc/main.dox
@@ -40,11 +40,17 @@ which should give you a taste of the Cloud Vision API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_IMAGE_ANNOTATOR_ENDPOINT=...` changes the default endpoint
-  (vision.googleapis.com) used by `ImageAnnotatorConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_PRODUCT_SEARCH_ENDPOINT=...` changes the default endpoint
-  (vision.googleapis.com) used by `ProductSearchConnection`.
+- `GOOGLE_CLOUD_CPP_IMAGE_ANNOTATOR_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "vision.googleapis.com")
+  used by `MakeImageAnnotatorConnection()`.
+
+- `GOOGLE_CLOUD_CPP_PRODUCT_SEARCH_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "vision.googleapis.com")
+  used by `MakeProductSearchConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vmmigration/doc/main.dox
+++ b/google/cloud/vmmigration/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the VM Migration API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_VM_MIGRATION_ENDPOINT=...` changes the default endpoint
-  (vmmigration.googleapis.com) used by `VmMigrationConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_VM_MIGRATION_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "vmmigration.googleapis.com")
+  used by `MakeVmMigrationConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/vpcaccess/doc/main.dox
+++ b/google/cloud/vpcaccess/doc/main.dox
@@ -38,8 +38,13 @@ which should give you a taste of the Serverless VPC Access API C++ client librar
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_VPC_ACCESS_SERVICE_ENDPOINT=...` changes the default endpoint
-  (vpcaccess.googleapis.com) used by `VpcAccessServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_VPC_ACCESS_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "vpcaccess.googleapis.com")
+  used by `MakeVpcAccessServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/webrisk/doc/main.dox
+++ b/google/cloud/webrisk/doc/main.dox
@@ -40,8 +40,13 @@ which should give you a taste of the Web Risk API C++ client library API.
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_WEB_RISK_SERVICE_ENDPOINT=...` changes the default endpoint
-  (webrisk.googleapis.com) used by `WebRiskServiceConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_WEB_RISK_SERVICE_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "webrisk.googleapis.com")
+  used by `MakeWebRiskServiceConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/websecurityscanner/doc/main.dox
+++ b/google/cloud/websecurityscanner/doc/main.dox
@@ -41,8 +41,13 @@ which should give you a taste of the Web Security Scanner API C++ client library
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_WEB_SECURITY_SCANNER_ENDPOINT=...` changes the default endpoint
-  (websecurityscanner.googleapis.com) used by `WebSecurityScannerConnection`.
+<!-- inject-endpoint-env-vars-start -->
+
+- `GOOGLE_CLOUD_CPP_WEB_SECURITY_SCANNER_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "websecurityscanner.googleapis.com")
+  used by `MakeWebSecurityScannerConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC

--- a/google/cloud/workflows/doc/main.dox
+++ b/google/cloud/workflows/doc/main.dox
@@ -40,11 +40,17 @@ which should give you a taste of the Workflow Executions API C++ client library 
 
 ## Environment Variables
 
-- `GOOGLE_CLOUD_CPP_EXECUTIONS_ENDPOINT=...` changes the default endpoint
-  (workflowexecutions.googleapis.com) used by `ExecutionsConnection`.
+<!-- inject-endpoint-env-vars-start -->
 
-- `GOOGLE_CLOUD_CPP_WORKFLOWS_ENDPOINT=...` changes the default endpoint
-  (workflows.googleapis.com) used by `WorkflowsConnection`.
+- `GOOGLE_CLOUD_CPP_EXECUTIONS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "workflowexecutions.googleapis.com")
+  used by `MakeExecutionsConnection()`.
+
+- `GOOGLE_CLOUD_CPP_WORKFLOWS_ENDPOINT=...` overrides the
+  `EndpointOption` (which defaults to "workflows.googleapis.com")
+  used by `MakeWorkflowsConnection()`.
+
+<!-- inject-endpoint-env-vars-end -->
 
 - `GOOGLE_CLOUD_CPP_ENABLE_TRACING=rpc` turns on tracing for most gRPC
   calls. The library injects an additional Stub decorator that prints each gRPC


### PR DESCRIPTION
Restore the "inject-endpoint-env-vars" markers to the `main.dox` files,
and run the `generate-libraries` build to update the descriptions of the
various endpoint environment variables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9062)
<!-- Reviewable:end -->
