### PR TITLE
ci: automatically start GCB builds for trusted contributors

### DIFF
--- a/.github/trusted-contribution.yml
+++ b/.github/trusted-contribution.yml
@@ -1,3 +1,5 @@
 annotations:
   - type: label
     text: "kokoro:force-run"
+  - type: comment
+    text: "/gcbrun"


### PR DESCRIPTION
I am mostly thinking about Renovate Bot contributions, but it applies
to anything else that the `trusted-contributor` bot knows about.