### PR TITLE
impl(bigtable): implement DataConnection::Apply()

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -38,7 +38,34 @@ class DataConnectionImpl : public DataConnection {
 
   Options options() override { return options_; }
 
+  Status Apply(std::string const& app_profile_id, std::string const& table_name,
+               bigtable::SingleRowMutation mut) override;
+
  private:
+  std::unique_ptr<DataRetryPolicy> retry_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DataRetryPolicyOption>()) {
+      return options.get<DataRetryPolicyOption>()->clone();
+    }
+    return options_.get<DataRetryPolicyOption>()->clone();
+  }
+
+  std::unique_ptr<BackoffPolicy> backoff_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<DataBackoffPolicyOption>()) {
+      return options.get<DataBackoffPolicyOption>()->clone();
+    }
+    return options_.get<DataBackoffPolicyOption>()->clone();
+  }
+
+  std::unique_ptr<bigtable::IdempotentMutationPolicy> idempotency_policy() {
+    auto const& options = internal::CurrentOptions();
+    if (options.has<IdempotentMutationPolicyOption>()) {
+      return options.get<IdempotentMutationPolicyOption>()->clone();
+    }
+    return options_.get<IdempotentMutationPolicyOption>()->clone();
+  }
+
   std::unique_ptr<BackgroundThreads> background_;
   std::shared_ptr<BigtableStub> stub_;
   Options options_;

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -14,8 +14,10 @@
 
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
 #include "google/cloud/bigtable/testing/mock_bigtable_stub.h"
+#include "google/cloud/bigtable/testing/mock_policies.h"
 #include "google/cloud/common_options.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/testing_util/mock_backoff_policy.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <grpcpp/client_context.h>
@@ -27,18 +29,56 @@ namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+namespace v2 = ::google::bigtable::v2;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
+using ::google::cloud::bigtable::testing::MockDataRetryPolicy;
+using ::google::cloud::bigtable::testing::MockIdempotentMutationPolicy;
+using ::google::cloud::testing_util::MockBackoffPolicy;
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::ByMove;
+using ::testing::Return;
+using ms = std::chrono::milliseconds;
+
+auto constexpr kNumRetries = 2;
+auto const* const kTableName =
+    "projects/the-project/instances/the-instance/tables/the-table";
+auto const* const kAppProfile = "the-profile";
+
+Status TransientError() {
+  return Status(StatusCode::kUnavailable, "try again");
+}
+
+Status PermanentError() {
+  return Status(StatusCode::kPermissionDenied, "fail");
+}
+
+bigtable::SingleRowMutation IdempotentMutation() {
+  return bigtable::SingleRowMutation(
+      "row", {bigtable::SetCell("fam", "col", ms(0), "val")});
+}
+
+bigtable::SingleRowMutation NonIdempotentMutation() {
+  return bigtable::SingleRowMutation("row",
+                                     {bigtable::SetCell("fam", "col", "val")});
+}
 
 class DataConnectionTest : public ::testing::Test {
  protected:
   std::shared_ptr<DataConnectionImpl> TestConnection() {
     auto options =
-        Options{}.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
+        Options{}
+            .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+            .set<DataRetryPolicyOption>(retry_.clone())
+            .set<DataBackoffPolicyOption>(backoff_.clone());
     auto background = internal::MakeBackgroundThreadsFactory(options)();
     return std::make_shared<DataConnectionImpl>(std::move(background),
                                                 mock_stub_, std::move(options));
   }
 
+  DataLimitedErrorCountRetryPolicy retry_ =
+      DataLimitedErrorCountRetryPolicy(kNumRetries);
+  ExponentialBackoffPolicy backoff_ =
+      ExponentialBackoffPolicy(ms(0), ms(0), 2.0);
   std::shared_ptr<MockBigtableStub> mock_stub_ =
       std::make_shared<MockBigtableStub>();
 };
@@ -48,6 +88,160 @@ TEST_F(DataConnectionTest, Options) {
   auto options = connection->options();
   EXPECT_TRUE(options.has<GrpcCredentialOption>());
   ASSERT_TRUE(options.has<EndpointOption>());
+}
+
+/**
+ * Verify that call options (provided via an OptionsSpan) take precedence over
+ * connection options (provided to the DataConnection constructor). We will only
+ * test this for Apply() and assume it holds true for all RPCs.
+ *
+ * This is testing the private `retry_policy()`, `backoff_policy()`,
+ * `idempotency_policy()` member functions.
+ */
+TEST_F(DataConnectionTest, CallOptionsOverrideConnectionOptions) {
+  EXPECT_CALL(*mock_stub_, MutateRow).WillOnce(Return(PermanentError()));
+
+  auto call_r = std::make_shared<MockDataRetryPolicy>();
+  auto call_b = std::make_shared<MockBackoffPolicy>();
+  auto call_i = std::make_shared<MockIdempotentMutationPolicy>();
+  auto call_opts = Options{}
+                       .set<DataRetryPolicyOption>(call_r)
+                       .set<DataBackoffPolicyOption>(call_b)
+                       .set<IdempotentMutationPolicyOption>(call_i);
+
+  EXPECT_CALL(*call_r, clone).WillOnce(Return(ByMove(retry_.clone())));
+  EXPECT_CALL(*call_b, clone).WillOnce(Return(ByMove(backoff_.clone())));
+  EXPECT_CALL(*call_i, clone)
+      .WillOnce(Return(ByMove(bigtable::DefaultIdempotentMutationPolicy())));
+
+  auto conn_r = std::make_shared<MockDataRetryPolicy>();
+  auto conn_b = std::make_shared<MockBackoffPolicy>();
+  auto conn_i = std::make_shared<MockIdempotentMutationPolicy>();
+  auto conn_opts = Options{}
+                       .set<DataRetryPolicyOption>(conn_r)
+                       .set<DataBackoffPolicyOption>(conn_b)
+                       .set<IdempotentMutationPolicyOption>(conn_i);
+
+  EXPECT_CALL(*conn_r, clone).Times(0);
+  EXPECT_CALL(*conn_b, clone).Times(0);
+  EXPECT_CALL(*conn_i, clone).Times(0);
+
+  auto connection = std::make_shared<DataConnectionImpl>(nullptr, mock_stub_,
+                                                         std::move(conn_opts));
+  internal::OptionsSpan span(call_opts);
+  (void)connection->Apply(kAppProfile, kTableName, IdempotentMutation());
+}
+
+/**
+ * Verify that connection options (provided to the DataConnection constructor)
+ * take affect. We will only test this for Apply() and assume it holds true for
+ * all RPCs.
+ *
+ * This is testing the private `retry_policy()`, `backoff_policy()`,
+ * `idempotency_policy()` member functions.
+ */
+TEST_F(DataConnectionTest, UseConnectionOptionsIfNoCallOptions) {
+  EXPECT_CALL(*mock_stub_, MutateRow).WillOnce(Return(PermanentError()));
+
+  auto conn_r = std::make_shared<MockDataRetryPolicy>();
+  auto conn_b = std::make_shared<MockBackoffPolicy>();
+  auto conn_i = std::make_shared<MockIdempotentMutationPolicy>();
+  auto conn_opts = Options{}
+                       .set<DataRetryPolicyOption>(conn_r)
+                       .set<DataBackoffPolicyOption>(conn_b)
+                       .set<IdempotentMutationPolicyOption>(conn_i);
+
+  EXPECT_CALL(*conn_r, clone).WillOnce(Return(ByMove(retry_.clone())));
+  EXPECT_CALL(*conn_b, clone).WillOnce(Return(ByMove(backoff_.clone())));
+  EXPECT_CALL(*conn_i, clone)
+      .WillOnce(Return(ByMove(bigtable::DefaultIdempotentMutationPolicy())));
+
+  auto connection = std::make_shared<DataConnectionImpl>(nullptr, mock_stub_,
+                                                         std::move(conn_opts));
+  (void)connection->Apply(kAppProfile, kTableName, IdempotentMutation());
+}
+
+TEST_F(DataConnectionTest, ApplySuccess) {
+  EXPECT_CALL(*mock_stub_, MutateRow)
+      .WillOnce([](grpc::ClientContext&, v2::MutateRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return v2::MutateRowResponse{};
+      });
+
+  auto connection = TestConnection();
+  auto status =
+      connection->Apply(kAppProfile, kTableName, IdempotentMutation());
+  ASSERT_STATUS_OK(status);
+}
+
+TEST_F(DataConnectionTest, ApplyPermanentFailure) {
+  EXPECT_CALL(*mock_stub_, MutateRow)
+      .WillOnce([](grpc::ClientContext&, v2::MutateRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return PermanentError();
+      });
+
+  auto connection = TestConnection();
+  auto status =
+      connection->Apply(kAppProfile, kTableName, IdempotentMutation());
+  EXPECT_THAT(status, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST_F(DataConnectionTest, ApplyRetryThenSuccess) {
+  EXPECT_CALL(*mock_stub_, MutateRow)
+      .WillOnce([](grpc::ClientContext&, v2::MutateRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return TransientError();
+      })
+      .WillOnce([](grpc::ClientContext&, v2::MutateRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return v2::MutateRowResponse{};
+      });
+
+  auto connection = TestConnection();
+  auto status =
+      connection->Apply(kAppProfile, kTableName, IdempotentMutation());
+  ASSERT_STATUS_OK(status);
+}
+
+TEST_F(DataConnectionTest, ApplyRetryExhausted) {
+  EXPECT_CALL(*mock_stub_, MutateRow)
+      .Times(kNumRetries + 1)
+      .WillRepeatedly(
+          [](grpc::ClientContext&, v2::MutateRowRequest const& request) {
+            EXPECT_EQ(kAppProfile, request.app_profile_id());
+            EXPECT_EQ(kTableName, request.table_name());
+            EXPECT_EQ("row", request.row_key());
+            return TransientError();
+          });
+
+  auto connection = TestConnection();
+  auto status =
+      connection->Apply(kAppProfile, kTableName, IdempotentMutation());
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
+}
+
+TEST_F(DataConnectionTest, ApplyRetryIdempotentOnly) {
+  EXPECT_CALL(*mock_stub_, MutateRow)
+      .WillOnce([](grpc::ClientContext&, v2::MutateRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return TransientError();
+      });
+
+  auto connection = TestConnection();
+  auto status =
+      connection->Apply(kAppProfile, kTableName, NonIdempotentMutation());
+  EXPECT_THAT(status, StatusIs(StatusCode::kUnavailable));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/testing/mock_policies.h
+++ b/google/cloud/bigtable/testing/mock_policies.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_POLICIES_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_TESTING_MOCK_POLICIES_H
 
+#include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/polling_policy.h"
 #include "google/cloud/bigtable/rpc_backoff_policy.h"
 #include "google/cloud/bigtable/rpc_retry_policy.h"
@@ -29,6 +30,26 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 namespace testing {
+
+class MockDataRetryPolicy : public bigtable_internal::DataRetryPolicy {
+ public:
+  MOCK_METHOD(std::unique_ptr<bigtable_internal::DataRetryPolicy>, clone, (),
+              (const, override));
+  MOCK_METHOD(bool, OnFailure, (Status const&), (override));
+  MOCK_METHOD(void, OnFailureImpl, (), (override));
+  MOCK_METHOD(bool, IsExhausted, (), (const, override));
+};
+
+class MockIdempotentMutationPolicy : public bigtable::IdempotentMutationPolicy {
+ public:
+  MOCK_METHOD(std::unique_ptr<bigtable::IdempotentMutationPolicy>, clone, (),
+              (const, override));
+  MOCK_METHOD(bool, is_idempotent, (google::bigtable::v2::Mutation const&),
+              (override));
+  MOCK_METHOD(bool, is_idempotent,
+              (google::bigtable::v2::CheckAndMutateRowRequest const&),
+              (override));
+};
 
 class MockRetryPolicy : public RPCRetryPolicy {
  public:


### PR DESCRIPTION
Part of the work for #8799 , #8798 

This PR implements DataConnection::Apply(). It includes getters for call vs. connection options. The Table::Apply() piece will be addressed in a later PR, when I have set up the integration tests to exercise the new code path.

The old code path is [here](https://github.com/googleapis/google-cloud-cpp/blob/e6a8a6ffe1396cdd16ce4405d8578fbd9420d2cc/google/cloud/bigtable/table.cc#L72)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9070)
<!-- Reviewable:end -->
