### PR TITLE
feat(GCS+gRPC): timeout downloads on lack of progress

### DIFF
--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -14,18 +14,32 @@
 
 #include "google/cloud/storage/internal/grpc_object_read_source.h"
 #include "google/cloud/storage/internal/grpc_object_metadata_parser.h"
-#include "absl/functional/function_ref.h"
 #include "absl/strings/string_view.h"
 #include <algorithm>
+#include <limits>
 
 namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+namespace {
 
-GrpcObjectReadSource::GrpcObjectReadSource(std::unique_ptr<StreamingRpc> stream)
-    : stream_(std::move(stream)) {}
+std::chrono::milliseconds DefaultDownloadStallTimeout(
+    std::chrono::milliseconds value) {
+  if (value != std::chrono::milliseconds(0)) return value;
+  return std::chrono::seconds(
+      std::numeric_limits<std::chrono::seconds::rep>::max());
+}
+
+}  // namespace
+
+GrpcObjectReadSource::GrpcObjectReadSource(
+    std::unique_ptr<StreamingRpc> stream,
+    std::chrono::milliseconds download_stall_timeout)
+    : stream_(std::move(stream)),
+      download_stall_timeout_(
+          DefaultDownloadStallTimeout(download_stall_timeout)) {}
 
 StatusOr<HttpResponse> GrpcObjectReadSource::Close() {
   if (stream_) stream_ = nullptr;
@@ -47,72 +61,84 @@ StatusOr<ReadSourceResult> GrpcObjectReadSource::Read(char* buf,
     return absl::string_view(end, source.size() - nbytes);
   };
 
-  using BufferUpdater = absl::FunctionRef<absl::string_view(absl::string_view)>;
-  struct Visitor {
-    Visitor(GrpcObjectReadSource& source, BufferUpdater update)
-        : self(source), update_buf(std::move(update)) {
-      result.response.status_code = HttpStatusCode::kContinue;
+  ReadSourceResult result;
+  result.response.status_code = HttpStatusCode::kContinue;
+  result.bytes_received = 0;
+  auto update_result = [&](google::storage::v2::ReadObjectResponse response) {
+    // The google.storage.v1.Storage documentation says this field can be
+    // empty.
+    if (response.has_checksummed_data()) {
+      // Sometimes protobuf bytes are not strings, but the explicit conversion
+      // always works.
+      spill_ = std::string(
+          std::move(*response.mutable_checksummed_data()->mutable_content()));
+      spill_view_ = update_buf(spill_);
+      result.bytes_received = offset;
     }
-
-    GrpcObjectReadSource& self;
-    BufferUpdater update_buf;
-    ReadSourceResult result;
-
-    void operator()(Status s) {
-      // A status, whether success or failure, closes the stream.
-      self.status_ = std::move(s);
-      auto metadata = self.stream_->GetRequestMetadata();
-      result.response.headers.insert(metadata.begin(), metadata.end());
-      self.stream_ = nullptr;
+    if (response.has_object_checksums()) {
+      auto const& checksums = response.object_checksums();
+      if (checksums.has_crc32c()) {
+        result.hashes = Merge(
+            std::move(result.hashes),
+            HashValues{
+                GrpcObjectMetadataParser::Crc32cFromProto(checksums.crc32c()),
+                {}});
+      }
+      if (!checksums.md5_hash().empty()) {
+        result.hashes = Merge(std::move(result.hashes),
+                              HashValues{{},
+                                         GrpcObjectMetadataParser::MD5FromProto(
+                                             checksums.md5_hash())});
+      }
     }
-    void operator()(google::storage::v2::ReadObjectResponse response) {
-      // The google.storage.v1.Storage documentation says this field can be
-      // empty.
-      if (response.has_checksummed_data()) {
-        // Sometimes protobuf bytes are not strings, but the explicit conversion
-        // always works.
-        self.spill_ = std::string(
-            std::move(*response.mutable_checksummed_data()->mutable_content()));
-        self.spill_view_ = update_buf(self.spill_);
-      }
-      if (response.has_object_checksums()) {
-        auto const& checksums = response.object_checksums();
-        if (checksums.has_crc32c()) {
-          result.hashes = Merge(
-              std::move(result.hashes),
-              HashValues{
-                  GrpcObjectMetadataParser::Crc32cFromProto(checksums.crc32c()),
-                  {}});
-        }
-        if (!checksums.md5_hash().empty()) {
-          result.hashes =
-              Merge(std::move(result.hashes),
-                    HashValues{{},
-                               GrpcObjectMetadataParser::MD5FromProto(
-                                   checksums.md5_hash())});
-        }
-      }
-      if (response.has_metadata()) {
-        result.generation =
-            result.generation.value_or(response.metadata().generation());
-        result.metageneration = result.metageneration.value_or(
-            response.metadata().metageneration());
-        result.storage_class =
-            result.storage_class.value_or(response.metadata().storage_class());
-        result.size = result.size.value_or(response.metadata().size());
-      }
+    if (response.has_metadata()) {
+      auto const& metadata = response.metadata();
+      result.generation = result.generation.value_or(metadata.generation());
+      result.metageneration =
+          result.metageneration.value_or(metadata.metageneration());
+      result.storage_class =
+          result.storage_class.value_or(metadata.storage_class());
+      result.size = result.size.value_or(metadata.size());
     }
   };
 
   spill_view_ = update_buf(spill_view_);
-  Visitor visitor{*this, update_buf};
+  result.bytes_received = offset;
   while (offset < n && stream_) {
-    absl::visit(visitor, stream_->Read());
+    auto data_future = stream_->Read();
+    auto state = data_future.wait_for(download_stall_timeout_);
+    if (state != std::future_status::ready) {
+      status_ = Status(StatusCode::kDeadlineExceeded,
+                       "Deadline exceeded waiting for data in ReadObject");
+      stream_->Cancel();
+
+      // Schedule a call to `Finish()` to close the stream.  gRPC requires the
+      // `Read()` call to complete before calling `Finish()`, and we do not
+      // want to block waiting for that here.
+      using ::google::storage::v2::ReadObjectResponse;
+      struct CaptureByMove {
+        std::unique_ptr<StreamingRpc> stream;
+        void operator()(future<absl::optional<ReadObjectResponse>>) {
+          (void)stream->Finish();
+          stream.reset();
+        }
+      };
+      (void)data_future.then(CaptureByMove{std::move(stream_)});
+      return status_;
+    }
+    auto data = data_future.get();
+    if (!data.has_value()) {
+      status_ = stream_->Finish().get();
+      auto metadata = stream_->GetRequestMetadata();
+      result.response.headers.insert(metadata.begin(), metadata.end());
+      stream_.reset();
+      if (!status_.ok()) return status_;
+      return result;
+    }
+    update_result(std::move(*data));
   }
 
-  if (!status_.ok()) return status_;
-  visitor.result.bytes_received = offset;
-  return std::move(visitor.result);
+  return result;
 }
 
 }  // namespace internal

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -152,13 +152,15 @@ class MockInsertStream : public google::cloud::internal::StreamingWriteRpc<
               (override));
 };
 
-class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
-                                  google::storage::v2::ReadObjectResponse> {
+class MockObjectMediaStream
+    : public google::cloud::internal::AsyncStreamingReadRpc<
+          google::storage::v2::ReadObjectResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  using ReadResultType =
-      absl::variant<Status, google::storage::v2::ReadObjectResponse>;
-  MOCK_METHOD(ReadResultType, Read, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<google::storage::v2::ReadObjectResponse>>,
+              Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
   MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
               (), (const, override));
 };


### PR DESCRIPTION
Previously we timed out a download if it failed to complete the download
in a given time. This requires setting excessive timeouts for
applications that download both small objects (which take milliseconds)
and large objects (which can take minutes).

Furthermore, some applications start a download and then consume the
data slowly.  The timeout values for such applications would need to be
too large too.

This PR uses the asynchronous API to download objects. This API allows
us to timeout a `Read()` call, and abort the download if it is not
making progress.

Fixes #7300

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9072)
<!-- Reviewable:end -->
