### PR TITLE
ci: pin gcp-docuploader to a working version

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -75,7 +75,9 @@ fi
 
 io::log_h2 "Installing the docuploader package"
 python3 -m pip install --upgrade --user --quiet --disable-pip-version-check \
-  --no-warn-script-location gcp-docuploader protobuf
+  --no-warn-script-location \
+  "git+https://github.com/googleapis/docuploader@993badb47be3bf548a4c1726658eadba4bafeaca"
+python3 -m pip list
 
 # For docuploader to work
 export LC_ALL=C.UTF-8


### PR DESCRIPTION
The latest release of gcp-docuploader does not work (version mismatches
with Protobuf). This pins the script to use an unreleased version, that
is ugly, but works.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9076)
<!-- Reviewable:end -->
