### PR TITLE
feat(generator): `SetIamPolicy()` can be idempotent

### DIFF
--- a/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection_idempotency_policy.cc
@@ -70,8 +70,9 @@ class DefaultGoldenThingAdminConnectionIdempotencyPolicy : public GoldenThingAdm
   }
 
   Idempotency
-  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+  SetIamPolicy(google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency

--- a/google/cloud/artifactregistry/artifact_registry_connection_idempotency_policy.cc
+++ b/google/cloud/artifactregistry/artifact_registry_connection_idempotency_policy.cc
@@ -170,8 +170,9 @@ class DefaultArtifactRegistryConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/bigquery/connection_connection_idempotency_policy.cc
+++ b/google/cloud/bigquery/connection_connection_idempotency_policy.cc
@@ -79,8 +79,9 @@ class DefaultConnectionServiceConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection_idempotency_policy.cc
@@ -136,8 +136,9 @@ class DefaultBigtableInstanceAdminConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection_idempotency_policy.cc
@@ -121,8 +121,9 @@ class DefaultBigtableTableAdminConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/billing/cloud_billing_connection_idempotency_policy.cc
+++ b/google/cloud/billing/cloud_billing_connection_idempotency_policy.cc
@@ -86,8 +86,9 @@ class DefaultCloudBillingConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/containeranalysis/container_analysis_connection_idempotency_policy.cc
+++ b/google/cloud/containeranalysis/container_analysis_connection_idempotency_policy.cc
@@ -44,8 +44,9 @@ class DefaultContainerAnalysisConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/datacatalog/data_catalog_connection_idempotency_policy.cc
+++ b/google/cloud/datacatalog/data_catalog_connection_idempotency_policy.cc
@@ -199,8 +199,9 @@ class DefaultDataCatalogConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/datacatalog/policy_tag_manager_connection_idempotency_policy.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_connection_idempotency_policy.cc
@@ -99,8 +99,9 @@ class DefaultPolicyTagManagerConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/functions/cloud_functions_connection_idempotency_policy.cc
+++ b/google/cloud/functions/cloud_functions_connection_idempotency_policy.cc
@@ -85,8 +85,9 @@ class DefaultCloudFunctionsServiceConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/iam/iam_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_connection_idempotency_policy.cc
@@ -111,8 +111,9 @@ class DefaultIAMConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/iam/iam_policy_connection_idempotency_policy.cc
+++ b/google/cloud/iam/iam_policy_connection_idempotency_policy.cc
@@ -43,8 +43,9 @@ class DefaultIAMPolicyConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/iap/identity_aware_proxy_admin_connection_idempotency_policy.cc
+++ b/google/cloud/iap/identity_aware_proxy_admin_connection_idempotency_policy.cc
@@ -46,8 +46,9 @@ class DefaultIdentityAwareProxyAdminServiceConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/iot/device_manager_connection_idempotency_policy.cc
+++ b/google/cloud/iot/device_manager_connection_idempotency_policy.cc
@@ -109,8 +109,9 @@ class DefaultDeviceManagerConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/resourcemanager/folders_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/folders_connection_idempotency_policy.cc
@@ -88,8 +88,9 @@ class DefaultFoldersConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/resourcemanager/organizations_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/organizations_connection_idempotency_policy.cc
@@ -60,8 +60,9 @@ class DefaultOrganizationsConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/resourcemanager/projects_connection_idempotency_policy.cc
+++ b/google/cloud/resourcemanager/projects_connection_idempotency_policy.cc
@@ -91,8 +91,9 @@ class DefaultProjectsConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/secretmanager/secret_manager_connection_idempotency_policy.cc
+++ b/google/cloud/secretmanager/secret_manager_connection_idempotency_policy.cc
@@ -110,8 +110,9 @@ class DefaultSecretManagerServiceConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/securitycenter/security_center_connection_idempotency_policy.cc
+++ b/google/cloud/securitycenter/security_center_connection_idempotency_policy.cc
@@ -170,8 +170,9 @@ class DefaultSecurityCenterConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/servicedirectory/registration_connection_idempotency_policy.cc
+++ b/google/cloud/servicedirectory/registration_connection_idempotency_policy.cc
@@ -134,8 +134,9 @@ class DefaultRegistrationServiceConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(

--- a/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/database_admin_connection_idempotency_policy.cc
@@ -79,8 +79,9 @@ class DefaultDatabaseAdminConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection_idempotency_policy.cc
@@ -85,8 +85,9 @@ class DefaultInstanceAdminConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency GetIamPolicy(

--- a/google/cloud/tasks/cloud_tasks_connection_idempotency_policy.cc
+++ b/google/cloud/tasks/cloud_tasks_connection_idempotency_policy.cc
@@ -88,8 +88,9 @@ class DefaultCloudTasksConnectionIdempotencyPolicy
   }
 
   Idempotency SetIamPolicy(
-      google::iam::v1::SetIamPolicyRequest const&) override {
-    return Idempotency::kNonIdempotent;
+      google::iam::v1::SetIamPolicyRequest const& request) override {
+    return request.policy().etag().empty() ? Idempotency::kNonIdempotent
+                                           : Idempotency::kIdempotent;
   }
 
   Idempotency TestIamPermissions(


### PR DESCRIPTION
The `SetIamPolicy()` operations can be idempotent if the request has an
ETag value. The ETag value is a pre-condition, that changes when the
operation succeeds.  In other words, the operation can succeed at
most once: all such operations are idempotent.

Fixes #2595

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9078)
<!-- Reviewable:end -->
