### PR TITLE
ci: deflake `publish-docs` build

### DIFF
--- a/ci/cloudbuild/builds/publish-docs.sh
+++ b/ci/cloudbuild/builds/publish-docs.sh
@@ -96,11 +96,13 @@ function upload_docs() {
   io::log_h2 "Uploading docs: ${package}"
   io::log "docs_dir=${docs_dir}"
 
-  env -C "${docs_dir}" python3 -m docuploader create-metadata \
+  env -C "${docs_dir}" "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
+    python3 -m docuploader create-metadata \
     --name "${package}" \
     --version "${version}" \
     --language cpp
-  env -C "${docs_dir}" python3 -m docuploader upload . --staging-bucket "${bucket}"
+  env -C "${docs_dir}" "${PROJECT_ROOT}/ci/retry-command.sh" 3 120 \
+    python3 -m docuploader upload . --staging-bucket "${bucket}"
 }
 
 io::log_h2 "Publishing docs"


### PR DESCRIPTION
Make multiple attempts to upload the documentation tarballs.  The
`docuploader` Python module does not do this automatically, and changing
it looks more complicated than I expected.

Fixes #9012

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9079)
<!-- Reviewable:end -->
