### PR TITLE
test(spanner): expose spanner::MakeTestRow() as spanner_mocks::MakeRow()

### DIFF
--- a/google/cloud/spanner/BUILD.bazel
+++ b/google/cloud/spanner/BUILD.bazel
@@ -119,8 +119,9 @@ load(":spanner_client_benchmarks.bzl", "spanner_client_benchmarks")
     srcs = [benchmark],
     tags = ["benchmark"],
     deps = [
+        ":google_cloud_cpp_spanner",
+        ":google_cloud_cpp_spanner_mocks",
         "//:common",
-        "//:spanner",
         "@com_google_benchmark//:benchmark_main",
     ],
 ) for benchmark in spanner_client_benchmarks]

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -235,7 +235,8 @@ target_sources(
         ${CMAKE_CURRENT_SOURCE_DIR}/admin/mocks/mock_instance_admin_connection.h
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_database_admin_connection.h
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_instance_admin_connection.h
-        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_spanner_connection.h)
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/mock_spanner_connection.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks/row.h)
 target_link_libraries(
     google_cloud_cpp_spanner_mocks
     INTERFACE google-cloud-cpp::spanner GTest::gmock_main GTest::gmock
@@ -415,8 +416,10 @@ function (spanner_client_define_benchmarks)
     foreach (fname ${spanner_client_benchmarks})
         google_cloud_cpp_add_executable(target "spanner" "${fname}")
         add_test(NAME ${target} COMMAND ${target})
-        target_link_libraries(${target} PRIVATE google-cloud-cpp::spanner
-                                                benchmark::benchmark_main)
+        target_link_libraries(
+            ${target}
+            PRIVATE google-cloud-cpp::spanner google-cloud-cpp::spanner_mocks
+                    benchmark::benchmark_main)
         google_cloud_cpp_add_common_options(${target})
 
         add_dependencies(spanner-client-benchmarks ${target})

--- a/google/cloud/spanner/client_test.cc
+++ b/google/cloud/spanner/client_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/spanner/connection.h"
 #include "google/cloud/spanner/internal/defaults.h"
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
+#include "google/cloud/spanner/mocks/row.h"
 #include "google/cloud/spanner/mutations.h"
 #include "google/cloud/spanner/results.h"
 #include "google/cloud/spanner/timestamp.h"
@@ -99,8 +100,8 @@ TEST(ClientTest, ReadSuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Steve", 12)))
-      .WillOnce(Return(MakeTestRow("Ann", 42)))
+      .WillOnce(Return(spanner_mocks::MakeRow("Steve", 12)))
+      .WillOnce(Return(spanner_mocks::MakeRow("Ann", 42)))
       .WillOnce(Return(Row()));
 
   EXPECT_CALL(*conn, Read)
@@ -140,8 +141,8 @@ TEST(ClientTest, ReadFailure) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Steve")))
-      .WillOnce(Return(MakeTestRow("Ann")))
+      .WillOnce(Return(spanner_mocks::MakeRow("Steve")))
+      .WillOnce(Return(spanner_mocks::MakeRow("Ann")))
       .WillOnce(Return(Status(StatusCode::kDeadlineExceeded, "deadline!")));
 
   EXPECT_CALL(*conn, Read)
@@ -186,8 +187,8 @@ TEST(ClientTest, ExecuteQuerySuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Steve", 12)))
-      .WillOnce(Return(MakeTestRow("Ann", 42)))
+      .WillOnce(Return(spanner_mocks::MakeRow("Steve", 12)))
+      .WillOnce(Return(spanner_mocks::MakeRow("Ann", 42)))
       .WillOnce(Return(Row()));
 
   EXPECT_CALL(*conn, ExecuteQuery)
@@ -227,8 +228,8 @@ TEST(ClientTest, ExecuteQueryFailure) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Steve")))
-      .WillOnce(Return(MakeTestRow("Ann")))
+      .WillOnce(Return(spanner_mocks::MakeRow("Steve")))
+      .WillOnce(Return(spanner_mocks::MakeRow("Ann")))
       .WillOnce(Return(Status(StatusCode::kDeadlineExceeded, "deadline!")));
 
   EXPECT_CALL(*conn, ExecuteQuery)
@@ -435,7 +436,7 @@ TEST(ClientTest, CommitMutatorSuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText, &metadata));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Bob")))
+      .WillOnce(Return(spanner_mocks::MakeRow("Bob")))
       .WillOnce(Return(Row()));
 
   EXPECT_CALL(*conn, Read)
@@ -1006,7 +1007,7 @@ TEST(ClientTest, ProfileQuerySuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText1, &stats));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Ann", 42)))
+      .WillOnce(Return(spanner_mocks::MakeRow("Ann", 42)))
       .WillOnce(Return(Row()));
   EXPECT_CALL(*source, Stats()).WillRepeatedly(Return(stats));
 
@@ -1070,7 +1071,7 @@ TEST(ClientTest, ProfileQueryWithOptionsSuccess) {
   ASSERT_TRUE(TextFormat::ParseFromString(kText1, &stats));
   EXPECT_CALL(*source, Metadata()).WillRepeatedly(Return(metadata));
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(MakeTestRow("Ann", 42)))
+      .WillOnce(Return(spanner_mocks::MakeRow("Ann", 42)))
       .WillOnce(Return(Row()));
   EXPECT_CALL(*source, Stats()).WillRepeatedly(Return(stats));
 

--- a/google/cloud/spanner/google_cloud_cpp_spanner_mocks.bzl
+++ b/google/cloud/spanner/google_cloud_cpp_spanner_mocks.bzl
@@ -22,6 +22,7 @@ google_cloud_cpp_spanner_mocks_hdrs = [
     "mocks/mock_database_admin_connection.h",
     "mocks/mock_instance_admin_connection.h",
     "mocks/mock_spanner_connection.h",
+    "mocks/row.h",
 ]
 
 google_cloud_cpp_spanner_mocks_srcs = [

--- a/google/cloud/spanner/internal/partial_result_set_source_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/partial_result_set_source.h"
+#include "google/cloud/spanner/mocks/row.h"
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/testing/mock_partial_result_set_reader.h"
 #include "google/cloud/spanner/value.h"
@@ -33,7 +34,6 @@ namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::spanner::MakeTestRow;
 using ::google::cloud::spanner_testing::MockPartialResultSetReader;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::StatusIs;
@@ -133,8 +133,8 @@ TEST(PartialResultSetSourceTest, ReadSuccessThenFailure) {
   internal::OptionsSpan overlay(Options{}.set<StringOption>("uh-oh"));
   auto reader = CreatePartialResultSetSource(std::move(grpc_reader));
   EXPECT_STATUS_OK(reader.status());
-  EXPECT_THAT((*reader)->NextRow(),
-              IsValidAndEquals(MakeTestRow({{"AnInt", spanner::Value(80)}})));
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow(
+                                        {{"AnInt", spanner::Value(80)}})));
   auto row = (*reader)->NextRow();
   EXPECT_THAT(row, StatusIs(StatusCode::kCancelled, "cancelled"));
 }
@@ -271,7 +271,7 @@ TEST(PartialResultSetSourceTest, SingleResponse) {
   EXPECT_THAT(*actual_metadata, IsProtoEqual(expected_metadata));
 
   // Verify the returned rows are correct.
-  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(MakeTestRow({
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow({
                                         {"UserId", spanner::Value(10)},
                                         {"UserName", spanner::Value("user10")},
                                     })));
@@ -375,16 +375,16 @@ TEST(PartialResultSetSourceTest, MultipleResponses) {
   EXPECT_STATUS_OK(reader.status());
 
   // Verify the returned rows are correct.
-  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(MakeTestRow({
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow({
                                         {"UserId", spanner::Value(10)},
                                         {"UserName", spanner::Value("user10")},
                                     })));
-  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(MakeTestRow({
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow({
                                         {"UserId", spanner::Value(22)},
                                         {"UserName", spanner::Value("user22")},
                                     })));
   EXPECT_THAT((*reader)->NextRow(),
-              IsValidAndEquals(MakeTestRow({
+              IsValidAndEquals(spanner_mocks::MakeRow({
                   {"UserId", spanner::Value(99)},
                   {"UserName", spanner::Value("99user99")},
               })));
@@ -432,8 +432,8 @@ TEST(PartialResultSetSourceTest, ResponseWithNoValues) {
   EXPECT_STATUS_OK(reader.status());
 
   // Verify the returned row is correct.
-  EXPECT_THAT((*reader)->NextRow(),
-              IsValidAndEquals(MakeTestRow({{"UserId", spanner::Value(22)}})));
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow(
+                                        {{"UserId", spanner::Value(22)}})));
 
   // At end of stream, we get an 'ok' response with an empty row.
   EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner::Row{}));
@@ -501,9 +501,8 @@ TEST(PartialResultSetSourceTest, ChunkedStringValueWellFormed) {
        {"not_chunked", "first_chunksecond_chunkthird_chunk",
         "second group first_chunk second group second_chunk",
         "also not_chunked", "still not_chunked"}) {
-    EXPECT_THAT(
-        (*reader)->NextRow(),
-        IsValidAndEquals(MakeTestRow({{"Prose", spanner::Value(value)}})));
+    EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow(
+                                          {{"Prose", spanner::Value(value)}})));
   }
 
   // At end of stream, we get an 'ok' response with an empty row.
@@ -756,11 +755,11 @@ TEST(PartialResultSetSourceTest, ErrorOnIncompleteRow) {
   EXPECT_STATUS_OK(reader.status());
 
   // Verify the first two rows are correct.
-  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(MakeTestRow({
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow({
                                         {"UserId", spanner::Value(10)},
                                         {"UserName", spanner::Value("user10")},
                                     })));
-  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(MakeTestRow({
+  EXPECT_THAT((*reader)->NextRow(), IsValidAndEquals(spanner_mocks::MakeRow({
                                         {"UserId", spanner::Value(22)},
                                         {"UserName", spanner::Value("user22")},
                                     })));

--- a/google/cloud/spanner/mocks/row.h
+++ b/google/cloud/spanner/mocks/row.h
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_MOCKS_ROW_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_MOCKS_ROW_H
+
+#include "google/cloud/spanner/row.h"
+#include "google/cloud/spanner/value.h"
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace spanner_mocks {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Creates a `spanner::Row` with the specified column names and values.
+ *
+ * This overload accepts a vector of pairs, allowing the caller to specify both
+ * the column names and the `spanner::Value` that goes in each column.
+ *
+ * This function is intended for application developers who are mocking the
+ * results of a `Client::ExecuteQuery` call.
+ */
+inline spanner::Row MakeRow(
+    std::vector<std::pair<std::string, spanner::Value>> pairs) {
+  return spanner::MakeTestRow(std::move(pairs));
+}
+
+/**
+ * Creates a `spanner::Row` with `spanner::Value`s created from the given
+ * arguments and with auto-generated column names.
+ *
+ * This overload accepts a variadic list of arguments that will be used to
+ * create the `spanner::Value`s in the row. The column names will be implicitly
+ * generated, the first column being "0", the second "1", and so on,
+ * corresponding to the argument's position.
+ *
+ * This function is intended for application developers who are mocking the
+ * results of a `Client::ExecuteQuery` call.
+ */
+template <typename... Ts>
+spanner::Row MakeRow(Ts&&... ts) {
+  return spanner::MakeTestRow(std::forward<Ts>(ts)...);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner_mocks
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_MOCKS_ROW_H

--- a/google/cloud/spanner/results_test.cc
+++ b/google/cloud/spanner/results_test.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/spanner/results.h"
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
+#include "google/cloud/spanner/mocks/row.h"
 #include "google/cloud/spanner/timestamp.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
@@ -54,8 +55,8 @@ TEST(RowStream, IterateNoRows) {
 TEST(RowStream, IterateOverRows) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
   EXPECT_CALL(*mock_source, NextRow())
-      .WillOnce(Return(MakeTestRow(5, true, "foo")))
-      .WillOnce(Return(MakeTestRow(10, false, "bar")))
+      .WillOnce(Return(spanner_mocks::MakeRow(5, true, "foo")))
+      .WillOnce(Return(spanner_mocks::MakeRow(10, false, "bar")))
       .WillOnce(Return(Row()));
 
   RowStream rows(std::move(mock_source));
@@ -87,7 +88,7 @@ TEST(RowStream, IterateOverRows) {
 TEST(RowStream, IterateError) {
   auto mock_source = absl::make_unique<MockResultSetSource>();
   EXPECT_CALL(*mock_source, NextRow())
-      .WillOnce(Return(MakeTestRow(5, true, "foo")))
+      .WillOnce(Return(spanner_mocks::MakeRow(5, true, "foo")))
       .WillOnce(Return(Status(StatusCode::kUnknown, "oops")));
 
   RowStream rows(std::move(mock_source));

--- a/google/cloud/spanner/row_benchmark.cc
+++ b/google/cloud/spanner/row_benchmark.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "google/cloud/spanner/mocks/row.h"
 #include "google/cloud/spanner/row.h"
 #include <benchmark/benchmark.h>
 
@@ -35,7 +36,7 @@ namespace {
 // BM_RowGetByColumnName               195 ns          194 ns      3590333
 
 void BM_RowGetByPosition(benchmark::State& state) {
-  Row row = MakeTestRow(1, "blah", true);
+  Row row = spanner_mocks::MakeRow(1, "blah", true);
   for (auto _ : state) {
     benchmark::DoNotOptimize(row.get(0));
     benchmark::DoNotOptimize(row.get(1));
@@ -45,7 +46,7 @@ void BM_RowGetByPosition(benchmark::State& state) {
 BENCHMARK(BM_RowGetByPosition);
 
 void BM_RowGetByColumnName(benchmark::State& state) {
-  Row row = MakeTestRow({
+  Row row = spanner_mocks::MakeRow({
       {"a", Value(1)},       //
       {"b", Value("blah")},  //
       {"c", Value(true)}     //

--- a/google/cloud/spanner/row_test.cc
+++ b/google/cloud/spanner/row_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/row.h"
+#include "google/cloud/spanner/mocks/row.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <tuple>
@@ -64,7 +65,7 @@ TEST(Row, DefaultConstruct) {
 }
 
 TEST(Row, ValueSemantics) {
-  Row row = MakeTestRow(1, "blah", true);
+  Row row = spanner_mocks::MakeRow(1, "blah", true);
 
   Row copy = row;
   EXPECT_EQ(copy, row);
@@ -83,7 +84,7 @@ TEST(Row, ValueSemantics) {
 TEST(Row, BasicAccessors) {
   auto values = std::vector<Value>{Value(1), Value("blah"), Value(true)};
   auto columns = std::vector<std::string>{"a", "b", "c"};
-  Row row = MakeTestRow({
+  Row row = spanner_mocks::MakeRow({
       {columns[0], values[0]},  //
       {columns[1], values[1]},  //
       {columns[2], values[2]}   //
@@ -96,7 +97,7 @@ TEST(Row, BasicAccessors) {
 }
 
 TEST(Row, GetByPosition) {
-  Row row = MakeTestRow(1, "blah", true);
+  Row row = spanner_mocks::MakeRow(1, "blah", true);
 
   EXPECT_STATUS_OK(row.get(0));
   EXPECT_STATUS_OK(row.get(1));
@@ -109,7 +110,7 @@ TEST(Row, GetByPosition) {
 }
 
 TEST(Row, GetByColumnName) {
-  Row row = MakeTestRow({
+  Row row = spanner_mocks::MakeRow({
       {"a", Value(1)},       //
       {"b", Value("blah")},  //
       {"c", Value(true)}     //
@@ -126,7 +127,7 @@ TEST(Row, GetByColumnName) {
 }
 
 TEST(Row, TemplatedGetByPosition) {
-  Row row = MakeTestRow(1, "blah", true);
+  Row row = spanner_mocks::MakeRow(1, "blah", true);
 
   EXPECT_STATUS_OK(row.get<std::int64_t>(0));
   EXPECT_STATUS_OK(row.get<std::string>(1));
@@ -144,7 +145,7 @@ TEST(Row, TemplatedGetByPosition) {
 }
 
 TEST(Row, TemplatedGetByColumnName) {
-  Row row = MakeTestRow({
+  Row row = spanner_mocks::MakeRow({
       {"a", Value(1)},       //
       {"b", Value("blah")},  //
       {"c", Value(true)}     //
@@ -166,7 +167,7 @@ TEST(Row, TemplatedGetByColumnName) {
 }
 
 TEST(Row, TemplatedGetAsTuple) {
-  Row row = MakeTestRow(1, "blah", true);
+  Row row = spanner_mocks::MakeRow(1, "blah", true);
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
   EXPECT_STATUS_OK(row.get<RowType>());
@@ -190,14 +191,14 @@ TEST(Row, TemplatedGetAsTuple) {
   EXPECT_EQ(std::make_tuple(1, "blah", true), *std::move(row).get<RowType>());
 }
 
-TEST(MakeTestRow, ExplicitColumnNames) {
-  auto row = MakeTestRow({{"a", Value(42)}, {"b", Value(52)}});
+TEST(MakeRow, ExplicitColumnNames) {
+  auto row = spanner_mocks::MakeRow({{"a", Value(42)}, {"b", Value(52)}});
   EXPECT_EQ(Value(42), *row.get("a"));
   EXPECT_EQ(Value(52), *row.get("b"));
 }
 
-TEST(MakeTestRow, ImplicitColumnNames) {
-  auto row = MakeTestRow(42, 52);
+TEST(MakeRow, ImplicitColumnNames) {
+  auto row = spanner_mocks::MakeRow(42, 52);
   EXPECT_EQ(Value(42), *row.get("0"));
   EXPECT_EQ(Value(52), *row.get("1"));
 }
@@ -207,9 +208,9 @@ TEST(RowStreamIterator, Basics) {
   EXPECT_EQ(end, end);
 
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
-  rows.emplace_back(MakeTestRow(2, "bar", true));
-  rows.emplace_back(MakeTestRow(3, "baz", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(2, "bar", true));
+  rows.emplace_back(spanner_mocks::MakeRow(3, "baz", true));
 
   auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_EQ(it, it);
@@ -250,7 +251,7 @@ TEST(RowStreamIterator, Empty) {
 TEST(RowStreamIterator, OneRow) {
   RowStreamIterator end;
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
   auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_NE(it, end);
   EXPECT_STATUS_OK(*it);
@@ -264,9 +265,9 @@ TEST(RowStreamIterator, OneRow) {
 TEST(RowStreamIterator, IterationError) {
   RowStreamIterator end;
   std::vector<StatusOr<Row>> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
   rows.emplace_back(Status(StatusCode::kUnknown, "some error"));
-  rows.emplace_back(MakeTestRow(2, "bar", true));
+  rows.emplace_back(spanner_mocks::MakeRow(2, "bar", true));
 
   auto it = RowStreamIterator(MakeRowStreamIteratorSource(rows));
   EXPECT_NE(it, end);
@@ -286,9 +287,9 @@ TEST(RowStreamIterator, IterationError) {
 
 TEST(RowStreamIterator, ForLoop) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(3)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(5)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(3)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(5)}}));
 
   auto source = MakeRowStreamIteratorSource(rows);
   std::int64_t product = 1;
@@ -303,9 +304,9 @@ TEST(RowStreamIterator, ForLoop) {
 
 TEST(RowStreamIterator, RangeForLoop) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(3)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(5)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(3)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(5)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   std::int64_t product = 1;
@@ -320,8 +321,8 @@ TEST(RowStreamIterator, RangeForLoop) {
 
 TEST(RowStreamIterator, MovedFromValueOk) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(1)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   auto it = range.begin();
@@ -348,9 +349,9 @@ TEST(RowStreamIterator, MovedFromValueOk) {
 
 TEST(TupleStreamIterator, Basics) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
-  rows.emplace_back(MakeTestRow(2, "bar", true));
-  rows.emplace_back(MakeTestRow(3, "baz", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(2, "bar", true));
+  rows.emplace_back(spanner_mocks::MakeRow(3, "baz", true));
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
   using TupleIterator = TupleStreamIterator<RowType>;
@@ -404,9 +405,9 @@ TEST(TupleStreamIterator, Empty) {
 
 TEST(TupleStreamIterator, Error) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
-  rows.emplace_back(MakeTestRow(2, "bar", "should be a bool"));
-  rows.emplace_back(MakeTestRow(3, "baz", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(2, "bar", "should be a bool"));
+  rows.emplace_back(spanner_mocks::MakeRow(3, "baz", true));
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
   using TupleIterator = TupleStreamIterator<RowType>;
@@ -434,8 +435,8 @@ TEST(TupleStreamIterator, Error) {
 
 TEST(TupleStreamIterator, MovedFromValueOk) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(1)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   using RowType = std::tuple<std::int64_t>;
@@ -460,9 +461,9 @@ TEST(TupleStreamIterator, MovedFromValueOk) {
 
 TEST(TupleStream, Basics) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
-  rows.emplace_back(MakeTestRow(2, "bar", true));
-  rows.emplace_back(MakeTestRow(3, "baz", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(2, "bar", true));
+  rows.emplace_back(spanner_mocks::MakeRow(3, "baz", true));
 
   using RowType = std::tuple<std::int64_t, std::string, bool>;
   RowRange range(MakeRowStreamIteratorSource(rows));
@@ -495,9 +496,9 @@ TEST(TupleStream, Basics) {
 
 TEST(TupleStream, RangeForLoop) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(3)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(5)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(3)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(5)}}));
   using RowType = std::tuple<std::int64_t>;
 
   RowRange range(MakeRowStreamIteratorSource(rows));
@@ -511,9 +512,9 @@ TEST(TupleStream, RangeForLoop) {
 
 TEST(TupleStream, IterationError) {
   std::vector<StatusOr<Row>> rows;
-  rows.emplace_back(MakeTestRow(1, "foo", true));
+  rows.emplace_back(spanner_mocks::MakeRow(1, "foo", true));
   rows.emplace_back(Status(StatusCode::kUnknown, "some error"));
-  rows.emplace_back(MakeTestRow(2, "bar", true));
+  rows.emplace_back(spanner_mocks::MakeRow(2, "bar", true));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
 
@@ -555,7 +556,7 @@ TEST(GetSingularRow, TupleStreamEmpty) {
 
 TEST(GetSingularRow, BasicSingleRow) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(1)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(range);
@@ -565,7 +566,7 @@ TEST(GetSingularRow, BasicSingleRow) {
 
 TEST(GetSingularRow, TupleStreamSingleRow) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(1)}}));
 
   auto row_range = RowRange(MakeRowStreamIteratorSource(rows));
   auto tup_range = StreamOf<std::tuple<std::int64_t>>(row_range);
@@ -577,8 +578,8 @@ TEST(GetSingularRow, TupleStreamSingleRow) {
 
 TEST(GetSingularRow, BasicTooManyRows) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(1)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(range);
@@ -588,8 +589,8 @@ TEST(GetSingularRow, BasicTooManyRows) {
 
 TEST(GetSingularRow, TupleStreamTooManyRows) {
   std::vector<Row> rows;
-  rows.emplace_back(MakeTestRow({{"num", Value(1)}}));
-  rows.emplace_back(MakeTestRow({{"num", Value(2)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(1)}}));
+  rows.emplace_back(spanner_mocks::MakeRow({{"num", Value(2)}}));
 
   RowRange range(MakeRowStreamIteratorSource(rows));
   auto row = GetSingularRow(StreamOf<std::tuple<std::int64_t>>(range));

--- a/google/cloud/spanner/samples/mock_execute_query.cc
+++ b/google/cloud/spanner/samples/mock_execute_query.cc
@@ -17,6 +17,7 @@
 //! [required-includes]
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/mocks/mock_spanner_connection.h"
+#include "google/cloud/spanner/mocks/row.h"
 #include "absl/memory/memory.h"
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
@@ -57,12 +58,12 @@ TEST(MockSpannerClient, SuccessfulExecuteQuery) {
   // Setup the mock source to return some values:
   //! [simulate-streaming-results]
   EXPECT_CALL(*source, NextRow())
-      .WillOnce(Return(
-          spanner::MakeTestRow({{"Id", spanner::Value(1)},
-                                {"Greeting", spanner::Value("Hello World")}})))
-      .WillOnce(Return(
-          spanner::MakeTestRow({{"Id", spanner::Value(2)},
-                                {"Greeting", spanner::Value("Hello World")}})))
+      .WillOnce(Return(google::cloud::spanner_mocks::MakeRow(
+          {{"Id", spanner::Value(1)},
+           {"Greeting", spanner::Value("Hello World")}})))
+      .WillOnce(Return(google::cloud::spanner_mocks::MakeRow(
+          {{"Id", spanner::Value(2)},
+           {"Greeting", spanner::Value("Hello World")}})))
       //! [simulate-streaming-results]
       //! [simulate-streaming-end]
       .WillOnce(Return(spanner::Row()));


### PR DESCRIPTION
Begin a migration of test-only code out of `google_cloud_cpp_spanner` and
into `google_cloud_cpp_spanner_mocks`.  Followup work will deprecate
`spanner::MakeTestRow()`.  The implementation probably can't move until
the deprecation is complete because of the restrictions on test-only
dependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9080)
<!-- Reviewable:end -->
