### PR TITLE
feat(bigtable): configure `*Client`s with `EndpointOption`

### DIFF
--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -79,9 +79,7 @@ Benchmark::Benchmark(BenchmarkOptions options)
     server_thread_ = std::thread([this]() { server_->Wait(); });
 
     opts_.set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
-        .set<DataEndpointOption>(address)
-        .set<AdminEndpointOption>(address)
-        .set<InstanceAdminEndpointOption>(address);
+        .set<EndpointOption>(address);
   }
 }
 
@@ -98,10 +96,8 @@ Benchmark::~Benchmark() {
 
 std::string Benchmark::CreateTable() {
   // Create the table, with an initial split.
-  auto admin_opts = opts_;
-  admin_opts.set<EndpointOption>(opts_.get<AdminEndpointOption>());
   auto admin = bigtable_admin::BigtableTableAdminClient(
-      bigtable_admin::MakeBigtableTableAdminConnection(admin_opts));
+      bigtable_admin::MakeBigtableTableAdminConnection(opts_));
 
   google::bigtable::admin::v2::CreateTableRequest r;
   r.set_parent(InstanceName(options_.project_id, options_.instance_id));
@@ -117,10 +113,8 @@ std::string Benchmark::CreateTable() {
 }
 
 void Benchmark::DeleteTable() {
-  auto admin_opts = opts_;
-  admin_opts.set<EndpointOption>(opts_.get<AdminEndpointOption>());
   auto admin = bigtable_admin::BigtableTableAdminClient(
-      bigtable_admin::MakeBigtableTableAdminConnection(admin_opts));
+      bigtable_admin::MakeBigtableTableAdminConnection(opts_));
   auto status = admin.DeleteTable(
       TableName(options_.project_id, options_.instance_id, options_.table_id));
   if (!status.ok()) {

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -73,7 +73,7 @@ TEST(EmbeddedServer, TableApply) {
   auto options =
       Options{}
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
-          .set<DataEndpointOption>(server->address());
+          .set<EndpointOption>(server->address());
 
   Table table(MakeDataClient("fake-project", "fake-instance", options),
               "fake-table");
@@ -98,7 +98,7 @@ TEST(EmbeddedServer, TableBulkApply) {
   auto options =
       Options{}
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
-          .set<DataEndpointOption>(server->address());
+          .set<EndpointOption>(server->address());
 
   Table table(MakeDataClient("fake-project", "fake-instance", options),
               "fake-table");
@@ -125,7 +125,7 @@ TEST(EmbeddedServer, ReadRows1) {
   auto options =
       Options{}
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
-          .set<DataEndpointOption>(server->address());
+          .set<EndpointOption>(server->address());
 
   Table table(MakeDataClient("fake-project", "fake-instance", options),
               "fake-table");
@@ -147,7 +147,7 @@ TEST(EmbeddedServer, ReadRows100) {
   auto options =
       Options{}
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
-          .set<DataEndpointOption>(server->address());
+          .set<EndpointOption>(server->address());
 
   Table table(MakeDataClient("fake-project", "fake-instance", options),
               "fake-table");

--- a/google/cloud/bigtable/client_options.h
+++ b/google/cloud/bigtable/client_options.h
@@ -124,10 +124,11 @@ class ClientOptions {
    * Return the current endpoint for data RPCs.
    *
    * @deprecated Please configure `google::cloud::Options` with
-   *     `bigtable::DataEndpointOption` instead.
+   *     `google::cloud::EndpointOption` instead.
    */
   GOOGLE_CLOUD_CPP_DEPRECATED(
-      "use `google::cloud::Options` with `DataEndpointOption` instead")
+      "use `google::cloud::Options` with `google::cloud::EndpointOption` "
+      "instead")
   std::string const& data_endpoint() const {
     return opts_.get<DataEndpointOption>();
   }
@@ -136,10 +137,11 @@ class ClientOptions {
    * Set the current endpoint for data RPCs.
    *
    * @deprecated Please configure `google::cloud::Options` with
-   *     `bigtable::DataEndpointOption` instead.
+   *     `google::cloud::EndpointOption` instead.
    */
   GOOGLE_CLOUD_CPP_DEPRECATED(
-      "use `google::cloud::Options` with `DataEndpointOption` instead")
+      "use `google::cloud::Options` with `google::cloud::EndpointOption` "
+      "instead")
   ClientOptions& set_data_endpoint(std::string endpoint) {
     opts_.set<DataEndpointOption>(std::move(endpoint));
     return *this;
@@ -149,12 +151,11 @@ class ClientOptions {
    * Return the current endpoint for admin RPCs.
    *
    * @deprecated Please configure `google::cloud::Options` with
-   *     `bigtable::AdminEndpointOption` and
-   *     `bigtable::InstanceAdminEndpointOption` instead.
+   *     `google::cloud::EndpointOption` instead.
    */
   GOOGLE_CLOUD_CPP_DEPRECATED(
-      "use `google::cloud::Options` with `AdminEndpointOption` and "
-      "`InstanceAdminEndpointOption` instead")
+      "use `google::cloud::Options` with `google::cloud::EndpointOption` "
+      "instead")
   std::string const& admin_endpoint() const {
     return opts_.get<AdminEndpointOption>();
   }
@@ -163,12 +164,11 @@ class ClientOptions {
    * Set the current endpoint for admin RPCs.
    *
    * @deprecated Please configure `google::cloud::Options` with
-   *     `bigtable::AdminEndpointOption` and
-   *     `bigtable::InstanceAdminEndpointOption` instead.
+   *     `google::cloud::EndpointOption` instead.
    */
   GOOGLE_CLOUD_CPP_DEPRECATED(
-      "use `google::cloud::Options` with `AdminEndpointOption` and "
-      "`InstanceAdminEndpointOption` instead")
+      "use `google::cloud::Options` with `google::cloud::EndpointOption` "
+      "instead")
   ClientOptions& set_admin_endpoint(std::string endpoint) {
     opts_.set<AdminEndpointOption>(endpoint);
     // These two endpoints are generally equivalent, but they may differ in

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -81,9 +81,15 @@ Options DefaultOptions(Options opts) {
 
   if (opts.has<EndpointOption>()) {
     auto const& ep = opts.get<EndpointOption>();
-    opts.set<DataEndpointOption>(ep);
-    opts.set<AdminEndpointOption>(ep);
-    opts.set<InstanceAdminEndpointOption>(ep);
+    if (!opts.has<DataEndpointOption>()) {
+      opts.set<DataEndpointOption>(ep);
+    }
+    if (!opts.has<AdminEndpointOption>()) {
+      opts.set<AdminEndpointOption>(ep);
+    }
+    if (!opts.has<InstanceAdminEndpointOption>()) {
+      opts.set<InstanceAdminEndpointOption>(ep);
+    }
   }
 
   auto emulator = GetEnv("BIGTABLE_EMULATOR_HOST");

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -79,6 +79,13 @@ int DefaultConnectionPoolSize() {
 Options DefaultOptions(Options opts) {
   using ::google::cloud::internal::GetEnv;
 
+  if (opts.has<EndpointOption>()) {
+    auto const& ep = opts.get<EndpointOption>();
+    opts.set<DataEndpointOption>(ep);
+    opts.set<AdminEndpointOption>(ep);
+    opts.set<InstanceAdminEndpointOption>(ep);
+  }
+
   auto emulator = GetEnv("BIGTABLE_EMULATOR_HOST");
   if (emulator) {
     opts.set<DataEndpointOption>(*emulator);

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -125,12 +125,30 @@ TEST(OptionsTest, DefaultOptionsDoesNotOverride) {
   EXPECT_THAT(*s, HasSubstr("test-prefix"));
 }
 
+TEST(OptionsTest, EndpointOptionSetsAll) {
+  auto options =
+      Options{}
+          .set<EndpointOption>("endpoint-option")
+          .set<DataEndpointOption>("overridden-data")
+          .set<AdminEndpointOption>("overridden-table-admin")
+          .set<InstanceAdminEndpointOption>("overridden-instance-admin");
+  options = DefaultOptions(std::move(options));
+  EXPECT_EQ("endpoint-option", options.get<EndpointOption>());
+  EXPECT_EQ("endpoint-option", options.get<DataEndpointOption>());
+  EXPECT_EQ("endpoint-option", options.get<AdminEndpointOption>());
+  EXPECT_EQ("endpoint-option", options.get<InstanceAdminEndpointOption>());
+}
+
 TEST(OptionsTest, DefaultDataOptionsEndpoint) {
   auto options =
       Options{}
           .set<DataEndpointOption>("data.googleapis.com")
           .set<AdminEndpointOption>("tableadmin.googleapis.com")
           .set<InstanceAdminEndpointOption>("instanceadmin.googleapis.com");
+  options = DefaultDataOptions(std::move(options));
+  EXPECT_EQ("data.googleapis.com", options.get<EndpointOption>());
+
+  options = Options{}.set<EndpointOption>("data.googleapis.com");
   options = DefaultDataOptions(std::move(options));
   EXPECT_EQ("data.googleapis.com", options.get<EndpointOption>());
 }
@@ -143,6 +161,10 @@ TEST(OptionsTest, DefaultInstanceAdminOptions) {
           .set<InstanceAdminEndpointOption>("instanceadmin.googleapis.com");
   options = DefaultInstanceAdminOptions(std::move(options));
   EXPECT_EQ("instanceadmin.googleapis.com", options.get<EndpointOption>());
+
+  options = Options{}.set<EndpointOption>("instanceadmin.googleapis.com");
+  options = DefaultInstanceAdminOptions(std::move(options));
+  EXPECT_EQ("instanceadmin.googleapis.com", options.get<EndpointOption>());
 }
 
 TEST(OptionsTest, DefaultTableAdminOptions) {
@@ -151,6 +173,10 @@ TEST(OptionsTest, DefaultTableAdminOptions) {
           .set<DataEndpointOption>("data.googleapis.com")
           .set<AdminEndpointOption>("tableadmin.googleapis.com")
           .set<InstanceAdminEndpointOption>("instanceadmin.googleapis.com");
+  options = DefaultTableAdminOptions(std::move(options));
+  EXPECT_EQ("tableadmin.googleapis.com", options.get<EndpointOption>());
+
+  options = Options{}.set<EndpointOption>("tableadmin.googleapis.com");
   options = DefaultTableAdminOptions(std::move(options));
   EXPECT_EQ("tableadmin.googleapis.com", options.get<EndpointOption>());
 }
@@ -220,6 +246,7 @@ TEST(EndpointEnvTest, EmulatorEnvOverridesUserOptions) {
 
   auto opts = DefaultOptions(
       Options{}
+          .set<EndpointOption>("ignored-any")
           .set<DataEndpointOption>("ignored-data")
           .set<AdminEndpointOption>("ignored-admin")
           .set<InstanceAdminEndpointOption>("ignored-instance-admin"));
@@ -234,7 +261,9 @@ TEST(EndpointEnvTest, InstanceEmulatorEnvOverridesUserOption) {
                                       "instance-emulator-host:9000");
 
   auto opts = DefaultOptions(
-      Options{}.set<InstanceAdminEndpointOption>("ignored-instance-admin"));
+      Options{}
+          .set<EndpointOption>("ignored-any")
+          .set<InstanceAdminEndpointOption>("ignored-instance-admin"));
 
   EXPECT_EQ("instance-emulator-host:9000",
             opts.get<InstanceAdminEndpointOption>());

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -126,17 +126,24 @@ TEST(OptionsTest, DefaultOptionsDoesNotOverride) {
 }
 
 TEST(OptionsTest, EndpointOptionSetsAll) {
-  auto options =
-      Options{}
-          .set<EndpointOption>("endpoint-option")
-          .set<DataEndpointOption>("overridden-data")
-          .set<AdminEndpointOption>("overridden-table-admin")
-          .set<InstanceAdminEndpointOption>("overridden-instance-admin");
+  auto options = Options{}.set<EndpointOption>("endpoint-option");
   options = DefaultOptions(std::move(options));
   EXPECT_EQ("endpoint-option", options.get<EndpointOption>());
   EXPECT_EQ("endpoint-option", options.get<DataEndpointOption>());
   EXPECT_EQ("endpoint-option", options.get<AdminEndpointOption>());
   EXPECT_EQ("endpoint-option", options.get<InstanceAdminEndpointOption>());
+}
+
+TEST(OptionsTest, EndpointOptionOverridden) {
+  auto options = Options{}
+                     .set<EndpointOption>("ignored")
+                     .set<DataEndpointOption>("data")
+                     .set<AdminEndpointOption>("table-admin")
+                     .set<InstanceAdminEndpointOption>("instance-admin");
+  options = DefaultOptions(std::move(options));
+  EXPECT_EQ("data", options.get<DataEndpointOption>());
+  EXPECT_EQ("table-admin", options.get<AdminEndpointOption>());
+  EXPECT_EQ("instance-admin", options.get<InstanceAdminEndpointOption>());
 }
 
 TEST(OptionsTest, DefaultDataOptionsEndpoint) {

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -51,12 +51,20 @@ namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-/// The endpoint for data operations.
+/**
+ * The endpoint for data operations.
+ *
+ * @deprecated Please use `google::cloud::EndpointOption` instead.
+ */
 struct DataEndpointOption {
   using Type = std::string;
 };
 
-/// The endpoint for table admin operations.
+/**
+ * The endpoint for table admin operations.
+ *
+ * @deprecated Please use `google::cloud::EndpointOption` instead.
+ */
 struct AdminEndpointOption {
   using Type = std::string;
 };
@@ -67,6 +75,8 @@ struct AdminEndpointOption {
  * In most scenarios this should have the same value as `AdminEndpointOption`.
  * The most common exception is testing, where the emulator for instance admin
  * operations may be different than the emulator for admin and data operations.
+ *
+ * @deprecated Please use `google::cloud::EndpointOption` instead.
  */
 struct InstanceAdminEndpointOption {
   using Type = std::string;


### PR DESCRIPTION
Fixes #9027 and does a tiny bit of the work for #9081 

This change:
1. Makes it possible to use `EndpointOption` with `DataClient`, `AdminClient`, and `InstanceAdminClient`
2. Recommends against using `DataEndpointOption`, `AdminEndpointOption`, and `InstanceAdminEndpointOption` to configure the above classes in documentation only.

Note that our `Default*Options()` functions expect `DefaultOptions()` to provide input via `*EndpointOption`. (for example [here](https://github.com/googleapis/google-cloud-cpp/blob/7b535eeb2db520e47988a02e6601199268a2fa08/google/cloud/bigtable/internal/defaults.cc#L199-L200)). I will clean this stuff up as part of #9081.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9082)
<!-- Reviewable:end -->
