### PR TITLE
test(spanner): start deprecation period for spanner::MakeTestRow()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,18 @@ on it.
 For status on this, see https://github.com/googleapis/google-cloud-cpp/issues/8854
 </details>
 
+<details>
+<summary>2023-06-01: remove `spanner::MakeTestRow()`</summary>
+<br>
+
+* On 2023-06-01 (or shortly after) we will remove `spanner::MakeTestRow()`,
+  which has been replaced by `spanner_mocks::MakeRow()`. Starting with the
+  v1.41.0 release, and depending on your compiler settings, using
+  `spanner::MakeTestRow()` may elicit a deprecation warning. See
+  [#9086](https://github.com/googleapis/google-cloud-cpp/issues/9086) for more
+  details.
+</details>
+
 ## v1.41.0 - TBD
 
 ### [IAM](https://github.com/googleapis/google-cloud-cpp/blob/main/google/cloud/iam/README.md)

--- a/google/cloud/spanner/mocks/row.h
+++ b/google/cloud/spanner/mocks/row.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/spanner/row.h"
 #include "google/cloud/spanner/value.h"
+#include "google/cloud/version.h"
 #include <string>
 #include <utility>
 #include <vector>
@@ -25,6 +26,9 @@ namespace google {
 namespace cloud {
 namespace spanner_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+// TODO(#9086): Delete this when the MakeRow() implementation is moved here.
+#include "google/cloud/internal/disable_deprecation_warnings.inc"
 
 /**
  * Creates a `spanner::Row` with the specified column names and values.
@@ -56,6 +60,9 @@ template <typename... Ts>
 spanner::Row MakeRow(Ts&&... ts) {
   return spanner::MakeTestRow(std::forward<Ts>(ts)...);
 }
+
+// TODO(#9086): Delete this when the MakeRow() implementation is moved here.
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace spanner_mocks

--- a/google/cloud/spanner/row.h
+++ b/google/cloud/spanner/row.h
@@ -80,9 +80,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  *   std::cout << "LastName=" << *x << "\n";
  * }
  * @endcode
- *
- * @note There is a helper function defined below named `MakeTestRow()` to make
- *     creating `Row` instances for testing easier.
  */
 class Row {
  public:
@@ -211,6 +208,7 @@ class Row {
  * This function is intended for application developers who are mocking the
  * results of a `Client::ExecuteQuery` call.
  */
+GOOGLE_CLOUD_CPP_SPANNER_MAKE_TEST_ROW_DEPRECATED()
 Row MakeTestRow(std::vector<std::pair<std::string, Value>> pairs);
 
 /**
@@ -226,6 +224,7 @@ Row MakeTestRow(std::vector<std::pair<std::string, Value>> pairs);
  * results of a `Client::ExecuteQuery` call.
  */
 template <typename... Ts>
+GOOGLE_CLOUD_CPP_SPANNER_MAKE_TEST_ROW_DEPRECATED()
 Row MakeTestRow(Ts&&... ts) {
   auto columns = std::make_shared<std::vector<std::string>>();
   for (std::size_t i = 0; i < sizeof...(ts); ++i) {

--- a/google/cloud/spanner/version.h
+++ b/google/cloud/spanner/version.h
@@ -27,6 +27,13 @@
       " Please use google::cloud::spanner_admin::" name                     \
       " instead. See GitHub issue #7356 for more information.")
 
+#define GOOGLE_CLOUD_CPP_SPANNER_MAKE_TEST_ROW_DEPRECATED()      \
+  GOOGLE_CLOUD_CPP_DEPRECATED(                                   \
+      "google::cloud::spanner::MakeTestRow() is deprecated, and" \
+      " will be removed on or shortly after 2023-06-01. Please"  \
+      " use google::cloud::spanner_mocks::MakeRow() instead."    \
+      " See GitHub issue #9086 for more information.")
+
 // This preprocessor symbol is deprecated and should never be used anywhere. It
 // exists solely for backward compatibility to avoid breaking anyone who may
 // have been using it.


### PR DESCRIPTION
See #9086 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9087)
<!-- Reviewable:end -->
