### PR TITLE
ci: update code coverage uploader

### DIFF
--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -86,7 +86,7 @@ time {
   # Verifies the codecov uploader before executing it.
   curl -sSL -o /var/tmp/codecov https://uploader.codecov.io/v0.2.3/linux/codecov
   sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
-  if ! sha256sum -c <(echo "${sha256sum} -") </var/tmp/codecov; then
+  if ! sha256sum -b -c <(echo "${sha256sum} -") </var/tmp/codecov; then
     io::log_h2 "ERROR: Invalid sha256sum for codecov program"
     exit 1
   fi

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -86,7 +86,7 @@ time {
   # Verifies the codecov uploader before executing it.
   curl -sSL -o /var/tmp/codecov https://uploader.codecov.io/v0.2.3/linux/codecov
   sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
-  if ! sha256sum -b -c <(echo "${sha256sum} -") </var/tmp/codecov; then
+  if ! sha256sum -c <(echo "${sha256sum} -") </var/tmp/codecov; then
     io::log_h2 "ERROR: Invalid sha256sum for codecov program"
     exit 1
   fi

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -83,13 +83,14 @@ io::log_h2 "Uploading ${MERGED_COVERAGE} to codecov.io"
 io::log "Flags: ${codecov_args[*]}"
 TIMEFORMAT="==> 🕑 codecov.io upload done in %R seconds"
 time {
-  # Verifies the codecov uploader before executing it.
-  curl -sSL -o /var/tmp/codecov https://uploader.codecov.io/v0.2.3/linux/codecov
+  # Downloads and verifies the codecov uploader before executing it.
+  codecov="$(mktemp -u -t codecov.XXXXXXXXXX)"
+  curl -sSL -o "${codecov}" https://uploader.codecov.io/v0.2.3/linux/codecov
   sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
-  if ! sha256sum -c <(echo "${sha256sum} *-") </var/tmp/codecov; then
+  if ! sha256sum -c <(echo "${sha256sum} *${codecov}") <"${codecov}"; then
     io::log_h2 "ERROR: Invalid sha256sum for codecov program"
     exit 1
   fi
-  chmod +x /var/tmp/codecov
-  env -i HOME="${HOME}" /var/tmp/codecov -t "${CODECOV_TOKEN}" "${codecov_args[@]}"
+  chmod +x "${codecov}"
+  env -i HOME="${HOME}" "${codecov}" -t "${CODECOV_TOKEN}" "${codecov_args[@]}"
 }

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -87,10 +87,11 @@ time {
   codecov="$(mktemp -u -t codecov.XXXXXXXXXX)"
   curl -sSL -o "${codecov}" https://uploader.codecov.io/v0.2.3/linux/codecov
   sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
-  if ! sha256sum -c <(echo "${sha256sum} *${codecov}") <"${codecov}"; then
+  if ! sha256sum -c <(echo "${sha256sum} *${codecov}"); then
     io::log_h2 "ERROR: Invalid sha256sum for codecov program"
     exit 1
   fi
   chmod +x "${codecov}"
   env -i HOME="${HOME}" "${codecov}" -t "${CODECOV_TOKEN}" "${codecov_args[@]}"
+  rm "${codecov}"
 }

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -94,6 +94,5 @@ time {
     exit 1
   fi
   chmod +x /var/tmp/codecov
-  env -i CODECOV_TOKEN="${CODECOV_TOKEN:-}" HOME="${HOME}" \
-    /var/tmp/codecov -t "${CODECOV_TOKEN}" "${codecov_args[@]}"
+  env -i HOME="${HOME}" /var/tmp/codecov -t "${CODECOV_TOKEN}" "${codecov_args[@]}"
 }

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -86,7 +86,7 @@ time {
   # Verifies the codecov uploader before executing it.
   curl -sSL -o /var/tmp/codecov https://uploader.codecov.io/v0.2.3/linux/codecov
   sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
-  if ! sha256sum -c <(echo "${sha256sum} -") </var/tmp/codecov; then
+  if ! sha256sum -c <(echo "${sha256sum} *-") </var/tmp/codecov; then
     io::log_h2 "ERROR: Invalid sha256sum for codecov program"
     exit 1
   fi

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -83,14 +83,11 @@ io::log_h2 "Uploading ${MERGED_COVERAGE} to codecov.io"
 io::log "Flags: ${codecov_args[*]}"
 TIMEFORMAT="==> 🕑 codecov.io upload done in %R seconds"
 time {
-  # Verifies the codecov bash uploader before executing it.
+  # Verifies the codecov uploader before executing it.
   curl -sSL -o /var/tmp/codecov https://uploader.codecov.io/v0.2.3/linux/codecov
   sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
-  codecov_url="https://raw.githubusercontent.com/codecov/codecov-bash/1b4b96ac38946b20043b3ca3bad88d95462259b6/codecov"
-  codecov_script="$(curl -s "${codecov_url}")"
   if ! sha256sum -c <(echo "${sha256sum} -") </var/tmp/codecov; then
-    io::log_h2 "ERROR: Invalid sha256sum for codecov_script:"
-    echo "${codecov_script}"
+    io::log_h2 "ERROR: Invalid sha256sum for codecov program"
     exit 1
   fi
   chmod +x /var/tmp/codecov

--- a/ci/cloudbuild/builds/coverage.sh
+++ b/ci/cloudbuild/builds/coverage.sh
@@ -84,14 +84,16 @@ io::log "Flags: ${codecov_args[*]}"
 TIMEFORMAT="==> 🕑 codecov.io upload done in %R seconds"
 time {
   # Verifies the codecov bash uploader before executing it.
-  sha256sum="d6aa3207c4908d123bd8af62ec0538e3f2b9f257c3de62fad4e29cd3b59b41d9"
+  curl -sSL -o /var/tmp/codecov https://uploader.codecov.io/v0.2.3/linux/codecov
+  sha256sum="648b599397548e4bb92429eec6391374c2cbb0edb835e3b3f03d4281c011f401"
   codecov_url="https://raw.githubusercontent.com/codecov/codecov-bash/1b4b96ac38946b20043b3ca3bad88d95462259b6/codecov"
   codecov_script="$(curl -s "${codecov_url}")"
-  if ! sha256sum -c <(echo "${sha256sum} -") <<<"${codecov_script}"; then
+  if ! sha256sum -c <(echo "${sha256sum} -") </var/tmp/codecov; then
     io::log_h2 "ERROR: Invalid sha256sum for codecov_script:"
     echo "${codecov_script}"
     exit 1
   fi
+  chmod +x /var/tmp/codecov
   env -i CODECOV_TOKEN="${CODECOV_TOKEN:-}" HOME="${HOME}" \
-    bash <(echo "${codecov_script}") "${codecov_args[@]}"
+    /var/tmp/codecov -t "${CODECOV_TOKEN}" "${codecov_args[@]}"
 }


### PR DESCRIPTION
The bash-based code coverage uploader is deprecated, and the new thing
is v0.2.x... sigh.  In any case, it makes little sense to stay on the
deprecated version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9088)
<!-- Reviewable:end -->
