### PR TITLE
fix: re-enable google/cloud/storagetransfer on macOS

### DIFF
--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -34,11 +34,6 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(#8785): Enable on macOS.
-    target_compatible_with = select({
-        "@platforms//os:macos": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",

--- a/google/cloud/storagetransfer/CMakeLists.txt
+++ b/google/cloud/storagetransfer/CMakeLists.txt
@@ -14,16 +14,6 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#8785): Enable on macOS.
-if (APPLE)
-    message(
-        WARNING
-            "Cannot build google/cloud/storagetransfer on Apple platforms."
-            " More details at https://github.com/googleapis/google-cloud-cpp/issues/8785 ."
-    )
-    return()
-endif ()
-
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Storage Transfer API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Storage Transfer API")


### PR DESCRIPTION
Reverse #8789 now that #9092 has imported a new protobuf release
that avoids the macOS `UID_MAX` issue.

Closes #8785.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9102)
<!-- Reviewable:end -->
