### PR TITLE
feat: if available use compile features to request C++ >= 11

### DIFF
--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -40,6 +40,13 @@ endfunction ()
 
 function (google_cloud_cpp_add_common_options target)
     google_cloud_cpp_silence_warnings_in_deps(${target})
+    # Require C++ >= 11.  Unfortunately CMake can only express such requirements
+    # starting with CMake == 3.8.0. Note that this is a *minimum* requirement.
+    # It is still possible to compile the library (and its dependencies) with
+    # C++14 or higher.
+    if (NOT ("${CMAKE_VERSION}" VERSION_LESS 3.8))
+        target_compile_features(${target} PUBLIC cxx_std_11)
+    endif ()
     if (MSVC)
         target_compile_options(${target} PRIVATE "/W3")
         if (GOOGLE_CLOUD_CPP_ENABLE_WERROR)
@@ -68,12 +75,5 @@ function (google_cloud_cpp_add_common_options target)
         # With GCC 4.x this warning is too noisy to be useful.
         target_compile_options(${target}
                                PRIVATE "-Wno-missing-field-initializers")
-    endif ()
-    # Require C++ >= 11.  Unfortunately CMake can only express such requirements
-    # starting with CMake == 3.8.0. Note that this is a *minimum* requirement.
-    # It is still possible to compile the library (and its dependencies) with
-    # C++14 or higher.
-    if (NOT ("${CMAKE_VERSION}" VERSION_LESS 3.8))
-        target_compile_features(${target} PUBLIC cxx_std_11)
     endif ()
 endfunction ()

--- a/cmake/EnableWerror.cmake
+++ b/cmake/EnableWerror.cmake
@@ -69,4 +69,11 @@ function (google_cloud_cpp_add_common_options target)
         target_compile_options(${target}
                                PRIVATE "-Wno-missing-field-initializers")
     endif ()
+    # Require C++ >= 11.  Unfortunately CMake can only express such requirements
+    # starting with CMake == 3.8.0. Note that this is a *minimum* requirement.
+    # It is still possible to compile the library (and its dependencies) with
+    # C++14 or higher.
+    if (NOT ("${CMAKE_VERSION}" VERSION_LESS 3.8))
+        target_compile_features(${target} PUBLIC cxx_std_11)
+    endif ()
 endfunction ()


### PR DESCRIPTION
As long as CMake >= 3.8, this will automatically require C++ >= 11 to
compile the library and their dependencies.  This is only relevant with
Apple Clang, the last compiler we support that defaults to C++98 (and
apparently will always default to C++98).  All other compilers we
support default to C++14 or higher.

While this only works for CMake >= 3.8, I expect this is almost always
the case on macOS.  In other words, this can fail to automate things in
theory, but should work well in practice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9104)
<!-- Reviewable:end -->
