### PR TITLE
impl(bigtable): ReadRows w Connection implementation

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
+#include "google/cloud/bigtable/internal/default_row_reader.h"
 #include "google/cloud/bigtable/internal/defaults.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/idempotency.h"
@@ -58,6 +59,16 @@ Status DataConnectionImpl::Apply(std::string const& app_profile_id,
       request, __func__);
   if (!sor) return std::move(sor).status();
   return Status{};
+}
+
+bigtable::RowReader DataConnectionImpl::ReadRows(
+    std::string const& app_profile_id, std::string const& table_name,
+    bigtable::RowSet row_set, std::int64_t rows_limit,
+    bigtable::Filter filter) {
+  auto impl = std::make_shared<DefaultRowReader>(
+      stub_, app_profile_id, table_name, std::move(row_set), rows_limit,
+      std::move(filter), retry_policy(), backoff_policy());
+  return MakeRowReader(std::move(impl));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -41,6 +41,12 @@ class DataConnectionImpl : public DataConnection {
   Status Apply(std::string const& app_profile_id, std::string const& table_name,
                bigtable::SingleRowMutation mut) override;
 
+  bigtable::RowReader ReadRows(std::string const& app_profile_id,
+                               std::string const& table_name,
+                               bigtable::RowSet row_set,
+                               std::int64_t rows_limit,
+                               bigtable::Filter filter) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();


### PR DESCRIPTION
Fixes #8804 

Note that:
1. there are no integration tests that exercise the `DataConnection` path of `Table::ReadRows()`.
2. the Table does not yet instantiate an `OptionsSpan` before making the call to the Connection.
 
I will add these things in future PRs. They are easier to do after an RPC is implemented.