### PR TITLE
test(storage): support transfer timeouts in benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -251,8 +251,12 @@ gcs_bm::ClientProvider PerTransport(gcs_bm::ClientProvider const& provider) {
 
 gcs_bm::ClientProvider BaseProvider(ThroughputOptions const& options) {
   return [=](ExperimentTransport t) {
-    auto opts =
-        google::cloud::Options{}.set<gcs::ProjectIdOption>(options.project_id);
+    auto opts = google::cloud::Options{}
+                    .set<gcs::ProjectIdOption>(options.project_id)
+                    .set<gcs::DownloadStallTimeoutOption>(
+                        options.download_stall_timeout)
+                    .set<gcs::TransferStallTimeoutOption>(
+                        options.transfer_stall_timeout);
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     using ::google::cloud::storage_experimental::DefaultGrpcClient;
     if (t == ExperimentTransport::kDirectPath) {

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -160,6 +160,23 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options](std::string const& val) {
          options.direct_path_endpoint = val;
        }},
+      {"--transfer-stall-timeout",
+       "configure the storage::TransferStallTimeoutOption: the maximum time"
+       " allowed for data to 'stall' (make no progress) on all operations,"
+       " except for downloads (see --download-stall-timeout)."
+       " This option is intended for troubleshooting, most of the time the"
+       " value is not expected to change the library performance.",
+       [&options](std::string const& val) {
+         options.transfer_stall_timeout = ParseDuration(val);
+       }},
+      {"--download-stall-timeout",
+       "configure the storage::DownloadStallTimeoutOption: the maximum time"
+       " allowed for data to 'stall' during a download."
+       " This option is intended for troubleshooting, most of the time the"
+       " value is not expected to change the library performance.",
+       [&options](std::string const& val) {
+         options.download_stall_timeout = ParseDuration(val);
+       }},
   };
   auto usage = BuildUsage(desc, argv[0]);
 

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -56,6 +56,8 @@ struct ThroughputOptions {
   std::string rest_endpoint = "https://storage.googleapis.com";
   std::string grpc_endpoint = "storage.googleapis.com";
   std::string direct_path_endpoint = "google-c2p:///storage.googleapis.com";
+  std::chrono::seconds transfer_stall_timeout{};
+  std::chrono::seconds download_stall_timeout{};
 };
 
 google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -53,6 +53,8 @@ TEST(ThroughputOptions, Basic) {
       "--rest-endpoint=test-only-rest",
       "--grpc-endpoint=test-only-grpc",
       "--direct-path-endpoint=test-only-direct-path",
+      "--transfer-stall-timeout=86400s",
+      "--download-stall-timeout=86401s",
   });
   ASSERT_STATUS_OK(options);
   EXPECT_EQ("test-project", options->project_id);
@@ -83,6 +85,8 @@ TEST(ThroughputOptions, Basic) {
   EXPECT_EQ("test-only-rest", options->rest_endpoint);
   EXPECT_EQ("test-only-grpc", options->grpc_endpoint);
   EXPECT_EQ("test-only-direct-path", options->direct_path_endpoint);
+  EXPECT_EQ(std::chrono::seconds(86400), options->transfer_stall_timeout);
+  EXPECT_EQ(std::chrono::seconds(86401), options->download_stall_timeout);
 }
 
 TEST(ThroughputOptions, Description) {


### PR DESCRIPTION
This is intended for troubleshooting, adding a timeout is unlikely to
produce better performance (except maybe by cutting tail latencies).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9109)
<!-- Reviewable:end -->
