### PR TITLE
test(bigtable): exercise DataConnection in integration tests

### DIFF
--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -112,6 +112,7 @@ void TableAdminTestEnvironment::TearDown() {
 }
 
 void TableIntegrationTest::SetUp() {
+  data_connection_ = bigtable_internal::MakeDataConnection();
   data_client_ = bigtable::MakeDataClient(TableTestEnvironment::project_id(),
                                           TableTestEnvironment::instance_id());
 
@@ -153,7 +154,14 @@ void TableIntegrationTest::SetUp() {
   }
 }
 
-bigtable::Table TableIntegrationTest::GetTable() {
+bigtable::Table TableIntegrationTest::GetTable(
+    std::string const& implementation) {
+  if (implementation == "with-data-connection") {
+    return bigtable_internal::MakeTable(data_connection_,
+                                        TableTestEnvironment::project_id(),
+                                        TableTestEnvironment::instance_id(), "",
+                                        TableTestEnvironment::table_id());
+  }
   return bigtable::Table(data_client_, TableTestEnvironment::table_id());
 }
 

--- a/google/cloud/bigtable/testing/table_integration_test.h
+++ b/google/cloud/bigtable/testing/table_integration_test.h
@@ -96,7 +96,8 @@ class TableIntegrationTest
   void SetUp() override;
 
   /// Gets a Table object for the current test.
-  bigtable::Table GetTable();
+  bigtable::Table GetTable(
+      std::string const& implementation = "with-data-client");
 
   /// Return all the cells in @p table that pass @p filter.
   static std::vector<bigtable::Cell> ReadRows(bigtable::Table& table,
@@ -179,6 +180,7 @@ class TableIntegrationTest
   }
 
   std::shared_ptr<bigtable::DataClient> data_client_;
+  std::shared_ptr<bigtable_internal::DataConnection> data_connection_;
 };
 
 }  // namespace testing


### PR DESCRIPTION
Fixes #8798 

Introduce the mechanism to test both the `DataClient` and `DataConnection` implementations of `Table` in integration tests.

Most tests use multiple client calls, but `TableReadRowsWrongTable` only calls `ReadRows()`. So we can convert that one to use value parameters. As more client calls are implemented, we will convert more tests to `TEST_P`s

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9110)
<!-- Reviewable:end -->
