### PR TITLE
impl(storage): add `AsyncDeleteObject()` to stubs

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -1190,6 +1190,7 @@ service {
   omit_connection: true
   omit_stub_factory: true
   gen_async_rpcs: [
+    "DeleteObject",
     "ReadObject"
   ]
   omitted_rpcs: [

--- a/google/cloud/storage/internal/storage_auth_decorator.h
+++ b/google/cloud/storage/internal/storage_auth_decorator.h
@@ -142,6 +142,11 @@ class StorageAuth : public StorageStub {
       grpc::ClientContext& context,
       google::storage::v2::UpdateHmacKeyRequest const& request) override;
 
+  future<Status> AsyncDeleteObject(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v2::DeleteObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::storage::v2::ReadObjectResponse>>
   AsyncReadObject(

--- a/google/cloud/storage/internal/storage_logging_decorator.cc
+++ b/google/cloud/storage/internal/storage_logging_decorator.cc
@@ -337,6 +337,19 @@ StatusOr<google::storage::v2::HmacKeyMetadata> StorageLogging::UpdateHmacKey(
       context, request, __func__, tracing_options_);
 }
 
+future<Status> StorageLogging::AsyncDeleteObject(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::storage::v2::DeleteObjectRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](google::cloud::CompletionQueue& cq,
+             std::unique_ptr<grpc::ClientContext> context,
+             google::storage::v2::DeleteObjectRequest const& request) {
+        return child_->AsyncDeleteObject(cq, std::move(context), request);
+      },
+      cq, std::move(context), request, __func__, tracing_options_);
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
 StorageLogging::AsyncReadObject(

--- a/google/cloud/storage/internal/storage_logging_decorator.h
+++ b/google/cloud/storage/internal/storage_logging_decorator.h
@@ -142,6 +142,11 @@ class StorageLogging : public StorageStub {
       grpc::ClientContext& context,
       google::storage::v2::UpdateHmacKeyRequest const& request) override;
 
+  future<Status> AsyncDeleteObject(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v2::DeleteObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::storage::v2::ReadObjectResponse>>
   AsyncReadObject(

--- a/google/cloud/storage/internal/storage_metadata_decorator.cc
+++ b/google/cloud/storage/internal/storage_metadata_decorator.cc
@@ -218,6 +218,14 @@ StatusOr<google::storage::v2::HmacKeyMetadata> StorageMetadata::UpdateHmacKey(
   return child_->UpdateHmacKey(context, request);
 }
 
+future<Status> StorageMetadata::AsyncDeleteObject(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::storage::v2::DeleteObjectRequest const& request) {
+  SetMetadata(*context);
+  return child_->AsyncDeleteObject(cq, std::move(context), request);
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
 StorageMetadata::AsyncReadObject(

--- a/google/cloud/storage/internal/storage_metadata_decorator.h
+++ b/google/cloud/storage/internal/storage_metadata_decorator.h
@@ -138,6 +138,11 @@ class StorageMetadata : public StorageStub {
       grpc::ClientContext& context,
       google::storage::v2::UpdateHmacKeyRequest const& request) override;
 
+  future<Status> AsyncDeleteObject(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v2::DeleteObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::storage::v2::ReadObjectResponse>>
   AsyncReadObject(

--- a/google/cloud/storage/internal/storage_round_robin.cc
+++ b/google/cloud/storage/internal/storage_round_robin.cc
@@ -181,6 +181,13 @@ StatusOr<google::storage::v2::HmacKeyMetadata> StorageRoundRobin::UpdateHmacKey(
   return Child()->UpdateHmacKey(context, request);
 }
 
+future<Status> StorageRoundRobin::AsyncDeleteObject(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::storage::v2::DeleteObjectRequest const& request) {
+  return Child()->AsyncDeleteObject(cq, std::move(context), request);
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
 StorageRoundRobin::AsyncReadObject(

--- a/google/cloud/storage/internal/storage_round_robin.h
+++ b/google/cloud/storage/internal/storage_round_robin.h
@@ -134,6 +134,11 @@ class StorageRoundRobin : public StorageStub {
       grpc::ClientContext& context,
       google::storage::v2::UpdateHmacKeyRequest const& request) override;
 
+  future<Status> AsyncDeleteObject(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v2::DeleteObjectRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::storage::v2::ReadObjectResponse>>
   AsyncReadObject(

--- a/google/cloud/storage/internal/storage_stub.cc
+++ b/google/cloud/storage/internal/storage_stub.cc
@@ -323,6 +323,23 @@ DefaultStorageStub::UpdateHmacKey(
   return response;
 }
 
+future<Status> DefaultStorageStub::AsyncDeleteObject(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::storage::v2::DeleteObjectRequest const& request) {
+  return cq
+      .MakeUnaryRpc(
+          [this](grpc::ClientContext* context,
+                 google::storage::v2::DeleteObjectRequest const& request,
+                 grpc::CompletionQueue* cq) {
+            return grpc_stub_->AsyncDeleteObject(context, request, cq);
+          },
+          request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        return f.get().status();
+      });
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::storage::v2::ReadObjectResponse>>
 DefaultStorageStub::AsyncReadObject(

--- a/google/cloud/storage/internal/storage_stub.h
+++ b/google/cloud/storage/internal/storage_stub.h
@@ -143,6 +143,11 @@ class StorageStub {
       grpc::ClientContext& context,
       google::storage::v2::UpdateHmacKeyRequest const& request) = 0;
 
+  virtual future<Status> AsyncDeleteObject(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v2::DeleteObjectRequest const& request) = 0;
+
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::storage::v2::ReadObjectResponse>>
   AsyncReadObject(google::cloud::CompletionQueue const& cq,
@@ -259,6 +264,11 @@ class DefaultStorageStub : public StorageStub {
   StatusOr<google::storage::v2::HmacKeyMetadata> UpdateHmacKey(
       grpc::ClientContext& client_context,
       google::storage::v2::UpdateHmacKeyRequest const& request) override;
+
+  future<Status> AsyncDeleteObject(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::storage::v2::DeleteObjectRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::storage::v2::ReadObjectResponse>>

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -130,6 +130,11 @@ class MockStorageStub : public storage_internal::StorageStub {
               (grpc::ClientContext&,
                google::storage::v2::UpdateHmacKeyRequest const&),
               (override));
+  MOCK_METHOD(future<Status>, AsyncDeleteObject,
+              (google::cloud::CompletionQueue&,
+               std::unique_ptr<grpc::ClientContext>,
+               google::storage::v2::DeleteObjectRequest const&),
+              (override));
   MOCK_METHOD(std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
                   google::storage::v2::ReadObjectResponse>>,
               AsyncReadObject,


### PR DESCRIPTION
This is the start of implementing Async operations for GCS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9115)
<!-- Reviewable:end -->
