### PR TITLE
ci: allow --verbose flag to affect output of docker build

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -105,7 +105,7 @@ CLEAN_FLAG="false"
 LOCAL_FLAG="false"
 DOCKER_FLAG="false"
 SHELL_FLAG="false"
-VERBOSE_FLAG="false"
+: "${VERBOSE_FLAG:=false}"
 while true; do
   case "$1" in
     --build)


### PR DESCRIPTION
`ci/cloudbuild/build.sh --docker --trigger=xxx --verbose` failed
to actually be verbose in the local build within the docker image
because the `--env=VERBOSE_FLAG=${VERBOSE_FLAG:-}` setting was
ignored in the `ci/cloudbuild/build.sh --local` reinvocation.
So, make the `VERBOSE_FLAG` initialization heed an existing value
in the environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9119)
<!-- Reviewable:end -->
