### PR TITLE
fix(storage): disable MSVC C++17 deprecation warnings

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -266,6 +266,14 @@ if (${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU" AND ${CMAKE_CXX_COMPILER_VERSION}
         PROPERTY COMPILE_FLAGS "-Wno-maybe-uninitialized")
 endif ()
 
+if (MSVC)
+    set_property(
+        SOURCE internal/policy_document_request.cc
+        APPEND_STRING
+        PROPERTY COMPILE_FLAGS
+                 "-D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING")
+endif ()
+
 set_target_properties(
     google_cloud_cpp_storage
     PROPERTIES EXPORT_NAME "google-cloud-cpp::storage"


### PR DESCRIPTION
I think we may need to reimplement these functions to convert from
UTF-8 to UTF-16 (or is it UTF-32?).  For now, just disable the
deprecation warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9143)
<!-- Reviewable:end -->
