### PR TITLE
cleanup: some quickstarts reference GA targets

### DIFF
--- a/google/cloud/dataplex/quickstart/BUILD.bazel
+++ b/google/cloud/dataplex/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-dataplex",
+        "@com_github_googleapis_google_cloud_cpp//:dataplex",
     ],
 )

--- a/google/cloud/dataplex/quickstart/CMakeLists.txt
+++ b/google/cloud/dataplex/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-dataplex)
+target_link_libraries(quickstart google-cloud-cpp::dataplex)

--- a/google/cloud/dialogflow_cx/quickstart/BUILD.bazel
+++ b/google/cloud/dialogflow_cx/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-dialogflow_cx",
+        "@com_github_googleapis_google_cloud_cpp//:dialogflow_cx",
     ],
 )

--- a/google/cloud/dialogflow_cx/quickstart/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-dialogflow_cx)
+target_link_libraries(quickstart google-cloud-cpp::dialogflow_cx)

--- a/google/cloud/dialogflow_es/quickstart/BUILD.bazel
+++ b/google/cloud/dialogflow_es/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-dialogflow_es",
+        "@com_github_googleapis_google_cloud_cpp//:dialogflow_es",
     ],
 )

--- a/google/cloud/dialogflow_es/quickstart/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-dialogflow_es)
+target_link_libraries(quickstart google-cloud-cpp::dialogflow_es)


### PR DESCRIPTION
I forgot these in #9137

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9148)
<!-- Reviewable:end -->
