### PR TITLE
impl(bigtable): implement DataConnection::BulkApply()

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -47,6 +47,10 @@ class DataConnectionImpl : public DataConnection {
                                std::int64_t rows_limit,
                                bigtable::Filter filter) override;
 
+  std::vector<bigtable::FailedMutation> BulkApply(
+      std::string const& app_profile_id, std::string const& table_name,
+      bigtable::BulkMutation mut) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();


### PR DESCRIPTION
Part of the work for #8802 

Here is the Table implementation of this retry loop: https://github.com/googleapis/google-cloud-cpp/blob/2a00f3d17425a15987674ba79548680be4330bed/google/cloud/bigtable/table.cc#L153-L180

The tests are mostly from: [table_bulk_apply_test.cc](https://github.com/googleapis/google-cloud-cpp/blob/2a00f3d17425a15987674ba79548680be4330bed/google/cloud/bigtable/table_bulk_apply_test.cc), but hopefully they are a bit clearer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9155)
<!-- Reviewable:end -->
