### PR TITLE
fix(storage): do not duplicate debugging headers

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -625,7 +625,6 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
     return bytes_read;
   }
   TRACE_STATE() << ", http code=" << http_code_ << "\n";
-  received_headers_.emplace(":curl-peer", handle_.GetPeer());
   return bytes_read;
 }
 

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -208,7 +208,6 @@ StatusOr<ReadSourceResult> CurlDownloadRequest::Read(char* buf, std::size_t n) {
     return MakeReadResult(bytes_read, std::move(response));
   }
   TRACE_STATE() << ", code=100";
-  received_headers_.emplace(":curl-peer", handle_.GetPeer());
   return MakeReadResult(bytes_read, HttpResponse{HttpStatusCode::kContinue,
                                                  {},
                                                  std::move(received_headers_)});

--- a/google/cloud/storage/tests/object_read_headers_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_headers_integration_test.cc
@@ -199,9 +199,7 @@ TEST_F(ObjectReadHeadersIntegrationTest, NoDuplicatePeers) {
 
   auto const headers = is.headers();
   EXPECT_THAT(headers, AnyOf(ContainsOnce(Pair(":curl-peer", _)),
-                             Not(Contains(Pair(":curl-peer", _)))));
-  EXPECT_THAT(headers, AnyOf(ContainsOnce(Pair(":grpc-context-peer", _)),
-                             Not(Contains(Pair(":grpc-context-peer", _)))));
+                             ContainsOnce(Pair(":grpc-context-peer", _))));
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/object_read_headers_integration_test.cc
+++ b/google/cloud/storage/tests/object_read_headers_integration_test.cc
@@ -35,7 +35,6 @@ using ::testing::_;
 using ::testing::AnyOf;
 using ::testing::Contains;
 using ::testing::IsSupersetOf;
-using ::testing::Not;
 using ::testing::Pair;
 
 class ObjectReadHeadersIntegrationTest


### PR DESCRIPTION
The `storage::ObjectReadStream` class exposes debugging information via
the `std::multimap<std::string, std::string> headers()` function. Note
that this is a **multi** map because headers can be duplicated in some
cases.  At some point I made a mistake and returned an extra
`:curl-peer` header in each `ObjectReadSource::Read()` call.

If the application is downloading a very large object (say 100GiB) and
the application processes the data in small chunks (say a few KiB) then
millions of calls to `ObjectReadSource::Read()` would take place.
Consequently, the multimap contained millions of duplicate entries.

Previously this went unnoticed because (1) the multimap is released
when the download completes, and (2) our benchmarks and tests tend to
perform larger reads (say a few MiB) from objects that are at most a
few GiB in size. The memory did not grow enough to be noticeable.

Fixes #9161

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9162)
<!-- Reviewable:end -->
