### PR TITLE
test(bigtable): integration tests for BulkApply via Connection

### DIFF
--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -27,6 +27,7 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::bigtable::testing::TableIntegrationTest;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::std::chrono::duration_cast;
 using ::std::chrono::microseconds;
@@ -34,10 +35,9 @@ using ::std::chrono::milliseconds;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 
-using DataIntegrationTestClientOnly =
-    ::google::cloud::bigtable::testing::TableIntegrationTest;
+using DataIntegrationTestClientOnly = TableIntegrationTest;
 
-class DataIntegrationTest : public DataIntegrationTestClientOnly,
+class DataIntegrationTest : public TableIntegrationTest,
                             public ::testing::WithParamInterface<std::string> {
 };
 
@@ -98,8 +98,8 @@ TEST_F(DataIntegrationTestClientOnly, TableApply) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableBulkApply) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableBulkApply) {
+  auto table = GetTable(GetParam());
 
   std::vector<Cell> created{{"row-key-1", kFamily4, "c0", 1000, "v1000"},
                             {"row-key-1", kFamily4, "c1", 2000, "v2000"},
@@ -170,8 +170,8 @@ TEST_F(DataIntegrationTestClientOnly, TableReadRowNotExistTest) {
   EXPECT_FALSE(row_cell->first);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadRowsAllRows) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadRowsAllRows) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3(1024, '3');    // a long key
@@ -202,8 +202,8 @@ TEST_F(DataIntegrationTestClientOnly, TableReadRowsAllRows) {
   CheckEqualUnordered(created, MoveCellsFromReader(read4));
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadRowsPartialRows) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadRowsPartialRows) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3 = "row-key-3";
@@ -244,8 +244,8 @@ TEST_F(DataIntegrationTestClientOnly, TableReadRowsPartialRows) {
   }
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadRowsNoRows) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadRowsNoRows) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const row_key3 = "row-key-3";

--- a/google/cloud/bigtable/tests/filters_integration_test.cc
+++ b/google/cloud/bigtable/tests/filters_integration_test.cc
@@ -95,7 +95,7 @@ void CreateComplexRows(Table& table, std::string const& prefix) {
 };
 
 TEST_F(FilterIntegrationTest, PassAll) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "pass-all-row-key";
   std::vector<Cell> expected{
       {row_key, "family1", "c", 0, "v-c-0-0"},
@@ -112,7 +112,7 @@ TEST_F(FilterIntegrationTest, PassAll) {
 }
 
 TEST_F(FilterIntegrationTest, BlockAll) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "block-all-row-key";
   std::vector<Cell> created{
       {row_key, "family1", "c", 0, "v-c-0-0"},
@@ -130,7 +130,7 @@ TEST_F(FilterIntegrationTest, BlockAll) {
 }
 
 TEST_F(FilterIntegrationTest, Latest) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "latest-row-key";
   std::vector<Cell> created{
       {row_key, "family1", "c", 0, "v-c-0-0"},
@@ -155,7 +155,7 @@ TEST_F(FilterIntegrationTest, Latest) {
 }
 
 TEST_F(FilterIntegrationTest, FamilyRegex) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "family-regex-row-key";
   std::vector<Cell> created{
       {row_key, "family1", "c2", 0, "bar"},
@@ -178,7 +178,7 @@ TEST_F(FilterIntegrationTest, FamilyRegex) {
 }
 
 TEST_F(FilterIntegrationTest, ColumnRegex) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "column-regex-row-key";
   std::vector<Cell> created{
       {row_key, "family1", "abc", 0, "bar"},
@@ -201,7 +201,7 @@ TEST_F(FilterIntegrationTest, ColumnRegex) {
 }
 
 TEST_F(FilterIntegrationTest, ColumnRange) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "column-range-row-key";
   std::vector<Cell> created{
       {row_key, "family1", "a00", 0, "bar"},
@@ -223,7 +223,7 @@ TEST_F(FilterIntegrationTest, ColumnRange) {
 }
 
 TEST_F(FilterIntegrationTest, TimestampRange) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "timestamp-range-row-key";
   std::vector<Cell> created{
       {row_key, "family1", "c0", 1000, "v1000"},
@@ -247,7 +247,7 @@ TEST_F(FilterIntegrationTest, TimestampRange) {
 }
 
 TEST_F(FilterIntegrationTest, RowKeysRegex) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const row_key = "row-key-regex-row-key";
   std::vector<Cell> created{
       {row_key + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -267,7 +267,7 @@ TEST_F(FilterIntegrationTest, RowKeysRegex) {
 }
 
 TEST_F(FilterIntegrationTest, ValueRegex) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "value-regex-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -288,7 +288,7 @@ TEST_F(FilterIntegrationTest, ValueRegex) {
 }
 
 TEST_F(FilterIntegrationTest, ValueRange) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "value-range-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -311,7 +311,7 @@ TEST_F(FilterIntegrationTest, ValueRange) {
 }
 
 TEST_F(FilterIntegrationTest, CellsRowLimit) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "cell-row-limit-prefix";
   ASSERT_NO_FATAL_FAILURE(CreateComplexRows(table, prefix));
 
@@ -332,7 +332,7 @@ TEST_F(FilterIntegrationTest, CellsRowLimit) {
 }
 
 TEST_F(FilterIntegrationTest, CellsRowOffset) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "cell-row-offset-prefix";
   ASSERT_NO_FATAL_FAILURE(CreateComplexRows(table, prefix));
 
@@ -353,7 +353,7 @@ TEST_F(FilterIntegrationTest, CellsRowOffset) {
 }
 
 TEST_F(FilterIntegrationTest, RowSample) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "row-sample-prefix";
 
   int constexpr kRowCount = 20000;
@@ -408,7 +408,7 @@ TEST_F(FilterIntegrationTest, RowSample) {
 }
 
 TEST_F(FilterIntegrationTest, StripValueTransformer) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "strip-value-transformer-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -433,7 +433,7 @@ TEST_F(FilterIntegrationTest, StripValueTransformer) {
 }
 
 TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "apply-label-transformer-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -458,7 +458,7 @@ TEST_F(FilterIntegrationTest, ApplyLabelTransformer) {
 }
 
 TEST_F(FilterIntegrationTest, Condition) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "condition-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -486,7 +486,7 @@ TEST_F(FilterIntegrationTest, Condition) {
 }
 
 TEST_F(FilterIntegrationTest, Chain) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "chain-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -510,7 +510,7 @@ TEST_F(FilterIntegrationTest, Chain) {
 }
 
 TEST_F(FilterIntegrationTest, ChainFromRange) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "chain-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -534,7 +534,7 @@ TEST_F(FilterIntegrationTest, ChainFromRange) {
 }
 
 TEST_F(FilterIntegrationTest, Interleave) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "interleave-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},
@@ -562,7 +562,7 @@ TEST_F(FilterIntegrationTest, Interleave) {
 }
 
 TEST_F(FilterIntegrationTest, InterleaveFromRange) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
   std::string const prefix = "interleave-prefix";
   std::vector<Cell> created{
       {prefix + "/abc0", "family1", "c0", 1000, "v1000"},

--- a/google/cloud/bigtable/tests/mutations_integration_test.cc
+++ b/google/cloud/bigtable/tests/mutations_integration_test.cc
@@ -28,6 +28,7 @@ using ::testing::Not;
 
 using MutationIntegrationTest =
     ::google::cloud::bigtable::testing::TableIntegrationTest;
+
 /**
  * This function creates Cell by ignoring the timestamp.
  * In this case Cloud Bigtable will insert the default server
@@ -61,7 +62,7 @@ std::string const kColumnFamily3 = "family3";
  * Cloud Bigtable
  */
 TEST_F(MutationIntegrationTest, SetCellTest) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
 
   // Create a vector of cells which will be inserted into bigtable
   std::string const row_key = "SetCellRowKey";
@@ -85,7 +86,7 @@ TEST_F(MutationIntegrationTest, SetCellTest) {
  * correctly inserted into Cloud Bigtable
  */
 TEST_F(MutationIntegrationTest, SetCellNumericValueTest) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
 
   // Create a vector of cells which will be inserted into bigtable
   std::string const row_key = "SetCellNumRowKey";
@@ -128,7 +129,7 @@ TEST_F(MutationIntegrationTest, SetCellNumericValueErrorTest) {
  * correctly inserted into Cloud Bigtable.
  */
 TEST_F(MutationIntegrationTest, SetCellIgnoreTimestampTest) {
-  auto table = GetTable();
+  auto table = GetTable("with-data-connection");
 
   // Create a vector of cell which will be inserted into bigtable
   std::string const row_key = "SetCellRowKey";


### PR DESCRIPTION
Part of the work for #9164. (See this issue for context on why `DataIntegrationTest` is a `TEST_P` but the other ones are `TEST_F`s)

The filters integration test can be marked as done. The mutations integration test is half done - the other half is blocked on implementing `Table::Apply()` with the `DataConnection`.