### PR TITLE
refactor(bigtable): reorder code; waste builds

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -62,16 +62,6 @@ Status DataConnectionImpl::Apply(std::string const& app_profile_id,
   return Status{};
 }
 
-bigtable::RowReader DataConnectionImpl::ReadRows(
-    std::string const& app_profile_id, std::string const& table_name,
-    bigtable::RowSet row_set, std::int64_t rows_limit,
-    bigtable::Filter filter) {
-  auto impl = std::make_shared<DefaultRowReader>(
-      stub_, app_profile_id, table_name, std::move(row_set), rows_limit,
-      std::move(filter), retry_policy(), backoff_policy());
-  return MakeRowReader(std::move(impl));
-}
-
 std::vector<bigtable::FailedMutation> DataConnectionImpl::BulkApply(
     std::string const& app_profile_id, std::string const& table_name,
     bigtable::BulkMutation mut) {
@@ -92,6 +82,16 @@ std::vector<bigtable::FailedMutation> DataConnectionImpl::BulkApply(
     std::this_thread::sleep_for(delay);
   } while (mutator.HasPendingMutations());
   return std::move(mutator).OnRetryDone();
+}
+
+bigtable::RowReader DataConnectionImpl::ReadRows(
+    std::string const& app_profile_id, std::string const& table_name,
+    bigtable::RowSet row_set, std::int64_t rows_limit,
+    bigtable::Filter filter) {
+  auto impl = std::make_shared<DefaultRowReader>(
+      stub_, app_profile_id, table_name, std::move(row_set), rows_limit,
+      std::move(filter), retry_policy(), backoff_policy());
+  return MakeRowReader(std::move(impl));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -41,15 +41,15 @@ class DataConnectionImpl : public DataConnection {
   Status Apply(std::string const& app_profile_id, std::string const& table_name,
                bigtable::SingleRowMutation mut) override;
 
+  std::vector<bigtable::FailedMutation> BulkApply(
+      std::string const& app_profile_id, std::string const& table_name,
+      bigtable::BulkMutation mut) override;
+
   bigtable::RowReader ReadRows(std::string const& app_profile_id,
                                std::string const& table_name,
                                bigtable::RowSet row_set,
                                std::int64_t rows_limit,
                                bigtable::Filter filter) override;
-
-  std::vector<bigtable::FailedMutation> BulkApply(
-      std::string const& app_profile_id, std::string const& table_name,
-      bigtable::BulkMutation mut) override;
 
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {


### PR DESCRIPTION
Define member functions in the same order as they appear in `data_connection.{h,cc}`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9167)
<!-- Reviewable:end -->
