### PR TITLE
feat(common): include status error payloads in the RPC log

### DIFF
--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -35,6 +35,8 @@ namespace internal {
 std::string DebugString(google::protobuf::Message const& m,
                         TracingOptions const& options);
 
+std::string DebugString(Status const& status, TracingOptions const& options);
+
 char const* DebugFutureStatus(std::future_status s);
 
 // Create a unique ID that can be used to match asynchronous requests/response
@@ -86,7 +88,8 @@ Result LogWrapper(Functor&& functor, grpc::ClientContext& context,
   GCP_LOG(DEBUG) << where << "() << " << DebugString(request, options);
   auto response = functor(context, request);
   if (!response) {
-    GCP_LOG(DEBUG) << where << "() >> status=" << response.status();
+    GCP_LOG(DEBUG) << where << "() >> status="
+                   << DebugString(response.status(), options);
   } else {
     GCP_LOG(DEBUG) << where
                    << "() >> response=" << DebugString(*response, options);
@@ -158,7 +161,8 @@ Result LogWrapper(Functor&& functor, Request request, char const* where,
   return response.then([prefix, options](decltype(response) f) {
     auto response = f.get();
     if (!response) {
-      GCP_LOG(DEBUG) << prefix << " >> status=" << response.status();
+      GCP_LOG(DEBUG) << prefix << " >> status="
+                     << DebugString(response.status(), options);
     } else {
       GCP_LOG(DEBUG) << prefix
                      << " >> response=" << DebugString(*response, options);
@@ -191,7 +195,8 @@ Result LogWrapper(Functor&& functor, google::cloud::CompletionQueue& cq,
   return response.then([prefix, options](decltype(response) f) {
     auto response = f.get();
     if (!response) {
-      GCP_LOG(DEBUG) << prefix << " >> status=" << response.status();
+      GCP_LOG(DEBUG) << prefix << " >> status="
+                     << DebugString(response.status(), options);
     } else {
       GCP_LOG(DEBUG) << prefix
                      << " >> response=" << DebugString(*response, options);


### PR DESCRIPTION
Include the `google.rpc.Status.details` messages when adding a failing
`Status` value to the RPC log.

See https://cloud.google.com/apis/design/errors#error_payloads for the
details on what is available.

`Status` already has smarts for dealing with a `google.rpc.ErrorInfo`
message.  I was never sure why this support didn't extend to the other
error-detail messages, but @devjgm assured me that `ErrorInfo` was all
that was required for user access.

But let's at least add all the available information to the RPC log.
This will help us understand failures, like the notoriously inscrutable
"Invalid request", where we'll now be able to see which field was bad
and a description of what went wrong.