### PR TITLE
impl(bigtable): implement modern Table::ReadRow()

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -107,8 +107,9 @@ StatusOr<std::pair<bool, bigtable::Row>> DataConnectionImpl::ReadRow(
   if (!*it) return it->status();
   auto result = std::make_pair(true, std::move(**it));
   if (++it != reader.end()) {
-    return Status(StatusCode::kInternal,
-                  "internal error - RowReader returned 2 rows in ReadRow()");
+    return Status(
+        StatusCode::kInternal,
+        "internal error - RowReader returned more than one row in ReadRow()");
   }
   return result;
 }

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -51,6 +51,10 @@ class DataConnectionImpl : public DataConnection {
                                std::int64_t rows_limit,
                                bigtable::Filter filter) override;
 
+  StatusOr<std::pair<bool, bigtable::Row>> ReadRow(
+      std::string const& app_profile_id, std::string const& table_name,
+      std::string row_key, bigtable::Filter filter) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -219,6 +219,11 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
 
 StatusOr<std::pair<bool, Row>> Table::ReadRow(std::string row_key,
                                               Filter filter) {
+  if (connection_) {
+    return connection_->ReadRow(app_profile_id_, table_name_,
+                                std::move(row_key), std::move(filter));
+  }
+
   RowSet row_set(std::move(row_key));
   std::int64_t const rows_limit = 1;
   RowReader reader =

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -238,8 +238,9 @@ StatusOr<std::pair<bool, Row>> Table::ReadRow(std::string row_key,
   }
   auto result = std::make_pair(true, std::move(**it));
   if (++it != reader.end()) {
-    return Status(StatusCode::kInternal,
-                  "internal error - RowReader returned 2 rows in ReadRow()");
+    return Status(
+        StatusCode::kInternal,
+        "internal error - RowReader returned more than one row in ReadRow()");
   }
   return result;
 }

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -187,6 +187,25 @@ TEST(TableTest, ReadRowsWithRowLimit) {
   EXPECT_EQ(++it, reader.end());
 }
 
+TEST(TableTest, ReadRow) {
+  auto mock = std::make_shared<MockDataConnection>();
+  EXPECT_CALL(*mock, ReadRow)
+      .WillOnce([](std::string const& app_profile_id,
+                   std::string const& table_name, std::string const& row_key,
+                   bigtable::Filter const& filter) {
+        EXPECT_EQ(kAppProfileId, app_profile_id);
+        EXPECT_EQ(kTableName, table_name);
+        EXPECT_EQ("row", row_key);
+        EXPECT_THAT(filter, IsTestFilter());
+        return PermanentError();
+      });
+
+  auto table = bigtable_internal::MakeTable(mock, kProjectId, kInstanceId,
+                                            kAppProfileId, kTableId);
+  auto resp = table.ReadRow("row", TestFilter());
+  EXPECT_THAT(resp, StatusIs(StatusCode::kPermissionDenied));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -140,8 +140,8 @@ TEST_P(DataIntegrationTest, TableSingleRow) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadRowTest) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadRowTest) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
@@ -157,8 +157,8 @@ TEST_F(DataIntegrationTestClientOnly, TableReadRowTest) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadRowNotExistTest) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadRowNotExistTest) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 
@@ -463,8 +463,8 @@ TEST_F(DataIntegrationTestClientOnly, TableCellValueInt64Test) {
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadMultipleCellsBigValue) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadMultipleCellsBigValue) {
+  auto table = GetTable(GetParam());
 
   std::string const row_key = "row-key-1";
   // cell vector contains 4 cells of 32 MiB each, or 128 MiB (without


### PR DESCRIPTION
Fixes #8804 

The implementation is a direct copy from `table.cc`: https://github.com/googleapis/google-cloud-cpp/blob/be0097b0adea5fd1a911e47e105ee84021042bcb/google/cloud/bigtable/table.cc#L222-L239

(We copy the code instead of factoring it out, because eventually there will only be one version of the code).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9176)
<!-- Reviewable:end -->
