### PR TITLE
refactor(bigtable): move transform; add unit test

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -26,6 +26,29 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+bigtable::Row TransformReadModifyWriteRowResponse(
+    google::bigtable::v2::ReadModifyWriteRowResponse response) {
+  std::vector<bigtable::Cell> cells;
+  auto& row = *response.mutable_row();
+  for (auto& family : *row.mutable_families()) {
+    for (auto& column : *family.mutable_columns()) {
+      for (auto& cell : *column.mutable_cells()) {
+        std::vector<std::string> labels;
+        std::move(cell.mutable_labels()->begin(), cell.mutable_labels()->end(),
+                  std::back_inserter(labels));
+        bigtable::Cell new_cell(row.key(), family.name(), column.qualifier(),
+                                cell.timestamp_micros(),
+                                std::move(*cell.mutable_value()),
+                                std::move(labels));
+
+        cells.emplace_back(std::move(new_cell));
+      }
+    }
+  }
+
+  return bigtable::Row(std::move(*row.mutable_key()), std::move(cells));
+}
+
 DataConnectionImpl::DataConnectionImpl(
     std::unique_ptr<BackgroundThreads> background,
     std::shared_ptr<BigtableStub> stub, Options options)

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -36,12 +36,9 @@ bigtable::Row TransformReadModifyWriteRowResponse(
         std::vector<std::string> labels;
         std::move(cell.mutable_labels()->begin(), cell.mutable_labels()->end(),
                   std::back_inserter(labels));
-        bigtable::Cell new_cell(row.key(), family.name(), column.qualifier(),
-                                cell.timestamp_micros(),
-                                std::move(*cell.mutable_value()),
-                                std::move(labels));
-
-        cells.emplace_back(std::move(new_cell));
+        cells.emplace_back(row.key(), family.name(), column.qualifier(),
+                           cell.timestamp_micros(),
+                           std::move(*cell.mutable_value()), std::move(labels));
       }
     }
   }

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -29,6 +29,9 @@ namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+bigtable::Row TransformReadModifyWriteRowResponse(
+    google::bigtable::v2::ReadModifyWriteRowResponse response);
+
 class DataConnectionImpl : public DataConnection {
  public:
   ~DataConnectionImpl() override = default;


### PR DESCRIPTION
Part of the work for #8799 (implementing `Table::(Async)ReadModifyWriteRow()`)

I want to use this function in the `DataConnection`, so let's move it now to keep PRs small-ish. Also add a unit test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9177)
<!-- Reviewable:end -->
