### PR TITLE
impl(bigtable): modern `Table::ReadModifyWriteRow()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection.cc
+++ b/google/cloud/bigtable/internal/data_connection.cc
@@ -114,13 +114,13 @@ DataConnection::AsyncSampleRows(std::string const&, std::string const&) {
 
 StatusOr<bigtable::Row> DataConnection::ReadModifyWriteRow(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    google::bigtable::v2::MutateRowRequest) {
+    google::bigtable::v2::ReadModifyWriteRowRequest) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 future<StatusOr<bigtable::Row>> DataConnection::AsyncReadModifyWriteRow(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    google::bigtable::v2::MutateRowRequest) {
+    google::bigtable::v2::ReadModifyWriteRowRequest) {
   return make_ready_future<StatusOr<bigtable::Row>>(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }

--- a/google/cloud/bigtable/internal/data_connection.h
+++ b/google/cloud/bigtable/internal/data_connection.h
@@ -98,10 +98,10 @@ class DataConnection {
       std::string const& app_profile_id, std::string const& table_name);
 
   virtual StatusOr<bigtable::Row> ReadModifyWriteRow(
-      google::bigtable::v2::MutateRowRequest request);
+      google::bigtable::v2::ReadModifyWriteRowRequest request);
 
   virtual future<StatusOr<bigtable::Row>> AsyncReadModifyWriteRow(
-      google::bigtable::v2::MutateRowRequest request);
+      google::bigtable::v2::ReadModifyWriteRowRequest request);
 
   virtual void AsyncReadRows(std::string const& app_profile_id,
                              std::string const& table_name,

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -134,6 +134,19 @@ StatusOr<std::pair<bool, bigtable::Row>> DataConnectionImpl::ReadRow(
   return result;
 }
 
+StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(
+    google::bigtable::v2::ReadModifyWriteRowRequest request) {
+  auto sor = google::cloud::internal::RetryLoop(
+      retry_policy(), backoff_policy(), Idempotency::kNonIdempotent,
+      [this](grpc::ClientContext& context,
+             google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
+        return stub_->ReadModifyWriteRow(context, request);
+      },
+      request, __func__);
+  if (!sor) return std::move(sor).status();
+  return TransformReadModifyWriteRowResponse(*std::move(sor));
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal
 }  // namespace cloud

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -58,6 +58,9 @@ class DataConnectionImpl : public DataConnection {
       std::string const& app_profile_id, std::string const& table_name,
       std::string row_key, bigtable::Filter filter) override;
 
+  StatusOr<bigtable::Row> ReadModifyWriteRow(
+      google::bigtable::v2::ReadModifyWriteRowRequest request) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -648,6 +648,96 @@ TEST(DataConnectionTest, ReadRowFailure) {
   EXPECT_THAT(resp, StatusIs(StatusCode::kPermissionDenied));
 }
 
+TEST(DataConnectionTest, ReadModifyWriteRowSuccess) {
+  v2::ReadModifyWriteRowResponse response;
+  auto constexpr kText = R"pb(
+    row {
+      key: "row"
+      families {
+        name: "cf"
+        columns {
+          qualifier: "cq"
+          cells { value: "value" }
+        }
+      }
+    })pb";
+  EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &response));
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, ReadModifyWriteRow)
+      .WillOnce([&response](grpc::ClientContext&,
+                            v2::ReadModifyWriteRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return response;
+      });
+
+  v2::ReadModifyWriteRowRequest req;
+  req.set_app_profile_id(kAppProfile);
+  req.set_table_name(kTableName);
+  req.set_row_key("row");
+
+  auto conn = TestConnection(std::move(mock));
+  auto row = conn->ReadModifyWriteRow(req);
+  ASSERT_STATUS_OK(row);
+  EXPECT_EQ("row", row->row_key());
+
+  auto c = bigtable::Cell("row", "cf", "cq", 0, "value");
+  EXPECT_THAT(row->cells(), ElementsAre(MatchCell(c)));
+}
+
+TEST(DataConnectionTest, ReadModifyWriteRowPermanentError) {
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, ReadModifyWriteRow)
+      .WillOnce([](grpc::ClientContext&,
+                   v2::ReadModifyWriteRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return PermanentError();
+      });
+
+  v2::ReadModifyWriteRowRequest req;
+  req.set_app_profile_id(kAppProfile);
+  req.set_table_name(kTableName);
+  req.set_row_key("row");
+
+  auto conn = TestConnection(std::move(mock));
+  auto row = conn->ReadModifyWriteRow(req);
+  EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
+}
+
+TEST(DataConnectionTest, ReadModifyWriteRowTransientErrorNotRetried) {
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, ReadModifyWriteRow)
+      .WillOnce([](grpc::ClientContext&,
+                   v2::ReadModifyWriteRowRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        EXPECT_EQ("row", request.row_key());
+        return TransientError();
+      });
+
+  v2::ReadModifyWriteRowRequest req;
+  req.set_app_profile_id(kAppProfile);
+  req.set_table_name(kTableName);
+  req.set_row_key("row");
+
+  auto mock_b = absl::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, clone).WillOnce([]() {
+    auto clone = absl::make_unique<MockBackoffPolicy>();
+    EXPECT_CALL(*clone, OnCompletion).Times(0);
+    return clone;
+  });
+
+  internal::OptionsSpan span(
+      Options{}.set<DataBackoffPolicyOption>(std::move(mock_b)));
+  auto conn = TestConnection(std::move(mock));
+  auto row = conn->ReadModifyWriteRow(req);
+  EXPECT_THAT(row, StatusIs(StatusCode::kUnavailable));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal

--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -96,10 +96,12 @@ class MockDataConnection : public bigtable_internal::DataConnection {
               (override));
 
   MOCK_METHOD(StatusOr<bigtable::Row>, ReadModifyWriteRow,
-              (google::bigtable::v2::MutateRowRequest request), (override));
+              (google::bigtable::v2::ReadModifyWriteRowRequest request),
+              (override));
 
   MOCK_METHOD(future<StatusOr<bigtable::Row>>, AsyncReadModifyWriteRow,
-              (google::bigtable::v2::MutateRowRequest request), (override));
+              (google::bigtable::v2::ReadModifyWriteRowRequest request),
+              (override));
 
   MOCK_METHOD(void, AsyncReadRows,
               (std::string const& app_profile_id, std::string const& table_name,

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -354,6 +354,9 @@ StatusOr<Row> Table::ReadModifyWriteRowImpl(
   SetCommonTableOperationRequest<
       ::google::bigtable::v2::ReadModifyWriteRowRequest>(
       request, app_profile_id_, table_name_);
+  if (connection_) {
+    return connection_->ReadModifyWriteRow(std::move(request));
+  }
 
   grpc::Status status;
   auto response = ClientUtils::MakeNonIdempotentCall(

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -320,8 +320,8 @@ TEST_F(DataIntegrationTestClientOnly, TableCheckAndMutateRowFail) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadModifyWriteAppendValueTest) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadModifyWriteAppendValueTest) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const add_suffix1 = "-suffix";
@@ -356,9 +356,8 @@ TEST_F(DataIntegrationTestClientOnly, TableReadModifyWriteAppendValueTest) {
                       actual_cells_ignore_timestamp);
 }
 
-TEST_F(DataIntegrationTestClientOnly,
-       TableReadModifyWriteRowIncrementAmountTest) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadModifyWriteRowIncrementAmountTest) {
+  auto table = GetTable(GetParam());
   std::string const key = "row-key";
 
   // An initial; big-endian int64 number with value 0.
@@ -384,8 +383,8 @@ TEST_F(DataIntegrationTestClientOnly,
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableReadModifyWriteRowMultipleTest) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableReadModifyWriteRowMultipleTest) {
+  auto table = GetTable(GetParam());
   std::string const key = "row-key";
 
   std::string v1("\x00\x00\x00\x00\x00\x00\x00\x00", 8);
@@ -428,8 +427,8 @@ TEST_F(DataIntegrationTestClientOnly, TableReadModifyWriteRowMultipleTest) {
   CheckEqualUnordered(expected_ignore_timestamp, actual_ignore_timestamp);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableCellValueInt64Test) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableCellValueInt64Test) {
+  auto table = GetTable(GetParam());
   std::string const key = "row-key";
 
   std::vector<Cell> created{{key, kFamily1, "c1", 0, 42},


### PR DESCRIPTION
Part of the work for #8799

Note that I made an oopsies in the Connection's API. Good thing I am developing in `internal`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9181)
<!-- Reviewable:end -->
