### PR TITLE
impl(spanner): teach IsSessionNotFound() to use google.rpc.ResourceInfo

### DIFF
--- a/google/cloud/grpc_error_delegate.cc
+++ b/google/cloud/grpc_error_delegate.cc
@@ -72,11 +72,9 @@ absl::optional<google::rpc::ErrorInfo> GetErrorInfoProto(
   // While in theory there _could_ be multiple ErrorInfo protos in this
   // repeated field, we're told that there will be at most one, and our
   // user-facing APIs should only expose one. So if we find one, we're done.
+  google::rpc::ErrorInfo error_info;
   for (google::protobuf::Any const& any : proto.details()) {
-    if (any.Is<google::rpc::ErrorInfo>()) {
-      google::rpc::ErrorInfo error_info;
-      if (any.UnpackTo(&error_info)) return error_info;
-    }
+    if (any.UnpackTo(&error_info)) return error_info;
   }
   return absl::nullopt;
 }

--- a/google/cloud/spanner/CMakeLists.txt
+++ b/google/cloud/spanner/CMakeLists.txt
@@ -287,7 +287,9 @@ function (spanner_client_define_tests)
         testing/random_database_name.cc
         testing/random_database_name.h
         testing/random_instance_name.cc
-        testing/random_instance_name.h)
+        testing/random_instance_name.h
+        testing/status_utils.cc
+        testing/status_utils.h)
     target_link_libraries(
         spanner_client_testing
         PUBLIC google_cloud_cpp_testing google-cloud-cpp::spanner_mocks

--- a/google/cloud/spanner/internal/status_utils_test.cc
+++ b/google/cloud/spanner/internal/status_utils_test.cc
@@ -13,30 +13,35 @@
 // limitations under the License.
 
 #include "google/cloud/spanner/internal/status_utils.h"
+#include "google/cloud/spanner/database.h"
+#include "google/cloud/spanner/testing/status_utils.h"
 #include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
-namespace spanner {
+namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 TEST(StatusUtils, SessionNotFound) {
-  google::cloud::Status const session_not_found(StatusCode::kNotFound,
-                                                "Session not found");
-  EXPECT_TRUE(spanner_internal::IsSessionNotFound(session_not_found));
+  Status const session_not_found(StatusCode::kNotFound, "Session not found");
+  EXPECT_TRUE(IsSessionNotFound(session_not_found));
 
-  google::cloud::Status const other_not_found(StatusCode::kNotFound,
-                                              "Other not found");
-  EXPECT_FALSE(spanner_internal::IsSessionNotFound(other_not_found));
+  Status const other_not_found(StatusCode::kNotFound, "Other not found");
+  EXPECT_FALSE(IsSessionNotFound(other_not_found));
 
-  google::cloud::Status const not_not_found(StatusCode::kUnavailable,
-                                            "Session not found");
-  EXPECT_FALSE(spanner_internal::IsSessionNotFound(not_not_found));
+  Status const not_not_found(StatusCode::kUnavailable, "Session not found");
+  EXPECT_FALSE(IsSessionNotFound(not_not_found));
+}
+
+TEST(StatusUtils, SessionNotFoundResourceInfo) {
+  auto db = spanner::Database("project", "instance", "database");
+  auto name = db.FullName() + "/sessions/session";
+  EXPECT_TRUE(IsSessionNotFound(spanner_testing::SessionNotFoundError(name)));
 }
 
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace spanner
+}  // namespace spanner_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/spanner/spanner_client_testing.bzl
+++ b/google/cloud/spanner/spanner_client_testing.bzl
@@ -32,6 +32,7 @@ spanner_client_testing_hdrs = [
     "testing/random_backup_name.h",
     "testing/random_database_name.h",
     "testing/random_instance_name.h",
+    "testing/status_utils.h",
 ]
 
 spanner_client_testing_srcs = [
@@ -44,4 +45,5 @@ spanner_client_testing_srcs = [
     "testing/random_backup_name.cc",
     "testing/random_database_name.cc",
     "testing/random_instance_name.cc",
+    "testing/status_utils.cc",
 ]

--- a/google/cloud/spanner/testing/status_utils.cc
+++ b/google/cloud/spanner/testing/status_utils.cc
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/spanner/testing/status_utils.h"
+#include "google/cloud/grpc_error_delegate.h"
+#include <google/rpc/error_details.pb.h>
+#include <google/rpc/status.pb.h>
+#include <google/spanner/v1/spanner.pb.h>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+grpc::Status SessionNotFoundRpcError(std::string name) {
+  google::spanner::v1::Session session;
+  auto session_url = "type.googleapis.com/" + session.GetTypeName();
+
+  google::rpc::ResourceInfo resource_info;
+  resource_info.set_resource_type(session_url);
+  *resource_info.mutable_resource_name() = std::move(name);
+  resource_info.set_description("Session does not exist.");
+
+  google::rpc::Status proto;
+  proto.set_code(grpc::StatusCode::NOT_FOUND);
+  proto.set_message("Session not found");
+  proto.add_details()->PackFrom(resource_info);
+
+  return grpc::Status(grpc::StatusCode::NOT_FOUND, proto.message(),
+                      proto.SerializeAsString());
+}
+
+Status SessionNotFoundError(std::string name) {
+  return MakeStatusFromRpcError(SessionNotFoundRpcError(std::move(name)));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/spanner/testing/status_utils.h
+++ b/google/cloud/spanner/testing/status_utils.h
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_STATUS_UTILS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_STATUS_UTILS_H
+
+#include "google/cloud/spanner/version.h"
+#include "google/cloud/status.h"
+#include <grpcpp/grpcpp.h>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace spanner_testing {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// A `grpc::Status` asserting that the Session cannot be found.
+grpc::Status SessionNotFoundRpcError(std::string name);
+
+/// A `google::cloud::Status` asserting that the Session cannot be found.
+Status SessionNotFoundError(std::string name);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace spanner_testing
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_SPANNER_TESTING_STATUS_UTILS_H


### PR DESCRIPTION
Use the `google.rpc.ResourceInfo.resource_type` field found within
the `google.rpc.Status.details` to distinguish the particular variety
of "NOT_FOUND" error, rather than depending upon the contents of
`google.rpc.Status.message`.

Also add a test-only module to build `google::cloud::Status` and
`grpc::Status` values that will satisfy `IsSessionNotFound()`.