### PR TITLE
feat(common): include status error payloads in the RPC log

### DIFF
--- a/google/cloud/internal/async_read_write_stream_logging.h
+++ b/google/cloud/internal/async_read_write_stream_logging.h
@@ -92,10 +92,11 @@ class AsyncStreamingReadWriteRpcLogging
 
   future<Status> Finish() override {
     auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+    auto opt = tracing_options_;
     GCP_LOG(DEBUG) << prefix << " <<";
-    return child_->Finish().then([prefix](future<Status> f) {
+    return child_->Finish().then([prefix, opt](future<Status> f) {
       auto status = f.get();
-      GCP_LOG(DEBUG) << prefix << " >> " << status;
+      GCP_LOG(DEBUG) << prefix << " >> " << DebugString(status, opt);
       return status;
     });
   }

--- a/google/cloud/internal/async_streaming_read_rpc_logging.h
+++ b/google/cloud/internal/async_streaming_read_rpc_logging.h
@@ -69,10 +69,11 @@ class AsyncStreamingReadRpcLogging : public AsyncStreamingReadRpc<Response> {
 
   future<Status> Finish() override {
     auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+    auto opt = tracing_options_;
     GCP_LOG(DEBUG) << prefix << " <<";
-    return child_->Finish().then([prefix](future<Status> f) {
+    return child_->Finish().then([prefix, opt](future<Status> f) {
       auto status = f.get();
-      GCP_LOG(DEBUG) << prefix << " >> " << status;
+      GCP_LOG(DEBUG) << prefix << " >> " << DebugString(status, opt);
       return status;
     });
   }

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -342,8 +342,8 @@ TEST(LogWrapper, StatusValueError) {
   EXPECT_THAT(log_lines,
               Contains(AllOf(HasSubstr("in-test("), HasSubstr(" << "))));
   EXPECT_THAT(log_lines,
-              Contains(AllOf(HasSubstr("in-test("),
-                             HasSubstr(" >> status=" + status_as_string))));
+              Contains(AllOf(HasSubstr("in-test("), HasSubstr(" >> status="),
+                             HasSubstr(status_as_string))));
 }
 
 /// @test the overload for functions returning ClientReaderInterface

--- a/google/cloud/internal/minimal_iam_credentials_stub.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub.cc
@@ -99,13 +99,14 @@ class AsyncAccessTokenGeneratorLogging : public MinimalIamCredentialsStub {
       CompletionQueue& cq, std::unique_ptr<grpc::ClientContext> context,
       GenerateAccessTokenRequest const& request) override {
     auto prefix = std::string(__func__) + "(" + RequestIdForLogging() + ")";
-    GCP_LOG(DEBUG) << prefix << " << "
-                   << DebugString(request, tracing_options_);
+    auto opts = tracing_options_;
+    GCP_LOG(DEBUG) << prefix << " << " << DebugString(request, opts);
     return child_->AsyncGenerateAccessToken(cq, std::move(context), request)
-        .then([prefix](future<StatusOr<GenerateAccessTokenResponse>> f) {
+        .then([prefix, opts](future<StatusOr<GenerateAccessTokenResponse>> f) {
           auto response = f.get();
           if (!response) {
-            GCP_LOG(DEBUG) << prefix << " >> status=" << response.status();
+            GCP_LOG(DEBUG) << prefix << " >> status="
+                           << DebugString(response.status(), opts);
           } else {
             // We do not want to log the access token
             GCP_LOG(DEBUG) << prefix

--- a/google/cloud/internal/streaming_write_rpc_logging.h
+++ b/google/cloud/internal/streaming_write_rpc_logging.h
@@ -67,7 +67,8 @@ class StreamingWriteRpcLogging
       GCP_LOG(DEBUG) << prefix << "() << "
                      << DebugString(*result, tracing_options_);
     } else {
-      GCP_LOG(DEBUG) << prefix << "() << " << result.status();
+      GCP_LOG(DEBUG) << prefix << "() << "
+                     << DebugString(result.status(), tracing_options_);
     }
     return result;
   }

--- a/google/cloud/pubsub/internal/subscriber_logging.cc
+++ b/google/cloud/pubsub/internal/subscriber_logging.cc
@@ -274,10 +274,11 @@ future<bool> LoggingAsyncPullStream::WritesDone() {
 
 future<Status> LoggingAsyncPullStream::Finish() {
   auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+  auto opts = tracing_options_;
   GCP_LOG(DEBUG) << prefix << " <<";
-  return child_->Finish().then([prefix](future<Status> f) {
+  return child_->Finish().then([prefix, opts](future<Status> f) {
     auto r = f.get();
-    GCP_LOG(DEBUG) << prefix << " >> status=" << r;
+    GCP_LOG(DEBUG) << prefix << " >> status=" << DebugString(r, opts);
     return r;
   });
 }

--- a/google/cloud/spanner/internal/logging_result_set_reader.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader.cc
@@ -44,7 +44,8 @@ absl::optional<PartialResultSet> LoggingResultSetReader::Read() {
 Status LoggingResultSetReader::Finish() {
   GCP_LOG(DEBUG) << __func__ << "() << (void)";
   auto status = impl_->Finish();
-  GCP_LOG(DEBUG) << __func__ << "() >> " << status;
+  GCP_LOG(DEBUG) << __func__ << "() >> "
+                 << DebugString(status, tracing_options_);
   return status;
 }
 


### PR DESCRIPTION
Followup to #9169 to add error payloads to remaining `Status` logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9186)
<!-- Reviewable:end -->
