### PR TITLE
impl(bigtable): modern `Table::CheckAndMutateRow()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -134,6 +134,39 @@ StatusOr<std::pair<bool, bigtable::Row>> DataConnectionImpl::ReadRow(
   return result;
 }
 
+StatusOr<bigtable::MutationBranch> DataConnectionImpl::CheckAndMutateRow(
+    std::string const& app_profile_id, std::string const& table_name,
+    std::string row_key, bigtable::Filter filter,
+    std::vector<bigtable::Mutation> true_mutations,
+    std::vector<bigtable::Mutation> false_mutations) {
+  google::bigtable::v2::CheckAndMutateRowRequest request;
+  request.set_app_profile_id(app_profile_id);
+  request.set_table_name(table_name);
+  request.set_row_key(std::move(row_key));
+  *request.mutable_predicate_filter() = std::move(filter).as_proto();
+  for (auto& m : true_mutations) {
+    *request.add_true_mutations() = std::move(m.op);
+  }
+  for (auto& m : false_mutations) {
+    *request.add_false_mutations() = std::move(m.op);
+  }
+  auto const idempotency = idempotency_policy()->is_idempotent(request)
+                               ? Idempotency::kIdempotent
+                               : Idempotency::kNonIdempotent;
+  auto sor = google::cloud::internal::RetryLoop(
+      retry_policy(), backoff_policy(), idempotency,
+      [this](grpc::ClientContext& context,
+             google::bigtable::v2::CheckAndMutateRowRequest const& request) {
+        return stub_->CheckAndMutateRow(context, request);
+      },
+      request, __func__);
+  if (!sor) return std::move(sor).status();
+  auto response = *std::move(sor);
+  return response.predicate_matched()
+             ? bigtable::MutationBranch::kPredicateMatched
+             : bigtable::MutationBranch::kPredicateNotMatched;
+}
+
 StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(
     google::bigtable::v2::ReadModifyWriteRowRequest request) {
   auto sor = google::cloud::internal::RetryLoop(

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -58,6 +58,12 @@ class DataConnectionImpl : public DataConnection {
       std::string const& app_profile_id, std::string const& table_name,
       std::string row_key, bigtable::Filter filter) override;
 
+  StatusOr<bigtable::MutationBranch> CheckAndMutateRow(
+      std::string const& app_profile_id, std::string const& table_name,
+      std::string row_key, bigtable::Filter filter,
+      std::vector<bigtable::Mutation> true_mutations,
+      std::vector<bigtable::Mutation> false_mutations) override;
+
   StatusOr<bigtable::Row> ReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request) override;
 

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -225,6 +225,12 @@ StatusOr<std::pair<bool, Row>> Table::ReadRow(std::string row_key,
 StatusOr<MutationBranch> Table::CheckAndMutateRow(
     std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
     std::vector<Mutation> false_mutations) {
+  if (connection_) {
+    return connection_->CheckAndMutateRow(
+        app_profile_id_, table_name_, std::move(row_key), std::move(filter),
+        std::move(true_mutations), std::move(false_mutations));
+  }
+
   grpc::Status status;
   btproto::CheckAndMutateRowRequest request;
   request.set_row_key(std::move(row_key));

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -35,8 +35,6 @@ using ::std::chrono::milliseconds;
 using ::testing::Contains;
 using ::testing::HasSubstr;
 
-using DataIntegrationTestClientOnly = TableIntegrationTest;
-
 class DataIntegrationTest : public TableIntegrationTest,
                             public ::testing::WithParamInterface<std::string> {
 };
@@ -284,8 +282,8 @@ TEST_P(DataIntegrationTest, TableReadRowsWrongTable) {
   EXPECT_EQ(read1.end(), it);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableCheckAndMutateRowPass) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableCheckAndMutateRowPass) {
+  auto table = GetTable(GetParam());
   std::string const key = "row-key";
 
   std::vector<Cell> created{{key, kFamily4, "c1", 0, "v1000"}};
@@ -302,8 +300,8 @@ TEST_F(DataIntegrationTestClientOnly, TableCheckAndMutateRowPass) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableCheckAndMutateRowFail) {
-  auto table = GetTable();
+TEST_P(DataIntegrationTest, TableCheckAndMutateRowFail) {
+  auto table = GetTable(GetParam());
   std::string const key = "row-key";
 
   std::vector<Cell> created{{key, kFamily4, "c1", 0, "v1000"}};


### PR DESCRIPTION
Part of the work for #8799 ; and this completes the `data_integration_test.cc` part of #9164 

The implementation code comes from:
https://github.com/googleapis/google-cloud-cpp/blob/f779bb99395bbdfe3aac51864ff2abf2a0b6dffc/google/cloud/bigtable/table.cc#L231-L244
https://github.com/googleapis/google-cloud-cpp/blob/f779bb99395bbdfe3aac51864ff2abf2a0b6dffc/google/cloud/bigtable/table.cc#L253-L254

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9190)
<!-- Reviewable:end -->
