### PR TITLE
impl(storage): ignore `google::cloud::Options` in `*Request`

### DIFF
--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -27,6 +27,10 @@
 
 namespace google {
 namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+// Forward declare google::cloud::Options, a dynamic container of options.
+class Options;
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
@@ -246,6 +250,19 @@ class GenericRequest
   template <typename H, typename... T>
   Derived& set_multiple_options(H&& h, T&&... tail) {
     Super::set_option(std::forward<H>(h));
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options const&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options&&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options&, T&&... tail) {
     return set_multiple_options(std::forward<T>(tail)...);
   }
 

--- a/google/cloud/storage/internal/generic_request_test.cc
+++ b/google/cloud/storage/internal/generic_request_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/generic_request.h"
+#include "google/cloud/options.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -51,6 +52,27 @@ TEST(GenericRequestTest, SetOptionLValueLastBase) {
   CustomHeader arg("header1", "val1");
   req.set_option(arg);
   EXPECT_TRUE(req.HasOption<CustomHeader>());
+  EXPECT_EQ("header1", req.GetOption<CustomHeader>().custom_header_name());
+}
+
+TEST(GenericRequestTest, IgnoreOptionsBundle) {
+  Placeholder req;
+  req.set_multiple_options(Options{}, CustomHeader{"header1", "val1"});
+  req.set_multiple_options(CustomHeader{"header1", "val1"}, Options{});
+  req.set_multiple_options(CustomHeader{"header1", "val1"}, Options{},
+                           CustomHeader{"header1", "val2"});
+  Options bundle;
+  auto const& cref = bundle;
+  req.set_multiple_options(cref, CustomHeader{"header1", "val1"});
+  req.set_multiple_options(CustomHeader{"header1", "val1"}, cref);
+  req.set_multiple_options(CustomHeader{"header1", "val1"}, cref,
+                           CustomHeader{"header1", "val2"});
+  auto& ref = bundle;
+  req.set_multiple_options(ref, CustomHeader{"header1", "val1"});
+  req.set_multiple_options(CustomHeader{"header1", "val1"}, ref);
+  req.set_multiple_options(CustomHeader{"header1", "val1"}, ref,
+                           CustomHeader{"header1", "val2"});
+  ASSERT_TRUE(req.HasOption<CustomHeader>());
   EXPECT_EQ("header1", req.GetOption<CustomHeader>().custom_header_name());
 }
 


### PR DESCRIPTION
With this change, the `storage::Client` class could accept
`google::cloud::Options` parameters in the parameter packs, and they
will be ignored by the `*Request::set_multiple_options()` calls.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9191)
<!-- Reviewable:end -->
