### PR TITLE
impl(storage): `internal::RawClient` gains `options()`

### DIFF
--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -179,6 +179,8 @@ CurlClient::CurlClient(google::cloud::Options options)
   CurlInitializeOnce(opts_);
 }
 
+Options CurlClient::options() const { return opts_; }
+
 StatusOr<ListBucketsResponse> CurlClient::ListBuckets(
     ListBucketsRequest const& request) {
   CurlRequestBuilder builder(storage_endpoint_ + "/b", storage_factory_);

--- a/google/cloud/storage/internal/curl_client.h
+++ b/google/cloud/storage/internal/curl_client.h
@@ -66,6 +66,7 @@ class CurlClient : public RawClient,
   ClientOptions const& client_options() const override {
     return backwards_compatibility_options_;
   }
+  Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -172,6 +172,8 @@ ClientOptions const& GrpcClient::client_options() const {
   return backwards_compatibility_options_;
 }
 
+Options GrpcClient::options() const { return options_; }
+
 StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
     ListBucketsRequest const& request) {
   OptionsSpan span(options_);

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -70,9 +70,8 @@ class GrpcClient : public RawClient,
       std::unique_ptr<grpc::ClientContext> context);
   //@}
 
-  Options const& options() const { return options_; }
-
   ClientOptions const& client_options() const override;
+  Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -33,6 +33,8 @@ ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();
 }
 
+Options HybridClient::options() const { return curl_->options(); }
+
 StatusOr<ListBucketsResponse> HybridClient::ListBuckets(
     ListBucketsRequest const& request) {
   return curl_->ListBuckets(request);

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -33,6 +33,7 @@ class HybridClient : public RawClient {
   ~HybridClient() override = default;
 
   ClientOptions const& client_options() const override;
+  Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;

--- a/google/cloud/storage/internal/logging_client.cc
+++ b/google/cloud/storage/internal/logging_client.cc
@@ -83,6 +83,8 @@ ClientOptions const& LoggingClient::client_options() const {
   return client_->client_options();
 }
 
+Options LoggingClient::options() const { return client_->options(); }
+
 StatusOr<ListBucketsResponse> LoggingClient::ListBuckets(
     ListBucketsRequest const& request) {
   return MakeCall(*client_, &RawClient::ListBuckets, request, __func__);

--- a/google/cloud/storage/internal/logging_client.h
+++ b/google/cloud/storage/internal/logging_client.h
@@ -33,6 +33,7 @@ class LoggingClient : public RawClient {
   ~LoggingClient() override = default;
 
   ClientOptions const& client_options() const override;
+  Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;

--- a/google/cloud/storage/internal/raw_client.h
+++ b/google/cloud/storage/internal/raw_client.h
@@ -33,6 +33,7 @@
 #include "google/cloud/storage/object_metadata.h"
 #include "google/cloud/storage/service_account.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include <string>
@@ -52,6 +53,8 @@ class RawClient {
   virtual ~RawClient() = default;
 
   virtual ClientOptions const& client_options() const = 0;
+
+  virtual google::cloud::Options options() const { return {}; }
 
   //@{
   /// @name Bucket resource operations

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -169,6 +169,8 @@ RestClient::RestClient(
       generator_(google::cloud::internal::MakeDefaultPRNG()),
       options_(std::move(options)) {}
 
+Options RestClient::options() const { return curl_client_->options(); }
+
 StatusOr<ListBucketsResponse> RestClient::ListBuckets(
     ListBucketsRequest const& request) {
   RestRequestBuilder builder(

--- a/google/cloud/storage/internal/rest_client.h
+++ b/google/cloud/storage/internal/rest_client.h
@@ -54,6 +54,7 @@ class RestClient : public RawClient,
   ClientOptions const& client_options() const override {
     return curl_client_->client_options();
   }
+  Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -111,6 +111,8 @@ ClientOptions const& RetryClient::client_options() const {
   return client_->client_options();
 }
 
+Options RetryClient::options() const { return client_->options(); }
+
 StatusOr<ListBucketsResponse> RetryClient::ListBuckets(
     ListBucketsRequest const& request) {
   auto retry_policy = retry_policy_prototype_->clone();

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -38,6 +38,7 @@ class RetryClient : public RawClient,
   ~RetryClient() override = default;
 
   ClientOptions const& client_options() const override;
+  Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
       ListBucketsRequest const& request) override;

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -35,6 +35,7 @@ class MockClient : public google::cloud::storage::internal::RawClient {
   }
 
   MOCK_METHOD(ClientOptions const&, client_options, (), (const, override));
+  MOCK_METHOD(Options, options, (), (const, override));
   MOCK_METHOD(StatusOr<internal::ListBucketsResponse>, ListBuckets,
               (internal::ListBucketsRequest const&), (override));
   MOCK_METHOD(StatusOr<storage::BucketMetadata>, CreateBucket,


### PR DESCRIPTION
To support per-operation options we need to get the
`google::cloud::Options` of a `RawClient`.  This is analogous to the
`options()` accessor in the `*Connection` classes for other libraries.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9192)
<!-- Reviewable:end -->
