### PR TITLE
impl(storage): helpers to create `OptionSpan`

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -67,6 +67,7 @@ google_cloud_cpp_storage_hdrs = [
     "internal/lifecycle_rule_parser.h",
     "internal/logging_client.h",
     "internal/make_jwt_assertion.h",
+    "internal/make_options_span.h",
     "internal/metadata_parser.h",
     "internal/minimal_iam_credentials_rest.h",
     "internal/notification_metadata_parser.h",

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -111,6 +111,7 @@ add_library(
     internal/logging_client.h
     internal/make_jwt_assertion.cc
     internal/make_jwt_assertion.h
+    internal/make_options_span.h
     internal/metadata_parser.cc
     internal/metadata_parser.h
     internal/minimal_iam_credentials_rest.cc
@@ -460,6 +461,7 @@ if (BUILD_TESTING)
         internal/impersonate_service_account_credentials_test.cc
         internal/logging_client_test.cc
         internal/make_jwt_assertion_test.cc
+        internal/make_options_span_test.cc
         internal/metadata_parser_test.cc
         internal/notification_requests_test.cc
         internal/object_acl_requests_test.cc

--- a/google/cloud/storage/internal/make_options_span.h
+++ b/google/cloud/storage/internal/make_options_span.h
@@ -1,0 +1,92 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_MAKE_OPTIONS_SPAN_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_MAKE_OPTIONS_SPAN_H
+
+#include "google/cloud/storage/version.h"
+#include "google/cloud/options.h"
+#include <utility>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+///@{
+/**
+ * The `GroupOptions()` overload set groups all the `google::cloud::Options`
+ * present in a parameter pack into a single `google::cloud::Options`.
+ *
+ * @note This does not support `volative`-qualified references.
+ */
+inline google::cloud::Options GroupOptions() {
+  return google::cloud::Options{};
+}
+
+template <typename... Tail>
+static Options GroupOptions(Options& bundle, Tail&&... t) {
+  return google::cloud::internal::MergeOptions(
+      GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
+}
+
+template <typename... Tail>
+static Options GroupOptions(Options&& bundle, Tail&&... t) {
+  return google::cloud::internal::MergeOptions(
+      GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
+}
+
+template <typename... Tail>
+static Options GroupOptions(Options const& bundle, Tail&&... t) {
+  return google::cloud::internal::MergeOptions(
+      GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
+}
+
+template <typename... Tail>
+static Options GroupOptions(Options const&& bundle, Tail&&... t) {
+  return google::cloud::internal::MergeOptions(
+      GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
+}
+
+template <typename Head, typename... Tail>
+static Options GroupOptions(Head&&, Tail&&... t) {
+  return GroupOptions(std::forward<Tail>(t)...);
+}
+///@}
+
+/**
+ * Create an option span for a `google::cloud::storage::Client` operation.
+ *
+ * All operations in `google::cloud::storage::Client` should create an option
+ * span combining the options in the `RawClient` with any
+ * `google::cloud::Options` in the parameter pack.
+ */
+template <typename... RequestOptions>
+google::cloud::internal::OptionsSpan MakeOptionsSpan(
+    Options defaults,  // NOLINT(performance-unnecessary-value-param)
+    RequestOptions&&... o) {
+  return google::cloud::internal::OptionsSpan(
+      google::cloud::internal::MergeOptions(
+          GroupOptions(std::forward<RequestOptions>(o)...),
+          std::move(defaults)));
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_MAKE_OPTIONS_SPAN_H

--- a/google/cloud/storage/internal/make_options_span.h
+++ b/google/cloud/storage/internal/make_options_span.h
@@ -30,6 +30,10 @@ namespace internal {
  * The `GroupOptions()` overload set groups all the `google::cloud::Options`
  * present in a parameter pack into a single `google::cloud::Options`.
  *
+ * If the parameter pack contains multiple `google::cloud::Options` the latter
+ * values are preferred (i.e. they override previous values) as defined by
+ * `google::cloud::internal::MergeOptions()`.
+ *
  * @note This does not support `volative`-qualified references.
  */
 inline google::cloud::Options GroupOptions() {
@@ -67,7 +71,7 @@ static Options GroupOptions(Head&&, Tail&&... t) {
 ///@}
 
 /**
- * Create an option span for a `google::cloud::storage::Client` operation.
+ * Create an `OptionsSpan` for a `google::cloud::storage::Client` operation.
  *
  * All operations in `google::cloud::storage::Client` should create an option
  * span combining the options in the `RawClient` with any

--- a/google/cloud/storage/internal/make_options_span_test.cc
+++ b/google/cloud/storage/internal/make_options_span_test.cc
@@ -1,0 +1,72 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/make_options_span.h"
+#include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/common_options.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::internal::CurrentOptions;
+
+google::cloud::Options SimulateRawClientOptions() {
+  return Options{}
+      .set<UserProjectOption>("u-p-default")
+      .set<AuthorityOption>("a-default");
+}
+
+TEST(MakeOptionSpanTest, JustDefaults) {
+  auto const span = MakeOptionsSpan(SimulateRawClientOptions());
+  auto const& current = CurrentOptions();
+  EXPECT_EQ("u-p-default", current.get<UserProjectOption>());
+  EXPECT_EQ("a-default", current.get<AuthorityOption>());
+}
+
+TEST(MakeOptionSpanTest, Overrides) {
+  auto const span =
+      MakeOptionsSpan(SimulateRawClientOptions(),
+                      Options{}.set<EndpointOption>("test-endpoint"),
+                      Options{}.set<AuthorityOption>("a-override-1"),
+                      Options{}.set<AuthorityOption>("a-override-2"));
+  auto const& current = CurrentOptions();
+  EXPECT_EQ("u-p-default", current.get<UserProjectOption>());
+  EXPECT_EQ("a-override-2", current.get<AuthorityOption>());
+  EXPECT_EQ("test-endpoint", current.get<EndpointOption>());
+}
+
+TEST(MakeOptionSpanTest, OverridesMixedWithRequestOptions) {
+  auto const span = MakeOptionsSpan(
+      SimulateRawClientOptions(), IfGenerationMatch(0),
+      Options{}.set<EndpointOption>("test-endpoint"), IfGenerationNotMatch(0),
+      Options{}.set<AuthorityOption>("a-override-1"), IfMetagenerationMatch(0),
+      Options{}.set<AuthorityOption>("a-override-2"),
+      IfMetagenerationNotMatch(0), Generation(7), IfGenerationMatch(0));
+  auto const& current = CurrentOptions();
+  EXPECT_EQ("u-p-default", current.get<UserProjectOption>());
+  EXPECT_EQ("a-override-2", current.get<AuthorityOption>());
+  EXPECT_EQ("test-endpoint", current.get<EndpointOption>());
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/make_options_span_test.cc
+++ b/google/cloud/storage/internal/make_options_span_test.cc
@@ -42,8 +42,9 @@ TEST(MakeOptionSpanTest, JustDefaults) {
 TEST(MakeOptionSpanTest, Overrides) {
   auto const span =
       MakeOptionsSpan(SimulateRawClientOptions(),
-                      Options{}.set<EndpointOption>("test-endpoint"),
-                      Options{}.set<AuthorityOption>("a-override-1"),
+                      Options{}
+                          .set<EndpointOption>("test-endpoint")
+                          .set<AuthorityOption>("a-override-1"),
                       Options{}.set<AuthorityOption>("a-override-2"));
   auto const& current = CurrentOptions();
   EXPECT_EQ("u-p-default", current.get<UserProjectOption>());

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -65,6 +65,7 @@ storage_client_unit_tests = [
     "internal/impersonate_service_account_credentials_test.cc",
     "internal/logging_client_test.cc",
     "internal/make_jwt_assertion_test.cc",
+    "internal/make_options_span_test.cc",
     "internal/metadata_parser_test.cc",
     "internal/notification_requests_test.cc",
     "internal/object_acl_requests_test.cc",


### PR DESCRIPTION
To add per-operation options we need some helpers to create a span from
the parameter pack received by each operation.  With these helpers we
will be able to more easily add spans. For example:

```cc
class Client {
 public:
...
  template <typename... RequestOptions>
  StatusOr<ObjectMetadata> GetObjectMetadata(
      std::string const& bucket_name, std::string const& object_name,
      RequestOptions&&... options) {
    auto const span = internal::MakeOptionSpan(
        options(), std::forward<RequestOptions>(options)...);
    ...
    ..
  }
};
```

Part of the work for #9150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9195)
<!-- Reviewable:end -->
