### PR TITLE
fix(storage): missing `set_multiple_options()` overload

### DIFF
--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -254,6 +254,10 @@ class GenericRequest
   }
 
   template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options const&&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
   Derived& set_multiple_options(google::cloud::Options const&, T&&... tail) {
     return set_multiple_options(std::forward<T>(tail)...);
   }


### PR DESCRIPTION
Addresses a question in https://github.com/googleapis/google-cloud-cpp/pull/9191#pullrequestreview-998755291 

Part of the work for #9150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9196)
<!-- Reviewable:end -->
