### PR TITLE
feat(GCS+gRPC): timeout uploads when stalled

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -163,6 +163,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         internal/grpc_client_insert_object_media_test.cc
         internal/grpc_client_read_object_test.cc
         internal/grpc_client_test.cc
+        internal/grpc_client_upload_chunk_test.cc
         internal/grpc_configure_client_context_test.cc
         internal/grpc_hmac_key_metadata_parser_test.cc
         internal/grpc_hmac_key_request_parser_test.cc

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -300,7 +300,8 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
   struct WaitForIdle {
     std::unique_ptr<WriteObjectStream> stream;
     void operator()(future<bool>) {
-      stream->Finish().then(WaitForFinish{std::move(stream)});
+      auto finish = stream->Finish();
+      (void)finish.then(WaitForFinish{std::move(stream)});
     }
   };
 
@@ -558,7 +559,8 @@ StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
   struct WaitForIdle {
     std::unique_ptr<WriteObjectStream> stream;
     void operator()(future<bool>) {
-      stream->Finish().then(WaitForFinish{std::move(stream)});
+      auto finish = stream->Finish();
+      (void)finish.then(WaitForFinish{std::move(stream)});
     }
   };
 

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -18,7 +18,7 @@
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/background_threads.h"
-#include "google/cloud/internal/streaming_write_rpc.h"
+#include "google/cloud/internal/async_streaming_write_rpc.h"
 #include <google/storage/v2/storage.pb.h>
 #include <functional>
 #include <memory>
@@ -56,19 +56,9 @@ class GrpcClient : public RawClient,
 
   ~GrpcClient() override = default;
 
-  //@{
-  /// @name Implement the ResumableSession operations.
-  // Note that these member functions are not inherited from RawClient, they are
-  // called only by `GrpcResumableUploadSession`, because the retry loop for
-  // them is very different from the standard retry loop. Also note that some of
-  // these member functions are virtual, but only because we need to override
-  // them in the *library* unit tests.
-  using WriteObjectStream = ::google::cloud::internal::StreamingWriteRpc<
+  using WriteObjectStream = ::google::cloud::internal::AsyncStreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
-  virtual std::unique_ptr<WriteObjectStream> CreateUploadWriter(
-      std::unique_ptr<grpc::ClientContext> context);
-  //@}
 
   ClientOptions const& client_options() const override;
   Options options() const override;

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -26,6 +26,7 @@ storage_client_grpc_unit_tests = [
     "internal/grpc_client_insert_object_media_test.cc",
     "internal/grpc_client_read_object_test.cc",
     "internal/grpc_client_test.cc",
+    "internal/grpc_client_upload_chunk_test.cc",
     "internal/grpc_configure_client_context_test.cc",
     "internal/grpc_hmac_key_metadata_parser_test.cc",
     "internal/grpc_hmac_key_request_parser_test.cc",

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -152,17 +152,21 @@ class MockStorageStub : public storage_internal::StorageStub {
               (override));
 };
 
-class MockInsertStream : public google::cloud::internal::StreamingWriteRpc<
+class MockInsertStream : public google::cloud::internal::AsyncStreamingWriteRpc<
                              google::storage::v2::WriteObjectRequest,
                              google::storage::v2::WriteObjectResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD(bool, Write,
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<bool>, Write,
               (google::storage::v2::WriteObjectRequest const&,
                grpc::WriteOptions),
               (override));
-  MOCK_METHOD(StatusOr<google::storage::v2::WriteObjectResponse>, Close, (),
-              (override));
+  MOCK_METHOD(future<bool>, WritesDone, (), (override));
+  MOCK_METHOD(future<StatusOr<google::storage::v2::WriteObjectResponse>>,
+              Finish, (), (override));
+  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
+              (), (const, override));
 };
 
 class MockObjectMediaStream


### PR DESCRIPTION
Predicting the total time (and therefore an appropriate timeout) for an
upload is difficult, as it depends on the size of the upload.  Instead,
we expect the upload to make progress, and timeout if they stall.

Fixes #9150

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9198)
<!-- Reviewable:end -->
