### PR TITLE
feat(storage): per-operation options / service accounts

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/hmac_key_metadata.h"
 #include "google/cloud/storage/internal/logging_client.h"
+#include "google/cloud/storage/internal/make_options_span.h"
 #include "google/cloud/storage/internal/parameter_pack_validation.h"
 #include "google/cloud/storage/internal/policy_document_request.h"
 #include "google/cloud/storage/internal/retry_client.h"
@@ -2493,6 +2494,7 @@ class Client {
   template <typename... Options>
   StatusOr<ServiceAccount> GetServiceAccountForProject(
       std::string const& project_id, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::GetProjectServiceAccountRequest request(project_id);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->GetServiceAccount(request);
@@ -2527,6 +2529,7 @@ class Client {
    */
   template <typename... Options>
   StatusOr<ServiceAccount> GetServiceAccount(Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     auto const& project_id = raw_client_->client_options().project_id();
     return GetServiceAccountForProject(project_id,
                                        std::forward<Options>(options)...);
@@ -2563,6 +2566,7 @@ class Client {
    */
   template <typename... Options>
   ListHmacKeysReader ListHmacKeys(Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     auto const& project_id = raw_client_->client_options().project_id();
     internal::ListHmacKeysRequest request(project_id);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2611,6 +2615,7 @@ class Client {
   template <typename... Options>
   StatusOr<std::pair<HmacKeyMetadata, std::string>> CreateHmacKey(
       std::string service_account, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     auto const& project_id = raw_client_->client_options().project_id();
     internal::CreateHmacKeyRequest request(project_id,
                                            std::move(service_account));
@@ -2653,6 +2658,7 @@ class Client {
    */
   template <typename... Options>
   Status DeleteHmacKey(std::string access_id, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     auto const& project_id = raw_client_->client_options().project_id();
     internal::DeleteHmacKeyRequest request(project_id, std::move(access_id));
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2689,6 +2695,7 @@ class Client {
   template <typename... Options>
   StatusOr<HmacKeyMetadata> GetHmacKey(std::string access_id,
                                        Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     auto const& project_id = raw_client_->client_options().project_id();
     internal::GetHmacKeyRequest request(project_id, std::move(access_id));
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2730,6 +2737,7 @@ class Client {
   StatusOr<HmacKeyMetadata> UpdateHmacKey(std::string access_id,
                                           HmacKeyMetadata resource,
                                           Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     auto const& project_id = raw_client_->client_options().project_id();
     internal::UpdateHmacKeyRequest request(project_id, std::move(access_id),
                                            std::move(resource));
@@ -3163,6 +3171,12 @@ class Client {
 
   ObjectWriteStream WriteObjectImpl(
       internal::ResumableUploadRequest const& request);
+
+  template <typename... RequestOptions>
+  google::cloud::internal::OptionsSpan MakeSpan(RequestOptions&&... o) const {
+    return internal::MakeOptionsSpan(raw_client_->options(),
+                                     std::forward<RequestOptions>(o)...);
+  }
 
   // The version of UploadFile() where UseResumableUploadSession is one of the
   // options. Note how this does not use InsertObjectMedia at all.

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -54,6 +54,22 @@ class GenericHmacKeyRequest
   }
 
   Derived& set_multiple_options() { return *static_cast<Derived*>(this); }
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options const&&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options const&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options&&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  Derived& set_multiple_options(google::cloud::Options&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
 
   using GenericRequest<Derived, UserProject, Options...>::set_option;
   void set_option(OverrideDefaultProject const& o) {

--- a/google/cloud/storage/internal/make_options_span.h
+++ b/google/cloud/storage/internal/make_options_span.h
@@ -34,7 +34,7 @@ namespace internal {
  * values are preferred (i.e. they override previous values) as defined by
  * `google::cloud::internal::MergeOptions()`.
  *
- * @note This does not support `volative`-qualified references.
+ * @note This does not support `volatile`-qualified references.
  */
 inline google::cloud::Options GroupOptions() {
   return google::cloud::Options{};

--- a/google/cloud/storage/testing/client_unit_test.cc
+++ b/google/cloud/storage/testing/client_unit_test.cc
@@ -19,11 +19,18 @@ namespace cloud {
 namespace storage {
 namespace testing {
 
+using ::testing::Return;
+using ::testing::ReturnRef;
+
 ClientUnitTest::ClientUnitTest()
     : mock_(std::make_shared<testing::MockClient>()),
       client_options_(ClientOptions(oauth2::CreateAnonymousCredentials())) {
   EXPECT_CALL(*mock_, client_options())
-      .WillRepeatedly(::testing::ReturnRef(client_options_));
+      .WillRepeatedly(ReturnRef(client_options_));
+  EXPECT_CALL(*mock_, options)
+      .WillRepeatedly(Return(Options{}
+                                 .set<AuthorityOption>("a-default")
+                                 .set<UserProjectOption>("u-p-default")));
 }
 
 Client ClientUnitTest::ClientForMock() {


### PR DESCRIPTION
This introduces support for per-operation `google::cloud::Options`,
starting with the operations related to service accounts.

This change also introduced some changes to the test fixtures that I
expect will be used in all tests.

Also fixed an unrelated typo.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9199)
<!-- Reviewable:end -->
