### PR TITLE
feat(storage): per-operation options / SignedPolicyDocuments

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2910,6 +2910,7 @@ class Client {
   template <typename... Options>
   StatusOr<PolicyDocumentResult> CreateSignedPolicyDocument(
       PolicyDocument document, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::PolicyDocumentRequest request(std::move(document));
     request.set_multiple_options(std::forward<Options>(options)...);
     return SignPolicyDocument(request);
@@ -2951,6 +2952,7 @@ class Client {
   template <typename... Options>
   StatusOr<PolicyDocumentV4Result> GenerateSignedPostPolicyV4(
       PolicyDocumentV4 document, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::PolicyDocumentV4Request request(std::move(document));
     request.set_multiple_options(std::forward<Options>(options)...);
     return SignPolicyDocumentV4(std::move(request));

--- a/google/cloud/storage/internal/policy_document_request.h
+++ b/google/cloud/storage/internal/policy_document_request.h
@@ -27,6 +27,9 @@
 
 namespace google {
 namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class Options;
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
@@ -70,6 +73,26 @@ class PolicyDocumentRequest {
   }
 
   PolicyDocumentRequest& set_multiple_options() { return *this; }
+  template <typename... T>
+  PolicyDocumentRequest& set_multiple_options(google::cloud::Options const&&,
+                                              T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  PolicyDocumentRequest& set_multiple_options(google::cloud::Options const&,
+                                              T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  PolicyDocumentRequest& set_multiple_options(google::cloud::Options&&,
+                                              T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  PolicyDocumentRequest& set_multiple_options(google::cloud::Options&,
+                                              T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
 
  private:
   PolicyDocument document_;
@@ -125,6 +148,26 @@ class PolicyDocumentV4Request {
   }
 
   PolicyDocumentV4Request& set_multiple_options() { return *this; }
+  template <typename... T>
+  PolicyDocumentV4Request& set_multiple_options(google::cloud::Options const&&,
+                                                T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  PolicyDocumentV4Request& set_multiple_options(google::cloud::Options const&,
+                                                T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  PolicyDocumentV4Request& set_multiple_options(google::cloud::Options&&,
+                                                T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  PolicyDocumentV4Request& set_multiple_options(google::cloud::Options&,
+                                                T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
 
   std::chrono::system_clock::time_point ExpirationDate() const;
   std::string Url() const;


### PR DESCRIPTION
Support per-operation `google::cloud::Options` for operations related to
signing policy documents.

Part of the work for #7691 