### PR TITLE
feat(storage): per-operation options / Notification

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2986,6 +2986,7 @@ class Client {
   template <typename... Options>
   StatusOr<std::vector<NotificationMetadata>> ListNotifications(
       std::string const& bucket_name, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ListNotificationsRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->ListNotifications(request);
@@ -3028,6 +3029,7 @@ class Client {
   StatusOr<NotificationMetadata> CreateNotification(
       std::string const& bucket_name, std::string const& topic_name,
       NotificationMetadata metadata, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     return CreateNotification(bucket_name, topic_name,
                               payload_format::JsonApiV1(), std::move(metadata),
                               std::forward<Options>(options)...);
@@ -3071,6 +3073,7 @@ class Client {
       std::string const& bucket_name, std::string const& topic_name,
       std::string const& payload_format, NotificationMetadata metadata,
       Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     metadata.set_topic(topic_name).set_payload_format(payload_format);
     internal::CreateNotificationRequest request(bucket_name, metadata);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -3106,6 +3109,7 @@ class Client {
   StatusOr<NotificationMetadata> GetNotification(
       std::string const& bucket_name, std::string const& notification_id,
       Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::GetNotificationRequest request(bucket_name, notification_id);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->GetNotification(request);
@@ -3142,6 +3146,7 @@ class Client {
   Status DeleteNotification(std::string const& bucket_name,
                             std::string const& notification_id,
                             Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::DeleteNotificationRequest request(bucket_name, notification_id);
     request.set_multiple_options(std::forward<Options>(options)...);
     return std::move(raw_client_->DeleteNotification(request)).status();

--- a/google/cloud/storage/client_notifications_test.cc
+++ b/google/cloud/storage/client_notifications_test.cc
@@ -30,6 +30,7 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -59,13 +60,15 @@ TEST_F(NotificationsTest, ListNotifications) {
       .WillOnce(Return(
           StatusOr<internal::ListNotificationsResponse>(TransientError())))
       .WillOnce([&expected](internal::ListNotificationsRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket", r.bucket_name());
 
         return make_status_or(internal::ListNotificationsResponse{expected});
       });
   auto client = ClientForMock();
-  StatusOr<std::vector<NotificationMetadata>> actual =
-      client.ListNotifications("test-bucket");
+  StatusOr<std::vector<NotificationMetadata>> actual = client.ListNotifications(
+      "test-bucket", Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, actual.value());
 }
@@ -103,6 +106,8 @@ TEST_F(NotificationsTest, CreateNotification) {
   EXPECT_CALL(*mock_, CreateNotification)
       .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce([&expected](internal::CreateNotificationRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_THAT(r.json_payload(), HasSubstr("test-topic-1"));
         EXPECT_THAT(r.json_payload(), HasSubstr("JSON_API_V1"));
@@ -116,7 +121,8 @@ TEST_F(NotificationsTest, CreateNotification) {
       "test-bucket", "test-topic-1", payload_format::JsonApiV1(),
       NotificationMetadata()
           .set_object_name_prefix("test-object-prefix-")
-          .append_event_type(event_type::ObjectFinalize()));
+          .append_event_type(event_type::ObjectFinalize()),
+      Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, actual.value());
 }
@@ -160,6 +166,8 @@ TEST_F(NotificationsTest, GetNotification) {
   EXPECT_CALL(*mock_, GetNotification)
       .WillOnce(Return(StatusOr<NotificationMetadata>(TransientError())))
       .WillOnce([&expected](internal::GetNotificationRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
@@ -167,7 +175,8 @@ TEST_F(NotificationsTest, GetNotification) {
       });
   auto client = ClientForMock();
   StatusOr<NotificationMetadata> actual =
-      client.GetNotification("test-bucket", "test-notification-1");
+      client.GetNotification("test-bucket", "test-notification-1",
+                             Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, actual.value());
 }
@@ -197,13 +206,17 @@ TEST_F(NotificationsTest, DeleteNotification) {
   EXPECT_CALL(*mock_, DeleteNotification)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteNotificationRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket", r.bucket_name());
         EXPECT_EQ("test-notification-1", r.notification_id());
 
         return make_status_or(internal::EmptyResponse{});
       });
   auto client = ClientForMock();
-  auto status = client.DeleteNotification("test-bucket", "test-notification-1");
+  auto status =
+      client.DeleteNotification("test-bucket", "test-notification-1",
+                                Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(status);
 }
 


### PR DESCRIPTION
Support per-operation `google::cloud::Options` for operations related to
`Notification` resources.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9205)
<!-- Reviewable:end -->
