### PR TITLE
feat(storage): per-operation options / ObjectAccessControl

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -1938,6 +1938,7 @@ class Client {
   StatusOr<std::vector<ObjectAccessControl>> ListObjectAcl(
       std::string const& bucket_name, std::string const& object_name,
       Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ListObjectAclRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto result = raw_client_->ListObjectAcl(request);
@@ -1975,6 +1976,7 @@ class Client {
                                                 std::string const& entity,
                                                 std::string const& role,
                                                 Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::CreateObjectAclRequest request(bucket_name, object_name, entity,
                                              role);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2005,6 +2007,7 @@ class Client {
   Status DeleteObjectAcl(std::string const& bucket_name,
                          std::string const& object_name,
                          std::string const& entity, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::DeleteObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->DeleteObjectAcl(request).status();
@@ -2033,6 +2036,7 @@ class Client {
                                              std::string const& object_name,
                                              std::string const& entity,
                                              Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::GetObjectAclRequest request(bucket_name, object_name, entity);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->GetObjectAcl(request);
@@ -2072,6 +2076,7 @@ class Client {
                                                 std::string const& object_name,
                                                 ObjectAccessControl const& acl,
                                                 Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::UpdateObjectAclRequest request(bucket_name, object_name,
                                              acl.entity(), acl.role());
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2119,6 +2124,7 @@ class Client {
       std::string const& bucket_name, std::string const& object_name,
       std::string const& entity, ObjectAccessControl const& original_acl,
       ObjectAccessControl const& new_acl, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::PatchObjectAclRequest request(bucket_name, object_name, entity,
                                             original_acl, new_acl);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2164,6 +2170,7 @@ class Client {
       std::string const& bucket_name, std::string const& object_name,
       std::string const& entity, ObjectAccessControlPatchBuilder const& builder,
       Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::PatchObjectAclRequest request(bucket_name, object_name, entity,
                                             builder);
     request.set_multiple_options(std::forward<Options>(options)...);


### PR DESCRIPTION
Support per-operation `google::cloud::Options` for operations related to
`ObjectAccessControl` resources.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9206)
<!-- Reviewable:end -->
