### PR TITLE
feat(storage): per-operation options / Object "copy"

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -975,6 +975,7 @@ class Client {
                                       std::string destination_bucket_name,
                                       std::string destination_object_name,
                                       Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::CopyObjectRequest request(
         std::move(source_bucket_name), std::move(source_object_name),
         std::move(destination_bucket_name), std::move(destination_object_name));
@@ -1459,6 +1460,7 @@ class Client {
   StatusOr<ObjectMetadata> ComposeObject(
       std::string bucket_name, std::vector<ComposeSourceObject> source_objects,
       std::string destination_object_name, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ComposeObjectRequest request(std::move(bucket_name),
                                            std::move(source_objects),
                                            std::move(destination_object_name));
@@ -1563,6 +1565,7 @@ class Client {
                                      std::string destination_object_name,
                                      std::string rewrite_token,
                                      Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::RewriteObjectRequest request(
         std::move(source_bucket_name), std::move(source_object_name),
         std::move(destination_bucket_name), std::move(destination_object_name),

--- a/google/cloud/storage/object_rewriter.cc
+++ b/google/cloud/storage/object_rewriter.cc
@@ -20,13 +20,16 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 ObjectRewriter::ObjectRewriter(std::shared_ptr<internal::RawClient> client,
                                internal::RewriteObjectRequest request)
     : client_(std::move(client)),
       request_(std::move(request)),
-      progress_{0, 0, false} {}
+      progress_{0, 0, false},
+      span_(google::cloud::internal::CurrentOptions()) {}
 
 StatusOr<RewriteProgress> ObjectRewriter::Iterate() {
+  auto span = google::cloud::internal::OptionsSpan(span_);
   StatusOr<internal::RewriteObjectResponse> response =
       client_->RewriteObject(request_);
   if (!response.ok()) {

--- a/google/cloud/storage/object_rewriter.h
+++ b/google/cloud/storage/object_rewriter.h
@@ -134,7 +134,9 @@ class ObjectRewriter {
   RewriteProgress progress_;
   ObjectMetadata result_;
   Status last_error_;
+  Options span_;
 };
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
Support per-operation `google::cloud::Options` for operations related to
copying existing objects into new objects, that is, `CopyObject()`, the
`RewriteObject()` overloads, and `ComposeObject()`.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9207)
<!-- Reviewable:end -->
