### PR TITLE
feat(storage): per-operation options / signed URLs

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -2805,6 +2805,7 @@ class Client {
                                           std::string bucket_name,
                                           std::string object_name,
                                           Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::V2SignUrlRequest request(std::move(verb), std::move(bucket_name),
                                        std::move(object_name));
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -2868,6 +2869,7 @@ class Client {
                                           std::string bucket_name,
                                           std::string object_name,
                                           Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::V4SignUrlRequest request(std::move(verb), std::move(bucket_name),
                                        std::move(object_name));
     request.set_multiple_options(std::forward<Options>(options)...);

--- a/google/cloud/storage/client_sign_url_test.cc
+++ b/google/cloud/storage/client_sign_url_test.cc
@@ -27,6 +27,7 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::testing::HasSubstr;
 using ::testing::Return;
@@ -92,12 +93,15 @@ TEST_F(CreateSignedUrlTest, V2SignRemote) {
   EXPECT_CALL(*mock_, SignBlob)
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
       .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         return make_status_or(
             internal::SignBlobResponse{"test-key-id", expected_signed_blob});
       });
   auto client = ClientForMock();
   StatusOr<std::string> actual =
-      client.CreateV2SignedUrl("GET", "test-bucket", "test-object");
+      client.CreateV2SignedUrl("GET", "test-bucket", "test-object",
+                               Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_THAT(*actual, HasSubstr(expected_signed_blob_safe));
 }
@@ -235,12 +239,15 @@ TEST_F(CreateSignedUrlTest, V4SignRemote) {
   EXPECT_CALL(*mock_, SignBlob)
       .WillOnce(Return(StatusOr<internal::SignBlobResponse>(TransientError())))
       .WillOnce([&expected_signed_blob](internal::SignBlobRequest const&) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         return make_status_or(
             internal::SignBlobResponse{"test-key-id", expected_signed_blob});
       });
   auto client = ClientForMock();
   StatusOr<std::string> actual =
-      client.CreateV4SignedUrl("GET", "test-bucket", "test-object");
+      client.CreateV4SignedUrl("GET", "test-bucket", "test-object",
+                               Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_THAT(*actual, HasSubstr(expected_signed_blob_hex));
 }

--- a/google/cloud/storage/internal/signed_url_requests.h
+++ b/google/cloud/storage/internal/signed_url_requests.h
@@ -146,6 +146,25 @@ class V2SignUrlRequest {
   }
 
   V2SignUrlRequest& set_multiple_options() { return *this; }
+  template <typename... T>
+  V2SignUrlRequest& set_multiple_options(google::cloud::Options const&&,
+                                         T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  V2SignUrlRequest& set_multiple_options(google::cloud::Options const&,
+                                         T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  V2SignUrlRequest& set_multiple_options(google::cloud::Options&&,
+                                         T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  V2SignUrlRequest& set_multiple_options(google::cloud::Options&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
 
  private:
   static std::chrono::system_clock::time_point DefaultExpirationTime();
@@ -258,6 +277,25 @@ class V4SignUrlRequest {
   }
 
   V4SignUrlRequest& set_multiple_options() { return *this; }
+  template <typename... T>
+  V4SignUrlRequest& set_multiple_options(google::cloud::Options const&&,
+                                         T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  V4SignUrlRequest& set_multiple_options(google::cloud::Options const&,
+                                         T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  V4SignUrlRequest& set_multiple_options(google::cloud::Options&&,
+                                         T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
+  template <typename... T>
+  V4SignUrlRequest& set_multiple_options(google::cloud::Options&, T&&... tail) {
+    return set_multiple_options(std::forward<T>(tail)...);
+  }
 
   Status Validate();
 


### PR DESCRIPTION
Support per-operation `google::cloud::Options` for operations related to
creating signed URLs.

Part of the work for #7691 