### PR TITLE
cleanup(common): correct the direction on some request/response logging

### DIFF
--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -248,7 +248,8 @@ Result LogWrapper(Functor&& functor, grpc::ClientContext* context,
     GCP_LOG(DEBUG) << where << "() >> status="
                    << DebugString(MakeStatusFromRpcError(status), options);
   } else {
-    GCP_LOG(DEBUG) << where << "() << " << DebugString(*response, options);
+    GCP_LOG(DEBUG) << where
+                   << "() >> response=" << DebugString(*response, options);
   }
   return status;
 }

--- a/google/cloud/internal/streaming_read_rpc_logging.h
+++ b/google/cloud/internal/streaming_read_rpc_logging.h
@@ -49,13 +49,13 @@ class StreamingReadRpcLogging : public StreamingReadRpc<ResponseType> {
 
   void Cancel() override {
     auto const prefix = std::string(__func__) + "(" + request_id_ + ")";
-    GCP_LOG(DEBUG) << prefix << "() >> (void)";
+    GCP_LOG(DEBUG) << prefix << "() << (void)";
     reader_->Cancel();
     GCP_LOG(DEBUG) << prefix << "() >> (void)";
   }
   absl::variant<Status, ResponseType> Read() override {
     auto const prefix = std::string(__func__) + "(" + request_id_ + ")";
-    GCP_LOG(DEBUG) << prefix << "() >> (void)";
+    GCP_LOG(DEBUG) << prefix << "() << (void)";
     auto result = reader_->Read();
     GCP_LOG(DEBUG) << prefix << "() >> "
                    << absl::visit(ResultVisitor(tracing_options_), result);

--- a/google/cloud/internal/streaming_write_rpc_logging.h
+++ b/google/cloud/internal/streaming_write_rpc_logging.h
@@ -64,10 +64,10 @@ class StreamingWriteRpcLogging
     GCP_LOG(DEBUG) << prefix << "() << (void)";
     auto result = stream_->Close();
     if (result) {
-      GCP_LOG(DEBUG) << prefix << "() << "
+      GCP_LOG(DEBUG) << prefix << "() >> "
                      << DebugString(*result, tracing_options_);
     } else {
-      GCP_LOG(DEBUG) << prefix << "() << "
+      GCP_LOG(DEBUG) << prefix << "() >> "
                      << DebugString(result.status(), tracing_options_);
     }
     return result;


### PR DESCRIPTION
Our logging convention is "func() << request" and "func() >> response".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9213)
<!-- Reviewable:end -->
