### PR TITLE
feat(storage): per-operation options / Object

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -923,6 +923,7 @@ class Client {
                                         std::string const& object_name,
                                         std::string contents,
                                         Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::InsertObjectMediaRequest request(bucket_name, object_name,
                                                std::move(contents));
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -1002,6 +1003,7 @@ class Client {
   StatusOr<ObjectMetadata> GetObjectMetadata(std::string const& bucket_name,
                                              std::string const& object_name,
                                              Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::GetObjectMetadataRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->GetObjectMetadata(request);
@@ -1025,6 +1027,7 @@ class Client {
   template <typename... Options>
   ListObjectsReader ListObjects(std::string const& bucket_name,
                                 Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ListObjectsRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto client = raw_client_;
@@ -1055,6 +1058,7 @@ class Client {
   template <typename... Options>
   ListObjectsAndPrefixesReader ListObjectsAndPrefixes(
       std::string const& bucket_name, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ListObjectsRequest request(bucket_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     auto client = raw_client_;
@@ -1132,6 +1136,7 @@ class Client {
                   "Cannot set ReadLast option with either ReadFromOffset or "
                   "ReadRange.");
 
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ReadObjectRangeRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return ReadObjectImpl(request);
@@ -1202,6 +1207,7 @@ class Client {
   ObjectWriteStream WriteObject(std::string const& bucket_name,
                                 std::string const& object_name,
                                 Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return WriteObjectImpl(request);
@@ -1268,6 +1274,7 @@ class Client {
   template <typename... Options>
   Status DeleteResumableUpload(std::string const& upload_session_url,
                                Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::DeleteResumableUploadRequest request(upload_session_url);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->DeleteResumableUpload(request).status();
@@ -1296,6 +1303,7 @@ class Client {
   Status DownloadToFile(std::string const& bucket_name,
                         std::string const& object_name,
                         std::string const& file_name, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ReadObjectRangeRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return DownloadFileImpl(request, file_name);
@@ -1322,6 +1330,7 @@ class Client {
   template <typename... Options>
   Status DeleteObject(std::string const& bucket_name,
                       std::string const& object_name, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::DeleteObjectRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return raw_client_->DeleteObject(request).status();
@@ -1354,6 +1363,7 @@ class Client {
                                         std::string object_name,
                                         ObjectMetadata metadata,
                                         Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::UpdateObjectRequest request(
         std::move(bucket_name), std::move(object_name), std::move(metadata));
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -1392,6 +1402,7 @@ class Client {
                                        ObjectMetadata const& original,
                                        ObjectMetadata const& updated,
                                        Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::PatchObjectRequest request(
         std::move(bucket_name), std::move(object_name), original, updated);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -1426,6 +1437,7 @@ class Client {
   StatusOr<ObjectMetadata> PatchObject(
       std::string bucket_name, std::string object_name,
       ObjectMetadataPatchBuilder const& builder, Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::PatchObjectRequest request(std::move(bucket_name),
                                          std::move(object_name), builder);
     request.set_multiple_options(std::forward<Options>(options)...);
@@ -3186,6 +3198,7 @@ class Client {
                                           std::string const& object_name,
                                           std::true_type,
                                           Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     internal::ResumableUploadRequest request(bucket_name, object_name);
     request.set_multiple_options(std::forward<Options>(options)...);
     return UploadFileResumable(file_name, std::move(request));
@@ -3200,6 +3213,7 @@ class Client {
                                           std::string const& object_name,
                                           std::false_type,
                                           Options&&... options) {
+    auto const span = MakeSpan(std::forward<Options>(options)...);
     std::size_t file_size = 0;
     if (UseSimpleUpload(file_name, file_size)) {
       internal::InsertObjectMediaRequest request(bucket_name, object_name,

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/storage/testing/client_unit_test.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/storage/testing/retry_tests.h"
+#include "google/cloud/storage/testing/temp_file.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 
@@ -29,9 +30,13 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::internal::CurrentOptions;
+using ::google::cloud::storage::testing::TempFile;
 using ::google::cloud::storage::testing::canonical_errors::PermanentError;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
 using ::google::cloud::testing_util::StatusIs;
+using ::testing::ByMove;
+using ::testing::ElementsAre;
 using ::testing::HasSubstr;
 using ::testing::Return;
 using ms = std::chrono::milliseconds;
@@ -45,6 +50,22 @@ using ms = std::chrono::milliseconds;
  */
 class ObjectTest : public ::google::cloud::storage::testing::ClientUnitTest {};
 
+ObjectMetadata CreateObject(int index) {
+  std::string id = "object-" + std::to_string(index);
+  std::string name = id;
+  std::string link =
+      "https://storage.googleapis.com/storage/v1/b/test-bucket/" + id + "#1";
+  nlohmann::json metadata{
+      {"bucket", "test-bucket"},
+      {"id", id},
+      {"name", name},
+      {"selfLink", link},
+      {"generation", "1"},
+      {"kind", "storage#object"},
+  };
+  return internal::ObjectMetadataParser::FromJson(metadata).value();
+};
+
 TEST_F(ObjectTest, InsertObjectMedia) {
   std::string text = R"""({
       "name": "test-bucket-name/test-object-name/1"
@@ -54,6 +75,8 @@ TEST_F(ObjectTest, InsertObjectMedia) {
 
   EXPECT_CALL(*mock_, InsertObjectMedia)
       .WillOnce([&expected](internal::InsertObjectMediaRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", request.bucket_name());
         EXPECT_EQ("test-object-name", request.object_name());
         EXPECT_EQ("test object contents", request.contents());
@@ -61,8 +84,9 @@ TEST_F(ObjectTest, InsertObjectMedia) {
       });
 
   auto client = ClientForMock();
-  auto actual = client.InsertObject("test-bucket-name", "test-object-name",
-                                    "test object contents");
+  auto actual = client.InsertObject(
+      "test-bucket-name", "test-object-name", "test object contents",
+      Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
@@ -126,13 +150,16 @@ TEST_F(ObjectTest, GetObjectMetadata) {
   EXPECT_CALL(*mock_, GetObjectMetadata)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::GetObjectMetadataRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", r.bucket_name());
         EXPECT_EQ("test-object-name", r.object_name());
         return make_status_or(expected);
       });
   auto client = ClientForMock();
   auto actual =
-      client.GetObjectMetadata("test-bucket-name", "test-object-name");
+      client.GetObjectMetadata("test-bucket-name", "test-object-name",
+                               Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
@@ -158,16 +185,270 @@ TEST_F(ObjectTest, GetObjectMetadataPermanentFailure) {
       "GetObjectMetadata");
 }
 
+TEST_F(ObjectTest, ListObjects) {
+  EXPECT_CALL(*mock_, ListObjects)
+      .WillOnce(Return(TransientError()))
+      .WillOnce([](internal::ListObjectsRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-bucket-name", r.bucket_name());
+        internal::ListObjectsResponse response;
+        response.items.emplace_back(CreateObject(1));
+        response.items.emplace_back(CreateObject(2));
+        response.items.emplace_back(CreateObject(3));
+        return response;
+      });
+  auto client = ClientForMock();
+  std::vector<std::string> names;
+  auto list = client.ListObjects("test-bucket-name",
+                                 Options{}.set<UserProjectOption>("u-p-test"));
+  for (auto&& o : list) {
+    EXPECT_STATUS_OK(o);
+    names.push_back(o->name());
+  }
+  EXPECT_THAT(names, ElementsAre("object-1", "object-2", "object-3"));
+}
+
+TEST_F(ObjectTest, ListObjectsAndPrefixes) {
+  EXPECT_CALL(*mock_, ListObjects)
+      .WillOnce(Return(TransientError()))
+      .WillOnce([](internal::ListObjectsRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-bucket-name", r.bucket_name());
+        internal::ListObjectsResponse response;
+        response.items.emplace_back(CreateObject(1));
+        response.items.emplace_back(CreateObject(2));
+        response.items.emplace_back(CreateObject(3));
+        return response;
+      });
+  auto client = ClientForMock();
+  std::vector<std::string> names;
+  auto list = client.ListObjectsAndPrefixes(
+      "test-bucket-name", Options{}.set<UserProjectOption>("u-p-test"));
+  for (auto&& o : list) {
+    EXPECT_STATUS_OK(o);
+    names.push_back(absl::get<ObjectMetadata>(*o).name());
+  }
+  EXPECT_THAT(names, ElementsAre("object-1", "object-2", "object-3"));
+}
+
+TEST_F(ObjectTest, ReadObject) {
+  EXPECT_CALL(*mock_, ReadObject)
+      .WillOnce(Return(ByMove(TransientError())))
+      .WillOnce([](internal::ReadObjectRangeRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-bucket-name", r.bucket_name());
+        EXPECT_EQ("test-object-name", r.object_name());
+        auto read_source = absl::make_unique<testing::MockObjectReadSource>();
+        EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*read_source, Read)
+            .WillOnce(Return(internal::ReadSourceResult{1024, {}}));
+        EXPECT_CALL(*read_source, Close).Times(1);
+        return StatusOr<std::unique_ptr<internal::ObjectReadSource>>(
+            std::move(read_source));
+      });
+  auto client = ClientForMock();
+  auto actual = client.ReadObject("test-bucket-name", "test-object-name",
+                                  Options{}.set<UserProjectOption>("u-p-test"));
+  ASSERT_STATUS_OK(actual.status());
+  std::vector<char> v(1024);
+  actual.read(v.data(), v.size());
+  EXPECT_EQ(actual.gcount(), 1024);
+}
+
+TEST_F(ObjectTest, ReadObjectTooManyFailures) {
+  // We cannot use google::cloud::storage::testing::TooManyFailuresStatusTest,
+  // because that assumes the type returned by the RawClient operation is
+  // copyable.
+  using ReturnType = std::unique_ptr<internal::ObjectReadSource>;
+
+  auto transient_error = [](internal::ReadObjectRangeRequest const&) {
+    return StatusOr<ReturnType>(TransientError());
+  };
+  EXPECT_CALL(*mock_, ReadObject)
+      .WillOnce(transient_error)
+      .WillOnce(transient_error)
+      .WillOnce(transient_error);
+
+  auto client = ClientForMock();
+  Status status =
+      client.ReadObject("test-bucket-name", "test-object-name").status();
+  EXPECT_EQ(TransientError().code(), status.code());
+  EXPECT_THAT(status.message(), HasSubstr("Retry policy exhausted"));
+  EXPECT_THAT(status.message(), HasSubstr("ReadObject"));
+}
+
+TEST_F(ObjectTest, ReadObjectPermanentFailure) {
+  // We cannot use google::cloud::storage::testing::PermanentFailureStatusTest,
+  // because that assumes the type returned by the RawClient operation is
+  // copyable.
+  using ReturnType = std::unique_ptr<internal::ObjectReadSource>;
+
+  auto permanent_error = [](internal::ReadObjectRangeRequest const&) {
+    return StatusOr<ReturnType>(PermanentError());
+  };
+  EXPECT_CALL(*mock_, ReadObject).WillOnce(permanent_error);
+
+  auto client = ClientForMock();
+  Status status =
+      client.ReadObject("test-bucket-name", "test-object-name").status();
+  EXPECT_EQ(PermanentError().code(), status.code());
+  EXPECT_THAT(status.message(), HasSubstr("Permanent error"));
+  EXPECT_THAT(status.message(), HasSubstr("ReadObject"));
+}
+
+TEST_F(ObjectTest, WriteObject) {
+  EXPECT_CALL(*mock_, CreateResumableUpload)
+      .WillOnce(Return(TransientError()))
+      .WillOnce([](internal::ResumableUploadRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-bucket-name", r.bucket_name());
+        EXPECT_EQ("test-object-name", r.object_name());
+        return internal::CreateResumableUploadResponse{"test-upload-id"};
+      });
+  auto client = ClientForMock();
+  auto writer =
+      client.WriteObject("test-bucket-name", "test-object-name",
+                         Options{}.set<UserProjectOption>("u-p-test"));
+  EXPECT_STATUS_OK(writer.last_status());
+  EXPECT_EQ(writer.resumable_session_id(), "test-upload-id");
+  std::move(writer).Suspend();
+}
+
+TEST_F(ObjectTest, WriteObjectTooManyFailures) {
+  // We cannot use google::cloud::storage::testing::TooManyFailuresStatusTest.
+  // The types do not follow the normal pattern.
+  EXPECT_CALL(*mock_, CreateResumableUpload)
+      .Times(3)
+      .WillRepeatedly(Return(TransientError()));
+
+  auto client = ClientForMock();
+  Status status =
+      client.WriteObject("test-bucket-name", "test-object-name").last_status();
+  EXPECT_THAT(status, StatusIs(TransientError().code(),
+                               HasSubstr("Retry policy exhausted")));
+}
+
+TEST_F(ObjectTest, WriteObjectPermanentFailure) {
+  // We cannot use google::cloud::storage::testing::TooManyFailuresStatusTest.
+  // The types do not follow the normal pattern.
+  EXPECT_CALL(*mock_, CreateResumableUpload).WillOnce(Return(PermanentError()));
+
+  auto client = ClientForMock();
+  Status status =
+      client.WriteObject("test-bucket-name", "test-object-name").last_status();
+  EXPECT_THAT(status,
+              StatusIs(PermanentError().code(), HasSubstr("Permanent error")));
+}
+
+TEST_F(ObjectTest, UploadFile) {
+  std::string text = R"""({
+      "name": "test-bucket-name/test-object-name/1"
+})""";
+  auto expected =
+      storage::internal::ObjectMetadataParser::FromString(text).value();
+  auto const contents = std::string{"How vexingly quick daft zebras jump!"};
+
+  EXPECT_CALL(*mock_, InsertObjectMedia)
+      .WillOnce([&](internal::InsertObjectMediaRequest const& request) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-bucket-name", request.bucket_name());
+        EXPECT_EQ("test-object-name", request.object_name());
+        EXPECT_EQ(contents, request.contents());
+        return make_status_or(expected);
+      });
+
+  TempFile temp(contents);
+
+  auto client = ClientForMock();
+  auto actual =
+      client.UploadFile(temp.name(), "test-bucket-name", "test-object-name",
+                        Options{}.set<UserProjectOption>("u-p-test"));
+  ASSERT_STATUS_OK(actual);
+  EXPECT_EQ(expected, *actual);
+}
+
+TEST_F(ObjectTest, DeleteResumableUpload) {
+  EXPECT_CALL(*mock_, DeleteResumableUpload)
+      .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
+      .WillOnce([](internal::DeleteResumableUploadRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-upload-id", r.upload_session_url());
+        return make_status_or(internal::EmptyResponse{});
+      });
+  auto client = ClientForMock();
+  auto status = client.DeleteResumableUpload(
+      "test-upload-id", Options{}.set<UserProjectOption>("u-p-test"));
+  EXPECT_STATUS_OK(status);
+}
+
+TEST_F(ObjectTest, DeleteResumableUploadTooManyFailures) {
+  testing::TooManyFailuresStatusTest<internal::EmptyResponse>(
+      mock_, EXPECT_CALL(*mock_, DeleteResumableUpload),
+      [](Client& client) {
+        return client.DeleteResumableUpload("test-upload-id");
+      },
+      "DeleteResumableUpload");
+}
+
+TEST_F(ObjectTest, DeleteResumableUploadPermanentFailure) {
+  auto client = ClientForMock();
+  testing::PermanentFailureStatusTest<internal::EmptyResponse>(
+      client, EXPECT_CALL(*mock_, DeleteResumableUpload),
+      [](Client& client) {
+        return client.DeleteResumableUpload("test-bucket-name");
+      },
+      "DeleteResumableUpload");
+}
+
+TEST_F(ObjectTest, DownloadToFile) {
+  auto const contents = std::string{"How vexingly quick daft zebras jump!"};
+
+  EXPECT_CALL(*mock_, ReadObject)
+      .WillOnce(Return(ByMove(TransientError())))
+      .WillOnce([&](internal::ReadObjectRangeRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
+        EXPECT_EQ("test-bucket-name", r.bucket_name());
+        EXPECT_EQ("test-object-name", r.object_name());
+        auto read_source = absl::make_unique<testing::MockObjectReadSource>();
+        EXPECT_CALL(*read_source, IsOpen()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*read_source, Read)
+            .WillOnce(Return(internal::ReadSourceResult{contents.size(), {}}))
+            .WillOnce(Return(internal::ReadSourceResult{0, {}}));
+        EXPECT_CALL(*read_source, Close).Times(1);
+        return StatusOr<std::unique_ptr<internal::ObjectReadSource>>(
+            std::move(read_source));
+      });
+
+  TempFile temp("");
+
+  auto client = ClientForMock();
+  auto actual =
+      client.DownloadToFile("test-bucket-name", "test-object-name", temp.name(),
+                            Options{}.set<UserProjectOption>("u-p-test"));
+  ASSERT_STATUS_OK(actual);
+}
+
 TEST_F(ObjectTest, DeleteObject) {
   EXPECT_CALL(*mock_, DeleteObject)
       .WillOnce(Return(StatusOr<internal::EmptyResponse>(TransientError())))
       .WillOnce([](internal::DeleteObjectRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", r.bucket_name());
         EXPECT_EQ("test-object-name", r.object_name());
         return make_status_or(internal::EmptyResponse{});
       });
   auto client = ClientForMock();
-  auto status = client.DeleteObject("test-bucket-name", "test-object-name");
+  auto status =
+      client.DeleteObject("test-bucket-name", "test-object-name",
+                          Options{}.set<UserProjectOption>("u-p-test"));
   EXPECT_STATUS_OK(status);
 }
 
@@ -222,6 +503,8 @@ TEST_F(ObjectTest, UpdateObject) {
   EXPECT_CALL(*mock_, UpdateObject)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::UpdateObjectRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", r.bucket_name());
         EXPECT_EQ("test-object-name", r.object_name());
         auto actual_payload = nlohmann::json::parse(r.json_payload());
@@ -255,7 +538,8 @@ TEST_F(ObjectTest, UpdateObject) {
   update.mutable_metadata().emplace("test-label", "test-value");
   auto client = ClientForMock();
   auto actual =
-      client.UpdateObject("test-bucket-name", "test-object-name", update);
+      client.UpdateObject("test-bucket-name", "test-object-name", update,
+                          Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
@@ -320,6 +604,8 @@ TEST_F(ObjectTest, PatchObject) {
   EXPECT_CALL(*mock_, PatchObject)
       .WillOnce(Return(StatusOr<ObjectMetadata>(TransientError())))
       .WillOnce([&expected](internal::PatchObjectRequest const& r) {
+        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), "a-default");
+        EXPECT_EQ(CurrentOptions().get<UserProjectOption>(), "u-p-test");
         EXPECT_EQ("test-bucket-name", r.bucket_name());
         EXPECT_EQ("test-object-name", r.object_name());
         EXPECT_THAT(r.payload(), HasSubstr("new-disposition"));
@@ -327,10 +613,12 @@ TEST_F(ObjectTest, PatchObject) {
         return make_status_or(expected);
       });
   auto client = ClientForMock();
-  auto actual = client.PatchObject("test-bucket-name", "test-object-name",
-                                   ObjectMetadataPatchBuilder()
-                                       .SetContentDisposition("new-disposition")
-                                       .SetContentLanguage("x-made-up-lang"));
+  auto actual =
+      client.PatchObject("test-bucket-name", "test-object-name",
+                         ObjectMetadataPatchBuilder()
+                             .SetContentDisposition("new-disposition")
+                             .SetContentLanguage("x-made-up-lang"),
+                         Options{}.set<UserProjectOption>("u-p-test"));
   ASSERT_STATUS_OK(actual);
   EXPECT_EQ(expected, *actual);
 }
@@ -370,67 +658,11 @@ TEST_F(ObjectTest, PatchObjectPermanentFailure) {
       "PatchObject");
 }
 
-TEST_F(ObjectTest, ReadObjectTooManyFailures) {
-  // We cannot use google::cloud::storage::testing::TooManyFailuresStatusTest,
-  // because that assumes the type returned by the RawClient operation is
-  // copyable.
-  using ReturnType = std::unique_ptr<internal::ObjectReadSource>;
-
-  auto transient_error = [](internal::ReadObjectRangeRequest const&) {
-    return StatusOr<ReturnType>(TransientError());
-  };
-  EXPECT_CALL(*mock_, ReadObject)
-      .WillOnce(transient_error)
-      .WillOnce(transient_error)
-      .WillOnce(transient_error);
-
-  auto client = ClientForMock();
-  Status status =
-      client.ReadObject("test-bucket-name", "test-object-name").status();
-  EXPECT_EQ(TransientError().code(), status.code());
-  EXPECT_THAT(status.message(), HasSubstr("Retry policy exhausted"));
-  EXPECT_THAT(status.message(), HasSubstr("ReadObject"));
-}
-
-TEST_F(ObjectTest, ReadObjectPermanentFailure) {
-  // We cannot use google::cloud::storage::testing::PermanentFailureStatusTest,
-  // because that assumes the type returned by the RawClient operation is
-  // copyable.
-  using ReturnType = std::unique_ptr<internal::ObjectReadSource>;
-
-  auto permanent_error = [](internal::ReadObjectRangeRequest const&) {
-    return StatusOr<ReturnType>(PermanentError());
-  };
-  EXPECT_CALL(*mock_, ReadObject).WillOnce(permanent_error);
-
-  auto client = ClientForMock();
-  Status status =
-      client.ReadObject("test-bucket-name", "test-object-name").status();
-  EXPECT_EQ(PermanentError().code(), status.code());
-  EXPECT_THAT(status.message(), HasSubstr("Permanent error"));
-  EXPECT_THAT(status.message(), HasSubstr("ReadObject"));
-}
-
-ObjectMetadata CreateObject(int index) {
-  std::string id = "object-" + std::to_string(index);
-  std::string name = id;
-  std::string link =
-      "https://storage.googleapis.com/storage/v1/b/test-bucket/" + id + "#1";
-  nlohmann::json metadata{
-      {"bucket", "test-bucket"},
-      {"id", id},
-      {"name", name},
-      {"selfLink", link},
-      {"generation", "1"},
-      {"kind", "storage#object"},
-  };
-  return internal::ObjectMetadataParser::FromJson(metadata).value();
-};
-
 TEST_F(ObjectTest, DeleteByPrefix) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -472,6 +704,7 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -509,6 +742,7 @@ TEST_F(ObjectTest, DeleteByPrefixListFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce(Return(StatusOr<internal::ListObjectsResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
@@ -522,6 +756,7 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -593,6 +828,7 @@ ObjectMetadata MockObject(std::string const& bucket_name,
 
 TEST_F(ObjectTest, ComposeManyOne) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
@@ -628,6 +864,7 @@ TEST_F(ObjectTest, ComposeManyOne) {
 
 TEST_F(ObjectTest, ComposeManyThree) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
@@ -669,6 +906,7 @@ TEST_F(ObjectTest, ComposeManyThree) {
 
 TEST_F(ObjectTest, ComposeManyThreeLayers) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources.
 
@@ -757,6 +995,7 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
 
 TEST_F(ObjectTest, ComposeManyComposeFails) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources - second composition fails.
 
@@ -803,6 +1042,7 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources - second composition fails.
 
@@ -841,6 +1081,7 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources - second composition fails.
 
@@ -880,6 +1121,7 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
 
 TEST_F(ObjectTest, ComposeManyLockingPrefixFails) {
   auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce(Return(


### PR DESCRIPTION
Support per-operation `google::cloud::Options` for operations related to
`Object` resources.

The test had many gaps that I took the opportunity to fill.  I also
sorted the tests to match the order of declaration of the tested
functions.

Part of the work for #7691 