### PR TITLE
impl(bigtable): add async streaming read helper

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -153,6 +153,7 @@ add_library(
     internal/async_row_reader.h
     internal/async_row_sampler.cc
     internal/async_row_sampler.h
+    internal/async_streaming_read.h
     internal/bigtable_auth_decorator.cc
     internal/bigtable_auth_decorator.h
     internal/bigtable_channel_refresh.cc
@@ -330,6 +331,7 @@ if (BUILD_TESTING)
         internal/async_bulk_apply_test.cc
         internal/async_row_reader_test.cc
         internal/async_row_sampler_test.cc
+        internal/async_streaming_read_test.cc
         internal/bigtable_channel_refresh_test.cc
         internal/bigtable_round_robin_test.cc
         internal/bigtable_stub_factory_test.cc

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -40,6 +40,7 @@ bigtable_client_unit_tests = [
     "internal/async_bulk_apply_test.cc",
     "internal/async_row_reader_test.cc",
     "internal/async_row_sampler_test.cc",
+    "internal/async_streaming_read_test.cc",
     "internal/bigtable_channel_refresh_test.cc",
     "internal/bigtable_round_robin_test.cc",
     "internal/bigtable_stub_factory_test.cc",

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -66,6 +66,7 @@ google_cloud_cpp_bigtable_hdrs = [
     "internal/async_retry_op.h",
     "internal/async_row_reader.h",
     "internal/async_row_sampler.h",
+    "internal/async_streaming_read.h",
     "internal/bigtable_auth_decorator.h",
     "internal/bigtable_channel_refresh.h",
     "internal/bigtable_logging_decorator.h",

--- a/google/cloud/bigtable/internal/async_streaming_read.h
+++ b/google/cloud/bigtable/internal/async_streaming_read.h
@@ -38,7 +38,7 @@ class AsyncStreamingReadImpl
       "OnReadHandler must return a future<bool>");
   static_assert(
       google::cloud::internal::is_invocable<OnFinishHandler, Status>::value,
-      "OnReadHandler must be invocable with Status");
+      "OnFinishHandler must be invocable with Status");
 
  public:
   explicit AsyncStreamingReadImpl(

--- a/google/cloud/bigtable/internal/async_streaming_read.h
+++ b/google/cloud/bigtable/internal/async_streaming_read.h
@@ -1,0 +1,135 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_STREAMING_READ_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_STREAMING_READ_H
+
+#include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "absl/types/variant.h"
+#include <memory>
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+template <typename Response, typename OnReadHandler, typename OnFinishHandler>
+class AsyncStreamingReadImpl
+    : public std::enable_shared_from_this<
+          AsyncStreamingReadImpl<Response, OnReadHandler, OnFinishHandler>> {
+  static_assert(
+      google::cloud::internal::is_invocable<OnReadHandler, Response>::value,
+      "OnReadHandler must be invocable with Response");
+  static_assert(
+      std::is_same<future<bool>, google::cloud::internal::invoke_result_t<
+                                     OnReadHandler, Response>>::value,
+      "OnReadHandler must return a future<bool>");
+  static_assert(
+      google::cloud::internal::is_invocable<OnFinishHandler, Status>::value,
+      "OnReadHandler must be invocable with Status");
+
+ public:
+  explicit AsyncStreamingReadImpl(
+      std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> stream,
+      OnReadHandler&& on_read, OnFinishHandler&& on_finish)
+      : stream_(std::move(stream)),
+        on_read_(std::move(on_read)),
+        on_finish_(std::move(on_finish)) {}
+
+  void Start() {
+    auto self = this->shared_from_this();
+    auto start = stream_->Start();
+    start.then([self](future<bool> f) {
+      // Start was unsuccessful, finish stream.
+      if (!f.get()) return self->Finish();
+      // Start was successful, start reading.
+      self->Read();
+    });
+  }
+
+ private:
+  void Read() {
+    auto self = this->shared_from_this();
+    auto read = stream_->Read();
+    read.then([self](future<absl::optional<Response>> f) {
+      auto r = f.get();
+      // Read did not yield a response, finish stream.
+      if (!r.has_value()) return self->Finish();
+      // Read yielded a response, keep reading or drain the stream.
+      self->on_read_(*std::move(r)).then([self](future<bool> keep_reading) {
+        if (keep_reading.get()) return self->Read();
+        self->stream_->Cancel();
+        self->Discard();
+      });
+    });
+  }
+
+  void Discard() {
+    auto self = this->shared_from_this();
+    auto read = stream_->Read();
+    read.then([self](future<absl::optional<Response>> f) {
+      auto r = f.get();
+      // Read did not yield a response, finish stream.
+      if (!r.has_value()) return self->Finish();
+      // Read yielded a response, keep discarding.
+      self->Discard();
+    });
+  }
+
+  void Finish() {
+    auto self = this->shared_from_this();
+    auto finish = stream_->Finish();
+    finish.then([self](future<Status> f) { self->on_finish_(f.get()); });
+  }
+
+  std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> stream_;
+  typename std::decay<OnReadHandler>::type on_read_;
+  typename std::decay<OnFinishHandler>::type on_finish_;
+};
+
+/**
+ * Make an asynchronous streaming read RPC.
+ *
+ * This method performs one loop of an asynchronous streaming read, from
+ * `Start()` to `Finish()`. There are callbacks for the caller to process each
+ * response, and the final status of the stream.
+ *
+ * @param stream abstraction for the asynchronous streaming read RPC.
+ * @param on_read the callback to be invoked on each successful Read(). If
+ * `false` is returned, we will attempt to cancel the stream, and drain the
+ *     stream of any subsequent responses.
+ * @param on_finish the callback to be invoked when the stream is closed.
+ *
+ * @tparam Response the type of the response in the async streaming RPC.
+ * @tparam OnReadHandler the type of the @p on_read callback.
+ * @tparam OnFinishHandler the type of the @p on_finish callback.
+ */
+template <typename Response, typename OnReadHandler, typename OnFinishHandler>
+void PerformAsyncStreamingRead(
+    std::unique_ptr<internal::AsyncStreamingReadRpc<Response>> stream,
+    OnReadHandler&& on_read, OnFinishHandler&& on_finish) {
+  auto loop = std::make_shared<
+      AsyncStreamingReadImpl<Response, OnReadHandler, OnFinishHandler>>(
+      std::move(stream), std::forward<OnReadHandler>(on_read),
+      std::forward<OnFinishHandler>(on_finish));
+  loop->Start();
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_STREAMING_READ_H

--- a/google/cloud/bigtable/internal/async_streaming_read_test.cc
+++ b/google/cloud/bigtable/internal/async_streaming_read_test.cc
@@ -1,0 +1,129 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/async_streaming_read.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::testing_util::StatusIs;
+using ::testing::MockFunction;
+using ::testing::StrictMock;
+
+struct FakeResponse {
+  std::string value;
+};
+
+class MockAsyncStreamingReadRpc
+    : public internal::AsyncStreamingReadRpc<FakeResponse> {
+ public:
+  ~MockAsyncStreamingReadRpc() override = default;
+
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<FakeResponse>>, Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (),
+              (const, override));
+};
+
+TEST(AsyncStreamingReadTest, FullStream) {
+  auto mock = absl::make_unique<StrictMock<MockAsyncStreamingReadRpc>>();
+  StrictMock<MockFunction<future<bool>(FakeResponse)>> on_read;
+  StrictMock<MockFunction<void(Status)>> on_finish;
+
+  ::testing::InSequence s;
+  EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::make_optional(FakeResponse{"v0"}));
+  });
+  EXPECT_CALL(on_read, Call).WillOnce([](FakeResponse const& r) {
+    EXPECT_EQ(r.value, "v0");
+    return make_ready_future(true);
+  });
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::make_optional(FakeResponse{"v1"}));
+  });
+  EXPECT_CALL(on_read, Call).WillOnce([](FakeResponse const& r) {
+    EXPECT_EQ(r.value, "v1");
+    return make_ready_future(true);
+  });
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::optional<FakeResponse>{});
+  });
+  EXPECT_CALL(*mock, Finish).WillOnce([] {
+    return make_ready_future(Status{});
+  });
+  EXPECT_CALL(on_finish, Call(StatusIs(StatusCode::kOk)));
+
+  PerformAsyncStreamingRead<FakeResponse>(
+      std::move(mock), on_read.AsStdFunction(), on_finish.AsStdFunction());
+}
+
+TEST(AsyncStreamingReadTest, BadStart) {
+  auto mock = absl::make_unique<StrictMock<MockAsyncStreamingReadRpc>>();
+  StrictMock<MockFunction<future<bool>(FakeResponse)>> on_read;
+  StrictMock<MockFunction<void(Status)>> on_finish;
+
+  ::testing::InSequence s;
+  EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(false); });
+  EXPECT_CALL(*mock, Finish).WillOnce([] {
+    return make_ready_future(Status(StatusCode::kPermissionDenied, "fail"));
+  });
+  EXPECT_CALL(on_finish, Call(StatusIs(StatusCode::kPermissionDenied)));
+
+  PerformAsyncStreamingRead<FakeResponse>(
+      std::move(mock), on_read.AsStdFunction(), on_finish.AsStdFunction());
+}
+
+TEST(AsyncStreamingReadTest, CancelMidStream) {
+  auto mock = absl::make_unique<StrictMock<MockAsyncStreamingReadRpc>>();
+  StrictMock<MockFunction<future<bool>(FakeResponse)>> on_read;
+  StrictMock<MockFunction<void(Status)>> on_finish;
+
+  ::testing::InSequence s;
+  EXPECT_CALL(*mock, Start).WillOnce([] { return make_ready_future(true); });
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::make_optional(FakeResponse{"v0"}));
+  });
+  EXPECT_CALL(on_read, Call).WillOnce([](FakeResponse const& r) {
+    EXPECT_EQ(r.value, "v0");
+    return make_ready_future(false);
+  });
+  EXPECT_CALL(*mock, Cancel);
+  EXPECT_CALL(*mock, Read).Times(3).WillRepeatedly([] {
+    return make_ready_future(absl::make_optional(FakeResponse{"ignored"}));
+  });
+  EXPECT_CALL(*mock, Read).WillOnce([] {
+    return make_ready_future(absl::optional<FakeResponse>{});
+  });
+  EXPECT_CALL(*mock, Finish).WillOnce([] {
+    return make_ready_future(Status(StatusCode::kCancelled, "cancelled"));
+  });
+  EXPECT_CALL(on_finish, Call(StatusIs(StatusCode::kCancelled)));
+
+  PerformAsyncStreamingRead<FakeResponse>(
+      std::move(mock), on_read.AsStdFunction(), on_finish.AsStdFunction());
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google


### PR DESCRIPTION
Fixes #9172 

In future PRs, calls to `CompletionQueue::MakeStreamingReadRpc`:
https://github.com/dbolduc/google-cloud-cpp/blob/1c5231c7020b3b875c2b1ee7556b012fe65a4c26/google/cloud/bigtable/internal/async_row_sampler.cc#L69-L82

will become:
https://github.com/dbolduc/google-cloud-cpp/blob/dad6578857859f6b35dfbb9777eb15bd9cd350e6/google/cloud/bigtable/internal/darren_sampler.cc#L60-L66

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9215)
<!-- Reviewable:end -->
