### PR TITLE
cleanup: consistency

### DIFF
--- a/generator/integration_tests/golden/internal/golden_thing_admin_connection_impl.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_connection_impl.cc
@@ -394,7 +394,7 @@ GoldenThingAdminConnectionImpl::LongRunningWithoutRouting(google::test::admin::d
 
 future<StatusOr<google::test::admin::database::v1::Database>>
 GoldenThingAdminConnectionImpl::AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request) {
-  auto& stub = stub_;
+  auto stub = stub_;
   return google::cloud::internal::AsyncRetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->GetDatabase(request),
@@ -409,7 +409,7 @@ GoldenThingAdminConnectionImpl::AsyncGetDatabase(google::test::admin::database::
 
 future<Status>
 GoldenThingAdminConnectionImpl::AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request) {
-  auto& stub = stub_;
+  auto stub = stub_;
   return google::cloud::internal::AsyncRetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->DropDatabase(request),

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -454,7 +454,7 @@ future<Status>)"""
 future<StatusOr<$response_type$>>)""",
                       R"""(
 $connection_class_name$Impl::Async$method_name$($request_type$ const& request) {
-  auto& stub = stub_;
+  auto stub = stub_;
   return google::cloud::internal::AsyncRetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->$method_name$(request),

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_connection_impl.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_connection_impl.cc
@@ -337,7 +337,7 @@ BigtableTableAdminConnectionImpl::TestIamPermissions(
 future<StatusOr<google::bigtable::admin::v2::CheckConsistencyResponse>>
 BigtableTableAdminConnectionImpl::AsyncCheckConsistency(
     google::bigtable::admin::v2::CheckConsistencyRequest const& request) {
-  auto& stub = stub_;
+  auto stub = stub_;
   return google::cloud::internal::AsyncRetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->CheckConsistency(request), background_->cq(),

--- a/google/cloud/monitoring/internal/metric_connection_impl.cc
+++ b/google/cloud/monitoring/internal/metric_connection_impl.cc
@@ -225,7 +225,7 @@ Status MetricServiceConnectionImpl::CreateServiceTimeSeries(
 
 future<Status> MetricServiceConnectionImpl::AsyncCreateTimeSeries(
     google::monitoring::v3::CreateTimeSeriesRequest const& request) {
-  auto& stub = stub_;
+  auto stub = stub_;
   return google::cloud::internal::AsyncRetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->CreateTimeSeries(request), background_->cq(),

--- a/google/cloud/pubsublite/internal/admin_connection_impl.cc
+++ b/google/cloud/pubsublite/internal/admin_connection_impl.cc
@@ -407,7 +407,7 @@ StreamRange<std::string> AdminServiceConnectionImpl::ListReservationTopics(
 future<StatusOr<google::cloud::pubsublite::v1::TopicPartitions>>
 AdminServiceConnectionImpl::AsyncGetTopicPartitions(
     google::cloud::pubsublite::v1::GetTopicPartitionsRequest const& request) {
-  auto& stub = stub_;
+  auto stub = stub_;
   return google::cloud::internal::AsyncRetryLoop(
       retry_policy(), backoff_policy(),
       idempotency_policy()->GetTopicPartitions(request), background_->cq(),


### PR DESCRIPTION
I dont think there is a difference either way, but we tend to write `auto stub = stub_;`. I was likely the one who introduced this inconsistency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9216)
<!-- Reviewable:end -->
