### PR TITLE
impl(storage): add HttpResponse overloads to be leveraged by rest refactor

### DIFF
--- a/google/cloud/storage/internal/bucket_acl_requests.cc
+++ b/google/cloud/storage/internal/bucket_acl_requests.cc
@@ -58,6 +58,11 @@ StatusOr<ListBucketAclResponse> ListBucketAclResponse::FromHttpResponse(
   return result;
 }
 
+StatusOr<ListBucketAclResponse> ListBucketAclResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, ListBucketAclResponse const& r) {
   os << "ListBucketAclResponse={items={";
   os << absl::StrJoin(r.items, ", ", absl::StreamFormatter());

--- a/google/cloud/storage/internal/bucket_acl_requests.h
+++ b/google/cloud/storage/internal/bucket_acl_requests.h
@@ -49,6 +49,8 @@ std::ostream& operator<<(std::ostream& os, ListBucketAclRequest const& r);
 struct ListBucketAclResponse {
   static StatusOr<ListBucketAclResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListBucketAclResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::vector<BucketAccessControl> items;
 };

--- a/google/cloud/storage/internal/bucket_requests.cc
+++ b/google/cloud/storage/internal/bucket_requests.cc
@@ -242,6 +242,11 @@ StatusOr<ListBucketsResponse> ListBucketsResponse::FromHttpResponse(
   return result;
 }
 
+StatusOr<ListBucketsResponse> ListBucketsResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, ListBucketsResponse const& r) {
   os << "ListBucketsResponse={next_page_token=" << r.next_page_token
      << ", items={";
@@ -335,6 +340,12 @@ TestBucketIamPermissionsResponse::FromHttpResponse(std::string const& payload) {
     result.permissions.emplace_back(kv.value().get<std::string>());
   }
   return result;
+}
+
+StatusOr<TestBucketIamPermissionsResponse>
+TestBucketIamPermissionsResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
 }
 
 std::ostream& operator<<(std::ostream& os,

--- a/google/cloud/storage/internal/bucket_requests.h
+++ b/google/cloud/storage/internal/bucket_requests.h
@@ -58,6 +58,8 @@ std::ostream& operator<<(std::ostream& os, ListBucketsRequest const& r);
 struct ListBucketsResponse {
   static StatusOr<ListBucketsResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListBucketsResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::string next_page_token;
   std::vector<BucketMetadata> items;
@@ -253,6 +255,8 @@ std::ostream& operator<<(std::ostream& os,
 struct TestBucketIamPermissionsResponse {
   static StatusOr<TestBucketIamPermissionsResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<TestBucketIamPermissionsResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::vector<std::string> permissions;
 };

--- a/google/cloud/storage/internal/default_object_acl_requests.cc
+++ b/google/cloud/storage/internal/default_object_acl_requests.cc
@@ -50,6 +50,11 @@ ListDefaultObjectAclResponse::FromHttpResponse(std::string const& payload) {
   return result;
 }
 
+StatusOr<ListDefaultObjectAclResponse>
+ListDefaultObjectAclResponse::FromHttpResponse(HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os,
                          ListDefaultObjectAclResponse const& r) {
   os << "ListDefaultObjectAclResponse={items={";

--- a/google/cloud/storage/internal/default_object_acl_requests.h
+++ b/google/cloud/storage/internal/default_object_acl_requests.h
@@ -53,6 +53,8 @@ std::ostream& operator<<(std::ostream& os,
 struct ListDefaultObjectAclResponse {
   static StatusOr<ListDefaultObjectAclResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListDefaultObjectAclResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::vector<ObjectAccessControl> items;
 };

--- a/google/cloud/storage/internal/hmac_key_requests.cc
+++ b/google/cloud/storage/internal/hmac_key_requests.cc
@@ -49,6 +49,11 @@ StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(
   return result;
 }
 
+StatusOr<CreateHmacKeyResponse> CreateHmacKeyResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, CreateHmacKeyResponse const& r) {
   return os << "CreateHmacKeyResponse={metadata=" << r.metadata
             << ", secret=[censored]"
@@ -80,6 +85,11 @@ StatusOr<ListHmacKeysResponse> ListHmacKeysResponse::FromHttpResponse(
   }
 
   return result;
+}
+
+StatusOr<ListHmacKeysResponse> ListHmacKeysResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
 }
 
 std::ostream& operator<<(std::ostream& os, ListHmacKeysResponse const& r) {

--- a/google/cloud/storage/internal/hmac_key_requests.h
+++ b/google/cloud/storage/internal/hmac_key_requests.h
@@ -103,6 +103,8 @@ std::ostream& operator<<(std::ostream& os, CreateHmacKeyRequest const& r);
 struct CreateHmacKeyResponse {
   static StatusOr<CreateHmacKeyResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<CreateHmacKeyResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::string kind;
   HmacKeyMetadata metadata;
@@ -135,6 +137,8 @@ std::ostream& operator<<(std::ostream& os, ListHmacKeysRequest const& r);
 struct ListHmacKeysResponse {
   static StatusOr<ListHmacKeysResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListHmacKeysResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::string next_page_token;
   std::vector<HmacKeyMetadata> items;

--- a/google/cloud/storage/internal/notification_requests.cc
+++ b/google/cloud/storage/internal/notification_requests.cc
@@ -45,6 +45,11 @@ StatusOr<ListNotificationsResponse> ListNotificationsResponse::FromHttpResponse(
   return result;
 }
 
+StatusOr<ListNotificationsResponse> ListNotificationsResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, ListNotificationsResponse const& r) {
   os << "ListNotificationResponse={items={";
   os << absl::StrJoin(r.items, ", ", absl::StreamFormatter());

--- a/google/cloud/storage/internal/notification_requests.h
+++ b/google/cloud/storage/internal/notification_requests.h
@@ -49,6 +49,8 @@ std::ostream& operator<<(std::ostream& os, ListNotificationsRequest const& r);
 struct ListNotificationsResponse {
   static StatusOr<ListNotificationsResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListNotificationsResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::vector<NotificationMetadata> items;
 };

--- a/google/cloud/storage/internal/object_acl_requests.cc
+++ b/google/cloud/storage/internal/object_acl_requests.cc
@@ -51,6 +51,11 @@ StatusOr<ListObjectAclResponse> ListObjectAclResponse::FromHttpResponse(
   return result;
 }
 
+StatusOr<ListObjectAclResponse> ListObjectAclResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, ListObjectAclResponse const& r) {
   os << "ListObjectAclResponse={items={";
   os << absl::StrJoin(r.items, ", ", absl::StreamFormatter());

--- a/google/cloud/storage/internal/object_acl_requests.h
+++ b/google/cloud/storage/internal/object_acl_requests.h
@@ -46,6 +46,8 @@ std::ostream& operator<<(std::ostream& os, ListObjectAclRequest const& r);
 struct ListObjectAclResponse {
   static StatusOr<ListObjectAclResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListObjectAclResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::vector<ObjectAccessControl> items;
 };

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -138,6 +138,11 @@ StatusOr<ListObjectsResponse> ListObjectsResponse::FromHttpResponse(
   return result;
 }
 
+StatusOr<ListObjectsResponse> ListObjectsResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
+}
+
 std::ostream& operator<<(std::ostream& os, ListObjectsResponse const& r) {
   os << "ListObjectsResponse={next_page_token=" << r.next_page_token
      << ", items={";
@@ -357,6 +362,11 @@ StatusOr<RewriteObjectResponse> RewriteObjectResponse::FromHttpResponse(
     result.resource = std::move(*parsed);
   }
   return result;
+}
+
+StatusOr<RewriteObjectResponse> RewriteObjectResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
 }
 
 std::ostream& operator<<(std::ostream& os, RewriteObjectResponse const& r) {

--- a/google/cloud/storage/internal/object_requests.h
+++ b/google/cloud/storage/internal/object_requests.h
@@ -66,6 +66,8 @@ std::ostream& operator<<(std::ostream& os, ListObjectsRequest const& r);
 struct ListObjectsResponse {
   static StatusOr<ListObjectsResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<ListObjectsResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::string next_page_token;
   std::vector<ObjectMetadata> items;
@@ -325,6 +327,8 @@ std::ostream& operator<<(std::ostream& os, RewriteObjectRequest const& r);
 struct RewriteObjectResponse {
   static StatusOr<RewriteObjectResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<RewriteObjectResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::uint64_t total_bytes_rewritten;
   std::uint64_t object_size;

--- a/google/cloud/storage/internal/sign_blob_requests.cc
+++ b/google/cloud/storage/internal/sign_blob_requests.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/sign_blob_requests.h"
+#include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <nlohmann/json.hpp>
 
@@ -38,6 +39,11 @@ StatusOr<SignBlobResponse> SignBlobResponse::FromHttpResponse(
   result.key_id = json.value("keyId", "");
   result.signed_blob = json.value("signedBlob", "");
   return result;
+}
+
+StatusOr<SignBlobResponse> SignBlobResponse::FromHttpResponse(
+    HttpResponse const& response) {
+  return FromHttpResponse(response.payload);
 }
 
 std::ostream& operator<<(std::ostream& os, SignBlobResponse const& r) {

--- a/google/cloud/storage/internal/sign_blob_requests.h
+++ b/google/cloud/storage/internal/sign_blob_requests.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_SIGN_BLOB_REQUESTS_H
 
 #include "google/cloud/storage/internal/generic_request.h"
+#include "google/cloud/storage/internal/http_response.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status_or.h"
 #include <string>
@@ -72,6 +73,8 @@ std::ostream& operator<<(std::ostream& os, SignBlobRequest const& r);
 struct SignBlobResponse {
   static StatusOr<SignBlobResponse> FromHttpResponse(
       std::string const& payload);
+  static StatusOr<SignBlobResponse> FromHttpResponse(
+      HttpResponse const& response);
 
   std::string key_id;
   std::string signed_blob;


### PR DESCRIPTION
Currently, some request types have `FromHttpResponse` methods that accept a `std::string const&` and other request types have `FromHttpResponse` methods that accept a `HttpResponse const&`. This makes it difficult to call them generically. This PR adds `HttpResponse const&` overloads to request types so that we can call `T::FromHttpResponse(HttpResponse const&)` on all request types.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9227)
<!-- Reviewable:end -->
