### PR TITLE
impl(storage): use `CurrentOptions()` for `RetryClient`

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -51,7 +51,7 @@ std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
   if (enable_logging) {
     client = std::make_shared<internal::LoggingClient>(std::move(client));
   }
-  return internal::RetryClient::Create(std::move(client), opts);
+  return internal::RetryClient::Create(std::move(client));
 }
 
 std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -103,8 +103,7 @@ TEST_F(ClientTest, Equality) {
 }
 
 TEST_F(ClientTest, OverrideRetryPolicy) {
-  auto client = internal::ClientImplDetails::CreateClient(
-      std::shared_ptr<internal::RawClient>(mock_), ObservableRetryPolicy(3));
+  auto client = testing::ClientFromMock(mock_, ObservableRetryPolicy(3));
 
   // Reset the counters at the beginning of the test.
 
@@ -120,9 +119,8 @@ TEST_F(ClientTest, OverrideRetryPolicy) {
 
 TEST_F(ClientTest, OverrideBackoffPolicy) {
   using ms = std::chrono::milliseconds;
-  auto client = internal::ClientImplDetails::CreateClient(
-      std::shared_ptr<internal::RawClient>(mock_),
-      ObservableBackoffPolicy(ms(20), ms(100), 2.0));
+  auto client = testing::ClientFromMock(
+      mock_, ObservableBackoffPolicy(ms(20), ms(100), 2.0));
 
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.
@@ -136,9 +134,9 @@ TEST_F(ClientTest, OverrideBackoffPolicy) {
 
 TEST_F(ClientTest, OverrideBothPolicies) {
   using ms = std::chrono::milliseconds;
-  auto client = internal::ClientImplDetails::CreateClient(
-      std::shared_ptr<internal::RawClient>(mock_),
-      ObservableBackoffPolicy(ms(20), ms(100), 2.0), ObservableRetryPolicy(3));
+  auto client = testing::ClientFromMock(
+      mock_, ObservableBackoffPolicy(ms(20), ms(100), 2.0),
+      ObservableRetryPolicy(3));
 
   // Call an API (any API) on the client, we do not care about the status, just
   // that our policy is called.

--- a/google/cloud/storage/client_write_object_test.cc
+++ b/google/cloud/storage/client_write_object_test.cc
@@ -185,6 +185,7 @@ TEST_F(WriteObjectTest, UploadStreamResumable) {
 
   ASSERT_TRUE(stream);
   auto client = ClientForMock();
+  google::cloud::internal::OptionsSpan const span(mock_->options());
   auto res = internal::ClientImplDetails::UploadStreamResumable(
       client, stream,
       internal::ResumableUploadRequest("test-bucket-name", "test-object-name")

--- a/google/cloud/storage/internal/object_write_streambuf_test.cc
+++ b/google/cloud/storage/internal/object_write_streambuf_test.cc
@@ -437,8 +437,8 @@ TEST(ObjectWriteStreambufTest, Regression8868) {
           Return(QueryResumableUploadResponse{quantum, ObjectMetadata()}));
 
   using us = std::chrono::microseconds;
-  auto retry = RetryClient::Create(
-      std::move(mock),
+  auto retry = RetryClient::Create(std::move(mock));
+  google::cloud::internal::OptionsSpan const span(
       Options{}
           .set<Oauth2CredentialsOption>(oauth2::CreateAnonymousCredentials())
           .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(3).clone())

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -32,8 +32,7 @@ namespace internal {
 class RetryClient : public RawClient,
                     public std::enable_shared_from_this<RetryClient> {
  public:
-  static std::shared_ptr<RetryClient> Create(std::shared_ptr<RawClient> client,
-                                             Options const& options);
+  static std::shared_ptr<RetryClient> Create(std::shared_ptr<RawClient> client);
 
   ~RetryClient() override = default;
 
@@ -155,13 +154,13 @@ class RetryClient : public RawClient,
   std::shared_ptr<RawClient> client() const { return client_; }
 
  private:
-  explicit RetryClient(std::shared_ptr<RawClient> client,
-                       Options const& options);
+  explicit RetryClient(std::shared_ptr<RawClient> client);
+
+  static std::unique_ptr<RetryPolicy> current_retry_policy();
+  static std::unique_ptr<BackoffPolicy> current_backoff_policy();
+  static IdempotencyPolicy& current_idempotency_policy();
 
   std::shared_ptr<RawClient> client_;
-  std::shared_ptr<RetryPolicy const> retry_policy_prototype_;
-  std::shared_ptr<BackoffPolicy const> backoff_policy_prototype_;
-  std::shared_ptr<IdempotencyPolicy const> idempotency_policy_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client_test.cc
+++ b/google/cloud/storage/internal/retry_client_test.cc
@@ -51,10 +51,10 @@ Options BasicTestPolicies() {
 /// @test Verify that non-idempotent operations return on the first failure.
 TEST(RetryClientTest, NonIdempotentErrorHandling) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   EXPECT_CALL(*mock, DeleteObject)
       .WillOnce(Return(StatusOr<EmptyResponse>(TransientError())));
@@ -69,8 +69,8 @@ TEST(RetryClientTest, NonIdempotentErrorHandling) {
 /// @test Verify that the retry loop returns on the first permanent failure.
 TEST(RetryClientTest, PermanentErrorHandling) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                                    BasicTestPolicies());
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(BasicTestPolicies());
 
   // Use a read-only operation because these are always idempotent.
   EXPECT_CALL(*mock, GetObjectMetadata)
@@ -85,8 +85,8 @@ TEST(RetryClientTest, PermanentErrorHandling) {
 /// @test Verify that the retry loop returns on the first permanent failure.
 TEST(RetryClientTest, TooManyTransientsHandling) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                                    BasicTestPolicies());
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(BasicTestPolicies());
 
   // Use a read-only operation because these are always idempotent.
   EXPECT_CALL(*mock, GetObjectMetadata)
@@ -100,8 +100,8 @@ TEST(RetryClientTest, TooManyTransientsHandling) {
 /// @test Verify that the retry loop works with exhausted retry policy.
 TEST(RetryClientTest, ExpiredRetryPolicy) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client = RetryClient::Create(
-      std::shared_ptr<internal::RawClient>(mock),
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
       BasicTestPolicies().set<RetryPolicyOption>(
           LimitedTimeRetryPolicy{std::chrono::milliseconds(0)}.clone()));
 
@@ -117,10 +117,10 @@ TEST(RetryClientTest, ExpiredRetryPolicy) {
 /// @test Verify that `CreateResumableUpload()` handles transients.
 TEST(RetryClientTest, CreateResumableUploadHandlesTransient) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              AlwaysRetryIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          AlwaysRetryIdempotencyPolicy().clone()));
 
   EXPECT_CALL(*mock, CreateResumableUpload)
       .WillOnce(
@@ -139,10 +139,10 @@ TEST(RetryClientTest, CreateResumableUploadHandlesTransient) {
 /// @test Verify that `QueryResumableUpload()` handles transients.
 TEST(RetryClientTest, QueryResumableUploadHandlesTransient) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   EXPECT_CALL(*mock, QueryResumableUpload)
       .WillOnce(
@@ -162,10 +162,10 @@ TEST(RetryClientTest, QueryResumableUploadHandlesTransient) {
 /// @test Verify that transient failures are handled as expected.
 TEST(RetryClientTest, UploadChunkHandleTransient) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
@@ -213,10 +213,10 @@ TEST(RetryClientTest, UploadChunkHandleTransient) {
 /// @test Verify that we can restore a session and continue writing.
 TEST(RetryClientTest, UploadChunkRestoreSession) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const p0(quantum, '0');
@@ -252,10 +252,10 @@ TEST(RetryClientTest, UploadChunkRestoreSession) {
 /// @test Verify that transient failures with partial writes are handled
 TEST(RetryClientTest, UploadChunkHandleTransientPartialFailures) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   auto const payload = std::string(quantum, 'X') + std::string(quantum, 'Y') +
@@ -296,10 +296,10 @@ TEST(RetryClientTest, UploadChunkHandleTransientPartialFailures) {
 /// @test Verify that a permanent error on UploadChunk results in a failure.
 TEST(RetryClientTest, UploadChunkPermanentError) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
@@ -316,10 +316,10 @@ TEST(RetryClientTest, UploadChunkPermanentError) {
 /// failure.
 TEST(RetryClientTest, UploadChunkPermanentErrorOnQuery) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
@@ -335,10 +335,10 @@ TEST(RetryClientTest, UploadChunkPermanentErrorOnQuery) {
 /// @test Verify that unexpected results return an error.
 TEST(RetryClientTest, UploadChunkHandleRollback) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
@@ -369,10 +369,10 @@ TEST(RetryClientTest, UploadChunkHandleRollback) {
 /// @test Verify that unexpected results return an error.
 TEST(RetryClientTest, UploadChunkHandleOvercommit) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(quantum, '0');
@@ -395,10 +395,10 @@ TEST(RetryClientTest, UploadChunkHandleOvercommit) {
 /// @test Verify that retry exhaustion following a short write fails.
 TEST(RetryClientTest, UploadChunkExhausted) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   std::string const payload(std::string(quantum * 2, 'X'));
@@ -417,8 +417,8 @@ TEST(RetryClientTest, UploadChunkExhausted) {
 
 TEST(RetryClientTest, UploadChunkUploadChunkPolicyExhaustedOnStart) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client = RetryClient::Create(
-      std::shared_ptr<internal::RawClient>(mock),
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
       BasicTestPolicies()
           .set<RetryPolicyOption>(
               LimitedTimeRetryPolicy(std::chrono::seconds(0)).clone())
@@ -436,10 +436,10 @@ TEST(RetryClientTest, UploadChunkUploadChunkPolicyExhaustedOnStart) {
 /// @test Verify that responses without a range header are handled.
 TEST(RetryClientTest, UploadChunkMissingRangeHeaderInUpload) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   auto const payload = std::string(quantum, '0');
@@ -477,10 +477,10 @@ TEST(RetryClientTest, UploadChunkMissingRangeHeaderInUpload) {
 /// @test Verify that responses without a range header are handled.
 TEST(RetryClientTest, UploadChunkMissingRangeHeaderInQueryResumableUpload) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   auto const payload = std::string(quantum, '0');
@@ -513,10 +513,10 @@ TEST(RetryClientTest, UploadChunkMissingRangeHeaderInQueryResumableUpload) {
 /// @test Verify that full but unfinalized uploads are handled correctly.
 TEST(RetryClientTest, UploadFinalChunkQueryMissingPayloadTriggersRetry) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   auto const payload = std::string(quantum, '0');
@@ -548,10 +548,10 @@ TEST(RetryClientTest, UploadFinalChunkQueryMissingPayloadTriggersRetry) {
 /// @test Verify that not returning a final payload eventually becomes an error.
 TEST(RetryClientTest, UploadFinalChunkQueryTooManyMissingPayloads) {
   auto mock = std::make_shared<testing::MockClient>();
-  auto client =
-      RetryClient::Create(std::shared_ptr<internal::RawClient>(mock),
-                          BasicTestPolicies().set<IdempotencyPolicyOption>(
-                              StrictIdempotencyPolicy().clone()));
+  auto client = RetryClient::Create(std::shared_ptr<internal::RawClient>(mock));
+  google::cloud::internal::OptionsSpan const span(
+      BasicTestPolicies().set<IdempotencyPolicyOption>(
+          StrictIdempotencyPolicy().clone()));
 
   auto const quantum = UploadChunkRequest::kChunkSizeQuantum;
   auto const payload = std::string(quantum, '0');

--- a/google/cloud/storage/object_test.cc
+++ b/google/cloud/storage/object_test.cc
@@ -662,7 +662,6 @@ TEST_F(ObjectTest, DeleteByPrefix) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -704,7 +703,6 @@ TEST_F(ObjectTest, DeleteByPrefixNoOptions) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -742,7 +740,6 @@ TEST_F(ObjectTest, DeleteByPrefixListFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce(Return(StatusOr<internal::ListObjectsResponse>(
           Status(StatusCode::kPermissionDenied, ""))));
@@ -756,7 +753,6 @@ TEST_F(ObjectTest, DeleteByPrefixDeleteFailure) {
   // Pretend ListObjects returns object-1, object-2, object-3.
 
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([](internal::ListObjectsRequest const& req)
                     -> StatusOr<internal::ListObjectsResponse> {
@@ -828,7 +824,6 @@ ObjectMetadata MockObject(std::string const& bucket_name,
 
 TEST_F(ObjectTest, ComposeManyOne) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
@@ -864,7 +859,6 @@ TEST_F(ObjectTest, ComposeManyOne) {
 
 TEST_F(ObjectTest, ComposeManyThree) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([](internal::ComposeObjectRequest const& req)
                     -> StatusOr<ObjectMetadata> {
@@ -906,7 +900,6 @@ TEST_F(ObjectTest, ComposeManyThree) {
 
 TEST_F(ObjectTest, ComposeManyThreeLayers) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources.
 
@@ -995,7 +988,6 @@ TEST_F(ObjectTest, ComposeManyThreeLayers) {
 
 TEST_F(ObjectTest, ComposeManyComposeFails) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources - second composition fails.
 
@@ -1042,7 +1034,6 @@ TEST_F(ObjectTest, ComposeManyComposeFails) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources - second composition fails.
 
@@ -1081,7 +1072,6 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsLoudly) {
 
 TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   // Test 63 sources - second composition fails.
 
@@ -1121,7 +1111,6 @@ TEST_F(ObjectTest, ComposeManyCleanupFailsSilently) {
 
 TEST_F(ObjectTest, ComposeManyLockingPrefixFails) {
   auto mock = std::make_shared<testing::MockClient>();
-  EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
 
   EXPECT_CALL(*mock, InsertObjectMedia)
       .WillOnce(Return(

--- a/google/cloud/storage/testing/client_unit_test.cc
+++ b/google/cloud/storage/testing/client_unit_test.cc
@@ -28,16 +28,20 @@ ClientUnitTest::ClientUnitTest()
   EXPECT_CALL(*mock_, client_options())
       .WillRepeatedly(ReturnRef(client_options_));
   EXPECT_CALL(*mock_, options)
-      .WillRepeatedly(Return(Options{}
-                                 .set<AuthorityOption>("a-default")
-                                 .set<UserProjectOption>("u-p-default")));
+      .WillRepeatedly(Return(storage::internal::DefaultOptionsWithCredentials(
+          Options{}
+              .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
+              .set<AuthorityOption>("a-default")
+              .set<UserProjectOption>("u-p-default")
+              .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())
+              .set<BackoffPolicyOption>(
+                  ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                                           std::chrono::milliseconds(1), 2.0)
+                      .clone()))));
 }
 
 Client ClientUnitTest::ClientForMock() {
-  return ::google::cloud::storage::testing::ClientFromMock(
-      mock_, LimitedErrorCountRetryPolicy(2),
-      ExponentialBackoffPolicy(std::chrono::milliseconds(1),
-                               std::chrono::milliseconds(1), 2.0));
+  return ::google::cloud::storage::testing::ClientFromMock(mock_);
 }
 
 }  // namespace testing


### PR DESCRIPTION
The most interesting options in this case are the `RetryPolicyOption`
and `BackoffPolicyOption`.

Because now the policies are obtained from the `CurrentOptions()` and
these are initialized from `mock->options()`, the mocks need to return
sensible values for the options.

Some tests need to set the OptionsSpan, or the unit under test will not
work.

Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9230)
<!-- Reviewable:end -->
