### PR TITLE
impl(bigtable): modern `Table::AsyncSampleRows()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/bigtable/internal/data_connection_impl.h"
+#include "google/cloud/bigtable/internal/async_row_sampler.h"
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
 #include "google/cloud/bigtable/internal/default_row_reader.h"
 #include "google/cloud/bigtable/internal/defaults.h"
@@ -200,6 +201,13 @@ StatusOr<bigtable::MutationBranch> DataConnectionImpl::CheckAndMutateRow(
   return response.predicate_matched()
              ? bigtable::MutationBranch::kPredicateMatched
              : bigtable::MutationBranch::kPredicateNotMatched;
+}
+
+future<StatusOr<std::vector<bigtable::RowKeySample>>>
+DataConnectionImpl::AsyncSampleRows(std::string const& app_profile_id,
+                                    std::string const& table_name) {
+  return AsyncRowSampler::Create(background_->cq(), stub_, retry_policy(),
+                                 backoff_policy(), app_profile_id, table_name);
 }
 
 StatusOr<bigtable::Row> DataConnectionImpl::ReadModifyWriteRow(

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -68,6 +68,10 @@ class DataConnectionImpl : public DataConnection {
       std::vector<bigtable::Mutation> true_mutations,
       std::vector<bigtable::Mutation> false_mutations) override;
 
+  future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows(
+      std::string const& app_profile_id,
+      std::string const& table_name) override;
+
   StatusOr<bigtable::Row> ReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request) override;
 

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -354,6 +354,10 @@ StatusOr<std::vector<bigtable::RowKeySample>> Table::SampleRows() {
 }
 
 future<StatusOr<std::vector<bigtable::RowKeySample>>> Table::AsyncSampleRows() {
+  if (connection_) {
+    return connection_->AsyncSampleRows(app_profile_id_, table_name_);
+  }
+
   auto cq = background_threads_->cq();
   return internal::LegacyAsyncRowSampler::Create(
       cq, client_, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -272,6 +272,23 @@ TEST(TableTest, CheckAndMutateRow) {
   EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
 }
 
+TEST(TableTest, AsyncSampleRows) {
+  auto mock = std::make_shared<MockDataConnection>();
+  EXPECT_CALL(*mock, AsyncSampleRows)
+      .WillOnce(
+          [](std::string const& app_profile_id, std::string const& table_name) {
+            EXPECT_EQ(kAppProfileId, app_profile_id);
+            EXPECT_EQ(kTableName, table_name);
+            return make_ready_future<StatusOr<std::vector<RowKeySample>>>(
+                PermanentError());
+          });
+
+  auto table = bigtable_internal::MakeTable(mock, kProjectId, kInstanceId,
+                                            kAppProfileId, kTableId);
+  auto samples = table.AsyncSampleRows().get();
+  EXPECT_THAT(samples, StatusIs(StatusCode::kPermissionDenied));
+}
+
 TEST(TableTest, ReadModifyWriteRow) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, ReadModifyWriteRow)

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -69,11 +69,11 @@ class SampleRowsIntegrationTest
   static void SetUpTestSuite() {
     // Create kBatchSize * kBatchCount rows. Use a special client with tracing
     // disabled because it simply generates too much data.
-    auto table =
-        Table(MakeDataClient(TableTestEnvironment::project_id(),
-                             TableTestEnvironment::instance_id(),
-                             Options{}.set<TracingComponentsOption>({"rpc"})),
-              TableTestEnvironment::table_id());
+    auto table = bigtable_internal::MakeTable(
+        bigtable_internal::MakeDataConnection(
+            Options{}.set<TracingComponentsOption>({"rpc"})),
+        TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
+        "", TableTestEnvironment::table_id());
 
     int constexpr kBatchCount = 10;
     int constexpr kBatchSize = 5000;
@@ -105,12 +105,21 @@ class SampleRowsIntegrationTest
   }
 };
 
-TEST_F(SampleRowsIntegrationTest, Synchronous) {
+TEST_F(SampleRowsIntegrationTest, AsyncWithDataConnection) {
+  auto table = bigtable_internal::MakeTable(
+      bigtable_internal::MakeDataConnection(),
+      TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
+      "", TableTestEnvironment::table_id());
+  auto fut = table.AsyncSampleRows();
+  VerifySamples(fut.get());
+};
+
+TEST_F(SampleRowsIntegrationTest, SyncWithDataClient) {
   auto table = GetTable();
   VerifySamples(table.SampleRows());
 };
 
-TEST_F(SampleRowsIntegrationTest, Asynchronous) {
+TEST_F(SampleRowsIntegrationTest, AsyncWithDataClient) {
   auto table = GetTable();
   auto fut = table.AsyncSampleRows();
 


### PR DESCRIPTION
Fixes #9173 

The integration test is a little different in this case. It is much simpler to have individual tests for the `DataConnection` and `DataClient` as opposed to setting up test value parameters.

(Because: We want to populate a big table once, before running the suite of tests. Also, there are only 2 tests that are only 2 or 3 lines long each).