### PR TITLE
impl(rest): add support for treating specified error codes as non-failures

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -628,11 +628,11 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
     TRACE_STATE() << ", status=" << status << ", http code=" << http_code_
                   << "\n";
 
-    if (!internal::Contains(ignored_http_error_codes_, http_code_) &&
-        !status.ok()) {
-      return status;
+    if (status.ok() ||
+        internal::Contains(ignored_http_error_codes_, http_code_)) {
+      return bytes_read;
     }
-    return bytes_read;
+    return status;
   }
   TRACE_STATE() << ", http code=" << http_code_ << "\n";
   received_headers_.emplace(":curl-peer", handle_.GetPeer());

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -175,6 +175,7 @@ void CurlImpl::ApplyOptions(Options const& options) {
   http_version_ = std::move(options.get<HttpVersionOption>());
   transfer_stall_timeout_ = options.get<TransferStallTimeoutOption>();
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
+  ignored_http_error_codes_ = options.get<IgnoredHttpErrorCodes>();
 }
 
 CurlImpl::CurlImpl(CurlHandle handle,
@@ -626,7 +627,11 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
         static_cast<HttpStatusCode>(http_code_), {});
     TRACE_STATE() << ", status=" << status << ", http code=" << http_code_
                   << "\n";
-    if (!status.ok()) return status;
+
+    if (!internal::Contains(ignored_http_error_codes_, http_code_) &&
+        !status.ok()) {
+      return status;
+    }
     return bytes_read;
   }
   TRACE_STATE() << ", http code=" << http_code_ << "\n";

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -25,6 +25,7 @@
 #include "google/cloud/version.h"
 #include "absl/types/span.h"
 #include <array>
+#include <set>
 #include <utility>
 
 namespace google {
@@ -129,6 +130,7 @@ class CurlImpl {
   std::chrono::seconds download_stall_timeout_;
   std::string http_version_;
   std::int32_t http_code_;
+  std::set<std::int32_t> ignored_http_error_codes_;
 
   // Explicitly closing the handle happens in two steps.
   // 1. This class needs to notify libcurl that the transfer is terminated by

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -28,9 +28,11 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::HasSubstr;
+using ::testing::Not;
 
 class RestClientIntegrationTest : public ::testing::Test {
  protected:
@@ -144,6 +146,32 @@ TEST_F(RestClientIntegrationTest, Get) {
   auto body = ReadAll(std::move(payload));
   EXPECT_STATUS_OK(body);
   EXPECT_GT(body->size(), 0);
+}
+
+TEST_F(RestClientIntegrationTest, GetWithIgnoredErrorCode) {
+  options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  auto client =
+      MakeDefaultRestClient(url_, Options{}.set<IgnoredHttpErrorCodes>({308}));
+  RestRequest request;
+  request.SetPath("status/308");
+  auto response_status = RetryRestRequest([&] { return client->Get(request); });
+  ASSERT_STATUS_OK(response_status);
+  auto response = std::move(response_status.value());
+  EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kResumeIncomplete));
+  EXPECT_GT(response->Headers().size(), 0);
+  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
+  auto body = ReadAll(std::move(payload));
+  EXPECT_STATUS_OK(body);
+  EXPECT_GT(body->size(), 0);
+}
+
+TEST_F(RestClientIntegrationTest, GetWithNonIgnoredErrorCode) {
+  options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
+  auto client = MakeDefaultRestClient(url_, {});
+  RestRequest request;
+  request.SetPath("status/308");
+  auto response_status = RetryRestRequest([&] { return client->Get(request); });
+  EXPECT_THAT(response_status, Not(IsOk()));
 }
 
 TEST_F(RestClientIntegrationTest, Delete) {

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -162,7 +162,6 @@ TEST_F(RestClientIntegrationTest, GetWithIgnoredErrorCode) {
   std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
   auto body = ReadAll(std::move(payload));
   EXPECT_STATUS_OK(body);
-  EXPECT_GT(body->size(), 0);
 }
 
 TEST_F(RestClientIntegrationTest, GetWithNonIgnoredErrorCode) {

--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -74,10 +74,20 @@ struct DownloadStallTimeoutOption {
   using Type = std::chrono::seconds;
 };
 
+/**
+ * Some services appropriate Http error codes for their own use. If any such
+ * error codes need to be treated as non-failures, this option can indicate
+ * which codes.
+ */
+struct IgnoredHttpErrorCodes {
+  using Type = std::set<std::int32_t>;
+};
+
 /// The complete list of options accepted by `CurlRestClient`
 using RestOptionList =
     ::google::cloud::OptionList<UserIpOption, TransferStallTimeoutOption,
-                                DownloadStallTimeoutOption>;
+                                DownloadStallTimeoutOption,
+                                IgnoredHttpErrorCodes>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal


### PR DESCRIPTION
Need to support GCS using 308 for upload resume, but in a generic fashion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9236)
<!-- Reviewable:end -->
