### PR TITLE
impl(bigtable): modern `Table::AsyncReadModifyWriteRow()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -75,6 +75,9 @@ class DataConnectionImpl : public DataConnection {
   StatusOr<bigtable::Row> ReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request) override;
 
+  future<StatusOr<bigtable::Row>> AsyncReadModifyWriteRow(
+      google::bigtable::v2::ReadModifyWriteRowRequest request) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -390,6 +390,9 @@ future<StatusOr<Row>> Table::AsyncReadModifyWriteRowImpl(
   SetCommonTableOperationRequest<
       ::google::bigtable::v2::ReadModifyWriteRowRequest>(
       request, app_profile_id_, table_name_);
+  if (connection_) {
+    return connection_->AsyncReadModifyWriteRow(std::move(request));
+  }
 
   auto cq = background_threads_->cq();
   auto& client = client_;

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -171,9 +171,8 @@ TEST_F(DataIntegrationTestClientOnly, TableAsyncCheckAndMutateRowFail) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly,
-       TableAsyncReadModifyWriteAppendValueTest) {
-  auto table = GetTable();
+TEST_P(DataAsyncIntegrationTest, TableAsyncReadModifyWriteAppendValueTest) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
   std::string const add_suffix1 = "-suffix";


### PR DESCRIPTION
Part of the work for #8799 

Scroll up in the files to see the `ReadModifyWriteRow()` implementations. These changes are almost identical, but made to be async.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9237)
<!-- Reviewable:end -->
