### PR TITLE
feat(GCS+gRPC): use per-operation options

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -90,8 +90,8 @@ std::chrono::milliseconds DefaultTransferStallTimeout(
 
 }  // namespace
 
+using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::internal::MakeBackgroundThreadsFactory;
-using ::google::cloud::internal::OptionsSpan;
 
 int DefaultGrpcNumChannels(std::string const& endpoint) {
   // When using DirectPath the gRPC library already does load balancing across
@@ -176,7 +176,6 @@ Options GrpcClient::options() const { return options_; }
 
 StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
     ListBucketsRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -187,7 +186,6 @@ StatusOr<ListBucketsResponse> GrpcClient::ListBuckets(
 
 StatusOr<BucketMetadata> GrpcClient::CreateBucket(
     CreateBucketRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -198,7 +196,6 @@ StatusOr<BucketMetadata> GrpcClient::CreateBucket(
 
 StatusOr<BucketMetadata> GrpcClient::GetBucketMetadata(
     GetBucketMetadataRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -209,7 +206,6 @@ StatusOr<BucketMetadata> GrpcClient::GetBucketMetadata(
 
 StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
     DeleteBucketRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -220,7 +216,6 @@ StatusOr<EmptyResponse> GrpcClient::DeleteBucket(
 
 StatusOr<BucketMetadata> GrpcClient::UpdateBucket(
     UpdateBucketRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -231,7 +226,6 @@ StatusOr<BucketMetadata> GrpcClient::UpdateBucket(
 
 StatusOr<BucketMetadata> GrpcClient::PatchBucket(
     PatchBucketRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
@@ -243,7 +237,6 @@ StatusOr<BucketMetadata> GrpcClient::PatchBucket(
 
 StatusOr<NativeIamPolicy> GrpcClient::GetNativeBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -254,7 +247,6 @@ StatusOr<NativeIamPolicy> GrpcClient::GetNativeBucketIamPolicy(
 
 StatusOr<NativeIamPolicy> GrpcClient::SetNativeBucketIamPolicy(
     SetNativeBucketIamPolicyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -265,7 +257,6 @@ StatusOr<NativeIamPolicy> GrpcClient::SetNativeBucketIamPolicy(
 
 StatusOr<TestBucketIamPermissionsResponse> GrpcClient::TestBucketIamPermissions(
     TestBucketIamPermissionsRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -276,7 +267,6 @@ StatusOr<TestBucketIamPermissionsResponse> GrpcClient::TestBucketIamPermissions(
 
 StatusOr<BucketMetadata> GrpcClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcBucketRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -287,7 +277,6 @@ StatusOr<BucketMetadata> GrpcClient::LockBucketRetentionPolicy(
 
 StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
     InsertObjectMediaRequest const& request) {
-  OptionsSpan span(options_);
   auto r = GrpcObjectRequestParser::ToProto(request);
   if (!r) return std::move(r).status();
   auto proto_request = *r;
@@ -386,7 +375,6 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
 
 StatusOr<ObjectMetadata> GrpcClient::CopyObject(
     CopyObjectRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request, "resource");
@@ -397,23 +385,22 @@ StatusOr<ObjectMetadata> GrpcClient::CopyObject(
         StatusCode::kOutOfRange,
         "Object too large, use RewriteObject() instead of CopyObject()");
   }
-  return GrpcObjectMetadataParser::FromProto(response->resource(), options_);
+  return GrpcObjectMetadataParser::FromProto(response->resource(),
+                                             CurrentOptions());
 }
 
 StatusOr<ObjectMetadata> GrpcClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->GetObject(context, proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, options_);
+  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
     ReadObjectRangeRequest const& request) {
-  OptionsSpan span(options_);
   // With the REST API this condition was detected by the server as an error,
   // generally we prefer the server to detect errors because its answers are
   // authoritative. In this case, the server cannot: with gRPC '0' is the same
@@ -437,23 +424,22 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
   }
   return std::unique_ptr<ObjectReadSource>(
       absl::make_unique<GrpcObjectReadSource>(
-          std::move(stream), options_.get<DownloadStallTimeoutOption>()));
+          std::move(stream),
+          CurrentOptions().get<DownloadStallTimeoutOption>()));
 }
 
 StatusOr<ListObjectsResponse> GrpcClient::ListObjects(
     ListObjectsRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->ListObjects(context, proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectRequestParser::FromProto(*response, options_);
+  return GrpcObjectRequestParser::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<EmptyResponse> GrpcClient::DeleteObject(
     DeleteObjectRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -464,62 +450,56 @@ StatusOr<EmptyResponse> GrpcClient::DeleteObject(
 
 StatusOr<ObjectMetadata> GrpcClient::UpdateObject(
     UpdateObjectRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->UpdateObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, options_);
+  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<ObjectMetadata> GrpcClient::PatchObject(
     PatchObjectRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->UpdateObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, options_);
+  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<ObjectMetadata> GrpcClient::ComposeObject(
     ComposeObjectRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->ComposeObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, options_);
+  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<RewriteObjectResponse> GrpcClient::RewriteObject(
     RewriteObjectRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcObjectRequestParser::ToProto(request);
   if (!proto) return std::move(proto).status();
   grpc::ClientContext context;
   ApplyQueryParameters(context, request, "resource");
   auto response = stub_->RewriteObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectRequestParser::FromProto(*response, options_);
+  return GrpcObjectRequestParser::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<CreateResumableUploadResponse> GrpcClient::CreateResumableUpload(
     ResumableUploadRequest const& request) {
-  OptionsSpan span(options_);
-
   auto proto_request = GrpcObjectRequestParser::ToProto(request);
   if (!proto_request) return std::move(proto_request).status();
 
   grpc::ClientContext context;
   ApplyQueryParameters(context, request, "resource");
-  auto const timeout = options_.get<TransferStallTimeoutOption>();
+  auto const timeout = CurrentOptions().get<TransferStallTimeoutOption>();
   if (timeout.count() != 0) {
     context.set_deadline(std::chrono::system_clock::now() + timeout);
   }
@@ -531,10 +511,9 @@ StatusOr<CreateResumableUploadResponse> GrpcClient::CreateResumableUpload(
 
 StatusOr<QueryResumableUploadResponse> GrpcClient::QueryResumableUpload(
     QueryResumableUploadRequest const& request) {
-  OptionsSpan span(options_);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request, "resource");
-  auto const timeout = options_.get<TransferStallTimeoutOption>();
+  auto const timeout = CurrentOptions().get<TransferStallTimeoutOption>();
   if (timeout.count() != 0) {
     context.set_deadline(std::chrono::system_clock::now() + timeout);
   }
@@ -564,7 +543,6 @@ StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
     }
   };
 
-  OptionsSpan span(options_);
   auto const timeout =
       DefaultTransferStallTimeout(google::cloud::internal::CurrentOptions()
                                       .get<TransferStallTimeoutOption>());
@@ -890,7 +868,6 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchDefaultObjectAcl(
 
 StatusOr<ServiceAccount> GrpcClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcServiceAccountParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -901,7 +878,6 @@ StatusOr<ServiceAccount> GrpcClient::GetServiceAccount(
 
 StatusOr<ListHmacKeysResponse> GrpcClient::ListHmacKeys(
     ListHmacKeysRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcHmacKeyRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -912,7 +888,6 @@ StatusOr<ListHmacKeysResponse> GrpcClient::ListHmacKeys(
 
 StatusOr<CreateHmacKeyResponse> GrpcClient::CreateHmacKey(
     CreateHmacKeyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcHmacKeyRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -923,7 +898,6 @@ StatusOr<CreateHmacKeyResponse> GrpcClient::CreateHmacKey(
 
 StatusOr<EmptyResponse> GrpcClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcHmacKeyRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -934,7 +908,6 @@ StatusOr<EmptyResponse> GrpcClient::DeleteHmacKey(
 
 StatusOr<HmacKeyMetadata> GrpcClient::GetHmacKey(
     GetHmacKeyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcHmacKeyRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
@@ -945,7 +918,6 @@ StatusOr<HmacKeyMetadata> GrpcClient::GetHmacKey(
 
 StatusOr<HmacKeyMetadata> GrpcClient::UpdateHmacKey(
     UpdateHmacKeyRequest const& request) {
-  OptionsSpan span(options_);
   auto proto = GrpcHmacKeyRequestParser::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -86,6 +86,7 @@ TEST(GrpcClientInsertObjectMediaTest, Small) {
                 Return(ByMove(make_ready_future(make_status_or(response)))));
         return stream;
       });
+
   auto client = GrpcClient::CreateMock(mock);
   auto metadata = client->InsertObjectMedia(
       InsertObjectMediaRequest("test-bucket", "test-object",
@@ -119,8 +120,10 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutStart) {
                 make_status_or(google::storage::v2::WriteObjectResponse{})))));
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto metadata = client->InsertObjectMedia(
       InsertObjectMediaRequest("test-bucket", "test-object",
                                "The quick brown fox jumps over the lazy dog"));
@@ -153,8 +156,10 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutWrite) {
                 make_status_or(google::storage::v2::WriteObjectResponse{})))));
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto metadata = client->InsertObjectMedia(
       InsertObjectMediaRequest("test-bucket", "test-object",
                                "The quick brown fox jumps over the lazy dog"));
@@ -187,8 +192,10 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutFinish) {
         });
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto metadata = client->InsertObjectMedia(
       InsertObjectMediaRequest("test-bucket", "test-object",
                                "The quick brown fox jumps over the lazy dog"));

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -60,6 +60,9 @@ TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
       });
 
   auto client = GrpcClient::CreateMock(mock);
+  // Normally the span is created by `storage::Client`, but we bypass that code
+  // in this test.
+  google::cloud::internal::OptionsSpan const span(client->options());
   auto stream =
       client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
   ASSERT_STATUS_OK(stream);
@@ -93,6 +96,9 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
 
   auto client = GrpcClient::CreateMock(
       mock, Options{}.set<TransferStallTimeoutOption>(configured_timeout));
+  // Normally the span is created by `storage::Client`, but we bypass that code
+  // in this test.
+  google::cloud::internal::OptionsSpan const span(client->options());
   auto stream =
       client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
   ASSERT_STATUS_OK(stream);

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -33,7 +33,6 @@ namespace internal {
 namespace {
 
 namespace v2 = ::google::storage::v2;
-using ::google::cloud::internal::CurrentOptions;
 using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
@@ -48,7 +47,6 @@ using ::testing::ResultOf;
 using ::testing::Return;
 using ::testing::UnorderedElementsAre;
 
-auto constexpr kAuthority = "storage.googleapis.com";
 auto constexpr kBucketProtoText = R"pb(
   name: "projects/_/buckets/test-bucket-id"
   bucket_id: "test-bucket-id"
@@ -238,7 +236,6 @@ TEST_F(GrpcClientTest, QueryResumableUpload) {
   EXPECT_CALL(*mock, QueryWriteStatus)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::QueryWriteStatusRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -262,7 +259,6 @@ TEST_F(GrpcClientTest, CreateBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::CreateBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -285,7 +281,6 @@ TEST_F(GrpcClientTest, GetBucket) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        google::storage::v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -307,7 +302,6 @@ TEST_F(GrpcClientTest, DeleteBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::DeleteBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -328,7 +322,6 @@ TEST_F(GrpcClientTest, ListBuckets) {
   EXPECT_CALL(*mock, ListBuckets)
       .WillOnce([this](grpc::ClientContext& context,
                        google::storage::v2::ListBucketsRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -350,7 +343,6 @@ TEST_F(GrpcClientTest, LockBucketRetentionPolicy) {
       .WillOnce(
           [this](grpc::ClientContext& context,
                  google::storage::v2::LockBucketRetentionPolicyRequest const&) {
-            EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
             auto metadata = GetMetadata(context);
             EXPECT_THAT(metadata,
                         UnorderedElementsAre(
@@ -372,7 +364,6 @@ TEST_F(GrpcClientTest, UpdateBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::UpdateBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -394,7 +385,6 @@ TEST_F(GrpcClientTest, PatchBucket) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::UpdateBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -416,7 +406,6 @@ TEST_F(GrpcClientTest, GetNativeBucketIamPolicy) {
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::GetIamPolicyRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -437,7 +426,6 @@ TEST_F(GrpcClientTest, SetNativeBucketIamPolicy) {
   EXPECT_CALL(*mock, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
                        google::iam::v1::SetIamPolicyRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -460,7 +448,6 @@ TEST_F(GrpcClientTest, TestBucketIamPermissions) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::iam::v1::TestIamPermissionsRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -482,7 +469,6 @@ TEST_F(GrpcClientTest, InsertObjectMedia) {
   EXPECT_CALL(*mock, AsyncWriteObject)
       .WillOnce([this](google::cloud::CompletionQueue const&,
                        std::unique_ptr<grpc::ClientContext> context) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -517,7 +503,6 @@ TEST_F(GrpcClientTest, CopyObject) {
   EXPECT_CALL(*mock, RewriteObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::RewriteObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -546,7 +531,6 @@ TEST_F(GrpcClientTest, CopyObjectTooLarge) {
   EXPECT_CALL(*mock, RewriteObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::RewriteObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -578,7 +562,6 @@ TEST_F(GrpcClientTest, GetObjectMetadata) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -625,7 +608,6 @@ TEST_F(GrpcClientTest, ListObjects) {
   EXPECT_CALL(*mock, ListObjects)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::ListObjectsRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -647,7 +629,6 @@ TEST_F(GrpcClientTest, DeleteObject) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::DeleteObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -670,7 +651,6 @@ TEST_F(GrpcClientTest, UpdateObject) {
       .WillOnce([this](
                     grpc::ClientContext& context,
                     google::storage::v2::UpdateObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -697,7 +677,6 @@ TEST_F(GrpcClientTest, PatchObject) {
   EXPECT_CALL(*mock, UpdateObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::UpdateObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -722,7 +701,6 @@ TEST_F(GrpcClientTest, ComposeObject) {
   EXPECT_CALL(*mock, ComposeObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::ComposeObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -745,7 +723,6 @@ TEST_F(GrpcClientTest, RewriteObject) {
   EXPECT_CALL(*mock, RewriteObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::RewriteObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -774,7 +751,6 @@ TEST_F(GrpcClientTest, CreateResumableUpload) {
   EXPECT_CALL(*mock, StartResumableWrite)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::StartResumableWriteRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata,
                     UnorderedElementsAre(
@@ -800,7 +776,6 @@ TEST_F(GrpcClientTest, ListBucketAclFailure) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -851,7 +826,6 @@ TEST_F(GrpcClientTest, GetBucketAclFailure) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -907,7 +881,6 @@ TEST_F(GrpcClientTest, CreateBucketAclFailure) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -956,7 +929,6 @@ TEST_F(GrpcClientTest, DeleteBucketAclFailure) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1022,7 +994,6 @@ TEST_F(GrpcClientTest, UpdateBucketAclFailure) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1071,7 +1042,6 @@ TEST_F(GrpcClientTest, PatchBucketAclFailure) {
   EXPECT_CALL(*mock, GetBucket)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1123,7 +1093,6 @@ TEST_F(GrpcClientTest, ListObjectAclFailure) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1180,7 +1149,6 @@ TEST_F(GrpcClientTest, GetObjectAclFailure) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1237,7 +1205,6 @@ TEST_F(GrpcClientTest, CreateObjectAclFailure) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1290,7 +1257,6 @@ TEST_F(GrpcClientTest, DeleteObjectAclFailure) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1359,7 +1325,6 @@ TEST_F(GrpcClientTest, UpdateObjectAclFailure) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1412,7 +1377,6 @@ TEST_F(GrpcClientTest, PatchObjectAclFailure) {
   EXPECT_CALL(*mock, GetObject)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetObjectRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1467,7 +1431,6 @@ TEST_F(GrpcClientTest, GetServiceAccount) {
   EXPECT_CALL(*mock, GetServiceAccount)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetServiceAccountRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1488,7 +1451,6 @@ TEST_F(GrpcClientTest, CreateHmacKey) {
   EXPECT_CALL(*mock, CreateHmacKey)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::CreateHmacKeyRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1509,7 +1471,6 @@ TEST_F(GrpcClientTest, DeleteHmacKey) {
   EXPECT_CALL(*mock, DeleteHmacKey)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::DeleteHmacKeyRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1530,7 +1491,6 @@ TEST_F(GrpcClientTest, GetHmacKey) {
   EXPECT_CALL(*mock, GetHmacKey)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetHmacKeyRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1551,7 +1511,6 @@ TEST_F(GrpcClientTest, ListHmacKeys) {
   EXPECT_CALL(*mock, ListHmacKeys)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::ListHmacKeysRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),
@@ -1572,7 +1531,6 @@ TEST_F(GrpcClientTest, UpdateHmacKey) {
   EXPECT_CALL(*mock, UpdateHmacKey)
       .WillOnce([this](grpc::ClientContext& context,
                        v2::UpdateHmacKeyRequest const& request) {
-        EXPECT_EQ(CurrentOptions().get<AuthorityOption>(), kAuthority);
         auto metadata = GetMetadata(context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
                                   Pair("x-goog-quota-user", "test-quota-user"),

--- a/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
@@ -58,8 +58,10 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutStart) {
                 make_status_or(google::storage::v2::WriteObjectResponse{})))));
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
@@ -92,8 +94,10 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
                 make_status_or(google::storage::v2::WriteObjectResponse{})))));
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
@@ -128,8 +132,10 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
                 make_status_or(google::storage::v2::WriteObjectResponse{})))));
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
@@ -164,8 +170,10 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutFinish) {
         });
         return stream;
       });
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+
+  auto client = GrpcClient::CreateMock(mock);
+  google::cloud::internal::OptionsSpan const span(
+      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -28,8 +28,10 @@ namespace {
 std::chrono::milliseconds DefaultDownloadStallTimeout(
     std::chrono::milliseconds value) {
   if (value != std::chrono::milliseconds(0)) return value;
-  return std::chrono::seconds(
-      std::numeric_limits<std::chrono::seconds::rep>::max());
+  // We need a large value for `wait_for()`, but not so large that it can easily
+  // overflow.  Fortunately, uploads automatically cancel (server side) after
+  // a few hours, so waiting for 14 days will not create spurious timeouts.
+  return std::chrono::milliseconds(std::chrono::hours(24) * 14);
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #7691

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9239)
<!-- Reviewable:end -->
