### PR TITLE
impl(rest): handle full url specification in request path

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/internal/user_agent_prefix.h"
 #include "google/cloud/log.h"
 #include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
 #include <numeric>
 
 // Note that TRACE-level messages are disabled by default, even in
@@ -379,9 +380,6 @@ void CurlImpl::SetHeaders(RestRequest const& request) {
   }
 }
 
-std::string const CurlImpl::kHttp_ = "http://";
-std::string const CurlImpl::kHttps_ = "https://";
-
 void CurlImpl::SetUrl(
     std::string const& endpoint, RestRequest const& request,
     RestRequest::HttpParameters const& additional_parameters) {
@@ -390,9 +388,8 @@ void CurlImpl::SetUrl(
     return;
   }
 
-  if (absl::AsciiStrToLower(request.path().substr(0, kHttps_.size())) ==
-          kHttps_ ||
-      absl::AsciiStrToLower(request.path().substr(0, kHttp_.size())) == kHttp_) {
+  if (absl::StartsWithIgnoreCase(request.path(), "http://") ||
+    absl::StartsWithIgnoreCase(request.path(), "https://")) {
     url_ = request.path();
   } else {
     url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -382,13 +382,16 @@ void CurlImpl::SetHeaders(RestRequest const& request) {
 void CurlImpl::SetUrl(
     std::string const& endpoint, RestRequest const& request,
     RestRequest::HttpParameters const& additional_parameters) {
+  static std::string const kHttp = "http://";
+  static std::string const kHttps = "https://";
   if (request.path().empty() && additional_parameters.empty()) {
     url_ = endpoint;
     return;
   }
 
-  if (absl::AsciiStrToLower(request.path()).substr(0, endpoint.size()) ==
-      absl::AsciiStrToLower(endpoint)) {
+  if (absl::AsciiStrToLower(request.path()).substr(0, kHttps.size()) ==
+          kHttps ||
+      absl::AsciiStrToLower(request.path()).substr(0, kHttp.size()) == kHttp) {
     url_ = request.path();
   } else {
     url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -379,19 +379,20 @@ void CurlImpl::SetHeaders(RestRequest const& request) {
   }
 }
 
+std::string const CurlImpl::kHttp_ = "http://";
+std::string const CurlImpl::kHttps_ = "https://";
+
 void CurlImpl::SetUrl(
     std::string const& endpoint, RestRequest const& request,
     RestRequest::HttpParameters const& additional_parameters) {
-  static std::string const kHttp = "http://";
-  static std::string const kHttps = "https://";
   if (request.path().empty() && additional_parameters.empty()) {
     url_ = endpoint;
     return;
   }
 
-  if (absl::AsciiStrToLower(request.path()).substr(0, kHttps.size()) ==
-          kHttps ||
-      absl::AsciiStrToLower(request.path()).substr(0, kHttp.size()) == kHttp) {
+  if (absl::AsciiStrToLower(request.path().substr(0, kHttps_.size())) ==
+          kHttps_ ||
+      absl::AsciiStrToLower(request.path().substr(0, kHttp_.size())) == kHttp_) {
     url_ = request.path();
   } else {
     url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -389,7 +389,7 @@ void CurlImpl::SetUrl(
   }
 
   if (absl::StartsWithIgnoreCase(request.path(), "http://") ||
-    absl::StartsWithIgnoreCase(request.path(), "https://")) {
+      absl::StartsWithIgnoreCase(request.path(), "https://")) {
     url_ = request.path();
   } else {
     url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/internal/rest_options.h"
 #include "google/cloud/internal/user_agent_prefix.h"
 #include "google/cloud/log.h"
+#include "absl/strings/ascii.h"
 #include <numeric>
 
 // Note that TRACE-level messages are disabled by default, even in
@@ -385,7 +386,14 @@ void CurlImpl::SetUrl(
     url_ = endpoint;
     return;
   }
-  url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());
+
+  if (absl::AsciiStrToLower(request.path()).substr(0, endpoint.size()) ==
+      absl::AsciiStrToLower(endpoint)) {
+    url_ = request.path();
+  } else {
+    url_ = absl::StrCat(NormalizeEndpoint(endpoint), request.path());
+  }
+
   char const* query_parameter_separator = InitialQueryParameterSeparator(url_);
   auto append_params = [&](RestRequest::HttpParameters const& parameters) {
     for (auto const& param : parameters) {

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -90,8 +90,6 @@ class CurlImpl {
                                           void* userdata);
   friend std::size_t RestCurlRequestHeader(char* contents, std::size_t size,
                                            std::size_t nitems, void* userdata);
-  static std::string const kHttp_;
-  static std::string const kHttps_;
 
   // Called by libcurl to show that more data is available in the request.
   std::size_t WriteCallback(void* ptr, std::size_t size, std::size_t nmemb);

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -90,6 +90,8 @@ class CurlImpl {
                                           void* userdata);
   friend std::size_t RestCurlRequestHeader(char* contents, std::size_t size,
                                            std::size_t nitems, void* userdata);
+  static std::string const kHttp_;
+  static std::string const kHttps_;
 
   // Called by libcurl to show that more data is available in the request.
   std::size_t WriteCallback(void* ptr, std::size_t size, std::size_t nmemb);

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -94,12 +94,20 @@ TEST_F(CurlImplTest,
                              "verb?path=param&sort=desc&query=foo"));
 }
 
-TEST_F(CurlImplTest, SetUrlPathContainsEndpoint) {
+TEST_F(CurlImplTest, SetUrlPathContainsHttps) {
   RestRequest request;
   request.SetPath("HTTPS://endpoint.googleapis.com/resource/verb");
   auto impl = CurlImpl(std::move(handle_), factory_, {});
   impl.SetUrl("https://endpoint.googleapis.com", request, {});
   EXPECT_THAT(impl.url(), Eq("HTTPS://endpoint.googleapis.com/resource/verb"));
+}
+
+TEST_F(CurlImplTest, SetUrlPathContainsHttp) {
+  RestRequest request;
+  request.SetPath("HTTP://endpoint.googleapis.com/resource/verb");
+  auto impl = CurlImpl(std::move(handle_), factory_, {});
+  impl.SetUrl("https://endpoint.googleapis.com", request, {});
+  EXPECT_THAT(impl.url(), Eq("HTTP://endpoint.googleapis.com/resource/verb"));
 }
 
 }  // namespace

--- a/google/cloud/internal/curl_impl_test.cc
+++ b/google/cloud/internal/curl_impl_test.cc
@@ -94,6 +94,14 @@ TEST_F(CurlImplTest,
                              "verb?path=param&sort=desc&query=foo"));
 }
 
+TEST_F(CurlImplTest, SetUrlPathContainsEndpoint) {
+  RestRequest request;
+  request.SetPath("HTTPS://endpoint.googleapis.com/resource/verb");
+  auto impl = CurlImpl(std::move(handle_), factory_, {});
+  impl.SetUrl("https://endpoint.googleapis.com", request, {});
+  EXPECT_THAT(impl.url(), Eq("HTTPS://endpoint.googleapis.com/resource/verb"));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal


### PR DESCRIPTION
Rest library needs to support requests specifying the full url in its path member, particularly in the case of GCS resumable uploads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9240)
<!-- Reviewable:end -->
