### PR TITLE
impl(bigtable): modern `Table::AsyncCheckAndMutateRow()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -68,6 +68,12 @@ class DataConnectionImpl : public DataConnection {
       std::vector<bigtable::Mutation> true_mutations,
       std::vector<bigtable::Mutation> false_mutations) override;
 
+  future<StatusOr<bigtable::MutationBranch>> AsyncCheckAndMutateRow(
+      std::string const& app_profile_id, std::string const& table_name,
+      std::string row_key, bigtable::Filter filter,
+      std::vector<bigtable::Mutation> true_mutations,
+      std::vector<bigtable::Mutation> false_mutations) override;
+
   future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows(
       std::string const& app_profile_id,
       std::string const& table_name) override;

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -266,6 +266,12 @@ StatusOr<MutationBranch> Table::CheckAndMutateRow(
 future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRow(
     std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
     std::vector<Mutation> false_mutations) {
+  if (connection_) {
+    return connection_->AsyncCheckAndMutateRow(
+        app_profile_id_, table_name_, std::move(row_key), std::move(filter),
+        std::move(true_mutations), std::move(false_mutations));
+  }
+
   btproto::CheckAndMutateRowRequest request;
   request.set_row_key(std::move(row_key));
   SetCommonTableOperationRequest<btproto::CheckAndMutateRowRequest>(

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -272,6 +272,36 @@ TEST(TableTest, CheckAndMutateRow) {
   EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
 }
 
+TEST(TableTest, AsyncCheckAndMutateRow) {
+  auto mock = std::make_shared<MockDataConnection>();
+  EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
+      .WillOnce([](std::string const& app_profile_id,
+                   std::string const& table_name, std::string const& row_key,
+                   Filter const& filter,
+                   std::vector<Mutation> const& true_mutations,
+                   std::vector<Mutation> const& false_mutations) {
+        EXPECT_EQ(kAppProfileId, app_profile_id);
+        EXPECT_EQ(kTableName, table_name);
+        EXPECT_EQ("row", row_key);
+        EXPECT_THAT(filter, IsTestFilter());
+        // We could check individual elements, but verifying the size is good
+        // enough for me.
+        EXPECT_EQ(1, true_mutations.size());
+        EXPECT_EQ(2, false_mutations.size());
+        return make_ready_future<StatusOr<bigtable::MutationBranch>>(
+            PermanentError());
+      });
+
+  auto t1 = bigtable::SetCell("f1", "c1", ms(0), "true1");
+  auto f1 = bigtable::SetCell("f1", "c1", ms(0), "false1");
+  auto f2 = bigtable::SetCell("f2", "c2", ms(0), "false2");
+  auto table = bigtable_internal::MakeTable(mock, kProjectId, kInstanceId,
+                                            kAppProfileId, kTableId);
+  auto row =
+      table.AsyncCheckAndMutateRow("row", TestFilter(), {t1}, {f1, f2}).get();
+  EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
+}
+
 TEST(TableTest, AsyncSampleRows) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncSampleRows)

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -117,8 +117,8 @@ TEST_F(DataIntegrationTestClientOnly, TableAsyncBulkApply) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableAsyncCheckAndMutateRowPass) {
-  auto table = GetTable();
+TEST_P(DataAsyncIntegrationTest, TableAsyncCheckAndMutateRowPass) {
+  auto table = GetTable(GetParam());
 
   std::string const key = "row-key";
 
@@ -144,8 +144,8 @@ TEST_F(DataIntegrationTestClientOnly, TableAsyncCheckAndMutateRowPass) {
   CheckEqualUnordered(expected, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableAsyncCheckAndMutateRowFail) {
-  auto table = GetTable();
+TEST_P(DataAsyncIntegrationTest, TableAsyncCheckAndMutateRowFail) {
+  auto table = GetTable(GetParam());
 
   std::string const key = "row-key";
 


### PR DESCRIPTION
Fixes #8799 

Again, this is basically a copy/paste of the synchronous implementation/tests directly above the new code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9242)
<!-- Reviewable:end -->
