### PR TITLE
impl(bigtable): modern `Table::SampleRows()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -74,6 +74,10 @@ class DataConnectionImpl : public DataConnection {
       std::vector<bigtable::Mutation> true_mutations,
       std::vector<bigtable::Mutation> false_mutations) override;
 
+  StatusOr<std::vector<bigtable::RowKeySample>> SampleRows(
+      std::string const& app_profile_id,
+      std::string const& table_name) override;
+
   future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows(
       std::string const& app_profile_id,
       std::string const& table_name) override;

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -319,6 +319,10 @@ future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRow(
 // policies in effect tell us to stop. Note that each retry must clear the
 // samples otherwise the result is an inconsistent set of sample row keys.
 StatusOr<std::vector<bigtable::RowKeySample>> Table::SampleRows() {
+  if (connection_) {
+    return connection_->SampleRows(app_profile_id_, table_name_);
+  }
+
   // Copy the policies in effect for this operation.
   auto backoff_policy = clone_rpc_backoff_policy();
   auto retry_policy = clone_rpc_retry_policy();

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -302,6 +302,22 @@ TEST(TableTest, AsyncCheckAndMutateRow) {
   EXPECT_THAT(row, StatusIs(StatusCode::kPermissionDenied));
 }
 
+TEST(TableTest, SampleRows) {
+  auto mock = std::make_shared<MockDataConnection>();
+  EXPECT_CALL(*mock, SampleRows)
+      .WillOnce(
+          [](std::string const& app_profile_id, std::string const& table_name) {
+            EXPECT_EQ(kAppProfileId, app_profile_id);
+            EXPECT_EQ(kTableName, table_name);
+            return PermanentError();
+          });
+
+  auto table = bigtable_internal::MakeTable(mock, kProjectId, kInstanceId,
+                                            kAppProfileId, kTableId);
+  auto samples = table.SampleRows();
+  EXPECT_THAT(samples, StatusIs(StatusCode::kPermissionDenied));
+}
+
 TEST(TableTest, AsyncSampleRows) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncSampleRows)

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -105,6 +105,14 @@ class SampleRowsIntegrationTest
   }
 };
 
+TEST_F(SampleRowsIntegrationTest, SyncWithDataConnection) {
+  auto table = bigtable_internal::MakeTable(
+      bigtable_internal::MakeDataConnection(),
+      TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
+      "", TableTestEnvironment::table_id());
+  VerifySamples(table.SampleRows());
+};
+
 TEST_F(SampleRowsIntegrationTest, AsyncWithDataConnection) {
   auto table = bigtable_internal::MakeTable(
       bigtable_internal::MakeDataConnection(),


### PR DESCRIPTION
Fixes #8803 and finishes the sample fixture of #9164

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9246)
<!-- Reviewable:end -->
