### PR TITLE
fix: relax parsing for GCE informational fields

### DIFF
--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -15,10 +15,10 @@
 #include "google/cloud/internal/oauth2_compute_engine_credentials.h"
 #include "google/cloud/internal/compute_engine_util.h"
 #include "google/cloud/internal/curl_options.h"
-#include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/oauth2_credential_constants.h"
 #include "google/cloud/internal/oauth2_credentials.h"
 #include "google/cloud/internal/rest_response.h"
+#include "absl/strings/str_split.h"
 #include <nlohmann/json.hpp>
 #include <set>
 
@@ -31,25 +31,31 @@ StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     rest_internal::RestResponse& response) {
   auto payload = rest_internal::ReadAll(std::move(response).ExtractPayload());
   if (!payload.ok()) return payload.status();
-  auto response_body = nlohmann::json::parse(*payload, nullptr, false);
-  // Note that the "scopes" attribute will always be present and contain a
-  // JSON array. At minimum, for the request to succeed, the instance must
-  // have been granted the scope that allows it to retrieve info from the
-  // metadata server.
-  if (response_body.is_discarded() || response_body.count("email") == 0 ||
-      response_body.count("scopes") == 0) {
-    auto error_payload =
-        *payload +
-        "Could not find all required fields in response (email, scopes).";
-    return Status{StatusCode::kInvalidArgument, error_payload, {}};
-  }
-  ServiceAccountMetadata metadata;
-  // Do not update any state until all potential errors are handled.
-  metadata.email = response_body.value("email", "");
-  // We need to call the .get<>() helper because the conversion is ambiguous
-  // otherwise.
-  metadata.scopes = response_body["scopes"].get<std::set<std::string>>();
-  return metadata;
+  return ParseMetadataServerResponse(*payload);
+}
+
+ServiceAccountMetadata ParseMetadataServerResponse(std::string const& payload) {
+  auto body = nlohmann::json::parse(payload, nullptr, false);
+  // Parse the body, ignoring invalid or missing values.
+  auto scopes = [&]() -> std::set<std::string> {
+    if (!body.contains("scopes")) return {};
+    auto const& s = body["scopes"];
+    if (s.is_string()) {
+      return absl::StrSplit(s.get<std::string>(), '\n', absl::SkipWhitespace());
+    }
+    if (!s.is_array()) return {};
+    std::set<std::string> result;
+    for (auto const& i : s) {
+      if (!i.is_string()) return {};
+      result.insert(i.get<std::string>());
+    }
+    return result;
+  };
+  auto email = [&]() -> std::string {
+    if (!body.contains("email") || !body["email"].is_string()) return {};
+    return body.value("email", "");
+  };
+  return ServiceAccountMetadata{scopes(), email()};
 }
 
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -43,6 +43,8 @@ ServiceAccountMetadata ParseMetadataServerResponse(std::string const& payload) {
     if (s.is_string()) {
       return absl::StrSplit(s.get<std::string>(), '\n', absl::SkipWhitespace());
     }
+    // If we cannot parse the `scopes` field as an array of strings, we return
+    // an empty set.
     if (!s.is_array()) return {};
     std::set<std::string> result;
     for (auto const& i : s) {

--- a/google/cloud/internal/oauth2_compute_engine_credentials.h
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.h
@@ -39,6 +39,16 @@ struct ServiceAccountMetadata {
 StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     rest_internal::RestResponse& response);
 
+/**
+ * Parses a metadata server response JSON string into a ServiceAccountMetadata.
+ *
+ * This function ignores all parsing errors, the data is purely informational,
+ * it is better to just return nothing than to fail authentication because some
+ * (most likely unused) data was not available or the service returned a
+ * malformed response.
+ */
+ServiceAccountMetadata ParseMetadataServerResponse(std::string const& payload);
+
 /// Parses a refresh response JSON string into an authorization header. The
 /// header and the current time (for the expiration) form a TemporaryToken.
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/oauth2/compute_engine_credentials.h"
+#include "google/cloud/internal/oauth2_compute_engine_credentials.h"
 #include <nlohmann/json.hpp>
 
 namespace google {
@@ -20,29 +21,12 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace oauth2 {
+
 StatusOr<ServiceAccountMetadata> ParseMetadataServerResponse(
     storage::internal::HttpResponse const& response) {
-  auto response_body = nlohmann::json::parse(response.payload, nullptr, false);
-  // Note that the "scopes" attribute will always be present and contain a
-  // JSON array. At minimum, for the request to succeed, the instance must
-  // have been granted the scope that allows it to retrieve info from the
-  // metadata server.
-  if (!response_body.is_object() || response_body.count("email") == 0 ||
-      response_body.count("scopes") == 0) {
-    auto payload =
-        response.payload +
-        "Could not find all required fields in response (email, scopes).";
-    return AsStatus(storage::internal::HttpResponse{
-        storage::internal::HttpStatusCode::kMinInvalidCode, payload,
-        response.headers});
-  }
-  ServiceAccountMetadata metadata;
-  // Do not update any state until all potential errors are handled.
-  metadata.email = response_body.value("email", "");
-  // We need to call the .get<>() helper because the conversion is ambiguous
-  // otherwise.
-  metadata.scopes = response_body["scopes"].get<std::set<std::string>>();
-  return metadata;
+  auto meta = google::cloud::oauth2_internal::ParseMetadataServerResponse(
+      response.payload);
+  return ServiceAccountMetadata{std::move(meta.scopes), std::move(meta.email)};
 }
 
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>


### PR DESCRIPTION
We parse (but largely ignore) some metadata information about the GCE
service account. This parsing was very strict, rejecting the data if
fields were missing.  We now accept missing fields, and field them
with blank data (or empty lists).  We also accept the responses from
Cloud Shell, where the `scopes` field is a newline separated string,
instead of an array of strings.  This may be a bug in Cloud Shell, but
it makes the library unusable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9251)
<!-- Reviewable:end -->
