### PR TITLE
fix: handle transient failures in the GCE credentials

### DIFF
--- a/google/cloud/internal/oauth2_google_credentials.cc
+++ b/google/cloud/internal/oauth2_google_credentials.cc
@@ -34,10 +34,6 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-char constexpr kAdcLink[] =
-    "https://developers.google.com/identity/protocols/"
-    "application-default-credentials";
-
 // Parses the JSON at `path` and creates the appropriate
 // Credentials type.
 //
@@ -153,18 +149,8 @@ StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
 
   // 3) Check for implicit environment-based credentials (GCE, GAE Flexible,
   // Cloud Run or GKE Environment).
-  auto gce_creds = std::make_shared<ComputeEngineCredentials>();
-  if (options.get<oauth2_internal::ForceGceOption>() ||
-      gce_creds->AuthorizationHeader().ok()) {
-    return std::shared_ptr<Credentials>(std::move(gce_creds));
-  }
-
-  // We've exhausted all search points, thus credentials cannot be constructed.
   return StatusOr<std::shared_ptr<Credentials>>(
-      Status(StatusCode::kUnknown,
-             "Could not automatically determine credentials. For more "
-             "information, please see " +
-                 std::string(kAdcLink)));
+      std::make_shared<ComputeEngineCredentials>());
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/oauth2_google_credentials.h
+++ b/google/cloud/internal/oauth2_google_credentials.h
@@ -30,13 +30,6 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * Forces credentials creation as if the program is running on a GCE instance.
- */
-struct ForceGceOption {
-  using Type = bool;
-};
-
-/**
  * Produces a Credentials type based on the runtime environment.
  *
  * If the GOOGLE_APPLICATION_CREDENTIALS environment variable is set, the JSON

--- a/google/cloud/storage/oauth2/google_credentials.cc
+++ b/google/cloud/storage/oauth2/google_credentials.cc
@@ -160,22 +160,10 @@ StatusOr<std::shared_ptr<Credentials>> GoogleDefaultCredentials(
     return StatusOr<std::shared_ptr<Credentials>>(std::move(*creds));
   }
 
-  // 3) Check for implicit environment-based credentials (GCE, GAE Flexible,
+  // 3) Use the implicit environment-based credentials (GCE, GAE Flexible,
   // Cloud Run or GKE Environment).
-  auto gce_creds = std::make_shared<ComputeEngineCredentials<>>();
-  auto override_val =
-      google::cloud::internal::GetEnv(internal::GceCheckOverrideEnvVar());
-  if (override_val.has_value() ? (std::string("1") == *override_val)
-                               : gce_creds->AuthorizationHeader().ok()) {
-    return StatusOr<std::shared_ptr<Credentials>>(std::move(gce_creds));
-  }
-
-  // We've exhausted all search points, thus credentials cannot be constructed.
   return StatusOr<std::shared_ptr<Credentials>>(
-      Status(StatusCode::kUnknown,
-             "Could not automatically determine credentials. For more "
-             "information, please see " +
-                 std::string(kAdcLink)));
+      std::make_shared<ComputeEngineCredentials<>>());
 }
 
 std::shared_ptr<Credentials> CreateAnonymousCredentials() {

--- a/google/cloud/storage/oauth2/google_credentials_test.cc
+++ b/google/cloud/storage/oauth2/google_credentials_test.cc
@@ -45,6 +45,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::AllOf;
 using ::testing::HasSubstr;
 using ::testing::Not;
+using ::testing::NotNull;
 
 class GoogleCredentialsTest : public ::testing::Test {
  public:
@@ -503,16 +504,19 @@ TEST_F(GoogleCredentialsTest, MissingCredentialsViaEnvVar) {
 TEST_F(GoogleCredentialsTest, MissingCredentialsViaGcloudFilePath) {
   char const filename[] = "missing-credentials.json";
 
-  ScopedEnvironment gce_check_override_env_var(GceCheckOverrideEnvVar(), "0");
   // The method to create default credentials should see that no file exists at
   // this path, then continue trying to load the other credential types,
   // eventually finding no valid credentials and hitting a runtime error.
   ScopedEnvironment gcloud_path_override_env_var(GoogleGcloudAdcFileEnvVar(),
                                                  filename);
+  ScopedEnvironment gcloud_metadata_host_override_env_var(
+      internal::GceMetadataHostnameEnvVar(), "invalid.google.internal");
 
   auto creds = GoogleDefaultCredentials();
-  EXPECT_THAT(creds, StatusIs(Not(StatusCode::kOk),
-                              HasSubstr("Could not automatically determine")));
+  ASSERT_STATUS_OK(creds);
+  ASSERT_THAT(*creds, NotNull());
+  auto header = (*creds)->AuthorizationHeader();
+  EXPECT_THAT(header, StatusIs(Not(StatusCode::kOk)));
 }
 
 TEST_F(GoogleCredentialsTest, LoadP12Credentials) {


### PR DESCRIPTION
Getting the authorization token from the GCE credentials can fail
when the credentials are created.  The metadata service may be
experiencing some kind of transient failure.  It is better to return the
credentials, and let the retry loops handle the problem.  If the failure
is not transient, the retry loop will handle that too.

Fixes #9249

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9252)
<!-- Reviewable:end -->
