### PR TITLE
impl(bigtable): cancel for `AsyncBulkApplier` future

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -51,7 +51,8 @@ AsyncBulkApplier::AsyncBulkApplier(
       stub_(std::move(stub)),
       retry_policy_(std::move(retry_policy)),
       backoff_policy_(std::move(backoff_policy)),
-      state_(app_profile_id, table_name, idempotent_policy, std::move(mut)) {}
+      state_(app_profile_id, table_name, idempotent_policy, std::move(mut)),
+      promise_([this] { stream_cancelled_ = true; }) {}
 
 void AsyncBulkApplier::StartIteration() {
   auto context = absl::make_unique<grpc::ClientContext>();
@@ -61,6 +62,7 @@ void AsyncBulkApplier::StartIteration() {
   PerformAsyncStreamingRead(
       stub_->AsyncMutateRows(cq_, std::move(context), state_.BeforeStart()),
       [self](google::bigtable::v2::MutateRowsResponse r) {
+        if (self->stream_cancelled_) return make_ready_future(false);
         self->OnRead(std::move(r));
         return make_ready_future(true);
       },

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -64,6 +64,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
   std::unique_ptr<DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   bigtable::internal::BulkMutatorState state_;
+  bool stream_cancelled_ = false;
   promise<std::vector<bigtable::FailedMutation>> promise_;
 };
 

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -33,6 +33,7 @@ using ::google::cloud::bigtable::testing::MockAsyncMutateRowsStream;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAreArray;
 using ::testing::Matcher;
 using ::testing::MockFunction;
@@ -424,6 +425,124 @@ TEST(AsyncBulkApplyTest, TimerError) {
       cq, mock, std::move(retry), std::move(mock_b), *idempotency, kAppProfile,
       kTableName, std::move(mut));
 
+  CheckFailedMutations(actual.get(), expected);
+}
+
+TEST(AsyncBulkApplyTest, CancelAfterSuccess) {
+  bigtable::BulkMutation mut(IdempotentMutation("r0"));
+  promise<absl::optional<v2::MutateRowsResponse>> p;
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncMutateRows)
+      .WillOnce([&p](CompletionQueue const&,
+                     std::unique_ptr<grpc::ClientContext>,
+                     v2::MutateRowsRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        auto stream = absl::make_unique<MockAsyncMutateRowsStream>();
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([] {
+              return make_ready_future(
+                  MakeResponse({{0, grpc::StatusCode::OK}}));
+            })
+            // We block here so the caller can cancel the request. The value
+            // returned will be empty, meaning the stream is complete.
+            .WillOnce([&p] { return p.get_future(); });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(Status{});
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  CompletionQueue cq(mock_cq);
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = absl::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+  auto idempotency = bigtable::DefaultIdempotentMutationPolicy();
+
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+  internal::OptionsSpan span(
+      Options{}.set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
+
+  auto actual = AsyncBulkApplier::Create(
+      cq, mock, std::move(retry), std::move(mock_b), *idempotency, kAppProfile,
+      kTableName, std::move(mut));
+
+  // Cancel the call after performing the one and only read of this test stream.
+  actual.cancel();
+  // Proceed with the rest of the stream. In this test, there are no more
+  // responses to be read. The client call should succeed.
+  p.set_value(absl::optional<v2::MutateRowsResponse>{});
+  CheckFailedMutations(actual.get(), {});
+}
+
+TEST(AsyncBulkApplyTest, CancelMidStream) {
+  std::vector<bigtable::FailedMutation> expected = {
+      {Status(StatusCode::kCancelled, "User cancelled"), 1}};
+  bigtable::BulkMutation mut(IdempotentMutation("r0"),
+                             IdempotentMutation("r1"));
+  promise<absl::optional<v2::MutateRowsResponse>> p;
+
+  auto mock = std::make_shared<MockBigtableStub>();
+  EXPECT_CALL(*mock, AsyncMutateRows)
+      .WillOnce([&p](CompletionQueue const&,
+                     std::unique_ptr<grpc::ClientContext>,
+                     v2::MutateRowsRequest const& request) {
+        EXPECT_EQ(kAppProfile, request.app_profile_id());
+        EXPECT_EQ(kTableName, request.table_name());
+        auto stream = absl::make_unique<MockAsyncMutateRowsStream>();
+        ::testing::InSequence s;
+        EXPECT_CALL(*stream, Start).WillOnce([] {
+          return make_ready_future(true);
+        });
+        EXPECT_CALL(*stream, Read)
+            .WillOnce([] {
+              return make_ready_future(
+                  MakeResponse({{0, grpc::StatusCode::OK}}));
+            })
+            // We block here so the caller can cancel the request. The value
+            // returned will be a response, meaning the stream is still active
+            // and needs to be drained.
+            .WillOnce([&p] { return p.get_future(); });
+        EXPECT_CALL(*stream, Cancel);
+        EXPECT_CALL(*stream, Read).WillOnce([] {
+          return make_ready_future(absl::optional<v2::MutateRowsResponse>{});
+        });
+        EXPECT_CALL(*stream, Finish).WillOnce([] {
+          return make_ready_future(
+              Status(StatusCode::kCancelled, "User cancelled"));
+        });
+        return stream;
+      });
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  CompletionQueue cq(mock_cq);
+
+  auto retry = DataLimitedErrorCountRetryPolicy(kNumRetries).clone();
+  auto mock_b = absl::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, OnCompletion).Times(0);
+  auto idempotency = bigtable::DefaultIdempotentMutationPolicy();
+
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(1);
+  internal::OptionsSpan span(
+      Options{}.set<internal::GrpcSetupOption>(mock_setup.AsStdFunction()));
+
+  auto actual = AsyncBulkApplier::Create(
+      cq, mock, std::move(retry), std::move(mock_b), *idempotency, kAppProfile,
+      kTableName, std::move(mut));
+
+  // Cancel the call after performing one read of this test stream.
+  actual.cancel();
+  // Proceed with the rest of the stream. In this test, there are more responses
+  // to be read, which we must drain. The client call should fail.
+  p.set_value(MakeResponse({{1, grpc::StatusCode::OK}}));
   CheckFailedMutations(actual.get(), expected);
 }
 


### PR DESCRIPTION
Part of the work for #9175 

Add cancelling for the `future` that will be returned by `Table::AsyncBulkApply()`. Code and tests are inspired by `AsyncRowSampler`.