### PR TITLE
fix(storage): respect policies in deprecated constructor

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -51,7 +51,7 @@ std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
   if (enable_logging) {
     client = std::make_shared<internal::LoggingClient>(std::move(client));
   }
-  return internal::RetryClient::Create(std::move(client));
+  return internal::RetryClient::Create(std::move(client), opts);
 }
 
 std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -257,9 +257,9 @@ TEST_F(ClientTest, DeprecatedButNotDecommissioned) {
 TEST_F(ClientTest, DeprecatedRetryPolicies) {
   auto constexpr kNumRetries = 2;
   auto mock_b = absl::make_unique<MockBackoffPolicy>();
-  EXPECT_CALL(*mock_b, clone).WillOnce([] {
+  EXPECT_CALL(*mock_b, clone).WillOnce([=] {
     auto clone_1 = absl::make_unique<MockBackoffPolicy>();
-    EXPECT_CALL(*clone_1, clone).WillOnce([] {
+    EXPECT_CALL(*clone_1, clone).WillOnce([=] {
       auto clone_2 = absl::make_unique<MockBackoffPolicy>();
       EXPECT_CALL(*clone_2, OnCompletion)
           .Times(kNumRetries)
@@ -275,7 +275,7 @@ TEST_F(ClientTest, DeprecatedRetryPolicies) {
       .WillRepeatedly(Return(TransientError()));
 
   auto client = storage::Client(mock, LimitedErrorCountRetryPolicy(kNumRetries),
-                                *std::move(mock_b));
+                                std::move(*mock_b));
   (void)client.ListBuckets();
 }
 

--- a/google/cloud/storage/client_test.cc
+++ b/google/cloud/storage/client_test.cc
@@ -20,8 +20,10 @@
 #include "google/cloud/storage/testing/canonical_errors.h"
 #include "google/cloud/storage/testing/mock_client.h"
 #include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/mock_backoff_policy.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 namespace google {
 namespace cloud {
@@ -31,6 +33,7 @@ namespace {
 
 using ::google::cloud::storage::internal::ClientImplDetails;
 using ::google::cloud::storage::testing::canonical_errors::TransientError;
+using ::google::cloud::testing_util::MockBackoffPolicy;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::Return;
 
@@ -249,6 +252,31 @@ TEST_F(ClientTest, DeprecatedButNotDecommissioned) {
   auto m2 = std::make_shared<testing::MockClient>();
   auto c2 = storage::Client(m2, LimitedErrorCountRetryPolicy(3));
   EXPECT_NE(c2.raw_client().get(), m2.get());
+}
+
+TEST_F(ClientTest, DeprecatedRetryPolicies) {
+  auto constexpr kNumRetries = 2;
+  auto mock_b = absl::make_unique<MockBackoffPolicy>();
+  EXPECT_CALL(*mock_b, clone).WillOnce([] {
+    auto clone_1 = absl::make_unique<MockBackoffPolicy>();
+    EXPECT_CALL(*clone_1, clone).WillOnce([] {
+      auto clone_2 = absl::make_unique<MockBackoffPolicy>();
+      EXPECT_CALL(*clone_2, OnCompletion)
+          .Times(kNumRetries)
+          .WillRepeatedly(Return(std::chrono::milliseconds(0)));
+      return clone_2;
+    });
+    return clone_1;
+  });
+
+  auto mock = std::make_shared<testing::MockClient>();
+  EXPECT_CALL(*mock, ListBuckets)
+      .Times(kNumRetries + 1)
+      .WillRepeatedly(Return(TransientError()));
+
+  auto client = storage::Client(mock, LimitedErrorCountRetryPolicy(kNumRetries),
+                                *std::move(mock_b));
+  (void)client.ListBuckets();
 }
 
 }  // namespace

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -28,6 +28,7 @@ namespace internal {
 namespace {
 
 using ::google::cloud::Idempotency;
+using ::google::cloud::internal::MergeOptions;
 using ::google::cloud::storage::internal::raw_client_wrapper_utils::Signature;
 
 /**
@@ -94,22 +95,21 @@ typename Signature<MemberFunction>::ReturnType MakeCall(
 }  // namespace
 
 std::shared_ptr<RetryClient> RetryClient::Create(
-    std::shared_ptr<RawClient> client, Options policies) {
+    std::shared_ptr<RawClient> client, Options options) {
   // Cannot use `std::make_shared<>` because the constructor is private.
   return std::shared_ptr<RetryClient>(
-      new RetryClient(std::move(client), std::move(policies)));
+      new RetryClient(std::move(client), std::move(options)));
 }
 
-RetryClient::RetryClient(std::shared_ptr<RawClient> client, Options policies)
-    : client_(std::move(client)), policies_(std::move(policies)) {}
+RetryClient::RetryClient(std::shared_ptr<RawClient> client, Options options)
+    : client_(std::move(client)),
+      options_(MergeOptions(std::move(options), client_->options())) {}
 
 ClientOptions const& RetryClient::client_options() const {
   return client_->client_options();
 }
 
-Options RetryClient::options() const {
-  return google::cloud::internal::MergeOptions(policies_, client_->options());
-}
+Options RetryClient::options() const { return options_; }
 
 StatusOr<ListBucketsResponse> RetryClient::ListBuckets(
     ListBucketsRequest const& request) {

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -32,7 +32,8 @@ namespace internal {
 class RetryClient : public RawClient,
                     public std::enable_shared_from_this<RetryClient> {
  public:
-  static std::shared_ptr<RetryClient> Create(std::shared_ptr<RawClient> client);
+  static std::shared_ptr<RetryClient> Create(std::shared_ptr<RawClient> client,
+                                             Options policies = {});
 
   ~RetryClient() override = default;
 
@@ -154,13 +155,14 @@ class RetryClient : public RawClient,
   std::shared_ptr<RawClient> client() const { return client_; }
 
  private:
-  explicit RetryClient(std::shared_ptr<RawClient> client);
+  explicit RetryClient(std::shared_ptr<RawClient> client, Options policies);
 
   static std::unique_ptr<RetryPolicy> current_retry_policy();
   static std::unique_ptr<BackoffPolicy> current_backoff_policy();
   static IdempotencyPolicy& current_idempotency_policy();
 
   std::shared_ptr<RawClient> client_;
+  Options policies_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/retry_client.h
+++ b/google/cloud/storage/internal/retry_client.h
@@ -33,7 +33,7 @@ class RetryClient : public RawClient,
                     public std::enable_shared_from_this<RetryClient> {
  public:
   static std::shared_ptr<RetryClient> Create(std::shared_ptr<RawClient> client,
-                                             Options policies = {});
+                                             Options options = {});
 
   ~RetryClient() override = default;
 
@@ -155,14 +155,14 @@ class RetryClient : public RawClient,
   std::shared_ptr<RawClient> client() const { return client_; }
 
  private:
-  explicit RetryClient(std::shared_ptr<RawClient> client, Options policies);
+  explicit RetryClient(std::shared_ptr<RawClient> client, Options options);
 
   static std::unique_ptr<RetryPolicy> current_retry_policy();
   static std::unique_ptr<BackoffPolicy> current_backoff_policy();
   static IdempotencyPolicy& current_idempotency_policy();
 
   std::shared_ptr<RawClient> client_;
-  Options policies_;
+  Options options_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/testing/client_unit_test.cc
+++ b/google/cloud/storage/testing/client_unit_test.cc
@@ -32,16 +32,14 @@ ClientUnitTest::ClientUnitTest()
           Options{}
               .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
               .set<AuthorityOption>("a-default")
-              .set<UserProjectOption>("u-p-default")
-              .set<RetryPolicyOption>(LimitedErrorCountRetryPolicy(2).clone())
-              .set<BackoffPolicyOption>(
-                  ExponentialBackoffPolicy(std::chrono::milliseconds(1),
-                                           std::chrono::milliseconds(1), 2.0)
-                      .clone()))));
+              .set<UserProjectOption>("u-p-default"))));
 }
 
 Client ClientUnitTest::ClientForMock() {
-  return ::google::cloud::storage::testing::ClientFromMock(mock_);
+  return ::google::cloud::storage::testing::ClientFromMock(
+      mock_, LimitedErrorCountRetryPolicy(2),
+      ExponentialBackoffPolicy(std::chrono::milliseconds(1),
+                               std::chrono::milliseconds(1), 2.0));
 }
 
 }  // namespace testing

--- a/google/cloud/storage/testing/mock_client.h
+++ b/google/cloud/storage/testing/mock_client.h
@@ -189,10 +189,8 @@ class MockStreambuf : public internal::ObjectWriteStreambuf {
 template <typename... Policies>
 Client ClientFromMock(std::shared_ptr<MockClient> const& mock,
                       Policies&&... p) {
-  auto opts =
-      internal::ApplyPolicies(mock->options(), std::forward<Policies>(p)...);
-  EXPECT_CALL(*mock, options).WillRepeatedly(::testing::Return(opts));
-  return internal::ClientImplDetails::CreateClient(mock);
+  return internal::ClientImplDetails::CreateClient(
+      mock, std::forward<Policies>(p)...);
 }
 
 }  // namespace testing


### PR DESCRIPTION
This deprecated constructor
https://github.com/googleapis/google-cloud-cpp/blob/2c83a865b680bb7c498b00770c3bbf5cfb0480a4/google/cloud/storage/client.h#L3236-L3244

... consolidates the retry/backoff/idempotency policies as options
https://github.com/googleapis/google-cloud-cpp/blob/2c83a865b680bb7c498b00770c3bbf5cfb0480a4/google/cloud/storage/client_options.h#L51-L55

... but when the options get to the `RetryClient`, only the logging configuration is used.
https://github.com/googleapis/google-cloud-cpp/blob/2c83a865b680bb7c498b00770c3bbf5cfb0480a4/google/cloud/storage/client.cc#L45-L58

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9255)
<!-- Reviewable:end -->
