### PR TITLE
ci(GCS+gRPC): also log the gRPC calls

### DIFF
--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -33,7 +33,7 @@ $env:GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
 $env:GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,1024,WARNING"
 $env:GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 $env:GOOGLE_CLOUD_CPP_TRACING_OPTIONS="single_line_mode=off,truncate_string_field_longer_than=512"
-$env:CLOUD_STORAGE_ENABLE_TRACING="raw-client"
+$env:CLOUD_STORAGE_ENABLE_TRACING="raw-client,rpc,rpc-streams"
 
 # Cloud Bigtable configuration parameters
 $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="test-instance"

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -41,7 +41,7 @@ export GOOGLE_CLOUD_CPP_AUTO_RUN_EXAMPLES="yes"
 export GOOGLE_CLOUD_CPP_EXPERIMENTAL_LOG_CONFIG="lastN,1024,WARNING"
 export GOOGLE_CLOUD_CPP_ENABLE_TRACING="rpc,rpc-streams"
 export GOOGLE_CLOUD_CPP_TRACING_OPTIONS="single_line_mode=off,truncate_string_field_longer_than=512"
-export CLOUD_STORAGE_ENABLE_TRACING="raw-client"
+export CLOUD_STORAGE_ENABLE_TRACING="raw-client,rpc,rpc-streams"
 
 # Cloud Bigtable configuration parameters
 export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_INSTANCE_ID="test-instance"


### PR DESCRIPTION
GCS can log at the gRPC `*Stub` level, which can be useful in detailed
troubleshooting.  This change adds these logs to the integration tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9257)
<!-- Reviewable:end -->
