### PR TITLE
impl(common): micro-optimization on `internal::MergeOptions`

### DIFF
--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -36,6 +36,7 @@ void CheckExpectedOptionsImpl(std::set<std::type_index> const& expected,
 }
 
 Options MergeOptions(Options preferred, Options alternatives) {
+  if (preferred.m_.empty()) return alternatives;
   preferred.m_.insert(std::make_move_iterator(alternatives.m_.begin()),
                       std::make_move_iterator(alternatives.m_.end()));
   return preferred;


### PR DESCRIPTION
I think it is common to call `MergeOptions()` with an empty set of
`preferred` options (all calls to `Make*Connection()` work like this).
Therefore, at the cost of a small `if()` we can change the function in
this case from `O(n)` to `O(1)`.  Seems worthwhile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9258)
<!-- Reviewable:end -->
