### PR TITLE
cleanup(GCS+gRPC): remove spurious `std::move()`

### DIFF
--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -26,7 +26,7 @@ std::shared_ptr<RawClient> HybridClient::Create(Options const& options) {
 }
 
 HybridClient::HybridClient(Options const& options)
-    : grpc_(GrpcClient::Create(DefaultOptionsGrpc(std::move(options)))),
+    : grpc_(GrpcClient::Create(DefaultOptionsGrpc(options))),
       curl_(CurlClient::Create(DefaultOptionsWithCredentials(options))) {}
 
 ClientOptions const& HybridClient::client_options() const {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9260)
<!-- Reviewable:end -->
