### PR TITLE
cleanup(storage): avoid using deprecated `storage::ClientOptions`

### DIFF
--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -3410,8 +3410,7 @@ struct ClientImplDetails {
   static Client CreateClient(std::shared_ptr<internal::RawClient> c,
                              Policies&&... p) {
     auto opts =
-        internal::ApplyPolicies(internal::MakeOptions(c->client_options()),
-                                std::forward<Policies>(p)...);
+        internal::ApplyPolicies(c->options(), std::forward<Policies>(p)...);
     return Client(Client::InternalOnlyNoDecorations{},
                   Client::CreateDefaultInternalClient(opts, std::move(c)));
   }


### PR DESCRIPTION
We have direct access to the `google::cloud::Options` used to initialize
a `RawClient`, we do not need to use the (deprecated) `ClientOptions`
created from it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9262)
<!-- Reviewable:end -->
