### PR TITLE
doc: broken link in Bigtable README

### DIFF
--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -1,7 +1,7 @@
 # Google Cloud Bigtable C++ Client Library
 
 This directory contains an idiomatic C++ client library for interacting with
-[Google Cloud Bigtable](https://cloud.google.com/bigtable}/), which is Google's
+[Google Cloud Bigtable](https://cloud.google.com/bigtable/), which is Google's
 NoSQL Big Data database service. It's the same database that powers many core
 Google services, including Search, Analytics, Maps, and Gmail.
 


### PR DESCRIPTION
I grepped for `"}/)"` and found this one too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9265)
<!-- Reviewable:end -->
