### PR TITLE
impl(bigtable): AsyncSampleRows cancel processes final response

### DIFF
--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -59,7 +59,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::string app_profile_id_;
   std::string table_name_;
 
-  bool stream_cancelled_ = false;
+  bool keep_reading_ = true;
   std::vector<bigtable::RowKeySample> samples_;
   promise<StatusOr<std::vector<bigtable::RowKeySample>>> promise_;
 };


### PR DESCRIPTION
If the user cancels the future, we might as well process the next response when we get it. I don't care enough to change this for the legacy code path.