### PR TITLE
feat(pubsub): implement per-batch compression

### DIFF
--- a/google/cloud/pubsub/internal/default_batch_sink.cc
+++ b/google/cloud/pubsub/internal/default_batch_sink.cc
@@ -57,7 +57,7 @@ DefaultBatchSink::AsyncPublish(google::pubsub::v1::PublishRequest request) {
         auto const& current = internal::CurrentOptions();
         if (current.has<CompressionThresholdOption>() &&
             current.has<CompressionAlgorithmOption>()) {
-          auto const threshold = current.has<CompressionThresholdOption>();
+          auto const threshold = current.get<CompressionThresholdOption>();
           if (RequestSize(request) >= threshold) {
             context->set_compression_algorithm(
                 static_cast<grpc_compression_algorithm>(

--- a/google/cloud/pubsub/internal/defaults.cc
+++ b/google/cloud/pubsub/internal/defaults.cc
@@ -98,6 +98,9 @@ Options DefaultPublisherOptionsOnly(Options opts) {
     opts.set<pubsub::FullPublisherActionOption>(
         pubsub::FullPublisherAction::kBlocks);
   }
+  if (!opts.has<pubsub::CompressionAlgorithmOption>()) {
+    opts.set<pubsub::CompressionAlgorithmOption>(GRPC_COMPRESS_DEFLATE);
+  }
 
   return opts;
 }

--- a/google/cloud/pubsub/internal/defaults_test.cc
+++ b/google/cloud/pubsub/internal/defaults_test.cc
@@ -133,6 +133,9 @@ TEST(OptionsTest, PublisherDefaults) {
   EXPECT_FALSE(opts.get<pubsub::MessageOrderingOption>());
   EXPECT_EQ(pubsub::FullPublisherAction::kBlocks,
             opts.get<pubsub::FullPublisherActionOption>());
+  EXPECT_EQ(GRPC_COMPRESS_DEFLATE,
+            opts.get<pubsub::CompressionAlgorithmOption>());
+  EXPECT_FALSE(opts.has<pubsub::CompressionThresholdOption>());
 }
 
 TEST(OptionsTest, UserSetPublisherOptions) {

--- a/google/cloud/pubsub/options.h
+++ b/google/cloud/pubsub/options.h
@@ -169,11 +169,34 @@ struct FullPublisherActionOption {
   using Type = FullPublisherAction;
 };
 
+/**
+ * Compression threshold.
+ *
+ * If set, the client library turns on gRPC compression for batches larger (in
+ * bytes) than the give threshold.
+ */
+struct CompressionThresholdOption {
+  using Type = std::size_t;
+};
+
+/**
+ * Compression algorithm.
+ *
+ * Select the gRPC compression algorithm when compression is enabled. As of this
+ * writing, gRPC supports `GRPC_COMPRESS_DEFLATE` and `GRPC_COMPRESS_GZIP`.
+ * Other values may be added in the future and should be settable via this
+ * feature.
+ */
+struct CompressionAlgorithmOption {
+  using Type = int;
+};
+
 /// The list of options specific to publishers.
 using PublisherOptionList =
     OptionList<MaxHoldTimeOption, MaxBatchMessagesOption, MaxBatchBytesOption,
                MaxPendingMessagesOption, MaxPendingBytesOption,
-               MessageOrderingOption, FullPublisherActionOption>;
+               MessageOrderingOption, FullPublisherActionOption,
+               CompressionThresholdOption>;
 
 /**
  * The maximum deadline for each incoming message.


### PR DESCRIPTION
New options to compress published messages before they are put on the
wire.  This can reduce bandwidth usage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9270)
<!-- Reviewable:end -->
