### PR TITLE
refactor(bigtable): untemplate `AsyncRowReader`

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -150,6 +150,7 @@ add_library(
     internal/async_bulk_apply.cc
     internal/async_bulk_apply.h
     internal/async_retry_op.h
+    internal/async_row_reader.cc
     internal/async_row_reader.h
     internal/async_row_sampler.cc
     internal/async_row_sampler.h

--- a/google/cloud/bigtable/data_client.h
+++ b/google/cloud/bigtable/data_client.h
@@ -27,7 +27,6 @@ namespace cloud {
 // Forward declare some classes so we can be friends.
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-template <typename RowFunctor, typename FinishFunctor>
 class AsyncRowReader;
 class LegacyRowReader;
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
@@ -117,7 +116,6 @@ class DataClient {
   friend class internal::LegacyAsyncRowSampler;
   friend class internal::BulkMutator;
   friend class bigtable_internal::LegacyRowReader;
-  template <typename RowFunctor, typename FinishFunctor>
   friend class bigtable_internal::AsyncRowReader;
   friend class internal::LoggingDataClient;
 

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -154,6 +154,7 @@ google_cloud_cpp_bigtable_srcs = [
     "instance_update_config.cc",
     "internal/admin_client_params.cc",
     "internal/async_bulk_apply.cc",
+    "internal/async_row_reader.cc",
     "internal/async_row_sampler.cc",
     "internal/bigtable_auth_decorator.cc",
     "internal/bigtable_channel_refresh.cc",

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -1,0 +1,282 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/bigtable/internal/async_row_reader.h"
+#include "google/cloud/bigtable/version.h"
+
+namespace google {
+namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+void AsyncRowReader::MakeRequest() {
+  status_ = Status();
+  google::bigtable::v2::ReadRowsRequest request;
+
+  request.set_app_profile_id(app_profile_id_);
+  request.set_table_name(table_name_);
+  auto row_set_proto = row_set_.as_proto();
+  request.mutable_rows()->Swap(&row_set_proto);
+
+  auto filter_proto = filter_.as_proto();
+  request.mutable_filter()->Swap(&filter_proto);
+
+  if (rows_limit_ != NO_ROWS_LIMIT) {
+    request.set_rows_limit(rows_limit_ - rows_count_);
+  }
+  parser_ = parser_factory_->Create();
+
+  auto context = absl::make_unique<grpc::ClientContext>();
+  rpc_retry_policy_->Setup(*context);
+  rpc_backoff_policy_->Setup(*context);
+  metadata_update_policy_.Setup(*context);
+
+  auto& client = client_;
+  auto self = this->shared_from_this();
+  cq_.MakeStreamingReadRpc(
+      [client](grpc::ClientContext* context,
+               google::bigtable::v2::ReadRowsRequest const& request,
+               grpc::CompletionQueue* cq) {
+        return client->PrepareAsyncReadRows(context, request, cq);
+      },
+      request, std::move(context),
+      [self](google::bigtable::v2::ReadRowsResponse r) {
+        return self->OnDataReceived(std::move(r));
+      },
+      [self](Status s) { self->OnStreamFinished(std::move(s)); });
+}
+
+void AsyncRowReader::TryGiveRowToUser() {
+  // The user is likely to ask for more rows immediately after receiving a
+  // row, which means that this function will be called recursively. The depth
+  // of the recursion can be as deep as the size of ready_rows_, which might
+  // be significant and potentially lead to stack overflow. The way to
+  // overcome this is to always switch thread to a CompletionQueue thread.
+  // Switching thread for every row has a non-trivial cost, though. To find a
+  // good balance, we allow for recursion no deeper than 100 and achieve it by
+  // tracking the level in `recursion_level_`.
+  //
+  // The magic value 100 is arbitrary, but back-of-the-envelope calculation
+  // indicates it should cap this stack usage to below 100K. Default stack
+  // size is usually 1MB.
+  struct CountFrame {
+    explicit CountFrame(int& cntr) : cntr(++cntr){};
+    ~CountFrame() { --cntr; }
+    int& cntr;
+  };
+  CountFrame frame(recursion_level_);
+
+  if (ready_rows_.empty()) {
+    if (whole_op_finished_) {
+      // The scan is finished for good, there will be no more rows.
+      on_finish_(status_);
+      return;
+    }
+    if (!continue_reading_) {
+      // TODO(#1402): replace with GCP_ASSERT(continue_reading_);
+      Terminate(
+          "No rows are ready and we can't continue reading. This is a bug, "
+          "please report it at "
+          "https://github.com/googleapis/google-cloud-cpp/issues/new");
+    }
+    // No rows, but we can fetch some.
+    auto continue_reading = std::move(continue_reading_);
+    continue_reading_.reset();
+    continue_reading->set_value(true);
+    return;
+  }
+
+  // Yay! We have something to give to the user and they want it.
+  auto row = std::move(ready_rows_.front());
+  ready_rows_.pop();
+
+  auto self = this->shared_from_this();
+  bool const break_recursion = recursion_level_ >= 100;
+  on_row_(std::move(row)).then([self, break_recursion](future<bool> fut) {
+    bool should_cancel;
+#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+    try {
+      should_cancel = !fut.get();
+    } catch (std::exception& ex) {
+      self->Cancel(
+          std::string("future<> returned from the user callback threw an "
+                      "exception: ") +
+          ex.what());
+      return;
+    } catch (...) {
+      self->Cancel(
+          "future<> returned from the user callback threw an unknown "
+          "exception");
+      return;
+    }
+#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+    should_cancel = !fut.get();
+#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
+    if (should_cancel) {
+      self->Cancel("User cancelled");
+      return;
+    }
+    if (break_recursion) {
+      self->cq_.RunAsync([self] { self->UserWantsRows(); });
+      return;
+    }
+    self->UserWantsRows();
+  });
+}
+
+future<bool> AsyncRowReader::OnDataReceived(
+    google::bigtable::v2::ReadRowsResponse response) {
+  // assert(!whole_op_finished_);
+  // assert(!continue_reading_);
+  // assert(status_.ok());
+  status_ = ConsumeResponse(std::move(response));
+  // We've processed the response.
+  //
+  // If there were errors (e.g. malformed response from the server), we should
+  // interrupt this stream. Interrupting it will yield lower layers calling
+  // `OnStreamFinished` with a status unrelated to the real reason, so we
+  // store the actual reason in status_ and proceed exactly the
+  // same way as if the stream was broken for other reasons.
+  //
+  // Even if status_ is not OK, we might have consumed some rows,
+  // but, don't give them to the user yet. We want to keep the invariant that
+  // either the user doesn't hold a `future<>` when we're fetching more rows.
+  // Retries (successful or not) will do it. Improving this behavior makes
+  // little sense because parser errors are very unexpected and probably not
+  // retryable anyway.
+
+  if (status_.ok()) {
+    continue_reading_.emplace(promise<bool>());
+    auto res = continue_reading_->get_future();
+    TryGiveRowToUser();
+    return res;
+  }
+  return make_ready_future<bool>(false);
+}
+
+void AsyncRowReader::OnStreamFinished(Status status) {
+  // assert(!continue_reading_);
+  if (status_.ok()) {
+    status_ = std::move(status);
+  }
+  grpc::Status parser_status;
+  parser_->HandleEndOfStream(parser_status);
+  if (!parser_status.ok() && status_.ok()) {
+    // If there stream finished with an error ignore what the parser says.
+    status_ = MakeStatusFromRpcError(parser_status);
+  }
+
+  // In the unlikely case when we have already reached the requested
+  // number of rows and still receive an error (the parser can throw
+  // an error at end of stream for example), there is no need to
+  // retry and we have no good value for rows_limit anyway.
+  if (rows_limit_ != NO_ROWS_LIMIT && rows_limit_ <= rows_count_) {
+    status_ = Status();
+  }
+
+  if (!last_read_row_key_.empty()) {
+    // We've returned some rows and need to make sure we don't
+    // request them again.
+    row_set_ =
+        row_set_.Intersect(bigtable::RowRange::Open(last_read_row_key_, ""));
+  }
+
+  // If we receive an error, but the retryable set is empty, consider it a
+  // success.
+  if (row_set_.IsEmpty()) {
+    status_ = Status();
+  }
+
+  if (status_.ok()) {
+    // We've successfully finished the scan.
+    whole_op_finished_ = true;
+    TryGiveRowToUser();
+    return;
+  }
+
+  if (!rpc_retry_policy_->OnFailure(status_)) {
+    // Can't retry.
+    whole_op_finished_ = true;
+    TryGiveRowToUser();
+    return;
+  }
+  auto self = this->shared_from_this();
+  cq_.MakeRelativeTimer(rpc_backoff_policy_->OnCompletion(status_))
+      .then(
+          [self](
+              future<StatusOr<std::chrono::system_clock::time_point>> result) {
+            if (auto tp = result.get()) {
+              self->MakeRequest();
+            } else {
+              self->whole_op_finished_ = true;
+              self->TryGiveRowToUser();
+            }
+          });
+}
+
+void AsyncRowReader::Cancel(std::string const& reason) {
+  ready_rows_ = std::queue<bigtable::Row>();
+  auto continue_reading = std::move(continue_reading_);
+  continue_reading_.reset();
+  Status status(StatusCode::kCancelled, reason);
+  if (!continue_reading) {
+    // If we're not in the middle of the stream fire some user callbacks, but
+    // also override the overall status.
+    // assert(whole_op_finished_);
+    status_ = std::move(status);
+    TryGiveRowToUser();
+    return;
+  }
+  // If we are in the middle of the stream, cancel the stream.
+  status_ = std::move(status);
+  continue_reading->set_value(false);
+}
+
+Status AsyncRowReader::DrainParser() {
+  grpc::Status status;
+  while (parser_->HasNext()) {
+    bigtable::Row parsed_row = parser_->Next(status);
+    if (!status.ok()) {
+      return MakeStatusFromRpcError(status);
+    }
+    ++rows_count_;
+    last_read_row_key_ = parsed_row.row_key();
+    ready_rows_.emplace(std::move(parsed_row));
+  }
+  return Status();
+}
+
+Status AsyncRowReader::ConsumeResponse(
+    google::bigtable::v2::ReadRowsResponse response) {
+  for (auto& chunk : *response.mutable_chunks()) {
+    grpc::Status status;
+    parser_->HandleChunk(std::move(chunk), status);
+    if (!status.ok()) {
+      return MakeStatusFromRpcError(status);
+    }
+    Status parser_status = DrainParser();
+    if (!parser_status.ok()) {
+      return parser_status;
+    }
+  }
+  if (!response.last_scanned_row_key().empty()) {
+    last_read_row_key_ = std::move(*response.mutable_last_scanned_row_key());
+  }
+  return Status();
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -30,7 +30,6 @@
 #include "google/cloud/optional.h"
 #include "google/cloud/status_or.h"
 #include "absl/types/optional.h"
-#include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <chrono>
 #include <queue>
 #include <string>
@@ -43,9 +42,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 /**
  * Objects of this class represent the state of reading rows via AsyncReadRows.
  */
-template <typename RowFunctor, typename FinishFunctor>
-class AsyncRowReader : public std::enable_shared_from_this<
-                           AsyncRowReader<RowFunctor, FinishFunctor>> {
+class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
+  using RowFunctor = std::function<future<bool>(bigtable::Row)>;
+  using FinishFunctor = std::function<void(Status)>;
+
  public:
   /// Special value to be used as rows_limit indicating no limit.
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -53,19 +53,6 @@ class AsyncRowReader : public std::enable_shared_from_this<
   // Callbacks keep pointers to these objects.
   AsyncRowReader(AsyncRowReader&&) = delete;
   AsyncRowReader(AsyncRowReader const&) = delete;
-
- private:
-  static_assert(
-      google::cloud::internal::is_invocable<RowFunctor, bigtable::Row>::value,
-      "RowFunctor must be invocable with Row.");
-  static_assert(
-      google::cloud::internal::is_invocable<FinishFunctor, Status>::value,
-      "RowFunctor must be invocable with Status.");
-  static_assert(
-      std::is_same<
-          google::cloud::internal::invoke_result_t<RowFunctor, bigtable::Row>,
-          future<bool>>::value,
-      "RowFunctor should return a future<bool>.");
 
   static std::shared_ptr<AsyncRowReader> Create(
       CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
@@ -87,6 +74,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
     return res;
   }
 
+ private:
   AsyncRowReader(
       CompletionQueue cq, std::shared_ptr<bigtable::DataClient> client,
       std::string app_profile_id, std::string table_name, RowFunctor on_row,
@@ -110,42 +98,7 @@ class AsyncRowReader : public std::enable_shared_from_this<
         metadata_update_policy_(std::move(metadata_update_policy)),
         parser_factory_(std::move(parser_factory)) {}
 
-  void MakeRequest() {
-    status_ = Status();
-    google::bigtable::v2::ReadRowsRequest request;
-
-    request.set_app_profile_id(app_profile_id_);
-    request.set_table_name(table_name_);
-    auto row_set_proto = row_set_.as_proto();
-    request.mutable_rows()->Swap(&row_set_proto);
-
-    auto filter_proto = filter_.as_proto();
-    request.mutable_filter()->Swap(&filter_proto);
-
-    if (rows_limit_ != NO_ROWS_LIMIT) {
-      request.set_rows_limit(rows_limit_ - rows_count_);
-    }
-    parser_ = parser_factory_->Create();
-
-    auto context = absl::make_unique<grpc::ClientContext>();
-    rpc_retry_policy_->Setup(*context);
-    rpc_backoff_policy_->Setup(*context);
-    metadata_update_policy_.Setup(*context);
-
-    auto& client = client_;
-    auto self = this->shared_from_this();
-    cq_.MakeStreamingReadRpc(
-        [client](grpc::ClientContext* context,
-                 google::bigtable::v2::ReadRowsRequest const& request,
-                 grpc::CompletionQueue* cq) {
-          return client->PrepareAsyncReadRows(context, request, cq);
-        },
-        request, std::move(context),
-        [self](google::bigtable::v2::ReadRowsResponse r) {
-          return self->OnDataReceived(std::move(r));
-        },
-        [self](Status s) { self->OnStreamFinished(std::move(s)); });
-  }
+  void MakeRequest();
 
   /**
    * Called when the user asks for more rows via satisfying the future returned
@@ -159,230 +112,22 @@ class AsyncRowReader : public std::enable_shared_from_this<
    * If no rows are ready, this will not call the callback immediately and
    * instead ask lower layers for more data.
    */
-  void TryGiveRowToUser() {
-    // The user is likely to ask for more rows immediately after receiving a
-    // row, which means that this function will be called recursively. The depth
-    // of the recursion can be as deep as the size of ready_rows_, which might
-    // be significant and potentially lead to stack overflow. The way to
-    // overcome this is to always switch thread to a CompletionQueue thread.
-    // Switching thread for every row has a non-trivial cost, though. To find a
-    // good balance, we allow for recursion no deeper than 100 and achieve it by
-    // tracking the level in `recursion_level_`.
-    //
-    // The magic value 100 is arbitrary, but back-of-the-envelope calculation
-    // indicates it should cap this stack usage to below 100K. Default stack
-    // size is usually 1MB.
-    struct CountFrame {
-      explicit CountFrame(int& cntr) : cntr(++cntr){};
-      ~CountFrame() { --cntr; }
-      int& cntr;
-    };
-    CountFrame frame(recursion_level_);
-
-    if (ready_rows_.empty()) {
-      if (whole_op_finished_) {
-        // The scan is finished for good, there will be no more rows.
-        on_finish_(status_);
-        return;
-      }
-      if (!continue_reading_) {
-        // TODO(#1402): replace with GCP_ASSERT(continue_reading_);
-        Terminate(
-            "No rows are ready and we can't continue reading. This is a bug, "
-            "please report it at "
-            "https://github.com/googleapis/google-cloud-cpp/issues/new");
-      }
-      // No rows, but we can fetch some.
-      auto continue_reading = std::move(continue_reading_);
-      continue_reading_.reset();
-      continue_reading->set_value(true);
-      return;
-    }
-
-    // Yay! We have something to give to the user and they want it.
-    auto row = std::move(ready_rows_.front());
-    ready_rows_.pop();
-
-    auto self = this->shared_from_this();
-    bool const break_recursion = recursion_level_ >= 100;
-    on_row_(std::move(row)).then([self, break_recursion](future<bool> fut) {
-      bool should_cancel;
-#if GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-      try {
-        should_cancel = !fut.get();
-      } catch (std::exception& ex) {
-        self->Cancel(
-            std::string("future<> returned from the user callback threw an "
-                        "exception: ") +
-            ex.what());
-        return;
-      } catch (...) {
-        self->Cancel(
-            "future<> returned from the user callback threw an unknown "
-            "exception");
-        return;
-      }
-#else   // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-      should_cancel = !fut.get();
-#endif  // GOOGLE_CLOUD_CPP_HAVE_EXCEPTIONS
-      if (should_cancel) {
-        self->Cancel("User cancelled");
-        return;
-      }
-      if (break_recursion) {
-        self->cq_.RunAsync([self] { self->UserWantsRows(); });
-        return;
-      }
-      self->UserWantsRows();
-    });
-  }
+  void TryGiveRowToUser();
 
   /// Called when lower layers provide us with a response chunk.
-  future<bool> OnDataReceived(
-      google::bigtable::v2::ReadRowsResponse const& response) {
-    // assert(!whole_op_finished_);
-    // assert(!continue_reading_);
-    // assert(status_.ok());
-    status_ = ConsumeResponse(std::move(response));
-    // We've processed the response.
-    //
-    // If there were errors (e.g. malformed response from the server), we should
-    // interrupt this stream. Interrupting it will yield lower layers calling
-    // `OnStreamFinished` with a status unrelated to the real reason, so we
-    // store the actual reason in status_ and proceed exactly the
-    // same way as if the stream was broken for other reasons.
-    //
-    // Even if status_ is not OK, we might have consumed some rows,
-    // but, don't give them to the user yet. We want to keep the invariant that
-    // either the user doesn't hold a `future<>` when we're fetching more rows.
-    // Retries (successful or not) will do it. Improving this behavior makes
-    // little sense because parser errors are very unexpected and probably not
-    // retryable anyway.
-
-    if (status_.ok()) {
-      continue_reading_.emplace(promise<bool>());
-      auto res = continue_reading_->get_future();
-      TryGiveRowToUser();
-      return res;
-    }
-    return make_ready_future<bool>(false);
-  }
+  future<bool> OnDataReceived(google::bigtable::v2::ReadRowsResponse response);
 
   /// Called when the whole stream finishes.
-  // NOLINTNEXTLINE(performance-unnecessary-value-param)
-  void OnStreamFinished(Status status) {
-    // assert(!continue_reading_);
-    if (status_.ok()) {
-      status_ = std::move(status);
-    }
-    grpc::Status parser_status;
-    parser_->HandleEndOfStream(parser_status);
-    if (!parser_status.ok() && status_.ok()) {
-      // If there stream finished with an error ignore what the parser says.
-      status_ = MakeStatusFromRpcError(parser_status);
-    }
-
-    // In the unlikely case when we have already reached the requested
-    // number of rows and still receive an error (the parser can throw
-    // an error at end of stream for example), there is no need to
-    // retry and we have no good value for rows_limit anyway.
-    if (rows_limit_ != NO_ROWS_LIMIT && rows_limit_ <= rows_count_) {
-      status_ = Status();
-    }
-
-    if (!last_read_row_key_.empty()) {
-      // We've returned some rows and need to make sure we don't
-      // request them again.
-      row_set_ =
-          row_set_.Intersect(bigtable::RowRange::Open(last_read_row_key_, ""));
-    }
-
-    // If we receive an error, but the retryable set is empty, consider it a
-    // success.
-    if (row_set_.IsEmpty()) {
-      status_ = Status();
-    }
-
-    if (status_.ok()) {
-      // We've successfully finished the scan.
-      whole_op_finished_ = true;
-      TryGiveRowToUser();
-      return;
-    }
-
-    if (!rpc_retry_policy_->OnFailure(status_)) {
-      // Can't retry.
-      whole_op_finished_ = true;
-      TryGiveRowToUser();
-      return;
-    }
-    auto self = this->shared_from_this();
-    cq_.MakeRelativeTimer(rpc_backoff_policy_->OnCompletion(status_))
-        .then([self](future<StatusOr<std::chrono::system_clock::time_point>>
-                         result) {
-          if (auto tp = result.get()) {
-            self->MakeRequest();
-          } else {
-            self->whole_op_finished_ = true;
-            self->TryGiveRowToUser();
-          }
-        });
-  }
+  void OnStreamFinished(Status status);
 
   /// User satisfied the future returned from the row callback with false.
-  void Cancel(std::string const& reason) {
-    ready_rows_ = std::queue<bigtable::Row>();
-    auto continue_reading = std::move(continue_reading_);
-    continue_reading_.reset();
-    Status status(StatusCode::kCancelled, reason);
-    if (!continue_reading) {
-      // If we're not in the middle of the stream fire some user callbacks, but
-      // also override the overall status.
-      // assert(whole_op_finished_);
-      status_ = std::move(status);
-      TryGiveRowToUser();
-      return;
-    }
-    // If we are in the middle of the stream, cancel the stream.
-    status_ = std::move(status);
-    continue_reading->set_value(false);
-  }
+  void Cancel(std::string const& reason);
 
   /// Process everything that is accumulated in the parser.
-  Status DrainParser() {
-    grpc::Status status;
-    while (parser_->HasNext()) {
-      bigtable::Row parsed_row = parser_->Next(status);
-      if (!status.ok()) {
-        return MakeStatusFromRpcError(status);
-      }
-      ++rows_count_;
-      last_read_row_key_ = parsed_row.row_key();
-      ready_rows_.emplace(std::move(parsed_row));
-    }
-    return Status();
-  }
+  Status DrainParser();
 
   /// Parse the data from the response.
-  Status ConsumeResponse(google::bigtable::v2::ReadRowsResponse response) {
-    for (auto& chunk : *response.mutable_chunks()) {
-      grpc::Status status;
-      parser_->HandleChunk(std::move(chunk), status);
-      if (!status.ok()) {
-        return MakeStatusFromRpcError(status);
-      }
-      Status parser_status = DrainParser();
-      if (!parser_status.ok()) {
-        return parser_status;
-      }
-    }
-    if (!response.last_scanned_row_key().empty()) {
-      last_read_row_key_ = std::move(*response.mutable_last_scanned_row_key());
-    }
-    return Status();
-  }
-
-  friend class bigtable::Table;
+  Status ConsumeResponse(google::bigtable::v2::ReadRowsResponse response);
 
   std::mutex mu_;
   CompletionQueue cq_;


### PR DESCRIPTION
Part of the work for #9174 

Our virtual connection base class cannot have templates. So we need to convert the arguments passed into `Table::AsyncReadRows(...)`.

I could use some help on whether the arguments to the `std::function` should be `const&` qualified or not:
```c++
// e.g. :
using RowFunctor = std::function<future<bool>(bigtable::Row const&)>;
using FinishFunctor = std::function<void(Status const&)>;
```

For the record, we `std::move` the row into the RowFunctor: https://github.com/dbolduc/google-cloud-cpp/blob/eba7d22730fd530caff55cb7469e54376b99e446/google/cloud/bigtable/internal/async_row_reader.cc#L106

but we do not `std::move` the status into the FinishFunctor:
https://github.com/dbolduc/google-cloud-cpp/blob/eba7d22730fd530caff55cb7469e54376b99e446/google/cloud/bigtable/internal/async_row_reader.cc#L83

does this imply that I should be doing:
```c++
using RowFunctor = std::function<future<bool>(bigtable::Row)>;
using FinishFunctor = std::function<void(Status const&)>;
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9272)
<!-- Reviewable:end -->
