### PR TITLE
impl(GCS+gRPC): async accumulator for `ReadObject()`

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -19,6 +19,7 @@
 google_cloud_cpp_storage_grpc_hdrs = [
     "async_client.h",
     "grpc_plugin.h",
+    "internal/async_accumulate_read_object.h",
     "internal/async_connection.h",
     "internal/async_connection_impl.h",
     "internal/grpc_bucket_access_control_parser.h",
@@ -47,6 +48,7 @@ google_cloud_cpp_storage_grpc_hdrs = [
 google_cloud_cpp_storage_grpc_srcs = [
     "async_client.cc",
     "grpc_plugin.cc",
+    "internal/async_accumulate_read_object.cc",
     "internal/async_connection_impl.cc",
     "internal/grpc_bucket_access_control_parser.cc",
     "internal/grpc_bucket_metadata_parser.cc",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -30,6 +30,8 @@ else ()
         async_client.h
         grpc_plugin.cc
         grpc_plugin.h
+        internal/async_accumulate_read_object.cc
+        internal/async_accumulate_read_object.h
         internal/async_connection.h
         internal/async_connection_impl.cc
         internal/async_connection_impl.h
@@ -155,6 +157,7 @@ if (BUILD_TESTING AND GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
     set(storage_client_grpc_unit_tests
         # cmake-format: sort
         grpc_plugin_test.cc
+        internal/async_accumulate_read_object_test.cc
         internal/async_connection_impl_test.cc
         internal/grpc_bucket_access_control_parser_test.cc
         internal/grpc_bucket_metadata_parser_test.cc

--- a/google/cloud/storage/internal/async_accumulate_read_object.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object.cc
@@ -1,0 +1,117 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/async_accumulate_read_object.h"
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+future<AsyncAccumulateReadObject::Result> AsyncAccumulateReadObject::Start(
+    CompletionQueue cq, std::unique_ptr<Stream> stream,
+    std::chrono::milliseconds timeout) {
+  // Private constructor, std::make_shared<> does not work here.
+  auto handle = std::shared_ptr<AsyncAccumulateReadObject>(
+      new AsyncAccumulateReadObject(std::move(cq), std::move(stream), timeout));
+
+  handle->DoStart();
+
+  return handle->promise_.get_future();
+}
+
+AsyncAccumulateReadObject::AsyncAccumulateReadObject(
+    CompletionQueue cq, std::unique_ptr<Stream> stream,
+    std::chrono::milliseconds timeout)
+    : cq_(std::move(cq)), stream_(std::move(stream)), timeout_(timeout) {}
+
+void AsyncAccumulateReadObject::DoStart() {
+  struct ByMove {
+    std::shared_ptr<AsyncAccumulateReadObject> self;
+    future<bool> tm;
+    void operator()(future<bool> f) { self->OnStart(std::move(tm), f.get()); }
+  };
+  auto tm = MakeTimeout();
+  stream_->Start().then(ByMove{shared_from_this(), std::move(tm)});
+}
+
+void AsyncAccumulateReadObject::OnStart(future<bool> tm, bool ok) {
+  tm.cancel();
+  if (tm.get()) return OnTimeout("Start()");
+  if (!ok) return Finish();
+  Read();
+}
+
+void AsyncAccumulateReadObject::Read() {
+  struct ByMove {
+    std::shared_ptr<AsyncAccumulateReadObject> self;
+    future<bool> tm;
+    void operator()(future<absl::optional<Response>> f) {
+      self->OnRead(std::move(tm), f.get());
+    }
+  };
+  auto tm = MakeTimeout();
+  stream_->Read().then(ByMove{shared_from_this(), std::move(tm)});
+}
+
+void AsyncAccumulateReadObject::OnRead(future<bool> tm,
+                                       absl::optional<Response> response) {
+  tm.cancel();
+  if (tm.get()) return OnTimeout("Read()");
+  if (!response.has_value()) return Finish();
+  accumulator_.push_back(*std::move(response));
+  Read();
+}
+
+void AsyncAccumulateReadObject::Finish() {
+  struct ByMove {
+    std::shared_ptr<AsyncAccumulateReadObject> self;
+    future<bool> tm;
+    void operator()(future<Status> f) {
+      self->OnFinish(std::move(tm), f.get());
+    }
+  };
+  auto tm = MakeTimeout();
+  stream_->Finish().then(ByMove{shared_from_this(), std::move(tm)});
+}
+
+void AsyncAccumulateReadObject::OnFinish(future<bool> tm, Status status) {
+  tm.cancel();
+  promise_.set_value(Result{std::move(status), std::move(accumulator_),
+                            stream_->GetRequestMetadata()});
+}
+
+future<bool> AsyncAccumulateReadObject::MakeTimeout() {
+  auto self = shared_from_this();
+  return cq_.MakeRelativeTimer(timeout_).then(
+      [self](future<StatusOr<std::chrono::system_clock::time_point>> f) {
+        if (!f.get().ok()) return false;
+        self->stream_->Cancel();
+        return true;
+      });
+}
+
+void AsyncAccumulateReadObject::OnTimeout(char const* where) {
+  auto finish = stream_->Finish();
+  finish.then(WaitForFinish{std::move(stream_)});
+  promise_.set_value(Result{Status(StatusCode::kDeadlineExceeded,
+                                   std::string{"Timeout waiting for "} + where),
+                            std::move(accumulator_),
+                            {}});
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/async_accumulate_read_object.h
+++ b/google/cloud/storage/internal/async_accumulate_read_object.h
@@ -1,0 +1,206 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_ACCUMULATE_READ_OBJECT_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_ACCUMULATE_READ_OBJECT_H
+
+#include "google/cloud/completion_queue.h"
+#include "google/cloud/future.h"
+#include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/version.h"
+#include <google/storage/v2/storage.pb.h>
+#include <chrono>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Implement an asynchronous loop to accumulate the data returned by
+ * `AsyncReadObject()`.
+ *
+ * The implementation of `AsyncClient::ReadObject()` needs to accumulate the
+ * results of one or more `ReadObject()` requests (which are streaming read
+ * RPCs) and return a single `future<T>` to the application. The implementation
+ * must also automatically resume interrupted calls, and restart the download
+ * from the last received byte.
+ *
+ * If we were using C++20, this would be a coroutine, and we will use that
+ * coroutine to explain what this code does.  First the easy version:
+ *
+ * @code
+ * using ::google::storage::v2::ReadResponse;
+ * using Stream =
+ *     ::google::cloud::internal::AsyncStreamingReadRpc<ReadResponse>;
+ * future<std::pair<Status, std::vector<ReadResponse>>>
+ * AsyncAccumulateReadObject(std::unique_ptr<Stream> stream) {
+ *   std::vector<ReadResponse> accumulator;
+ *   auto start = co_await stream->Start();
+ *   while (start) {
+ *     absl::optional<ReadResponse> value = co_await stream->Read();
+ *     if (!value) break;
+ *     accumulator.push_back(*std::move(value));
+ *   }
+ *   auto finish = co_await stream->Finish();
+ *   co_return std::make_pair(std::move(finish), std::move(response));
+ * }
+ * @endcode
+ *
+ * This is pretty straight forward.  To support C++ <= 17, we need to convert
+ * this into an object.  Each place where there is a `co_await` goes through
+ * a transformation like so:
+ *
+ * // This replaces the stream->Start() line
+ * void AsyncAccumulateReadObject::Start() {
+ *   auto self = shared_from_this();
+ *   stream_->Start().then([self](auto f) { self->OnStart(f.get()); });
+ * }
+ *
+ * void AsyncAccumulateReadObject::OnStart(bool ok) {
+ *   if (!ok) return Finish();
+ *   Read();
+ * }
+ *
+ * But we need to take into account timeouts. For downloads, it is not the total
+ * timeout that matters (downloading 1 TiB of data should take a long time, but
+ * whether the download is making progress. That is, we need to timeout each
+ * `Start()`, `Read()` and `Finish()` operation.  We will illustrate how this
+ * works by just adding the timeouts around `Read(), using coroutines first:
+ *
+ * @code
+ * using ::google::storage::v2::ReadResponse;
+ * using Stream =
+ *     ::google::cloud::internal::AsyncStreamingReadRpc<ReadResponse>;
+ *
+ * future<bool> CancelOnTimeout(
+ *     Stream& stream, CompletionQueue& cq, std::chrono::milliseconds timeout) {
+ *   return cq.MakeRelativeTimeout(timeout).then([&stream](auto f) {
+ *     if (!f.get().ok()) return false;  // false is the timer is cancelled
+ *     stream.Cancel();
+ *     return true;
+ *   });
+ * }
+ *
+ * // Close the stream after a timeout.
+ * future<void> HandleTimeout(std::unique_ptr<Stream>);
+ *
+ * future<std::pair<Status, std::vector<ReadResponse>>>
+ * AsyncAccumulateReadObject(
+ *     CompletionQueue cq, std::unique_ptr<Stream> stream,
+ *     std::chrono::milliseconds timeout) {
+ *   std::vector<ReadResponse> accumulator;
+ *   auto start = co_await stream->Start();
+ *   while (start) {
+ *     auto tm = CancelOnTimeout(*stream, cq, timeout);
+ *     absl::optional<ReadResponse> value = co_await stream->Read();
+ *     tm.cancel();
+ *     if (co_await tm) {
+ *       // The timer expired before the operation completed, return a timeout.
+ *       HandleTimeout(std::move(stream));
+ *       return std::make_pair(
+ *           Status(StatusCode::kDeadlineExceeded, "..."), std::move(response));
+ *     }
+ *     if (!value) break;
+ *     accumulator.push_back(*std::move(value));
+ *   }
+ *   auto finish = co_await stream->Finish();
+ *   co_return std::make_pair(std::move(finish), std::move(response));
+ * }
+ * @endcode
+ *
+ * This becomes a more serious set of callbacks:
+ *
+ * @code
+ * // This replaces the stream->Start() line
+ * void AsyncAccumulateReadObject::Read() {
+ *   auto self = shared_from_this();
+ *   auto tm = cq_->MakeRelativeTimer(timeout_).then([self](auto f) {
+ *       if (!f.ok()) return false;
+ *       stream_->Cancel();
+ *       return true;
+ *   });
+ *   stream_->Start().then([self, tm = std::move(tm)](auto f) mutable {
+ *     self->OnStart(std::move(tm), f.get());
+ *   });
+ * }
+ *
+ * void AsyncAccumulateReadObject::OnRead(
+ *     future<bool> tm, absl::optional<ReadResponse> response) {
+ *   tm.cancel();
+ *   if (tm.get()) {
+ *     HandleTimeout(std::move(stream_));
+ *     promise_.set_value(std::make_pair(
+ *       Status(StatusCode::kDeadlineExceeded, "..."), std::move(response_));
+ *     return;
+ *   }
+ *   if (!response.has_value()) return Finish();
+ *   accumulator.push_back(*std::move(response));
+ *   Read();
+ * }
+ * @endcode
+ *
+ */
+class AsyncAccumulateReadObject
+    : public std::enable_shared_from_this<AsyncAccumulateReadObject> {
+ public:
+  using Response = ::google::storage::v2::ReadObjectResponse;
+  using Stream = ::google::cloud::internal::AsyncStreamingReadRpc<Response>;
+  using StreamingRpcMetadata = ::google::cloud::internal::StreamingRpcMetadata;
+  struct Result {
+    Status status;
+    std::vector<Response> payload;
+    StreamingRpcMetadata metadata;
+  };
+
+  static future<Result> Start(CompletionQueue cq,
+                              std::unique_ptr<Stream> stream,
+                              std::chrono::milliseconds timeout);
+
+ private:
+  AsyncAccumulateReadObject(CompletionQueue cq, std::unique_ptr<Stream> stream,
+                            std::chrono::milliseconds timeout);
+
+  void DoStart();
+  void OnStart(future<bool> tm, bool ok);
+  void Read();
+  void OnRead(future<bool> tm, absl::optional<Response> response);
+  void Finish();
+  void OnFinish(future<bool> tm, Status status);
+
+  future<bool> MakeTimeout();
+  void OnTimeout(char const* where);
+
+  // Assume ownership of `stream` until its `Finish()` callback completes.
+  struct WaitForFinish {
+    std::unique_ptr<Stream> stream;
+    void operator()(future<Status>) const {}
+  };
+
+  promise<Result> promise_;
+  std::vector<Response> accumulator_;
+  CompletionQueue cq_;
+  std::unique_ptr<Stream> stream_;
+  std::chrono::milliseconds timeout_;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_ACCUMULATE_READ_OBJECT_H

--- a/google/cloud/storage/internal/async_accumulate_read_object_test.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object_test.cc
@@ -1,0 +1,327 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/async_accumulate_read_object.h"
+#include "google/cloud/testing_util/async_sequencer.h"
+#include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/mock_completion_queue_impl.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <google/protobuf/text_format.h>
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace storage_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::google::cloud::internal::StreamingRpcMetadata;
+using ::google::cloud::testing_util::AsyncSequencer;
+using ::google::cloud::testing_util::IsProtoEqual;
+using ::google::cloud::testing_util::MockCompletionQueueImpl;
+using ::google::cloud::testing_util::StatusIs;
+using ::google::protobuf::TextFormat;
+using ::google::storage::v2::ReadObjectResponse;
+using ::testing::ByMove;
+using ::testing::ElementsAre;
+using ::testing::IsEmpty;
+using ::testing::Pair;
+using ::testing::Return;
+using ::testing::UnorderedElementsAre;
+
+class MockStream : public google::cloud::internal::AsyncStreamingReadRpc<
+                       ReadObjectResponse> {
+ public:
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<absl::optional<ReadObjectResponse>>, Read, (), (override));
+  MOCK_METHOD(future<Status>, Finish, (), (override));
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
+};
+
+future<absl::optional<ReadObjectResponse>> MakeClosingRead() {
+  return make_ready_future(absl::optional<ReadObjectResponse>());
+}
+
+TEST(AsyncAccumulateReadObjectTest, Simple) {
+  auto constexpr kText0 = R"pb(
+    checksummed_data {
+      content: "message0: the quick brown fox jumps over the lazy dog"
+      crc32c: 1234
+    }
+    object_checksums { crc32c: 2345 md5_hash: "test-only-invalid" }
+    content_range { start: 1024 end: 2048 complete_length: 8192 }
+    metadata { bucket: "projects/_/buckets/bucket-name" name: "object-name" }
+  )pb";
+  auto constexpr kText1 = R"pb(
+    checksummed_data {
+      content: "message1: the quick brown fox jumps over the lazy dog"
+      crc32c: 1235
+    }
+  )pb";
+
+  ReadObjectResponse r0;
+  ASSERT_TRUE(TextFormat::ParseFromString(kText0, &r0));
+  ReadObjectResponse r1;
+  ASSERT_TRUE(TextFormat::ParseFromString(kText1, &r1));
+
+  auto mock = absl::make_unique<MockStream>();
+  ::testing::InSequence sequence;
+
+  EXPECT_CALL(*mock, Start).WillOnce(Return(ByMove(make_ready_future(true))));
+  EXPECT_CALL(*mock, Read)
+      .WillOnce(Return(ByMove(make_ready_future(absl::make_optional(r0)))))
+      .WillOnce(Return(ByMove(make_ready_future(absl::make_optional(r1)))))
+      .WillOnce(Return(ByMove(MakeClosingRead())));
+  EXPECT_CALL(*mock, Finish)
+      .WillOnce(Return(ByMove(
+          make_ready_future(Status(StatusCode::kUnavailable, "interrupted")))));
+  EXPECT_CALL(*mock, GetRequestMetadata)
+      .WillOnce(Return(StreamingRpcMetadata{{"key", "value"}}));
+
+  CompletionQueue cq;
+  auto runner = std::thread{[](CompletionQueue cq) { cq.Run(); }, cq};
+  auto response = storage_internal::AsyncAccumulateReadObject::Start(
+                      cq, std::move(mock), std::chrono::minutes(1))
+                      .get();
+  EXPECT_THAT(response.status, StatusIs(StatusCode::kUnavailable));
+  EXPECT_THAT(response.payload,
+              ElementsAre(IsProtoEqual(r0), IsProtoEqual(r1)));
+  EXPECT_THAT(response.metadata, UnorderedElementsAre(Pair("key", "value")));
+  cq.Shutdown();
+  runner.join();
+}
+
+TEST(AsyncAccumulateReadObjectTest, StartTimeout) {
+  AsyncSequencer<bool> async;
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  CompletionQueue cq(mock_cq);
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillRepeatedly([&](std::chrono::nanoseconds d) {
+        auto deadline = std::chrono::system_clock::now() + d;
+        return async.PushBack("MakeRelativeTimer")
+            .then([deadline](future<bool> f) {
+              if (f.get()) return make_status_or(deadline);
+              return StatusOr<std::chrono::system_clock::time_point>(
+                  Status(StatusCode::kCancelled, "cancelled"));
+            });
+      });
+
+  auto mock = absl::make_unique<MockStream>();
+
+  EXPECT_CALL(*mock, Start).WillRepeatedly([&] {
+    return async.PushBack("Start").then([](future<bool> f) { return f.get(); });
+  });
+  EXPECT_CALL(*mock, Read).WillRepeatedly([&] {
+    return async.PushBack("Read").then([](future<bool> f) {
+      if (f.get()) return absl::make_optional(ReadObjectResponse{});
+      return absl::optional<ReadObjectResponse>();
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillRepeatedly([&] {
+    return async.PushBack("Finish").then([](future<bool> f) {
+      if (f.get()) return Status{};
+      return Status(StatusCode::kUnavailable, "broken");
+    });
+  });
+
+  int cancel_count = 0;
+  EXPECT_CALL(*mock, Cancel).WillOnce([&] { ++cancel_count; });
+
+  auto pending = storage_internal::AsyncAccumulateReadObject::Start(
+      cq, std::move(mock), std::chrono::milliseconds(1000));
+  // We expect that just starting the "coroutine" will set up a timeout and
+  // invoke `Start()`. We will have the timeout complete successfully, which
+  // indicates `Start()` took too long.
+  auto p0 = async.PopFrontWithName();
+  auto p1 = async.PopFrontWithName();
+  EXPECT_EQ(p0.second, "MakeRelativeTimer");
+  EXPECT_EQ(p1.second, "Start");
+  p0.first.set_value(true);
+  EXPECT_EQ(cancel_count, 1);
+  p1.first.set_value(false);
+
+  // That should make the coroutine call Finish() to close the stream.
+  auto f = async.PopFrontWithName();
+  EXPECT_EQ(f.second, "Finish");
+  f.first.set_value(true);
+
+  // Now the coroutine should have finished
+  auto response = pending.get();
+  EXPECT_THAT(response.status, StatusIs(StatusCode::kDeadlineExceeded));
+  EXPECT_THAT(response.payload, IsEmpty());
+  EXPECT_THAT(response.metadata, IsEmpty());
+}
+
+TEST(AsyncAccumulateReadObjectTest, ReadTimeout) {
+  AsyncSequencer<bool> async;
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  CompletionQueue cq(mock_cq);
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillRepeatedly([&](std::chrono::nanoseconds d) {
+        auto deadline = std::chrono::system_clock::now() + d;
+        return async.PushBack("MakeRelativeTimer")
+            .then([deadline](future<bool> f) {
+              if (f.get()) return make_status_or(deadline);
+              return StatusOr<std::chrono::system_clock::time_point>(
+                  Status(StatusCode::kCancelled, "cancelled"));
+            });
+      });
+
+  auto mock = absl::make_unique<MockStream>();
+
+  EXPECT_CALL(*mock, Start).WillRepeatedly([&] {
+    return async.PushBack("Start").then([](future<bool> f) { return f.get(); });
+  });
+  EXPECT_CALL(*mock, Read).WillRepeatedly([&] {
+    return async.PushBack("Read").then([](future<bool> f) {
+      if (f.get()) return absl::make_optional(ReadObjectResponse{});
+      return absl::optional<ReadObjectResponse>();
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillRepeatedly([&] {
+    return async.PushBack("Finish").then([](future<bool> f) {
+      if (f.get()) return Status{};
+      return Status(StatusCode::kUnavailable, "broken");
+    });
+  });
+
+  int cancel_count = 0;
+  EXPECT_CALL(*mock, Cancel).WillOnce([&] { ++cancel_count; });
+
+  auto pending = storage_internal::AsyncAccumulateReadObject::Start(
+      cq, std::move(mock), std::chrono::milliseconds(1000));
+  // We expect that just starting the "coroutine" will set up a timeout and
+  // invoke `Start()`. We will have the `Start()` complete successfully, and the
+  // timeout canceled.
+  auto p0 = async.PopFrontWithName();
+  auto p1 = async.PopFrontWithName();
+  EXPECT_EQ(p0.second, "MakeRelativeTimer");
+  EXPECT_EQ(p1.second, "Start");
+  p0.first.set_value(false);
+  EXPECT_EQ(cancel_count, 0);
+  p1.first.set_value(true);
+
+  // This should trigger a new timer for the `Read()` call. This time we will
+  // have the timer expire before `Read()` completes successfully.
+  p0 = async.PopFrontWithName();
+  p1 = async.PopFrontWithName();
+  EXPECT_EQ(p0.second, "MakeRelativeTimer");
+  EXPECT_EQ(p1.second, "Read");
+  p0.first.set_value(true);
+  EXPECT_EQ(cancel_count, 1);
+  p1.first.set_value(false);
+
+  // That should make the coroutine call Finish() to close the stream.
+  auto f = async.PopFrontWithName();
+  EXPECT_EQ(f.second, "Finish");
+  f.first.set_value(true);
+
+  // Now the coroutine should have finished
+  auto response = pending.get();
+  EXPECT_THAT(response.status, StatusIs(StatusCode::kDeadlineExceeded));
+  EXPECT_THAT(response.payload, IsEmpty());
+  EXPECT_THAT(response.metadata, IsEmpty());
+}
+
+TEST(AsyncAccumulateReadObjectTest, FinishTimeout) {
+  AsyncSequencer<bool> async;
+
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  CompletionQueue cq(mock_cq);
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+      .WillRepeatedly([&](std::chrono::nanoseconds d) {
+        auto deadline = std::chrono::system_clock::now() + d;
+        return async.PushBack("MakeRelativeTimer")
+            .then([deadline](future<bool> f) {
+              if (f.get()) return make_status_or(deadline);
+              return StatusOr<std::chrono::system_clock::time_point>(
+                  Status(StatusCode::kCancelled, "cancelled"));
+            });
+      });
+
+  auto mock = absl::make_unique<MockStream>();
+
+  EXPECT_CALL(*mock, Start).WillRepeatedly([&] {
+    return async.PushBack("Start").then([](future<bool> f) { return f.get(); });
+  });
+  EXPECT_CALL(*mock, Read).WillRepeatedly([&] {
+    return async.PushBack("Read").then([](future<bool> f) {
+      if (f.get()) return absl::make_optional(ReadObjectResponse{});
+      return absl::optional<ReadObjectResponse>();
+    });
+  });
+  EXPECT_CALL(*mock, Finish).WillRepeatedly([&] {
+    return async.PushBack("Finish").then([](future<bool> f) {
+      if (f.get()) return Status{};
+      return Status(StatusCode::kCancelled, "cancel");
+    });
+  });
+  EXPECT_CALL(*mock, GetRequestMetadata)
+      .WillOnce(Return(StreamingRpcMetadata{{"k0", "v0"}, {"k1", "v1"}}));
+
+  int cancel_count = 0;
+  EXPECT_CALL(*mock, Cancel).WillOnce([&] { ++cancel_count; });
+
+  auto pending = storage_internal::AsyncAccumulateReadObject::Start(
+      cq, std::move(mock), std::chrono::milliseconds(1000));
+  // We expect that just starting the "coroutine" will set up a timeout and
+  // invoke `Start()`. We will have the `Start()` complete successfully, and the
+  // timeout canceled.
+  auto p0 = async.PopFrontWithName();
+  auto p1 = async.PopFrontWithName();
+  EXPECT_EQ(p0.second, "MakeRelativeTimer");
+  EXPECT_EQ(p1.second, "Start");
+  p0.first.set_value(false);
+  EXPECT_EQ(cancel_count, 0);
+  p1.first.set_value(true);
+
+  // This should trigger a new timer for the `Read()` call. This time we will
+  // have the `Read()` call succeed before the timer expires.
+  p0 = async.PopFrontWithName();
+  p1 = async.PopFrontWithName();
+  EXPECT_EQ(p0.second, "MakeRelativeTimer");
+  EXPECT_EQ(p1.second, "Read");
+  p0.first.set_value(false);
+  EXPECT_EQ(cancel_count, 0);
+  // Have the `Read()` call terminate the loop.
+  p1.first.set_value(false);
+
+  // That should trigger a new timer for the `Finish()` call, and a call to
+  // `Finish()`.
+  p0 = async.PopFrontWithName();
+  p1 = async.PopFrontWithName();
+  EXPECT_EQ(p0.second, "MakeRelativeTimer");
+  EXPECT_EQ(p1.second, "Finish");
+  // We have the timer expires before `Finish()` is completed
+  p0.first.set_value(true);
+  EXPECT_EQ(cancel_count, 1);
+  p1.first.set_value(false);
+
+  // Now the coroutine should have finished, note that the error code is
+  // whatever Finish() returns.
+  auto response = pending.get();
+  EXPECT_THAT(response.status, StatusIs(StatusCode::kCancelled, "cancel"));
+  EXPECT_THAT(response.payload, IsEmpty());
+  EXPECT_THAT(response.metadata,
+              UnorderedElementsAre(Pair("k0", "v0"), Pair("k1", "v1")));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/storage_client_grpc_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_grpc_unit_tests.bzl
@@ -18,6 +18,7 @@
 
 storage_client_grpc_unit_tests = [
     "grpc_plugin_test.cc",
+    "internal/async_accumulate_read_object_test.cc",
     "internal/async_connection_impl_test.cc",
     "internal/grpc_bucket_access_control_parser_test.cc",
     "internal/grpc_bucket_metadata_parser_test.cc",


### PR DESCRIPTION
The asynchronous version of `ReadObject()` will return all the bytes. We
need a function to asynchronously accumulate all the values from a
single `AsyncReadObject()` call to the `StorageStub`. This function does
to retry or resume the download, that will come later. In case you are
wonder, we will require applications to only make "ranged reads", where
the number of bytes downloaded is controlled by the application.

Part of the work for #9133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9277)
<!-- Reviewable:end -->
