### PR TITLE
impl(storage): use options to select REST implementation

### DIFF
--- a/google/cloud/storage/client.cc
+++ b/google/cloud/storage/client.cc
@@ -58,9 +58,7 @@ std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
 std::shared_ptr<internal::RawClient> Client::CreateDefaultInternalClient(
     Options const& opts) {
   namespace rest = ::google::cloud::rest_internal;
-  if (google::cloud::internal::GetEnv(
-          "GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT")
-          .has_value()) {
+  if (opts.get<internal::RestConfiguration>() == "rest") {
     Options rest_opts = opts;
     if (opts.has<DownloadStallTimeoutOption>()) {
       rest_opts.set<rest::DownloadStallTimeoutOption>(

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -211,8 +211,7 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
                                                                 "/iamapi");
   }
 
-  auto tracing =
-      google::cloud::internal::GetEnv("CLOUD_STORAGE_ENABLE_TRACING");
+  auto tracing = GetEnv("CLOUD_STORAGE_ENABLE_TRACING");
   if (tracing.has_value()) {
     for (auto c : absl::StrSplit(*tracing, ',')) {
       GCP_LOG(INFO) << "Enabling logging for " << c;
@@ -220,9 +219,14 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
     }
   }
 
-  auto project_id = google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT");
+  auto project_id = GetEnv("GOOGLE_CLOUD_PROJECT");
   if (project_id.has_value()) {
     o.set<ProjectIdOption>(std::move(*project_id));
+  }
+
+  auto rest = GetEnv("GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT");
+  if (rest.has_value()) {
+    o.set<RestConfiguration>("rest");
   }
 
   return o;

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -891,453 +891,147 @@ StatusOr<QueryResumableUploadResponse> RestClient::UploadChunk(
 
 StatusOr<ListBucketAclResponse> RestClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/acl"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ParseFromRestResponse<ListBucketAclResponse>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->ListBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> RestClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return CheckedFromString<BucketAccessControlParser>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->GetBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> RestClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/acl"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  nlohmann::json object;
-  object["entity"] = request.entity();
-  object["role"] = request.role();
-  auto payload = object.dump();
-  return CheckedFromString<BucketAccessControlParser>(
-      storage_rest_client_->Post(std::move(builder).BuildRequest(),
-                                 {absl::MakeConstSpan(payload)}));
+  return curl_client_->CreateBucketAcl(request);
 }
 
 StatusOr<EmptyResponse> RestClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ReturnEmptyResponse(
-      storage_rest_client_->Delete(std::move(builder).BuildRequest()));
+  return curl_client_->DeleteBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> RestClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  nlohmann::json object;
-  object["entity"] = request.entity();
-  object["role"] = request.role();
-  auto payload = object.dump();
-  return CheckedFromString<BucketAccessControlParser>(storage_rest_client_->Put(
-      std::move(builder).BuildRequest(), {absl::MakeConstSpan(payload)}));
+  return curl_client_->UpdateBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> RestClient::PatchBucketAcl(
     PatchBucketAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  auto payload = request.payload();
-  return CheckedFromString<BucketAccessControlParser>(
-      storage_rest_client_->Patch(std::move(builder).BuildRequest(),
-                                  {absl::MakeConstSpan(payload)}));
+  return curl_client_->PatchBucketAcl(request);
 }
 
 StatusOr<ListObjectAclResponse> RestClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/o/",
-                   UrlEscapeString(request.object_name()), "/acl"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ParseFromRestResponse<ListObjectAclResponse>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->ListObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/o/",
-                   UrlEscapeString(request.object_name()), "/acl"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  nlohmann::json object;
-  object["entity"] = request.entity();
-  object["role"] = request.role();
-  auto payload = object.dump();
-  return CheckedFromString<ObjectAccessControlParser>(
-      storage_rest_client_->Post(std::move(builder).BuildRequest(),
-                                 {absl::MakeConstSpan(payload)}));
+  return curl_client_->CreateObjectAcl(request);
 }
 
 StatusOr<EmptyResponse> RestClient::DeleteObjectAcl(
     DeleteObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/o/", UrlEscapeString(request.object_name()),
-      "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ReturnEmptyResponse(
-      storage_rest_client_->Delete(std::move(builder).BuildRequest()));
+  return curl_client_->DeleteObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::GetObjectAcl(
     GetObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/o/", UrlEscapeString(request.object_name()),
-      "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return CheckedFromString<ObjectAccessControlParser>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->GetObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::UpdateObjectAcl(
     UpdateObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/o/", UrlEscapeString(request.object_name()),
-      "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  nlohmann::json object;
-  object["entity"] = request.entity();
-  object["role"] = request.role();
-  auto payload = object.dump();
-  return CheckedFromString<ObjectAccessControlParser>(storage_rest_client_->Put(
-      std::move(builder).BuildRequest(), {absl::MakeConstSpan(payload)}));
+  return curl_client_->UpdateObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::PatchObjectAcl(
     PatchObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/b/",
-      request.bucket_name(), "/o/", UrlEscapeString(request.object_name()),
-      "/acl/", UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  auto payload = request.payload();
-  return CheckedFromString<ObjectAccessControlParser>(
-      storage_rest_client_->Patch(std::move(builder).BuildRequest(),
-                                  {absl::MakeConstSpan(payload)}));
+  return curl_client_->PatchObjectAcl(request);
 }
 
 StatusOr<ListDefaultObjectAclResponse> RestClient::ListDefaultObjectAcl(
     ListDefaultObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/defaultObjectAcl"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ParseFromRestResponse<ListDefaultObjectAclResponse>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->ListDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::CreateDefaultObjectAcl(
     CreateDefaultObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/defaultObjectAcl"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  nlohmann::json object;
-  object["entity"] = request.entity();
-  object["role"] = request.role();
-  auto payload = object.dump();
-  return CheckedFromString<ObjectAccessControlParser>(
-      storage_rest_client_->Post(std::move(builder).BuildRequest(),
-                                 {absl::MakeConstSpan(payload)}));
+  return curl_client_->CreateDefaultObjectAcl(request);
 }
 
 StatusOr<EmptyResponse> RestClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/defaultObjectAcl/",
-                   UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ReturnEmptyResponse(
-      storage_rest_client_->Delete(std::move(builder).BuildRequest()));
+  return curl_client_->DeleteDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/defaultObjectAcl/",
-                   UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return CheckedFromString<ObjectAccessControlParser>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->GetDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/defaultObjectAcl/",
-                   UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  nlohmann::json object;
-  object["entity"] = request.entity();
-  object["role"] = request.role();
-  auto payload = object.dump();
-  return CheckedFromString<ObjectAccessControlParser>(storage_rest_client_->Put(
-      std::move(builder).BuildRequest(), {absl::MakeConstSpan(payload)}));
+  return curl_client_->UpdateDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> RestClient::PatchDefaultObjectAcl(
     PatchDefaultObjectAclRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/defaultObjectAcl/",
-                   UrlEscapeString(request.entity())));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  auto payload = request.payload();
-  return CheckedFromString<ObjectAccessControlParser>(
-      storage_rest_client_->Patch(std::move(builder).BuildRequest(),
-                                  {absl::MakeConstSpan(payload)}));
+  return curl_client_->PatchDefaultObjectAcl(request);
 }
 
 StatusOr<ServiceAccount> RestClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(),
-                   "/projects/", request.project_id(), "/serviceAccount"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return CheckedFromString<ServiceAccountParser>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->GetServiceAccount(request);
 }
 
 StatusOr<ListHmacKeysResponse> RestClient::ListHmacKeys(
     ListHmacKeysRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(),
-                   "/projects/", request.project_id(), "/hmacKeys"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ParseFromRestResponse<ListHmacKeysResponse>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->ListHmacKeys(request);
 }
 
 StatusOr<CreateHmacKeyResponse> RestClient::CreateHmacKey(
     CreateHmacKeyRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(),
-                   "/projects/", request.project_id(), "/hmacKeys"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddQueryParameter("serviceAccountEmail", request.service_account());
-  return ParseFromRestResponse<CreateHmacKeyResponse>(
-      storage_rest_client_->Post(
-          std::move(builder).BuildRequest(),
-          std::vector<std::pair<std::string, std::string>>{}));
+  return curl_client_->CreateHmacKey(request);
 }
 
 StatusOr<EmptyResponse> RestClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/projects/",
-      request.project_id(), "/hmacKeys/", request.access_id()));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ReturnEmptyResponse(
-      storage_rest_client_->Delete(std::move(builder).BuildRequest()));
+  return curl_client_->DeleteHmacKey(request);
 }
 
 StatusOr<HmacKeyMetadata> RestClient::GetHmacKey(
     GetHmacKeyRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/projects/",
-      request.project_id(), "/hmacKeys/", request.access_id()));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return CheckedFromString<HmacKeyMetadataParser>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->GetHmacKey(request);
 }
 
 StatusOr<HmacKeyMetadata> RestClient::UpdateHmacKey(
     UpdateHmacKeyRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "storage/", current.get<TargetApiVersionOption>(), "/projects/",
-      request.project_id(), "/hmacKeys/", request.access_id()));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  nlohmann::json json_payload;
-  if (!request.resource().state().empty()) {
-    json_payload["state"] = request.resource().state();
-  }
-  if (!request.resource().etag().empty()) {
-    json_payload["etag"] = request.resource().etag();
-  }
-  builder.AddHeader("Content-Type", "application/json");
-  auto payload = json_payload.dump();
-  return CheckedFromString<HmacKeyMetadataParser>(storage_rest_client_->Put(
-      std::move(builder).BuildRequest(), {absl::MakeConstSpan(payload)}));
+  return curl_client_->UpdateHmacKey(request);
 }
 
 StatusOr<SignBlobResponse> RestClient::SignBlob(
     SignBlobRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(absl::StrCat(
-      "projects/-/serviceAccounts/", request.service_account(), ":signBlob"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  nlohmann::json json_payload;
-  json_payload["payload"] = request.base64_encoded_blob();
-  if (!request.delegates().empty()) {
-    json_payload["delegates"] = request.delegates();
-  }
-  builder.AddHeader("Content-Type", "application/json");
-  auto payload = json_payload.dump();
-  return ParseFromRestResponse<SignBlobResponse>(iam_rest_client_->Post(
-      std::move(builder).BuildRequest(), {absl::MakeConstSpan(payload)}));
+  return curl_client_->SignBlob(request);
 }
 
 StatusOr<ListNotificationsResponse> RestClient::ListNotifications(
     ListNotificationsRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/notificationConfigs"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ParseFromRestResponse<ListNotificationsResponse>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->ListNotifications(request);
 }
 
 StatusOr<NotificationMetadata> RestClient::CreateNotification(
     CreateNotificationRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/notificationConfigs"));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  builder.AddHeader("Content-Type", "application/json");
-  auto payload = request.json_payload();
-  return CheckedFromString<NotificationMetadataParser>(
-      storage_rest_client_->Post(std::move(builder).BuildRequest(),
-                                 {absl::MakeConstSpan(payload)}));
+  return curl_client_->CreateNotification(request);
 }
 
 StatusOr<NotificationMetadata> RestClient::GetNotification(
     GetNotificationRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/notificationConfigs/",
-                   request.notification_id()));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return CheckedFromString<NotificationMetadataParser>(
-      storage_rest_client_->Get(std::move(builder).BuildRequest()));
+  return curl_client_->GetNotification(request);
 }
 
 StatusOr<EmptyResponse> RestClient::DeleteNotification(
     DeleteNotificationRequest const& request) {
-  auto const& current = CurrentOptions();
-  RestRequestBuilder builder(
-      absl::StrCat("storage/", current.get<TargetApiVersionOption>(), "/b/",
-                   request.bucket_name(), "/notificationConfigs/",
-                   request.notification_id()));
-  auto auth = AddAuthorizationHeader(current, builder);
-  if (!auth.ok()) return auth;
-  request.AddOptionsToHttpRequest(builder);
-  return ReturnEmptyResponse(
-      storage_rest_client_->Delete(std::move(builder).BuildRequest()));
+  return curl_client_->DeleteNotification(request);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -30,6 +30,7 @@ namespace google {
 namespace cloud {
 namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Set the HTTP version used by the client.
  *
@@ -61,6 +62,11 @@ struct TargetApiVersionOption {
 
 /// This is only intended for testing. It is not for public use.
 struct CAPathOption {
+  using Type = std::string;
+};
+
+/// This is only intended for testing of the library. Not for public use.
+struct RestConfiguration {
   using Type = std::string;
 };
 


### PR DESCRIPTION
Use a new (internal-only option) to select between `RestClient` and
`CurlClient`. This will make it easier to write benchmarks that compare
these implementations side-by-side.  To support the CI builds, the
environment variable (`GOOGLE_CLOUD_CPP_STORAGE_HAVE_REST_CLIENT`) sets
the default value for the new option.