### PR TITLE
ci(kokoro/macOS): use GCS for vcpkg binary cache

### DIFF
--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -43,6 +43,8 @@ ci/retry-command.sh 3 120 curl -sSL "https://github.com/microsoft/vcpkg/archive/
   ./vcpkg install google-cloud-cpp
 )
 
+export VCPKG_BINARY_SOURCES="x-gcs,gs://${CACHE_BUCKET}/${CACHE_FOLDER}/vcpkg,readwrite"
+
 export NINJA_STATUS="T+%es [%f/%t] "
 cmake_flags=(
   "-DCMAKE_TOOLCHAIN_FILE=${vcpkg_dir}/scripts/buildsystems/vcpkg.cmake"

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -33,6 +33,10 @@ vcpkg_dir="${HOME}/vcpkg-quickstart"
 mkdir -p "${vcpkg_dir}"
 io::log "Downloading vcpkg into ${vcpkg_dir}..."
 VCPKG_COMMIT="$(<ci/etc/vcpkg-commit.txt)"
+readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
+readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/vcpkg/macos"
+export VCPKG_BINARY_SOURCES="x-gcs,gs://${CACHE_BUCKET}/${CACHE_FOLDER},readwrite"
+
 ci/retry-command.sh 3 120 curl -sSL "https://github.com/microsoft/vcpkg/archive/${VCPKG_COMMIT}.tar.gz" |
   tar -C "${vcpkg_dir}" --strip-components=1 -zxf -
 (
@@ -42,10 +46,6 @@ ci/retry-command.sh 3 120 curl -sSL "https://github.com/microsoft/vcpkg/archive/
   ./vcpkg remove --outdated --recurse
   ./vcpkg install google-cloud-cpp
 )
-
-readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
-readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/macos"
-export VCPKG_BINARY_SOURCES="x-gcs,gs://${CACHE_BUCKET}/${CACHE_FOLDER}/vcpkg,readwrite"
 
 export NINJA_STATUS="T+%es [%f/%t] "
 cmake_flags=(

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -43,6 +43,8 @@ ci/retry-command.sh 3 120 curl -sSL "https://github.com/microsoft/vcpkg/archive/
   ./vcpkg install google-cloud-cpp
 )
 
+readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
+readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/macos"
 export VCPKG_BINARY_SOURCES="x-gcs,gs://${CACHE_BUCKET}/${CACHE_FOLDER}/vcpkg,readwrite"
 
 export NINJA_STATUS="T+%es [%f/%t] "

--- a/ci/kokoro/macos/builds/quickstart-cmake.sh
+++ b/ci/kokoro/macos/builds/quickstart-cmake.sh
@@ -40,6 +40,7 @@ if cache_download_enabled; then
   readonly CACHE_BUCKET="${GOOGLE_CLOUD_CPP_KOKORO_RESULTS:-cloud-cpp-kokoro-results}"
   readonly CACHE_FOLDER="${CACHE_BUCKET}/build-cache/google-cloud-cpp/vcpkg/macos"
   export VCPKG_BINARY_SOURCES="x-gcs,gs://${CACHE_BUCKET}/${CACHE_FOLDER},readwrite"
+  export CLOUDSDK_ACTIVE_CONFIG_NAME="${GCLOUD_CONFIG}"
 
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"


### PR DESCRIPTION
vcpkg can use GCS to keep its binary cache (i.e. pre-built binaries of
each package).  This cache uploads each package as it is built, which
is nice when doing a large rebuild, as the results are immediately
saved.  This is a content-based cache, and it includes the signature of
the compiler and other elements in the toolchain.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9292)
<!-- Reviewable:end -->
