### PR TITLE
refactor(common): consolidate `ErrorInfo` parsing

### DIFF
--- a/google/cloud/google_cloud_cpp_rest_internal.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal.bzl
@@ -44,6 +44,7 @@ google_cloud_cpp_rest_internal_hdrs = [
     "internal/openssl_util.h",
     "internal/rest_client.h",
     "internal/rest_options.h",
+    "internal/rest_parse_json_error.h",
     "internal/rest_request.h",
     "internal/rest_response.h",
     "internal/unified_rest_credentials.h",
@@ -72,6 +73,7 @@ google_cloud_cpp_rest_internal_srcs = [
     "internal/oauth2_refreshing_credentials_wrapper.cc",
     "internal/oauth2_service_account_credentials.cc",
     "internal/openssl_util.cc",
+    "internal/rest_parse_json_error.cc",
     "internal/rest_request.cc",
     "internal/unified_rest_credentials.cc",
 ]

--- a/google/cloud/google_cloud_cpp_rest_internal.cmake
+++ b/google/cloud/google_cloud_cpp_rest_internal.cmake
@@ -70,6 +70,8 @@ add_library(
     internal/openssl_util.h
     internal/rest_client.h
     internal/rest_options.h
+    internal/rest_parse_json_error.cc
+    internal/rest_parse_json_error.h
     internal/rest_request.cc
     internal/rest_request.h
     internal/rest_response.h
@@ -194,6 +196,7 @@ if (BUILD_TESTING)
         internal/oauth2_refreshing_credentials_wrapper_test.cc
         internal/oauth2_service_account_credentials_test.cc
         internal/openssl_util_test.cc
+        internal/rest_parse_json_error_test.cc
         internal/rest_request_test.cc
         internal/unified_rest_credentials_test.cc)
 

--- a/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_rest_internal_unit_tests.bzl
@@ -37,6 +37,7 @@ google_cloud_cpp_rest_internal_unit_tests = [
     "internal/oauth2_refreshing_credentials_wrapper_test.cc",
     "internal/oauth2_service_account_credentials_test.cc",
     "internal/openssl_util_test.cc",
+    "internal/rest_parse_json_error_test.cc",
     "internal/rest_request_test.cc",
     "internal/unified_rest_credentials_test.cc",
 ]

--- a/google/cloud/internal/rest_parse_json_error.cc
+++ b/google/cloud/internal/rest_parse_json_error.cc
@@ -1,0 +1,99 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/rest_parse_json_error.h"
+#include <nlohmann/json.hpp>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+// Makes an `ErrorInfo` from an `"error"` JSON object that looks like
+//   [
+//     {
+//       "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+//       "reason": "..."
+//       "domain": "..."
+//       "metadata": {
+//         "key1": "value1"
+//         ...
+//       }
+//     }
+//   ]
+// See also https://cloud.google.com/apis/design/errors#http_mapping
+ErrorInfo MakeErrorInfo(int http_status_code, nlohmann::json const& details) {
+  static auto constexpr kErrorInfoType =
+      "type.googleapis.com/google.rpc.ErrorInfo";
+  if (!details.is_array()) return ErrorInfo{};
+  for (auto const& e : details.items()) {
+    auto const& v = e.value();
+    if (!v.is_object()) continue;
+    if (!v.contains("@type") || !v["@type"].is_string()) continue;
+    if (v.value("@type", "") != kErrorInfoType) continue;
+    if (!v.contains("reason") || !v["reason"].is_string()) continue;
+    if (!v.contains("domain") || !v["domain"].is_string()) continue;
+    if (!v.contains("metadata") || !v["metadata"].is_object()) continue;
+    auto const& metadata_json = v["metadata"];
+    auto metadata = std::unordered_map<std::string, std::string>{};
+    for (auto const& m : metadata_json.items()) {
+      if (!m.value().is_string()) continue;
+      metadata[m.key()] = m.value();
+    }
+    metadata["http_status_code"] = std::to_string(http_status_code);
+    return ErrorInfo{v.value("reason", ""), v.value("domain", ""),
+                     std::move(metadata)};
+  }
+  return ErrorInfo{};
+}
+
+}  // namespace
+
+std::pair<std::string, ErrorInfo> ParseJsonError(int http_status_code,
+                                                 std::string payload) {
+  // The default result if we cannot parse the ErrorInfo.
+  auto err = [&] { return std::make_pair(std::move(payload), ErrorInfo{}); };
+
+  // We try to parse the payload as JSON, which may allow us to provide a more
+  // structured and useful error Status. If the payload fails to parse as JSON,
+  // we simply attach the full error payload as the Status's message string.
+  auto json = nlohmann::json::parse(payload, nullptr, false);
+  if (!json.is_object()) return err();
+
+  // We expect JSON that looks like the following:
+  //   {
+  //     "error": {
+  //       "message": "..."
+  //       ...
+  //       "details": [
+  //         ...
+  //       ]
+  //     }
+  //   }
+  // See  https://cloud.google.com/apis/design/errors#http_mapping
+  if (!json.contains("error")) return err();
+  auto const& e = json["error"];
+  if (!e.is_object()) return err();
+  if (!e.contains("message") || !e.contains("details")) return err();
+  if (!e["message"].is_string()) return err();
+
+  return std::make_pair(e.value("message", ""),
+                        MakeErrorInfo(http_status_code, e["details"]));
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/rest_parse_json_error.h
+++ b/google/cloud/internal/rest_parse_json_error.h
@@ -1,0 +1,36 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_PARSE_JSON_ERROR_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_PARSE_JSON_ERROR_H
+
+#include "google/cloud/status.h"
+#include "google/cloud/version.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// Parse the message and ErrorInfo object from a JSON payload.
+std::pair<std::string, ErrorInfo> ParseJsonError(int http_status_code,
+                                                 std::string payload);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_REST_PARSE_JSON_ERROR_H

--- a/google/cloud/internal/rest_parse_json_error_test.cc
+++ b/google/cloud/internal/rest_parse_json_error_test.cc
@@ -1,0 +1,94 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/rest_parse_json_error.h"
+#include <gmock/gmock.h>
+
+namespace google {
+namespace cloud {
+namespace rest_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::Pair;
+
+TEST(RestParseErrorInfoTest, Success) {
+  // This example payload comes from
+  // https://cloud.google.com/apis/design/errors#http_mapping
+  auto constexpr kJsonPayload = R"(
+    {
+      "error": {
+        "code": 400,
+        "message": "API key not valid. Please pass a valid API key.",
+        "status": "INVALID_ARGUMENT",
+        "details": [
+          {
+            "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+            "reason": "API_KEY_INVALID",
+            "domain": "googleapis.com",
+            "metadata": {
+              "service": "translate.googleapis.com"
+            }
+          }
+        ]
+      }
+    }
+  )";
+
+  auto constexpr kMessage = "API key not valid. Please pass a valid API key.";
+  auto const error_info = ErrorInfo{
+      "API_KEY_INVALID",
+      "googleapis.com",
+      {{"service", "translate.googleapis.com"}, {"http_status_code", "400"}}};
+  EXPECT_THAT(ParseJsonError(400, kJsonPayload), Pair(kMessage, error_info));
+}
+
+TEST(RestParseErrorInfoTest, InvalidJson) {
+  // Some valid json, but not what we're looking for.
+  auto constexpr kJsonPayload = R"({"code":123, "message":"some message" })";
+  EXPECT_THAT(ParseJsonError(400, kJsonPayload),
+              Pair(kJsonPayload, ErrorInfo{}));
+}
+
+TEST(RestParseErrorInfoTest, InvalidOnlyString) {
+  // Some valid json, but not what we're looking for.
+  auto constexpr kJsonPayload = R"("uh-oh some error here")";
+  EXPECT_THAT(ParseJsonError(400, kJsonPayload),
+              Pair(kJsonPayload, ErrorInfo{}));
+}
+
+TEST(RestParseErrorInfoTest, InvalidUnexpectedFormat) {
+  std::string cases[] = {
+      R"js({"error": "invalid_grant", "error_description": "Invalid grant: account not found"})js",
+      R"js({"error": ["invalid"], "error_description": "Invalid grant: account not found"})js",
+      R"js({"error": {"missing-message": "msg"}})js",
+      R"js({"error": {"message": "msg", "missing-details": {}}})js",
+      R"js({"error": {"message": ["not string"], "details": {}}}})js",
+      R"js({"error": {"message": "the error", "details": "not-an-array"}}})js",
+      R"js({"error": {"message": "the error", "details": {"@type": "invalid-@type"}}}})js",
+      R"js({"error": {"message": "the error", "details": ["not-an-object"]}}})js",
+      R"js({"error": {"message": "the error", "details": [{"@type": "invalid-@type"}]}}})js",
+      R"js(Service Unavailable)js",
+      R"js("Service Unavailable")js",
+  };
+  for (auto const& payload : cases) {
+    EXPECT_THAT(ParseJsonError(400, payload), Pair(payload, ErrorInfo{}));
+  }
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace rest_internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/http_response_test.cc
+++ b/google/cloud/storage/internal/http_response_test.cc
@@ -117,9 +117,10 @@ TEST(HttpResponseTest, ErrorInfo) {
     }
   )";
 
-  ErrorInfo error_info{"API_KEY_INVALID",
-                       "googleapis.com",
-                       {{"service", "translate.googleapis.com"}}};
+  ErrorInfo error_info{
+      "API_KEY_INVALID",
+      "googleapis.com",
+      {{"service", "translate.googleapis.com"}, {"http_status_code", "400"}}};
   std::string message = "API key not valid. Please pass a valid API key.";
   Status expected{StatusCode::kInvalidArgument, message, error_info};
   EXPECT_EQ(AsStatus(HttpResponse{400, kJsonPayload, {}}), expected);


### PR DESCRIPTION
We had two versions of the `ErrorInfo` parser from JSON payloads.  The
version in `storage/` was more robust when the payload was malformed.
The version in `cloud/internal/` preserved the HTTP status code (a good
idea in general).

This change consolidates the two implementations to the `rest_internal`
library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9293)
<!-- Reviewable:end -->
