### PR TITLE
impl(bigtable): modern `Table::AsyncReadRows()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -92,6 +92,13 @@ class DataConnectionImpl : public DataConnection {
   future<StatusOr<bigtable::Row>> AsyncReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request) override;
 
+  void AsyncReadRows(std::string const& app_profile_id,
+                     std::string const& table_name,
+                     std::function<future<bool>(bigtable::Row)> on_row,
+                     std::function<void(Status)> on_finish,
+                     bigtable::RowSet row_set, std::int64_t rows_limit,
+                     bigtable::Filter filter) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -887,6 +887,13 @@ class Table {
             future<bool>>::value,
         "RowFunctor should return a future<bool>.");
 
+    if (connection_) {
+      connection_->AsyncReadRows(
+          app_profile_id_, table_name_, std::move(on_row), std::move(on_finish),
+          std::move(row_set), rows_limit, std::move(filter));
+      return;
+    }
+
     bigtable_internal::LegacyAsyncRowReader::Create(
         background_threads_->cq(), client_, app_profile_id_, table_name_,
         std::move(on_row), std::move(on_finish), std::move(row_set), rows_limit,

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -227,8 +227,8 @@ TEST_P(DataAsyncIntegrationTest, TableAsyncReadModifyWriteAppendValueTest) {
                       actual_cells_ignore_timestamp);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableAsyncReadRowsAllRows) {
-  auto table = GetTable();
+TEST_P(DataAsyncIntegrationTest, TableAsyncReadRowsAllRows) {
+  auto table = GetTable(GetParam());
 
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";


### PR DESCRIPTION
Part of the work for #9174 

The only remaining client call is `Table::AsyncReadRow` (singular).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9294)
<!-- Reviewable:end -->
