### PR TITLE
impl(bigtable): modern `Table::AsyncReadRow()`

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -99,6 +99,10 @@ class DataConnectionImpl : public DataConnection {
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter) override;
 
+  future<StatusOr<std::pair<bool, bigtable::Row>>> AsyncReadRow(
+      std::string const& app_profile_id, std::string const& table_name,
+      std::string row_key, bigtable::Filter filter) override;
+
  private:
   std::unique_ptr<DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -434,6 +434,11 @@ future<StatusOr<Row>> Table::AsyncReadModifyWriteRowImpl(
 
 future<StatusOr<std::pair<bool, Row>>> Table::AsyncReadRow(std::string row_key,
                                                            Filter filter) {
+  if (connection_) {
+    return connection_->AsyncReadRow(app_profile_id_, table_name_,
+                                     std::move(row_key), std::move(filter));
+  }
+
   class AsyncReadRowHandler {
    public:
     AsyncReadRowHandler() : row_("", {}) {}

--- a/google/cloud/bigtable/tests/data_async_future_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_async_future_integration_test.cc
@@ -25,8 +25,6 @@ namespace {
 using ::google::cloud::bigtable::testing::TableIntegrationTest;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 
-using DataIntegrationTestClientOnly = TableIntegrationTest;
-
 class DataAsyncIntegrationTest
     : public TableIntegrationTest,
       public ::testing::WithParamInterface<std::string> {};
@@ -266,8 +264,8 @@ TEST_P(DataAsyncIntegrationTest, TableAsyncReadRowsAllRows) {
   CheckEqualUnordered(created, actual);
 }
 
-TEST_F(DataIntegrationTestClientOnly, TableAsyncReadRowTest) {
-  auto table = GetTable();
+TEST_P(DataAsyncIntegrationTest, TableAsyncReadRowTest) {
+  auto table = GetTable(GetParam());
   std::string const row_key1 = "row-key-1";
   std::string const row_key2 = "row-key-2";
 


### PR DESCRIPTION
Fixes #9174 , Fixes #9164 

The implementation code is copied from: https://github.com/googleapis/google-cloud-cpp/blob/aa2c0873870fdef2349c03baefdde10be6c4fa39/google/cloud/bigtable/table.cc#L437-L486

I know we do not like the copying, but this is the last of it.

The test cases are exactly the same as the synchronous version, `ReadRow()`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9297)
<!-- Reviewable:end -->
