### PR TITLE
impl(GCS+gRPC): convert `AsyncReadObject()` results

### DIFF
--- a/google/cloud/storage/async_object_responses.h
+++ b/google/cloud/storage/async_object_responses.h
@@ -29,7 +29,7 @@ namespace storage_experimental {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /// Represents the response from reading a subset of an object.
-struct ReadObjectRangeResponse {
+struct AsyncReadObjectRangeResponse {
   /**
    * The final status of the download.
    *
@@ -52,7 +52,7 @@ struct ReadObjectRangeResponse {
    * you need to consolidate the contents use something like:
    *
    * @code
-   * ReadObjectRangeResponse response = ...;
+   * AsyncReadObjectRangeResponse response = ...;
    * auto all = std::accumulate(
    *     response.contents.begin(), response.contents.end(), std::string{},
    *     [](auto a, auto b) { a += b; return a; });
@@ -63,7 +63,7 @@ struct ReadObjectRangeResponse {
   /**
    * Per-request metadata and annotations.
    *
-   * These are intended as debugging tools, they are subject to change without
+   * These are intended as debugging tools. They are subject to change without
    * notice.
    */
   std::multimap<std::string, std::string> request_metadata;

--- a/google/cloud/storage/async_object_responses.h
+++ b/google/cloud/storage/async_object_responses.h
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_OBJECT_RESPONSES_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_OBJECT_RESPONSES_H
+
+#include "google/cloud/storage/object_metadata.h"
+#include "google/cloud/storage/version.h"
+#include "absl/types/optional.h"
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage_experimental {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/// Represents the response from reading a subset of an object.
+struct ReadObjectRangeResponse {
+  /**
+   * The final status of the download.
+   *
+   * Downloads can have partial failures, where only a subset of the data is
+   * successfully downloaded, and then the connection is interrupted. With the
+   * default configuration, the client library resumes the download. If,
+   * however, the `storage::RetryPolicy` is exhausted, only the partial results
+   * are returned, and the last error status is returned here.
+   */
+  Status status;
+
+  /// If available, the full object metadata.
+  absl::optional<storage::ObjectMetadata> object_metadata;
+
+  /**
+   * The object contents.
+   *
+   * The library receives the object contents as a sequence of `std::string`.
+   * To avoid copies the library returns the sequence to the application. If
+   * you need to consolidate the contents use something like:
+   *
+   * @code
+   * ReadObjectRangeResponse response = ...;
+   * auto all = std::accumulate(
+   *     response.contents.begin(), response.contents.end(), std::string{},
+   *     [](auto a, auto b) { a += b; return a; });
+   * @endcode
+   */
+  std::vector<std::string> contents;
+
+  /**
+   * Per-request metadata and annotations.
+   *
+   * These are intended as debugging tools, they are subject to change without
+   * notice.
+   */
+  std::multimap<std::string, std::string> request_metadata;
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage_experimental
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_OBJECT_RESPONSES_H

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -18,6 +18,7 @@
 
 google_cloud_cpp_storage_grpc_hdrs = [
     "async_client.h",
+    "async_object_responses.h",
     "grpc_plugin.h",
     "internal/async_accumulate_read_object.h",
     "internal/async_connection.h",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -28,6 +28,7 @@ else ()
         google_cloud_cpp_storage_grpc
         async_client.cc
         async_client.h
+        async_object_responses.h
         grpc_plugin.cc
         grpc_plugin.h
         internal/async_accumulate_read_object.cc

--- a/google/cloud/storage/internal/async_accumulate_read_object.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object.cc
@@ -324,9 +324,9 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
   return handle->Invoke();
 }
 
-storage_experimental::ReadObjectRangeResponse ToResponse(
+storage_experimental::AsyncReadObjectRangeResponse ToResponse(
     AsyncAccumulateReadObjectResult accumulated, Options const& options) {
-  storage_experimental::ReadObjectRangeResponse response;
+  storage_experimental::AsyncReadObjectRangeResponse response;
   response.status = std::move(accumulated.status);
   response.request_metadata = std::move(accumulated.metadata);
   response.contents.reserve(accumulated.payload.size());

--- a/google/cloud/storage/internal/async_accumulate_read_object.h
+++ b/google/cloud/storage/internal/async_accumulate_read_object.h
@@ -171,7 +171,7 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
     google::storage::v2::ReadObjectRequest request, Options const& options);
 
 /// Convert the proto into a representation more familiar to our customers.
-storage_experimental::ReadObjectRangeResponse ToResponse(
+storage_experimental::AsyncReadObjectRangeResponse ToResponse(
     AsyncAccumulateReadObjectResult accumulated, Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/internal/async_accumulate_read_object.h
+++ b/google/cloud/storage/internal/async_accumulate_read_object.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_ACCUMULATE_READ_OBJECT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_ACCUMULATE_READ_OBJECT_H
 
+#include "google/cloud/storage/async_object_responses.h"
 #include "google/cloud/storage/internal/storage_stub.h"
 #include "google/cloud/storage/options.h"
 #include "google/cloud/completion_queue.h"
@@ -168,6 +169,10 @@ future<AsyncAccumulateReadObjectResult> AsyncAccumulateReadObjectFull(
     CompletionQueue cq, std::shared_ptr<StorageStub> stub,
     std::function<std::unique_ptr<grpc::ClientContext>()> context_factory,
     google::storage::v2::ReadObjectRequest request, Options const& options);
+
+/// Convert the proto into a representation more familiar to our customers.
+storage_experimental::ReadObjectRangeResponse ToResponse(
+    AsyncAccumulateReadObjectResult accumulated, Options const& options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_internal


### PR DESCRIPTION
In the `storage` library we do not expose protos directly to the
application developer. This change introduces a function to convert the
protos accumulated by `AsyncAccumulateReadObjectFull()` into types that
are consistent with the public APIs.

Part for the work for #9133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9302)
<!-- Reviewable:end -->
