### PR TITLE
cleanup: no CMAKE_CXX_STANDARD in quickstarts

### DIFF
--- a/ci/verify_current_targets/CMakeLists.txt
+++ b/ci/verify_current_targets/CMakeLists.txt
@@ -15,10 +15,7 @@
 # ~~~
 
 cmake_minimum_required(VERSION 3.6)
-project(verify-exported-targets CXX C)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(verify-exported-targets CXX)
 
 # We list the common libraries first because we want to load their packages
 # early.

--- a/google/cloud/bigquery/quickstart/CMakeLists.txt
+++ b/google/cloud/bigquery/quickstart/CMakeLists.txt
@@ -16,10 +16,7 @@
 # library in CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(google-cloud-cpp-bigquery-quickstart CXX C)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(google-cloud-cpp-bigquery-quickstart CXX)
 
 find_package(google_cloud_cpp_bigquery REQUIRED)
 

--- a/google/cloud/bigtable/quickstart/CMakeLists.txt
+++ b/google/cloud/bigtable/quickstart/CMakeLists.txt
@@ -16,10 +16,7 @@
 # library in CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(google-cloud-cpp-bigtable-quickstart CXX C)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(google-cloud-cpp-bigtable-quickstart CXX)
 
 find_package(google_cloud_cpp_bigtable REQUIRED)
 

--- a/google/cloud/iam/quickstart/CMakeLists.txt
+++ b/google/cloud/iam/quickstart/CMakeLists.txt
@@ -16,10 +16,7 @@
 # CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(google-cloud-cpp-iam-quickstart CXX C)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(google-cloud-cpp-iam-quickstart CXX)
 
 find_package(google_cloud_cpp_iam REQUIRED)
 

--- a/google/cloud/pubsub/quickstart/CMakeLists.txt
+++ b/google/cloud/pubsub/quickstart/CMakeLists.txt
@@ -16,10 +16,7 @@
 # library in CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(google-cloud-cpp-pubsub-quickstart CXX C)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(google-cloud-cpp-pubsub-quickstart CXX)
 
 find_package(google_cloud_cpp_pubsub REQUIRED)
 

--- a/google/cloud/spanner/quickstart/CMakeLists.txt
+++ b/google/cloud/spanner/quickstart/CMakeLists.txt
@@ -16,12 +16,7 @@
 # CMake project.
 
 cmake_minimum_required(VERSION 3.5)
-project(google-cloud-cpp-spanner-quickstart CXX C)
-
-# In this example we only require C++11, you can use newer versions in your own
-# project:
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(google-cloud-cpp-spanner-quickstart CXX)
 
 find_package(google_cloud_cpp_spanner REQUIRED)
 

--- a/google/cloud/storage/quickstart/CMakeLists.txt
+++ b/google/cloud/storage/quickstart/CMakeLists.txt
@@ -16,10 +16,7 @@
 # library in CMake-based projects.
 
 cmake_minimum_required(VERSION 3.5)
-project(google-cloud-cpp-storage-quickstart CXX C)
-
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+project(google-cloud-cpp-storage-quickstart CXX)
 
 find_package(google_cloud_cpp_storage REQUIRED)
 


### PR DESCRIPTION
The generated quickstarts never set CMAKE_CXX_STANDARD, but we used to
set this in older code.  We also do not compile any "C" code so the
CMake projects do not need to waste time looking for a "C" compiler.

Also cleaned up one of the CI support files, which had a similar
set of problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9303)
<!-- Reviewable:end -->
