### PR TITLE
impl(GCS+gRPC): add `AsyncReadObjectRange`

### DIFF
--- a/google/cloud/storage/internal/async_connection.h
+++ b/google/cloud/storage/internal/async_connection.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ASYNC_CONNECTION_H
 
+#include "google/cloud/storage/async_object_responses.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/future.h"
@@ -45,6 +46,10 @@ class AsyncConnection {
   virtual ~AsyncConnection() = default;
 
   virtual Options options() const = 0;
+
+  virtual future<storage_experimental::AsyncReadObjectRangeResponse>
+  AsyncReadObjectRange(
+      storage::internal::ReadObjectRangeRequest const& request) = 0;
 
   virtual future<Status> AsyncDeleteObject(
       storage::internal::DeleteObjectRequest const& request) = 0;

--- a/google/cloud/storage/internal/async_connection_impl.h
+++ b/google/cloud/storage/internal/async_connection_impl.h
@@ -39,6 +39,10 @@ class AsyncConnectionImpl : public AsyncConnection {
 
   Options options() const override { return options_; }
 
+  future<storage_experimental::AsyncReadObjectRangeResponse>
+  AsyncReadObjectRange(
+      storage::internal::ReadObjectRangeRequest const& request) override;
+
   future<Status> AsyncDeleteObject(
       storage::internal::DeleteObjectRequest const& request) override;
 


### PR DESCRIPTION
Implement a function to asynchronously read a portion of the object
contents.  The callers must set the size of this portion, which gives
them control over how much memory this call uses. Use this new function
from one of the integration tests.

Fixes #9133

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9305)
<!-- Reviewable:end -->
