### PR TITLE
feat(bigtable): add `AsyncWaitForConsistency()` helper for Table Admin

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -205,8 +205,6 @@ add_library(
     internal/rpc_policy_parameters.h
     internal/rpc_policy_parameters.inc
     internal/unary_client_utils.h
-    internal/wait_for_consistency.cc
-    internal/wait_for_consistency.h
     metadata_update_policy.cc
     metadata_update_policy.h
     mutation_batcher.cc
@@ -241,7 +239,9 @@ add_library(
     table_config.h
     version.cc
     version.h
-    version_info.h)
+    version_info.h
+    wait_for_consistency.cc
+    wait_for_consistency.h)
 target_link_libraries(
     google_cloud_cpp_bigtable
     PUBLIC absl::memory
@@ -356,7 +356,6 @@ if (BUILD_TESTING)
         internal/legacy_row_reader_test.cc
         internal/logging_data_client_test.cc
         internal/prefix_range_end_test.cc
-        internal/wait_for_consistency_test.cc
         legacy_table_test.cc
         metadata_update_policy_test.cc
         mocks/mock_row_reader_test.cc
@@ -381,7 +380,8 @@ if (BUILD_TESTING)
         table_sample_row_keys_test.cc
         table_test.cc
         testing/cleanup_stale_resources_test.cc
-        testing/random_names_test.cc)
+        testing/random_names_test.cc
+        wait_for_consistency_test.cc)
 
     # Export the list of unit tests so the Bazel BUILD file can pick it up.
     export_list_to_bazel("bigtable_client_unit_tests.bzl"

--- a/google/cloud/bigtable/bigtable_client_unit_tests.bzl
+++ b/google/cloud/bigtable/bigtable_client_unit_tests.bzl
@@ -58,7 +58,6 @@ bigtable_client_unit_tests = [
     "internal/legacy_row_reader_test.cc",
     "internal/logging_data_client_test.cc",
     "internal/prefix_range_end_test.cc",
-    "internal/wait_for_consistency_test.cc",
     "legacy_table_test.cc",
     "metadata_update_policy_test.cc",
     "mocks/mock_row_reader_test.cc",
@@ -84,4 +83,5 @@ bigtable_client_unit_tests = [
     "table_test.cc",
     "testing/cleanup_stale_resources_test.cc",
     "testing/random_names_test.cc",
+    "wait_for_consistency_test.cc",
 ]

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -95,7 +95,6 @@ google_cloud_cpp_bigtable_hdrs = [
     "internal/rpc_policy_parameters.h",
     "internal/rpc_policy_parameters.inc",
     "internal/unary_client_utils.h",
-    "internal/wait_for_consistency.h",
     "metadata_update_policy.h",
     "mutation_batcher.h",
     "mutation_branch.h",
@@ -115,6 +114,7 @@ google_cloud_cpp_bigtable_hdrs = [
     "table.h",
     "table_admin.h",
     "table_config.h",
+    "wait_for_consistency.h",
     "version.h",
     "version_info.h",
 ]
@@ -179,7 +179,6 @@ google_cloud_cpp_bigtable_srcs = [
     "internal/logging_data_client.cc",
     "internal/prefix_range_end.cc",
     "internal/readrowsparser.cc",
-    "internal/wait_for_consistency.cc",
     "metadata_update_policy.cc",
     "mutation_batcher.cc",
     "mutations.cc",
@@ -193,5 +192,6 @@ google_cloud_cpp_bigtable_srcs = [
     "table.cc",
     "table_admin.cc",
     "table_config.cc",
+    "wait_for_consistency.cc",
     "version.cc",
 ]

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -114,9 +114,9 @@ google_cloud_cpp_bigtable_hdrs = [
     "table.h",
     "table_admin.h",
     "table_config.h",
-    "wait_for_consistency.h",
     "version.h",
     "version_info.h",
+    "wait_for_consistency.h",
 ]
 
 google_cloud_cpp_bigtable_srcs = [
@@ -192,6 +192,6 @@ google_cloud_cpp_bigtable_srcs = [
     "table.cc",
     "table_admin.cc",
     "table_config.cc",
-    "wait_for_consistency.cc",
     "version.cc",
+    "wait_for_consistency.cc",
 ]

--- a/google/cloud/bigtable/wait_for_consistency.h
+++ b/google/cloud/bigtable/wait_for_consistency.h
@@ -12,18 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_WAIT_FOR_CONSISTENCY_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_WAIT_FOR_CONSISTENCY_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_WAIT_FOR_CONSISTENCY_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_WAIT_FOR_CONSISTENCY_H
 
-#include "google/cloud/bigtable/admin/bigtable_table_admin_connection.h"
+#include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 
 namespace google {
 namespace cloud {
-namespace bigtable_admin_internal {
+namespace bigtable_admin {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * Checks consistency of a table with multiple calls using background threads
+ * Polls until a table is consistent, or until the polling policy has expired.
  *
  * @param cq the completion queue that will execute the asynchronous
  *    calls. The application must ensure that one or more threads are
@@ -34,19 +34,20 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * @param consistency_token the consistency token of the table.
  * @param options (optional) configuration options. Users who wish to modify the
  *     default polling behavior can supply a custom polling policy with
- *     `BigtableTableAdminPollingPolicyOption`.
+ *     `BigtableTableAdminPollingPolicyOption`. Note that the client's polling
+ *     policy is not used for this operation.
  * @return the consistency status for the table. The status is OK if and only if
  *     the table is consistent.
  */
-future<Status> AsyncWaitForConsistency(
-    CompletionQueue cq,
-    std::shared_ptr<bigtable_admin::BigtableTableAdminConnection> connection,
-    std::string table_name, std::string consistency_token,
-    Options options = {});
+future<Status> AsyncWaitForConsistency(CompletionQueue cq,
+                                       BigtableTableAdminClient client,
+                                       std::string table_name,
+                                       std::string consistency_token,
+                                       Options options = {});
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_admin_internal
+}  // namespace bigtable_admin
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_WAIT_FOR_CONSISTENCY_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_WAIT_FOR_CONSISTENCY_H


### PR DESCRIPTION
Fixes #7732 

This PR makes our internal helper to poll for consistency public. We change the type from a `Connection` to a `Client`, because it is a better API. We update our sample code to use the new shiny.

I considered putting this in `bigtable/admin/`, but decided against mixing the generated code. I could be convinced to change it and update the `.codecov.yml` to not ignore the entire `bigtable/admin/` directory

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9310)
<!-- Reviewable:end -->
