### PR TITLE
refactor(bigtable): actually type erase `AsyncReadRows` this time

### DIFF
--- a/google/cloud/bigtable/CMakeLists.txt
+++ b/google/cloud/bigtable/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(
     admin_client.h
     app_profile_config.cc
     app_profile_config.h
+    async_read_rows_callbacks.h
     async_row_reader.h
     cell.h
     client_options.cc

--- a/google/cloud/bigtable/async_read_rows_callbacks.h
+++ b/google/cloud/bigtable/async_read_rows_callbacks.h
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ASYNC_READ_ROWS_CALLBACKS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ASYNC_READ_ROWS_CALLBACKS_H
+
+#include "google/cloud/bigtable/row.h"
+#include "google/cloud/bigtable/version.h"
+#include "google/cloud/future.h"
+#include "google/cloud/status.h"
+#include <functional>
+
+namespace google {
+namespace cloud {
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * The type of the callback to be invoked on each successfully read row in a
+ * `Table::AsyncReadRows(...)` call.
+ *
+ * The `Row` passed to this callback is the latest row to be read.
+ *
+ * The returned `future<bool>` should be satisfied with `true` when the user is
+ * ready to receive the next callback and with `false` when the user doesn't
+ * want any more rows.
+ */
+using RowFunctor = std::function<future<bool>(Row)>;
+
+/**
+ * The type of the callback to be invoked upon the end of a
+ * `Table::AsyncReadRows(...)` call.
+ *
+ * The status passed to this callback is the final status of the operation.
+ */
+using FinishFunctor = std::function<void(Status)>;
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_ASYNC_READ_ROWS_CALLBACKS_H

--- a/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
+++ b/google/cloud/bigtable/google_cloud_cpp_bigtable.bzl
@@ -43,6 +43,7 @@ google_cloud_cpp_bigtable_hdrs = [
     "admin/internal/bigtable_table_admin_stub_factory.h",
     "admin_client.h",
     "app_profile_config.h",
+    "async_read_rows_callbacks.h",
     "async_row_reader.h",
     "cell.h",
     "client_options.h",

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_ROW_READER_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_ASYNC_ROW_READER_H
 
+#include "google/cloud/bigtable/async_read_rows_callbacks.h"
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/bigtable/internal/async_streaming_read.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
@@ -41,9 +42,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
  * Objects of this class represent the state of reading rows via AsyncReadRows.
  */
 class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
-  using RowFunctor = std::function<future<bool>(bigtable::Row)>;
-  using FinishFunctor = std::function<void(Status)>;
-
  public:
   /// Special value to be used as rows_limit indicating no limit.
   // NOLINTNEXTLINE(readability-identifier-naming)
@@ -54,7 +52,8 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
 
   static void Create(CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
                      std::string app_profile_id, std::string table_name,
-                     RowFunctor on_row, FinishFunctor on_finish,
+                     bigtable::RowFunctor on_row,
+                     bigtable::FinishFunctor on_finish,
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter,
                      std::unique_ptr<DataRetryPolicy> retry_policy,
@@ -70,7 +69,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
  private:
   AsyncRowReader(CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
                  std::string app_profile_id, std::string table_name,
-                 RowFunctor on_row, FinishFunctor on_finish,
+                 bigtable::RowFunctor on_row, bigtable::FinishFunctor on_finish,
                  bigtable::RowSet row_set, std::int64_t rows_limit,
                  bigtable::Filter filter,
                  std::unique_ptr<DataRetryPolicy> retry_policy,
@@ -123,8 +122,8 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   std::shared_ptr<BigtableStub> stub_;
   std::string app_profile_id_;
   std::string table_name_;
-  RowFunctor on_row_;
-  FinishFunctor on_finish_;
+  bigtable::RowFunctor on_row_;
+  bigtable::FinishFunctor on_finish_;
   bigtable::RowSet row_set_;
   std::int64_t rows_limit_;
   bigtable::Filter filter_;

--- a/google/cloud/bigtable/internal/data_connection.cc
+++ b/google/cloud/bigtable/internal/data_connection.cc
@@ -128,11 +128,9 @@ future<StatusOr<bigtable::Row>> DataConnection::AsyncReadModifyWriteRow(
 void DataConnection::AsyncReadRows(
     std::string const&, std::string const&,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::function<future<bool>(bigtable::Row)>,
+    bigtable::RowFunctor, bigtable::FinishFunctor on_finish, bigtable::RowSet,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::function<void(Status)> on_finish, bigtable::RowSet, std::int64_t,
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    bigtable::Filter) {
+    std::int64_t, bigtable::Filter) {
   on_finish(Status(StatusCode::kUnimplemented, "not implemented"));
 }
 

--- a/google/cloud/bigtable/internal/data_connection.h
+++ b/google/cloud/bigtable/internal/data_connection.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_DATA_CONNECTION_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_DATA_CONNECTION_H
 
+#include "google/cloud/bigtable/async_read_rows_callbacks.h"
 #include "google/cloud/bigtable/filters.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/bigtable/mutation_branch.h"
@@ -105,8 +106,8 @@ class DataConnection {
 
   virtual void AsyncReadRows(std::string const& app_profile_id,
                              std::string const& table_name,
-                             std::function<future<bool>(bigtable::Row)> on_row,
-                             std::function<void(Status)> on_finish,
+                             bigtable::RowFunctor on_row,
+                             bigtable::FinishFunctor on_finish,
                              bigtable::RowSet row_set, std::int64_t rows_limit,
                              bigtable::Filter filter);
 

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -349,11 +349,13 @@ future<StatusOr<bigtable::Row>> DataConnectionImpl::AsyncReadModifyWriteRow(
           });
 }
 
-void DataConnectionImpl::AsyncReadRows(
-    std::string const& app_profile_id, std::string const& table_name,
-    std::function<future<bool>(bigtable::Row)> on_row,
-    std::function<void(Status)> on_finish, bigtable::RowSet row_set,
-    std::int64_t rows_limit, bigtable::Filter filter) {
+void DataConnectionImpl::AsyncReadRows(std::string const& app_profile_id,
+                                       std::string const& table_name,
+                                       bigtable::RowFunctor on_row,
+                                       bigtable::FinishFunctor on_finish,
+                                       bigtable::RowSet row_set,
+                                       std::int64_t rows_limit,
+                                       bigtable::Filter filter) {
   bigtable_internal::AsyncRowReader::Create(
       background_->cq(), stub_, app_profile_id, table_name, std::move(on_row),
       std::move(on_finish), std::move(row_set), rows_limit, std::move(filter),

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -93,9 +93,8 @@ class DataConnectionImpl : public DataConnection {
       google::bigtable::v2::ReadModifyWriteRowRequest request) override;
 
   void AsyncReadRows(std::string const& app_profile_id,
-                     std::string const& table_name,
-                     std::function<future<bool>(bigtable::Row)> on_row,
-                     std::function<void(Status)> on_finish,
+                     std::string const& table_name, bigtable::RowFunctor on_row,
+                     bigtable::FinishFunctor on_finish,
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter) override;
 

--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -105,9 +105,9 @@ class MockDataConnection : public bigtable_internal::DataConnection {
 
   MOCK_METHOD(void, AsyncReadRows,
               (std::string const& app_profile_id, std::string const& table_name,
-               std::function<future<bool>(bigtable::Row)> on_row,
-               std::function<void(Status)> on_finish, bigtable::RowSet row_set,
-               std::int64_t rows_limit, bigtable::Filter filter),
+               bigtable::RowFunctor on_row, bigtable::FinishFunctor on_finish,
+               bigtable::RowSet row_set, std::int64_t rows_limit,
+               bigtable::Filter filter),
               (override));
 
   MOCK_METHOD((future<StatusOr<std::pair<bool, bigtable::Row>>>), AsyncReadRow,

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -416,9 +416,8 @@ TEST(TableTest, AsyncReadRows) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
-                   std::function<future<bool>(bigtable::Row)> const& on_row,
-                   std::function<void(Status)> const& on_finish,
+                   std::string const& table_name, RowFunctor const& on_row,
+                   FinishFunctor const& on_finish,
                    bigtable::RowSet const& row_set, std::int64_t rows_limit,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
@@ -459,9 +458,8 @@ TEST(TableTest, AsyncReadRowsWithRowLimit) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncReadRows)
       .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
-                   std::function<future<bool>(bigtable::Row)> const& on_row,
-                   std::function<void(Status)> const& on_finish,
+                   std::string const& table_name, RowFunctor const& on_row,
+                   FinishFunctor const& on_finish,
                    bigtable::RowSet const& row_set, std::int64_t rows_limit,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();


### PR DESCRIPTION
Type erase the `RowFunctor` and `FinishFunctor` templates for `Table::AsyncReadRows`.

We define aliases for the two types. (I personally think it's nicer to have aliases vs. saying `std::function<...>`). Then we move the no-longer-templated implementation from `table.h` to `table.cc`, dropping the `static_assert`s.

I should have done this in #9272.