### PR TITLE
feat(bigtable): modern Data API policy options

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -23,7 +23,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 future<std::vector<bigtable::FailedMutation>> AsyncBulkApplier::Create(
     CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
-    std::unique_ptr<DataRetryPolicy> retry_policy,
+    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
     std::string const& app_profile_id, std::string const& table_name,
@@ -42,7 +42,7 @@ future<std::vector<bigtable::FailedMutation>> AsyncBulkApplier::Create(
 
 AsyncBulkApplier::AsyncBulkApplier(
     CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
-    std::unique_ptr<DataRetryPolicy> retry_policy,
+    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     bigtable::IdempotentMutationPolicy& idempotent_policy,
     std::string const& app_profile_id, std::string const& table_name,

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -41,7 +41,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
  public:
   static future<std::vector<bigtable::FailedMutation>> Create(
       CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
-      std::unique_ptr<DataRetryPolicy> retry_policy,
+      std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
       std::unique_ptr<BackoffPolicy> backoff_policy,
       bigtable::IdempotentMutationPolicy& idempotent_policy,
       std::string const& app_profile_id, std::string const& table_name,
@@ -49,7 +49,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
 
  private:
   AsyncBulkApplier(CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
-                   std::unique_ptr<DataRetryPolicy> retry_policy,
+                   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy,
                    bigtable::IdempotentMutationPolicy& idempotent_policy,
                    std::string const& app_profile_id,
@@ -62,7 +62,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
 
   CompletionQueue cq_;
   std::shared_ptr<BigtableStub> stub_;
-  std::unique_ptr<DataRetryPolicy> retry_policy_;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   bigtable::internal::BulkMutatorState state_;
   std::atomic<bool> keep_reading_{true};

--- a/google/cloud/bigtable/internal/async_bulk_apply_test.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply_test.cc
@@ -29,6 +29,7 @@ namespace {
 
 namespace v2 = ::google::bigtable::v2;
 using ms = std::chrono::milliseconds;
+using ::google::cloud::bigtable::DataLimitedErrorCountRetryPolicy;
 using ::google::cloud::bigtable::testing::MockAsyncMutateRowsStream;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::testing_util::MockBackoffPolicy;

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -57,7 +57,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
                      RowFunctor on_row, FinishFunctor on_finish,
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter,
-                     std::unique_ptr<DataRetryPolicy> retry_policy,
+                     std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                      std::unique_ptr<BackoffPolicy> backoff_policy) {
     auto reader = std::shared_ptr<AsyncRowReader>(new AsyncRowReader(
         std::move(cq), std::move(stub), std::move(app_profile_id),
@@ -73,7 +73,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
                  RowFunctor on_row, FinishFunctor on_finish,
                  bigtable::RowSet row_set, std::int64_t rows_limit,
                  bigtable::Filter filter,
-                 std::unique_ptr<DataRetryPolicy> retry_policy,
+                 std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                  std::unique_ptr<BackoffPolicy> backoff_policy)
       : cq_(std::move(cq)),
         stub_(std::move(stub)),
@@ -128,7 +128,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   bigtable::RowSet row_set_;
   std::int64_t rows_limit_;
   bigtable::Filter filter_;
-  std::unique_ptr<DataRetryPolicy> retry_policy_;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   std::unique_ptr<bigtable::internal::ReadRowsParser> parser_;
   /// Number of rows read so far, used to set row_limit in retries.

--- a/google/cloud/bigtable/internal/async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/async_row_reader_test.cc
@@ -29,6 +29,7 @@ namespace {
 
 namespace v2 = ::google::bigtable::v2;
 using ms = std::chrono::milliseconds;
+using ::google::cloud::bigtable::DataLimitedErrorCountRetryPolicy;
 using ::google::cloud::bigtable::testing::MockAsyncReadRowsStream;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::bigtable_internal::AsyncRowReader;

--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -25,8 +25,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace v2 = ::google::bigtable::v2;
 
 future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncRowSampler::Create(
-    CompletionQueue cq, std::shared_ptr<bigtable_internal::BigtableStub> stub,
-    std::unique_ptr<bigtable_internal::DataRetryPolicy> retry_policy,
+    CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
+    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::string const& app_profile_id, std::string const& table_name) {
   std::shared_ptr<AsyncRowSampler> sampler(new AsyncRowSampler(
@@ -37,8 +37,8 @@ future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncRowSampler::Create(
 }
 
 AsyncRowSampler::AsyncRowSampler(
-    CompletionQueue cq, std::shared_ptr<bigtable_internal::BigtableStub> stub,
-    std::unique_ptr<bigtable_internal::DataRetryPolicy> retry_policy,
+    CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
+    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy,
     std::string const& app_profile_id, std::string const& table_name)
     : cq_(std::move(cq)),

--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -38,13 +38,13 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
  public:
   static future<StatusOr<std::vector<bigtable::RowKeySample>>> Create(
       CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
-      std::unique_ptr<DataRetryPolicy> retry_policy,
+      std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
       std::unique_ptr<BackoffPolicy> backoff_policy,
       std::string const& app_profile_id, std::string const& table_name);
 
  private:
   AsyncRowSampler(CompletionQueue cq, std::shared_ptr<BigtableStub> stub,
-                  std::unique_ptr<DataRetryPolicy> retry_policy,
+                  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                   std::unique_ptr<BackoffPolicy> backoff_policy,
                   std::string const& app_profile_id,
                   std::string const& table_name);
@@ -55,7 +55,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
 
   CompletionQueue cq_;
   std::shared_ptr<BigtableStub> stub_;
-  std::unique_ptr<DataRetryPolicy> retry_policy_;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
   std::string app_profile_id_;
   std::string table_name_;

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -29,6 +29,7 @@ namespace {
 
 namespace v2 = ::google::bigtable::v2;
 using ms = std::chrono::milliseconds;
+using ::google::cloud::bigtable::DataLimitedErrorCountRetryPolicy;
 using ::google::cloud::bigtable::testing::MockAsyncSampleRowKeysStream;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::testing_util::MockBackoffPolicy;

--- a/google/cloud/bigtable/internal/data_connection.cc
+++ b/google/cloud/bigtable/internal/data_connection.cc
@@ -144,8 +144,9 @@ future<StatusOr<std::pair<bool, bigtable::Row>>> DataConnection::AsyncReadRow(
 }
 
 std::shared_ptr<DataConnection> MakeDataConnection(Options options) {
-  internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 DataPolicyOptionList>(options, __func__);
+  google::cloud::internal::CheckExpectedOptions<
+      CommonOptionList, GrpcOptionList, bigtable::DataPolicyOptionList>(
+      options, __func__);
   options = bigtable::internal::DefaultDataOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = bigtable_internal::CreateBigtableStub(background->cq(), options);

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -128,7 +128,7 @@ std::vector<bigtable::FailedMutation> DataConnectionImpl::BulkApply(
       app_profile_id, table_name, *idempotency_policy(), std::move(mut));
   // We wait to allocate the policies until they are needed as a
   // micro-optimization.
-  std::unique_ptr<DataRetryPolicy> retry;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry;
   std::unique_ptr<BackoffPolicy> backoff;
   do {
     auto status = mutator.MakeOneRequest(*stub_);
@@ -265,7 +265,7 @@ StatusOr<std::vector<bigtable::RowKeySample>> DataConnectionImpl::SampleRows(
 
   Status status;
   std::vector<bigtable::RowKeySample> samples;
-  std::unique_ptr<DataRetryPolicy> retry;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry;
   std::unique_ptr<BackoffPolicy> backoff;
   while (true) {
     auto context = absl::make_unique<grpc::ClientContext>();

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -104,28 +104,28 @@ class DataConnectionImpl : public DataConnection {
       std::string row_key, bigtable::Filter filter) override;
 
  private:
-  std::unique_ptr<DataRetryPolicy> retry_policy() {
+  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();
-    if (options.has<DataRetryPolicyOption>()) {
-      return options.get<DataRetryPolicyOption>()->clone();
+    if (options.has<bigtable::DataRetryPolicyOption>()) {
+      return options.get<bigtable::DataRetryPolicyOption>()->clone();
     }
-    return options_.get<DataRetryPolicyOption>()->clone();
+    return options_.get<bigtable::DataRetryPolicyOption>()->clone();
   }
 
   std::unique_ptr<BackoffPolicy> backoff_policy() {
     auto const& options = internal::CurrentOptions();
-    if (options.has<DataBackoffPolicyOption>()) {
-      return options.get<DataBackoffPolicyOption>()->clone();
+    if (options.has<bigtable::DataBackoffPolicyOption>()) {
+      return options.get<bigtable::DataBackoffPolicyOption>()->clone();
     }
-    return options_.get<DataBackoffPolicyOption>()->clone();
+    return options_.get<bigtable::DataBackoffPolicyOption>()->clone();
   }
 
   std::unique_ptr<bigtable::IdempotentMutationPolicy> idempotency_policy() {
     auto const& options = internal::CurrentOptions();
-    if (options.has<IdempotentMutationPolicyOption>()) {
-      return options.get<IdempotentMutationPolicyOption>()->clone();
+    if (options.has<bigtable::IdempotentMutationPolicyOption>()) {
+      return options.get<bigtable::IdempotentMutationPolicyOption>()->clone();
     }
-    return options_.get<IdempotentMutationPolicyOption>()->clone();
+    return options_.get<bigtable::IdempotentMutationPolicyOption>()->clone();
   }
 
   std::unique_ptr<BackgroundThreads> background_;

--- a/google/cloud/bigtable/internal/data_connection_impl_test.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl_test.cc
@@ -32,6 +32,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 namespace v2 = ::google::bigtable::v2;
+using ::google::cloud::bigtable::DataBackoffPolicyOption;
+using ::google::cloud::bigtable::DataLimitedErrorCountRetryPolicy;
+using ::google::cloud::bigtable::DataRetryPolicyOption;
+using ::google::cloud::bigtable::IdempotentMutationPolicyOption;
 using ::google::cloud::bigtable::testing::MockAsyncReadRowsStream;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::bigtable::testing::MockDataRetryPolicy;

--- a/google/cloud/bigtable/internal/default_row_reader.cc
+++ b/google/cloud/bigtable/internal/default_row_reader.cc
@@ -26,7 +26,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DefaultRowReader::DefaultRowReader(
     std::shared_ptr<BigtableStub> stub, std::string app_profile_id,
     std::string table_name, bigtable::RowSet row_set, std::int64_t rows_limit,
-    bigtable::Filter filter, std::unique_ptr<DataRetryPolicy> retry_policy,
+    bigtable::Filter filter,
+    std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
     std::unique_ptr<BackoffPolicy> backoff_policy)
     : stub_(std::move(stub)),
       app_profile_id_(std::move(app_profile_id)),

--- a/google/cloud/bigtable/internal/default_row_reader.h
+++ b/google/cloud/bigtable/internal/default_row_reader.h
@@ -46,7 +46,7 @@ class DefaultRowReader : public RowReaderImpl {
                    std::string app_profile_id, std::string table_name,
                    bigtable::RowSet row_set, std::int64_t rows_limit,
                    bigtable::Filter filter,
-                   std::unique_ptr<DataRetryPolicy> retry_policy,
+                   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy,
                    std::unique_ptr<BackoffPolicy> backoff_policy);
 
   ~DefaultRowReader() override;
@@ -89,7 +89,7 @@ class DefaultRowReader : public RowReaderImpl {
   bigtable::RowSet row_set_;
   std::int64_t rows_limit_;
   bigtable::Filter filter_;
-  std::unique_ptr<DataRetryPolicy> retry_policy_;
+  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy_;
   std::unique_ptr<BackoffPolicy> backoff_policy_;
 
   std::unique_ptr<grpc::ClientContext> context_;

--- a/google/cloud/bigtable/internal/default_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/default_row_reader_test.cc
@@ -30,6 +30,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::bigtable::v2::ReadRowsRequest;
+using ::google::cloud::bigtable::DataLimitedErrorCountRetryPolicy;
 using ::google::cloud::bigtable::testing::MockBigtableStub;
 using ::google::cloud::bigtable::testing::MockDataRetryPolicy;
 using ::google::cloud::bigtable::testing::MockReadRowsStream;

--- a/google/cloud/bigtable/internal/defaults.cc
+++ b/google/cloud/bigtable/internal/defaults.cc
@@ -183,20 +183,20 @@ Options DefaultDataOptions(Options opts) {
   if (!opts.has<AuthorityOption>()) {
     opts.set<AuthorityOption>("bigtable.googleapis.com");
   }
-  if (!opts.has<bigtable_internal::DataRetryPolicyOption>()) {
-    opts.set<bigtable_internal::DataRetryPolicyOption>(
-        bigtable_internal::DataLimitedTimeRetryPolicy(
+  if (!opts.has<bigtable::DataRetryPolicyOption>()) {
+    opts.set<bigtable::DataRetryPolicyOption>(
+        bigtable::DataLimitedTimeRetryPolicy(
             kBigtableLimits.maximum_retry_period)
             .clone());
   }
-  if (!opts.has<bigtable_internal::DataBackoffPolicyOption>()) {
-    opts.set<bigtable_internal::DataBackoffPolicyOption>(
+  if (!opts.has<bigtable::DataBackoffPolicyOption>()) {
+    opts.set<bigtable::DataBackoffPolicyOption>(
         ExponentialBackoffPolicy(kBigtableLimits.initial_delay / 2,
                                  kBigtableLimits.maximum_delay, kBackoffScaling)
             .clone());
   }
-  if (!opts.has<bigtable_internal::IdempotentMutationPolicyOption>()) {
-    opts.set<bigtable_internal::IdempotentMutationPolicyOption>(
+  if (!opts.has<bigtable::IdempotentMutationPolicyOption>()) {
+    opts.set<bigtable::IdempotentMutationPolicyOption>(
         bigtable::DefaultIdempotentMutationPolicy());
   }
   opts = DefaultOptions(std::move(opts));

--- a/google/cloud/bigtable/internal/defaults_test.cc
+++ b/google/cloud/bigtable/internal/defaults_test.cc
@@ -190,9 +190,9 @@ TEST(OptionsTest, DefaultTableAdminOptions) {
 
 TEST(OptionsTest, DefaultDataOptionsPolicies) {
   auto options = DefaultDataOptions(Options{});
-  EXPECT_TRUE(options.has<bigtable_internal::DataRetryPolicyOption>());
-  EXPECT_TRUE(options.has<bigtable_internal::DataBackoffPolicyOption>());
-  EXPECT_TRUE(options.has<bigtable_internal::IdempotentMutationPolicyOption>());
+  EXPECT_TRUE(options.has<bigtable::DataRetryPolicyOption>());
+  EXPECT_TRUE(options.has<bigtable::DataBackoffPolicyOption>());
+  EXPECT_TRUE(options.has<bigtable::IdempotentMutationPolicyOption>());
 }
 
 TEST(OptionsTest, DataUserProjectOption) {

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -111,13 +111,6 @@ using ClientOptionList =
                InstanceAdminEndpointOption, MinConnectionRefreshOption,
                MaxConnectionRefreshOption>;
 
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable
-
-// TODO(#8860) - Make these options public.
-namespace bigtable_internal {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
 using DataRetryPolicy = ::google::cloud::internal::TraitBasedRetryPolicy<
     bigtable::internal::SafeGrpcRetry>;
 
@@ -149,7 +142,7 @@ using DataPolicyOptionList =
                IdempotentMutationPolicyOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_internal
+}  // namespace bigtable
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/testing/mock_policies.h
+++ b/google/cloud/bigtable/testing/mock_policies.h
@@ -31,9 +31,9 @@ namespace cloud {
 namespace bigtable {
 namespace testing {
 
-class MockDataRetryPolicy : public bigtable_internal::DataRetryPolicy {
+class MockDataRetryPolicy : public bigtable::DataRetryPolicy {
  public:
-  MOCK_METHOD(std::unique_ptr<bigtable_internal::DataRetryPolicy>, clone, (),
+  MOCK_METHOD(std::unique_ptr<bigtable::DataRetryPolicy>, clone, (),
               (const, override));
   MOCK_METHOD(bool, OnFailure, (Status const&), (override));
   MOCK_METHOD(void, OnFailureImpl, (), (override));


### PR DESCRIPTION
Part of the work for #8860 

I am going to release the modern Data API in pieces. Starting with the policies and their options. (Note that they are not used anywhere).

The root change is in `options.h`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9320)
<!-- Reviewable:end -->
