### PR TITLE
cleanup: no need to search for the "C" compiler

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ endif ()
 project(
     google-cloud-cpp
     VERSION 1.43.0
-    LANGUAGES CXX C)
+    LANGUAGES CXX)
 
 if (APPLE AND NOT DEFINED CMAKE_CXX_STANDARD)
     # AppleClang defaults to C++98, so we bump it to C++11.


### PR DESCRIPTION
The CMake project was defined as using both "C++" (aka `CXX`) and "C",
but only C++ is used. Removed the search for the "C" compiler, as we
will not use it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9324)
<!-- Reviewable:end -->
