### PR TITLE
doc: improve documentation around Abseil's ABI pinning

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-centos-7.Dockerfile
@@ -69,7 +69,7 @@ RUN curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.g
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By
-# default CentOS-7 does not search for shared libraries in these directories,
+# default, CentOS-7 does not search for shared libraries in these directories,
 # there are multiple ways to solve this problem, the following steps are one
 # solution:
 
@@ -83,6 +83,16 @@ ENV PATH=/usr/local/bin:${PATH}
 # #### Abseil
 
 # We need a recent version of Abseil.
+
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
 
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp

--- a/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-bullseye.Dockerfile
@@ -29,8 +29,18 @@ RUN apt-get update && \
 
 # #### Abseil
 
-# Debian 11 ships with Abseil==20200923.3.  Unfortunately, the current gRPC version needs
-# Abseil>=20210324.
+# Debian 11 ships with Abseil==20200923.3.  Unfortunately, the current gRPC
+# version needs Abseil >= 20210324.
+
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
 
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
@@ -100,7 +110,7 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.1.tar.gz |
 
 # #### gRPC
 
-# Finally we build gRPC from source also:
+# Finally, we build gRPC from source:
 
 # ```bash
 WORKDIR /var/tmp/build/grpc

--- a/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-buster.Dockerfile
@@ -31,6 +31,16 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
+
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \
@@ -111,7 +121,7 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.1.tar.gz |
 
 # #### gRPC
 
-# Finally we build gRPC from source also:
+# Finally, we build gRPC from source:
 
 # ```bash
 WORKDIR /var/tmp/build/grpc

--- a/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-debian-stretch.Dockerfile
@@ -20,7 +20,7 @@ ARG NCPU=4
 # First install the development tools and libcurl.
 # On Debian 9, libcurl links against openssl-1.0.2, and one must link
 # against the same version or risk an inconsistent configuration of the library.
-# This is especially important for multi-threaded applications, as openssl-1.0.2
+# This is especially important for multithreaded applications, as openssl-1.0.2
 # requires explicitly setting locking callbacks. Therefore, to use libcurl one
 # must link against openssl-1.0.2. To do so, we need to install libssl1.0-dev.
 # Note that this removes libssl-dev if you have it installed already, and would
@@ -37,6 +37,16 @@ RUN apt-get update && \
 # #### Abseil
 
 # We need a recent version of Abseil.
+
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
 
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp

--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -51,7 +51,7 @@ RUN curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.g
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By
-# default pkg-config does not search in these directories.
+# default, pkg-config does not search in these directories.
 
 # ```bash
 ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
@@ -60,6 +60,17 @@ ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib
 # #### Abseil
 
 # We need a recent version of Abseil.
+
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++17. Nevertheless, gRPC compiles with C++11 and depends on
+# some of the Abseil polyfills, such as `absl::string_view`. Therefore, we
+# pin Abseil's ABI to always use the polyfills. See [abseil/abseil-cpp#696]
+# for more information.
 
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
@@ -141,7 +152,7 @@ RUN curl -sSL https://github.com/protocolbuffers/protobuf/archive/v21.1.tar.gz |
 
 # #### gRPC
 
-# Finally we build gRPC from source also:
+# Finally, we build gRPC from source:
 
 # ```bash
 WORKDIR /var/tmp/build/grpc

--- a/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-opensuse-leap.Dockerfile
@@ -44,6 +44,16 @@ ENV PATH=/usr/local/bin:${PATH}
 
 # We need a recent version of Abseil.
 
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
+
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-rockylinux-8.Dockerfile
@@ -46,7 +46,7 @@ RUN curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.g
 # ```
 
 # The following steps will install libraries and tools in `/usr/local`. By
-# default Rocky Linux 8 does not search for shared libraries in these
+# default, Rocky Linux 8 does not search for shared libraries in these
 # directories, there are multiple ways to solve this problem, the following
 # steps are one solution:
 
@@ -60,6 +60,16 @@ ENV PATH=/usr/local/bin:${PATH}
 # #### Abseil
 
 # We need a recent version of Abseil.
+
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
 
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-bionic.Dockerfile
@@ -31,6 +31,16 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
+
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-focal.Dockerfile
@@ -32,6 +32,16 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+# use `absl::any`, `absl::string_view`, and `absl::variant`. See
+# [abseil/abseil-cpp#696] for more information.
+
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \

--- a/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-ubuntu-jammy.Dockerfile
@@ -32,6 +32,17 @@ RUN apt-get update && \
 
 # We need a recent version of Abseil.
 
+# :warning: By default, Abseil's ABI changes depending on whether it is used
+# with C++ >= 17 enabled or not. Installing Abseil with the default
+# configuration is error-prone, unless you can guarantee that all the code using
+# Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+# C++ version. We recommend that you switch the default configuration to pin
+# Abseil's ABI to the version used at compile time. In this case, the compiler
+# defaults to C++17. Nevertheless, gRPC compiles with C++11 and depends on
+# some of the Abseil polyfills, such as `absl::string_view`. Therefore, we
+# pin Abseil's ABI to always use the polyfills. See [abseil/abseil-cpp#696]
+# for more information.
+
 # ```bash
 WORKDIR /var/tmp/build/abseil-cpp
 RUN curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \

--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -35,17 +35,17 @@ directory.
 * Developers wanting to use the libraries as part of a larger CMake or Bazel
   project should consult the [quickstart guides](/README.md#quickstart) for the
   library or libraries they want to use.
-* Developers wanting to compile the library just to run some of the examples or
-  tests should consult the
-  [building and installing](/README.md#building-and-installing) section of the
-  top-level README file.
+* Developers wanting to compile the library just to run examples or tests should
+  consult the [building and installing](/README.md#building-and-installing)
+  section of the top-level README file.
 * Contributors and developers to `google-cloud-cpp` should consult the guide to
-  [setup a development workstation][howto-setup-dev-workstation].
+  [set up a development workstation][howto-setup-dev-workstation].
 
 [howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
 [ninja-build]: https://ninja-build.org/
 [ccmake]: https://cmake.org/cmake/help/latest/manual/ccmake.1.html
 [issues-5489]: https://github.com/googleapis/google-cloud-cpp/issues/5849
+[abseil/abseil-cpp#696]: https://github.com/abseil/abseil-cpp/issues/696
 
 There are two primary ways of obtaining `google-cloud-cpp`. You can use git:
 
@@ -93,7 +93,7 @@ the scope of this document, but here are a few highlights:
 
 * Consider using `-GNinja` to switch the generator from `make` (or msbuild on
   Windows) to [`ninja`][ninja-build]. In our experience `ninja` takes better
-  advantage of multi-core machines. Be aware that `ninja` is often not
+  advantage of multicore machines. Be aware that `ninja` is often not
   installed in development workstations, but it is available through most
   package managers.
 * If you use the default generator, consider appending `-- -j ${NCPU}` to the
@@ -104,8 +104,28 @@ the scope of this document, but here are a few highlights:
   standard `-DBUILD_SHARED_LIBS=ON` option can be used to switch this to shared
   libraries.  Having said this, on Windows there are [known issues][issues-5489]
   with DLLs and generated protos.
-* You can compile a subset of the libraries using
-  `-DGOOGLE_CLOUD_CPP_ENABLE=lib1,lib2`.
+* With the default configuration, our CMake scripts will only compile a small
+  subset of the libraries.  As the number of libraries grows, we did not want
+  to impose longer build times on existing customers.
+  * You can use the `-DGOOGLE_CLOUD_CPP_ENABLE=...` option to configure the set
+    of libraries compiled and installed by CMake.
+  * For example, passing `-DGOOGLE_CLOUD_CPP_ENABLE=storage` will only compile
+    the `storage` library.  The target for this library is
+    `google-cloud-cpp::storage`.
+  * The `google/cloud/${library}/README.md` files describe what services are
+    supported by each library.
+  * You can provide more than one library. For example,
+    `-DGOOGLE_CLOUD_CPP_ENABLE=pubsub;iam;speech` will compile the `pubsub`,
+    `iam`, and `speech` libraries.
+  * Be aware of how your shell treats semicolons and use appropriate quoting if
+    needed.
+  * The default is to compile `bigtable`, `bigquery`, `iam`, `logging`,
+    `pubsub`, `spanner`, and `storage`.
+  * Currently, there is no way to compile all libraries (see [#9333]).
+  * The `storage` library does not depend on `gRPC` or `Protobuf`. Customers
+    only using this library may want to customize their build.
+
+[#9333]: https://github.com/googleapis/google-cloud-cpp/issues/9333
 
 To find out about other configuration options, consider using
 [`ccmake`][ccmake], or `cmake -L`.
@@ -158,7 +178,7 @@ function extract() {
 
 # A "map" (comma separated) of dockerfile -> summary.
 DOCKER_DISTROS=(
-  "demo-fedora.Dockerfile,Fedora (34)"
+  "demo-fedora.Dockerfile,Fedora (35)"
   "demo-opensuse-leap.Dockerfile,openSUSE (Leap)"
   "demo-ubuntu-jammy.Dockerfile,Ubuntu (22.04 LTS - Jammy Jellyfish)"
   "demo-ubuntu-focal.Dockerfile,Ubuntu (20.04 LTS - Focal Fossa)"
@@ -214,6 +234,16 @@ brew install cmake ninja
 brew install abseil protobuf grpc nlohmann-json crc32c openssl@1.1
 ```
 
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. Homebrew's version of Abseil is compiled with C++17 and requires
+that all dependencies are thus compiled. See [abseil/abseil-cpp#696], and the
+[homebrew formula] for more information.
+
+[homebrew formula]: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/abseil.rb
+
 Now configure, build, and install the `google-cloud-cpp` libraries that you need.
 In this example, we install the [storage][storage-link] and
 [spanner][spanner-link] libraries.
@@ -221,7 +251,7 @@ In this example, we install the [storage][storage-link] and
 cmake -S . -B cmake-out \
   -GNinja \
   -DGOOGLE_CLOUD_CPP_ENABLE="storage;spanner" \
-  -DCMAKE_CXX_STANDARD=11 \
+  -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_BUILD_TYPE=release \
   -DBUILD_TESTING=OFF \
   -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)" \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -13,17 +13,17 @@ directory.
 * Developers wanting to use the libraries as part of a larger CMake or Bazel
   project should consult the [quickstart guides](/README.md#quickstart) for the
   library or libraries they want to use.
-* Developers wanting to compile the library just to run some of the examples or
-  tests should consult the
-  [building and installing](/README.md#building-and-installing) section of the
-  top-level README file.
+* Developers wanting to compile the library just to run examples or tests should
+  consult the [building and installing](/README.md#building-and-installing)
+  section of the top-level README file.
 * Contributors and developers to `google-cloud-cpp` should consult the guide to
-  [setup a development workstation][howto-setup-dev-workstation].
+  [set up a development workstation][howto-setup-dev-workstation].
 
 [howto-setup-dev-workstation]: /doc/contributor/howto-guide-setup-development-workstation.md
 [ninja-build]: https://ninja-build.org/
 [ccmake]: https://cmake.org/cmake/help/latest/manual/ccmake.1.html
 [issues-5489]: https://github.com/googleapis/google-cloud-cpp/issues/5849
+[abseil/abseil-cpp#696]: https://github.com/abseil/abseil-cpp/issues/696
 
 There are two primary ways of obtaining `google-cloud-cpp`. You can use git:
 
@@ -71,7 +71,7 @@ the scope of this document, but here are a few highlights:
 
 * Consider using `-GNinja` to switch the generator from `make` (or msbuild on
   Windows) to [`ninja`][ninja-build]. In our experience `ninja` takes better
-  advantage of multi-core machines. Be aware that `ninja` is often not
+  advantage of multicore machines. Be aware that `ninja` is often not
   installed in development workstations, but it is available through most
   package managers.
 * If you use the default generator, consider appending `-- -j ${NCPU}` to the
@@ -82,8 +82,28 @@ the scope of this document, but here are a few highlights:
   standard `-DBUILD_SHARED_LIBS=ON` option can be used to switch this to shared
   libraries.  Having said this, on Windows there are [known issues][issues-5489]
   with DLLs and generated protos.
-* You can compile a subset of the libraries using
-  `-DGOOGLE_CLOUD_CPP_ENABLE=lib1,lib2`.
+* With the default configuration, our CMake scripts will only compile a small
+  subset of the libraries.  As the number of libraries grows, we did not want
+  to impose longer build times on existing customers.
+  * You can use the `-DGOOGLE_CLOUD_CPP_ENABLE=...` option to configure the set
+    of libraries compiled and installed by CMake.
+  * For example, passing `-DGOOGLE_CLOUD_CPP_ENABLE=storage` will only compile
+    the `storage` library.  The target for this library is
+    `google-cloud-cpp::storage`.
+  * The `google/cloud/${library}/README.md` files describe what services are
+    supported by each library.
+  * You can provide more than one library. For example,
+    `-DGOOGLE_CLOUD_CPP_ENABLE=pubsub;iam;speech` will compile the `pubsub`,
+    `iam`, and `speech` libraries.
+  * Be aware of how your shell treats semicolons and use appropriate quoting if
+    needed.
+  * The default is to compile `bigtable`, `bigquery`, `iam`, `logging`,
+    `pubsub`, `spanner`, and `storage`.
+  * Currently, there is no way to compile all libraries (see [#9333]).
+  * The `storage` library does not depend on `gRPC` or `Protobuf`. Customers
+    only using this library may want to customize their build.
+
+[#9333]: https://github.com/googleapis/google-cloud-cpp/issues/9333
 
 To find out about other configuration options, consider using
 [`ccmake`][ccmake], or `cmake -L`.
@@ -128,7 +148,7 @@ the case, the instructions describe how you can manually download and install
 these dependencies.
 
 <details>
-<summary>Fedora (34)</summary>
+<summary>Fedora (35)</summary>
 <br>
 
 Install the minimal development tools:
@@ -165,7 +185,7 @@ sudo ldconfig
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default pkg-config does not search in these directories.
+default, pkg-config does not search in these directories.
 
 ```bash
 export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
@@ -174,6 +194,17 @@ export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++17. Nevertheless, gRPC compiles with C++11 and depends on
+some of the Abseil polyfills, such as `absl::string_view`. Therefore, we
+pin Abseil's ABI to always use the polyfills. See [abseil/abseil-cpp#696]
+for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -255,7 +286,7 @@ sudo ldconfig
 
 #### gRPC
 
-Finally we build gRPC from source also:
+Finally, we build gRPC from source:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -325,6 +356,16 @@ export PATH=/usr/local/bin:${PATH}
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -480,11 +521,22 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 
 We need a recent version of Abseil.
 
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++17. Nevertheless, gRPC compiles with C++11 and depends on
+some of the Abseil polyfills, such as `absl::string_view`. Therefore, we
+pin Abseil's ABI to always use the polyfills. See [abseil/abseil-cpp#696]
+for more information.
+
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
 curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 1/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_TESTING=OFF \
@@ -619,6 +671,16 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -758,6 +820,16 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -913,8 +985,18 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 
 #### Abseil
 
-Debian 11 ships with Abseil==20200923.3.  Unfortunately, the current gRPC version needs
-Abseil>=20210324.
+Debian 11 ships with Abseil==20200923.3.  Unfortunately, the current gRPC
+version needs Abseil >= 20210324.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -984,7 +1066,7 @@ sudo ldconfig
 
 #### gRPC
 
-Finally we build gRPC from source also:
+Finally, we build gRPC from source:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -1041,6 +1123,16 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -1122,7 +1214,7 @@ sudo ldconfig
 
 #### gRPC
 
-Finally we build gRPC from source also:
+Finally, we build gRPC from source:
 
 ```bash
 mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
@@ -1169,7 +1261,7 @@ cmake --build cmake-out --target install
 First install the development tools and libcurl.
 On Debian 9, libcurl links against openssl-1.0.2, and one must link
 against the same version or risk an inconsistent configuration of the library.
-This is especially important for multi-threaded applications, as openssl-1.0.2
+This is especially important for multithreaded applications, as openssl-1.0.2
 requires explicitly setting locking callbacks. Therefore, to use libcurl one
 must link against openssl-1.0.2. To do so, we need to install libssl1.0-dev.
 Note that this removes libssl-dev if you have it installed already, and would
@@ -1186,6 +1278,16 @@ sudo apt-get --no-install-recommends install -y apt-transport-https apt-utils \
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -1376,7 +1478,7 @@ sudo ldconfig
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default Rocky Linux 8 does not search for shared libraries in these
+default, Rocky Linux 8 does not search for shared libraries in these
 directories, there are multiple ways to solve this problem, the following
 steps are one solution:
 
@@ -1390,6 +1492,16 @@ export PATH=/usr/local/bin:${PATH}
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -1555,7 +1667,7 @@ sudo ldconfig
 ```
 
 The following steps will install libraries and tools in `/usr/local`. By
-default CentOS-7 does not search for shared libraries in these directories,
+default, CentOS-7 does not search for shared libraries in these directories,
 there are multiple ways to solve this problem, the following steps are one
 solution:
 
@@ -1569,6 +1681,16 @@ export PATH=/usr/local/bin:${PATH}
 #### Abseil
 
 We need a recent version of Abseil.
+
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. We recommend that you switch the default configuration to pin
+Abseil's ABI to the version used at compile time. In this case, the compiler
+defaults to C++14. Therefore, we change `absl/base/options.h` to **always**
+use `absl::any`, `absl::string_view`, and `absl::variant`. See
+[abseil/abseil-cpp#696] for more information.
 
 ```bash
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
@@ -1727,6 +1849,16 @@ brew install cmake ninja
 brew install abseil protobuf grpc nlohmann-json crc32c openssl@1.1
 ```
 
+:warning: By default, Abseil's ABI changes depending on whether it is used
+with C++ >= 17 enabled or not. Installing Abseil with the default
+configuration is error-prone, unless you can guarantee that all the code using
+Abseil (gRPC, google-cloud-cpp, your own code, etc.) is compiled with the same
+C++ version. Homebrew's version of Abseil is compiled with C++17 and requires
+that all dependencies are thus compiled. See [abseil/abseil-cpp#696], and the
+[homebrew formula] for more information.
+
+[homebrew formula]: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/abseil.rb
+
 Now configure, build, and install the `google-cloud-cpp` libraries that you need.
 In this example, we install the [storage][storage-link] and
 [spanner][spanner-link] libraries.
@@ -1734,7 +1866,7 @@ In this example, we install the [storage][storage-link] and
 cmake -S . -B cmake-out \
   -GNinja \
   -DGOOGLE_CLOUD_CPP_ENABLE="storage;spanner" \
-  -DCMAKE_CXX_STANDARD=11 \
+  -DCMAKE_CXX_STANDARD=17 \
   -DCMAKE_BUILD_TYPE=release \
   -DBUILD_TESTING=OFF \
   -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@1.1)" \

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -536,7 +536,7 @@ for more information.
 mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
 curl -sSL https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz | \
     tar -xzf - --strip-components=1 && \
-    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 1/' "absl/base/options.h" && \
+    sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h" && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
       -DBUILD_TESTING=OFF \


### PR DESCRIPTION
Our instructions did not highlight why we recommend the magic `sed`
command to tweak Abseil. The command is easy to miss, and deserves a
larger warning. On macOS with homebrew this is even more tricky, as
homebrew does not patch Abseil's headers.

I changed the recommended command to reflect the default C++ version for
each platform.

I also updated the instructions around enabling additional libraries
with CMake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9334)
<!-- Reviewable:end -->
