### PR TITLE
feat(bigtable): introduce `MockDataConnection` and `MakeRowReader`

### DIFF
--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -23,8 +23,6 @@ namespace google {
 namespace cloud {
 namespace bigtable_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-// TODO(#8860) - Remove the internal namespace
-namespace internal {
 
 /**
  * A class to mock `google::cloud::bigtable::DataConnection`.
@@ -116,7 +114,6 @@ class MockDataConnection : public bigtable::DataConnection {
               (override));
 };
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_mocks
 }  // namespace cloud

--- a/google/cloud/bigtable/mocks/mock_row_reader.cc
+++ b/google/cloud/bigtable/mocks/mock_row_reader.cc
@@ -19,11 +19,9 @@ namespace google {
 namespace cloud {
 namespace bigtable_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-// TODO(#8860) - Remove internal namespace.
-namespace internal {
 
-bigtable::RowReader MakeTestRowReader(std::vector<bigtable::Row> rows,
-                                      Status final_status) {
+bigtable::RowReader MakeRowReader(std::vector<bigtable::Row> rows,
+                                  Status final_status) {
   class ConvenientRowReader : public bigtable_internal::RowReaderImpl {
    public:
     explicit ConvenientRowReader(std::vector<bigtable::Row> rows,
@@ -53,7 +51,6 @@ bigtable::RowReader MakeTestRowReader(std::vector<bigtable::Row> rows,
   return bigtable_internal::MakeRowReader(std::move(impl));
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_mocks
 }  // namespace cloud

--- a/google/cloud/bigtable/mocks/mock_row_reader.h
+++ b/google/cloud/bigtable/mocks/mock_row_reader.h
@@ -22,8 +22,6 @@ namespace google {
 namespace cloud {
 namespace bigtable_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-// TODO(#8860) - Remove internal namespace.
-namespace internal {
 
 /**
  * Returns a `RowReader` with a fixed output stream.
@@ -49,7 +47,7 @@ namespace internal {
  *
  *   auto mock = std::shared_ptr<cbtm::MockDataConnection>();
  *   EXPECT_CALL(*mock, ReadRows)
- *       .WillOnce(Return(cbtm::MakeTestRowReader(rows)));
+ *       .WillOnce(Return(cbtm::MakeRowReader(rows)));
  *
  *   auto table = cbt::Table(mock);
  *   auto reader = table.ReadRows(...);
@@ -58,10 +56,9 @@ namespace internal {
  * }
  * @endcode
  */
-bigtable::RowReader MakeTestRowReader(std::vector<bigtable::Row> rows,
-                                      Status final_status = {});
+bigtable::RowReader MakeRowReader(std::vector<bigtable::Row> rows,
+                                  Status final_status = {});
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_mocks
 }  // namespace cloud

--- a/google/cloud/bigtable/mocks/mock_row_reader_test.cc
+++ b/google/cloud/bigtable/mocks/mock_row_reader_test.cc
@@ -22,7 +22,6 @@ namespace google {
 namespace cloud {
 namespace bigtable_mocks {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::bigtable::Row;
@@ -49,11 +48,11 @@ struct Result {
   Status final_status;
 };
 
-TEST(MakeTestRowReader, Empty) {
+TEST(MakeRowReaderTest, Empty) {
   std::vector<Row> rows;
   Status final_status;
 
-  auto reader = MakeTestRowReader(rows);
+  auto reader = MakeRowReader(rows);
 
   auto actual = Result(std::move(reader));
   auto expected = Result(rows, final_status);
@@ -61,11 +60,11 @@ TEST(MakeTestRowReader, Empty) {
   EXPECT_EQ(actual.final_status, expected.final_status);
 }
 
-TEST(MakeTestRowReader, Rows) {
+TEST(MakeRowReaderTest, Rows) {
   std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
   Status final_status;
 
-  auto reader = MakeTestRowReader(rows);
+  auto reader = MakeRowReader(rows);
 
   auto actual = Result(std::move(reader));
   auto expected = Result(rows, final_status);
@@ -73,11 +72,11 @@ TEST(MakeTestRowReader, Rows) {
   EXPECT_EQ(actual.final_status, expected.final_status);
 }
 
-TEST(MakeTestRowReader, StatusOnly) {
+TEST(MakeRowReaderTest, StatusOnly) {
   std::vector<Row> rows;
   auto final_status = Status(StatusCode::kPermissionDenied, "fail");
 
-  auto reader = MakeTestRowReader(rows, final_status);
+  auto reader = MakeRowReader(rows, final_status);
 
   auto actual = Result(std::move(reader));
   auto expected = Result(rows, final_status);
@@ -85,11 +84,11 @@ TEST(MakeTestRowReader, StatusOnly) {
   EXPECT_EQ(actual.final_status, expected.final_status);
 }
 
-TEST(MakeTestRowReader, RowsThenStatus) {
+TEST(MakeRowReaderTest, RowsThenStatus) {
   std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
   auto final_status = Status(StatusCode::kPermissionDenied, "fail");
 
-  auto reader = MakeTestRowReader(rows, final_status);
+  auto reader = MakeRowReader(rows, final_status);
 
   auto actual = Result(std::move(reader));
   auto expected = Result(rows, final_status);
@@ -97,11 +96,11 @@ TEST(MakeTestRowReader, RowsThenStatus) {
   EXPECT_EQ(actual.final_status, expected.final_status);
 }
 
-TEST(MakeTestRowReader, CancelEndsGoodStream) {
+TEST(MakeRowReaderTest, CancelEndsGoodStream) {
   std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
   Status final_status;
 
-  auto reader = MakeTestRowReader(rows);
+  auto reader = MakeRowReader(rows);
 
   auto it = reader.begin();
   ASSERT_STATUS_OK(*it);
@@ -117,11 +116,11 @@ TEST(MakeTestRowReader, CancelEndsGoodStream) {
   EXPECT_EQ(reader.begin(), reader.end());
 }
 
-TEST(MakeTestRowReader, CancelEndsBadStream) {
+TEST(MakeRowReaderTest, CancelEndsBadStream) {
   std::vector<Row> rows = {Row("r1", {}), Row("r2", {})};
   auto final_status = Status(StatusCode::kCancelled, "cancelled");
 
-  auto reader = MakeTestRowReader(rows, final_status);
+  auto reader = MakeRowReader(rows, final_status);
 
   auto it = reader.begin();
   ASSERT_STATUS_OK(*it);
@@ -141,7 +140,6 @@ TEST(MakeTestRowReader, CancelEndsBadStream) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_mocks
 }  // namespace cloud

--- a/google/cloud/bigtable/row_reader_test.cc
+++ b/google/cloud/bigtable/row_reader_test.cc
@@ -45,7 +45,7 @@ TEST(RowReaderTest, BadStatusOnly) {
 TEST(RowReaderTest, IteratorPostincrement) {
   std::vector<Row> rows = {Row("r1", {})};
 
-  auto reader = bigtable_mocks::internal::MakeTestRowReader(rows);
+  auto reader = bigtable_mocks::MakeRowReader(rows);
 
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -26,7 +26,7 @@ namespace {
 
 namespace v2 = ::google::bigtable::v2;
 using ms = std::chrono::milliseconds;
-using ::google::cloud::bigtable_mocks::internal::MockDataConnection;
+using ::google::cloud::bigtable_mocks::MockDataConnection;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ElementsAre;
 using ::testing::ElementsAreArray;
@@ -230,8 +230,7 @@ TEST(TableTest, ReadRows) {
         EXPECT_THAT(row_set, IsTestRowSet());
         EXPECT_EQ(rows_limit, RowReader::NO_ROWS_LIMIT);
         EXPECT_THAT(filter, IsTestFilter());
-        return bigtable_mocks::internal::MakeTestRowReader({},
-                                                           PermanentError());
+        return bigtable_mocks::MakeRowReader({}, PermanentError());
       });
 
   auto table = TestTable(std::move(mock));
@@ -254,8 +253,7 @@ TEST(TableTest, ReadRowsWithRowLimit) {
         EXPECT_THAT(row_set, IsTestRowSet());
         EXPECT_EQ(rows_limit, 42);
         EXPECT_THAT(filter, IsTestFilter());
-        return bigtable_mocks::internal::MakeTestRowReader({},
-                                                           PermanentError());
+        return bigtable_mocks::MakeRowReader({}, PermanentError());
       });
 
   auto table = TestTable(std::move(mock));


### PR DESCRIPTION
Part of the work for #8860 

this moves our two mock/test classes out of the `internal` namespace.

We also drop "Test" from the helper name to be consistent with `spanner_mocks::MakeRow(...)`: https://github.com/googleapis/google-cloud-cpp/blob/0673b956c128832a1ff510bf4f2a27d6cb328dab/google/cloud/spanner/mocks/row.h#L42