### PR TITLE
test(storage): log more details on success

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -51,6 +51,7 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
      << ',' << r.elapsed_time.count()          //
      << ',' << r.cpu_time.count()              //
      << ',' << CleanupCsv(r.peer)              //
+     << ',' << CleanupCsv(r.notes)             //
      << ',' << r.status.code()                 //
      << ',' << CleanupCsv(r.status.message())  //
      << '\n';
@@ -59,7 +60,7 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
 void PrintThroughputResultHeader(std::ostream& os) {
   os << "Library,Transport,Op,Start,ObjectSize,TransferSize,AppBufferSize"
      << ",LibBufferSize,Crc32cEnabled,MD5Enabled"
-     << ",ElapsedTimeUs,CpuTimeUs,Peer,StatusCode,Status\n";
+     << ",ElapsedTimeUs,CpuTimeUs,Peer,Notes,StatusCode,Status\n";
 }
 
 char const* ToString(OpType op) {

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -89,6 +89,8 @@ struct ThroughputResult {
   google::cloud::Status status;
   /// The peer used during the transfer
   std::string peer;
+  /// Additional notes
+  std::string notes;
 };
 
 /// Print @p r as a CSV line.

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -78,7 +78,7 @@ TEST(ThroughputResult, HeaderMatches) {
       /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
       /*crc_enabled=*/true, /*md5_enabled=*/false,
       std::chrono::microseconds(234000), std::chrono::microseconds(345000),
-      Status{StatusCode::kOutOfRange, "OOR-status-message"}, "peer"});
+      Status{StatusCode::kOutOfRange, "OOR-status-message"}, "peer", "notes"});
   ASSERT_STATUS_OK(line);
   ASSERT_FALSE(header.empty());
   ASSERT_FALSE(line->empty());
@@ -106,6 +106,7 @@ TEST(ThroughputResult, HeaderMatches) {
   EXPECT_THAT(*line, HasSubstr(StatusCodeToString(StatusCode::kOutOfRange)));
   EXPECT_THAT(*line, HasSubstr("OOR-status-message"));
   EXPECT_THAT(*line, HasSubstr("peer"));
+  EXPECT_THAT(*line, HasSubstr(",notes,"));
 }
 
 TEST(ThroughputResult, QuoteCsv) {


### PR DESCRIPTION
Sometimes we need to pair the upload and download lines. This adds
enough information (object name, generations) to the log lines to do
so.

It also flushes the default `google::cloud::LogSink` if an error is
detected.  That can produce better logs to troubleshoot problems.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9344)
<!-- Reviewable:end -->
