### PR TITLE
fix: add missing -DCURLSTATICLIB for system static Curl on Windows

### DIFF
--- a/cmake/FindCurlWithTargets.cmake
+++ b/cmake/FindCurlWithTargets.cmake
@@ -68,6 +68,10 @@ else ()
                 TARGET CURL::libcurl
                 APPEND
                 PROPERTY INTERFACE_LINK_LIBRARIES crypt32 wsock32 ws2_32)
+            set_property(
+                TARGET CURL::libcurl
+                APPEND
+                PROPERTY INTERFACE_COMPILE_DEFINITIONS "CURL_STATICLIB")
         endif ()
         if (APPLE)
             set_property(


### PR DESCRIPTION
We need to define CURL_STATICLIB when we use static Curl on Windows.
If we don't define CURL_STATICLIB for static Curl on Windows,
google-cloud-cpp refers wrong symbols.

For example, https://github.com/apache/arrow/pull/13404 encountered
this problem:

https://github.com/apache/arrow/runs/7004628336?check_suite_focus=true#step:11:751

    C:/rtools40/mingw32/bin/../lib/gcc/i686-w64-mingw32/8.3.0/../../../../i686-w64-mingw32/bin/ld.exe:
    ../windows/arrow-8.0.0.9000/lib/i386/libarrow_bundled_dependencies.a(curl_wrappers.cc.obj):(.text+0x2):
    undefined reference to `_imp__curl_global_cleanup'

libarrow_bundled_dependencies.a includes libgoogle_cloud_cpp*.a and
curl_wrappers.cc.obj in the above log is a file in google-cloud-cpp.

I confirmed that this change solves this problem in
https://github.com/apache/arrow/pull/13404 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9345)
<!-- Reviewable:end -->
