### PR TITLE
ci: create new build for Alpine:3.16 (aka Stable)

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-alpine-stable.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-alpine-stable.Dockerfile
@@ -1,0 +1,72 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM alpine:3.16
+ARG NCPU=4
+
+## [BEGIN packaging.md]
+
+# Install the minimal development tools, libcurl, and OpenSSL:
+
+# ```bash
+RUN apk update && \
+    apk add bash ca-certificates ccache cmake curl git \
+        gcc g++ make tar unzip zip zlib-dev
+# ```
+
+# Alpine's version of `pkg-config` (https://github.com/pkgconf/pkgconf) is slow
+# when handling `.pc` files with lots of `Requires:` deps, which happens with
+# Abseil, so we use the normal `pkg-config` binary, which seems to not suffer
+# from this bottleneck. For more details see
+# https://github.com/pkgconf/pkgconf/issues/229
+# https://github.com/googleapis/google-cloud-cpp/issues/7052
+WORKDIR /var/tmp/build/pkg-config-cpp
+RUN curl -sSL https://pkgconfig.freedesktop.org/releases/pkg-config-0.29.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    ./configure --with-internal-glib && \
+    make -j ${NCPU:-4} && \
+    make install
+ENV PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:/usr/lib64/pkgconfig
+
+# #### Dependencies
+
+# The versions of Abseil, Protobuf, gRPC, OpenSSL, and nlohmann-json included
+# with Alpine >= 3.16 meet `google-cloud-cpp`'s requirements. We can simply
+# install the development packages
+
+RUN apk update && \
+    apk add abseil-cpp-dev c-ares-dev curl-dev grpc-dev \
+        protobuf-dev nlohmann-json openssl-dev re2-dev
+
+# #### crc32c
+
+# The project depends on the Crc32c library, we need to compile this from
+# source:
+
+# ```bash
+WORKDIR /var/tmp/build/crc32c
+RUN curl -sSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | \
+    tar -xzf - --strip-components=1 && \
+    cmake \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_SHARED_LIBS=yes \
+        -DCRC32C_BUILD_TESTS=OFF \
+        -DCRC32C_BUILD_BENCHMARKS=OFF \
+        -DCRC32C_USE_GLOG=OFF \
+        -S . -B cmake-out && \
+    cmake --build cmake-out -- -j ${NCPU:-4} && \
+    cmake --build cmake-out --target install -- -j ${NCPU:-4}
+# ```
+
+## [DONE packaging.md]

--- a/ci/cloudbuild/triggers/demo-alpine-stable-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-alpine-stable-ci.yaml
@@ -1,0 +1,13 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  push:
+    branch: ^(master|main|v\d+\..*)$
+name: demo-alpine-stable-ci
+substitutions:
+  _BUILD_NAME: demo-install
+  _DISTRO: demo-alpine-stable
+  _TRIGGER_TYPE: ci
+tags:
+  - ci

--- a/ci/cloudbuild/triggers/demo-alpine-stable-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-alpine-stable-pr.yaml
@@ -1,0 +1,14 @@
+filename: ci/cloudbuild/cloudbuild.yaml
+github:
+  name: google-cloud-cpp
+  owner: googleapis
+  pullRequest:
+    branch: ^(master|main|v\d+\..*)$
+    commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
+name: demo-alpine-stable-pr
+substitutions:
+  _BUILD_NAME: demo-install
+  _DISTRO: demo-alpine-stable
+  _TRIGGER_TYPE: pr
+tags:
+  - pr

--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -178,6 +178,7 @@ function extract() {
 
 # A "map" (comma separated) of dockerfile -> summary.
 DOCKER_DISTROS=(
+  "demo-alpine-stable.Dockerfile,Alpine (Stable)"
   "demo-fedora.Dockerfile,Fedora (35)"
   "demo-opensuse-leap.Dockerfile,openSUSE (Leap)"
   "demo-ubuntu-jammy.Dockerfile,Ubuntu (22.04 LTS - Jammy Jellyfish)"

--- a/google/cloud/bigquery/quickstart/Makefile
+++ b/google/cloud/bigquery/quickstart/Makefile
@@ -18,7 +18,7 @@
 # The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
 # our tests, but applications would typically make them configurable parameters.
 CXX=g++
-CXXFLAGS=-std=c++11
+CXXFLAGS=
 CXXLD=$(CXX)
 BIN=.
 

--- a/google/cloud/bigtable/quickstart/Makefile
+++ b/google/cloud/bigtable/quickstart/Makefile
@@ -18,7 +18,7 @@
 # The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
 # our tests, but applications would typically make them configurable parameters.
 CXX=g++
-CXXFLAGS=-std=c++11
+CXXFLAGS=
 CXXLD=$(CXX)
 BIN=.
 

--- a/google/cloud/iam/quickstart/Makefile
+++ b/google/cloud/iam/quickstart/Makefile
@@ -18,7 +18,7 @@
 # The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
 # our tests, but applications would typically make them configurable parameters.
 CXX=g++
-CXXFLAGS=-std=c++11
+CXXFLAGS=
 CXXLD=$(CXX)
 BIN=.
 

--- a/google/cloud/pubsub/quickstart/Makefile
+++ b/google/cloud/pubsub/quickstart/Makefile
@@ -18,7 +18,7 @@
 # The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
 # our tests, but applications would typically make them configurable parameters.
 CXX=g++
-CXXFLAGS=-std=c++11
+CXXFLAGS=
 CXXLD=$(CXX)
 BIN=.
 

--- a/google/cloud/spanner/quickstart/Makefile
+++ b/google/cloud/spanner/quickstart/Makefile
@@ -18,7 +18,7 @@
 # The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
 # our tests, but applications would typically make them configurable parameters.
 CXX=g++
-CXXFLAGS=-std=c++11
+CXXFLAGS=
 CXXLD=$(CXX)
 BIN=.
 

--- a/google/cloud/storage/quickstart/Makefile
+++ b/google/cloud/storage/quickstart/Makefile
@@ -18,7 +18,7 @@
 # The CXX, CXXFLAGS and CXXLD variables are hard-coded. These values work for
 # our tests, but applications would typically make them configurable parameters.
 CXX=g++
-CXXFLAGS=-std=c++11
+CXXFLAGS=
 CXXLD=$(CXX)
 BIN=.
 


### PR DESCRIPTION
This is our first build using `musl`.  Fortunately, Alpine stays fairly
up-to-date with all our dependencies, so we can just use the packages.

I had to fix the `*/quickstart/Makefile` files because the default on
this platform is C++17, and our makefiles were unnecessarily hard-coding
C++11.

Part of the work for #510 (I need to manually add the triggers once this is merged)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9347)
<!-- Reviewable:end -->
