### PR TITLE
feat(common): truncation support for plain strings in the RPC log

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -99,9 +99,10 @@ std::string DebugString(Status const& status, TracingOptions const& options) {
   return std::move(os).str();
 }
 
-std::string RequestIdForLogging() {
-  static std::atomic<std::uint64_t> generator{0};
-  return std::to_string(++generator);
+std::string DebugString(std::string s, TracingOptions const& options) {
+  std::size_t const pos = options.truncate_string_field_longer_than();
+  if (s.size() > pos) s.replace(pos, std::string::npos, "...<truncated>...");
+  return s;
 }
 
 char const* DebugFutureStatus(std::future_status status) {
@@ -121,6 +122,11 @@ char const* DebugFutureStatus(std::future_status status) {
       break;
   }
   return msg;
+}
+
+std::string RequestIdForLogging() {
+  static std::atomic<std::uint64_t> generator{0};
+  return std::to_string(++generator);
 }
 
 }  // namespace internal

--- a/google/cloud/internal/log_wrapper.h
+++ b/google/cloud/internal/log_wrapper.h
@@ -38,6 +38,8 @@ std::string DebugString(google::protobuf::Message const& m,
 
 std::string DebugString(Status const& status, TracingOptions const& options);
 
+std::string DebugString(std::string s, TracingOptions const& options);
+
 char const* DebugFutureStatus(std::future_status s);
 
 // Create a unique ID that can be used to match asynchronous requests/response

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -144,6 +144,23 @@ TEST(LogWrapper, Truncate) {
   EXPECT_EQ(text, DebugString(MakeMutation(), tracing_options));
 }
 
+TEST(LogWrapper, TruncateString) {
+  TracingOptions tracing_options;
+  tracing_options.SetOptions("truncate_string_field_longer_than=8");
+  struct Case {
+    std::string actual;
+    std::string expected;
+  } cases[] = {
+      {"1234567", "1234567"},
+      {"12345678", "12345678"},
+      {"123456789", "12345678...<truncated>..."},
+      {"1234567890", "12345678...<truncated>..."},
+  };
+  for (auto const& c : cases) {
+    EXPECT_EQ(c.expected, DebugString(c.actual, tracing_options));
+  }
+}
+
 TEST(LogWrapper, FutureStatus) {
   struct Case {
     std::future_status actual;


### PR DESCRIPTION
Add `DebugString(std::string, TracingOptions const&)` for adding a plain
string to the RPC log, but with the `truncate_string_field_longer_than`
behavior of `google::protobuf::TextFormat::Printer`.

This will be used in an upcoming change that will log a `resume_token`
from the Spanner streaming read/query protocol, and which is extremely
long.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9351)
<!-- Reviewable:end -->
