### PR TITLE
impl(common): add explicit routing matcher

### DIFF
--- a/google/cloud/google_cloud_cpp_grpc_utils.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils.bzl
@@ -63,6 +63,7 @@ google_cloud_cpp_grpc_utils_hdrs = [
     "internal/resumable_streaming_read_rpc.h",
     "internal/retry_loop.h",
     "internal/retry_loop_helpers.h",
+    "internal/routing_matcher.h",
     "internal/setup_context.h",
     "internal/streaming_read_rpc.h",
     "internal/streaming_read_rpc_logging.h",

--- a/google/cloud/google_cloud_cpp_grpc_utils.cmake
+++ b/google/cloud/google_cloud_cpp_grpc_utils.cmake
@@ -82,6 +82,7 @@ add_library(
     internal/retry_loop.h
     internal/retry_loop_helpers.cc
     internal/retry_loop_helpers.h
+    internal/routing_matcher.h
     internal/setup_context.h
     internal/streaming_read_rpc.cc
     internal/streaming_read_rpc.h
@@ -246,6 +247,7 @@ if (BUILD_TESTING)
         internal/populate_grpc_options_test.cc
         internal/resumable_streaming_read_rpc_test.cc
         internal/retry_loop_test.cc
+        internal/routing_matcher_test.cc
         internal/streaming_read_rpc_logging_test.cc
         internal/streaming_read_rpc_test.cc
         internal/streaming_write_rpc_logging_test.cc

--- a/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_grpc_utils_unit_tests.bzl
@@ -47,6 +47,7 @@ google_cloud_cpp_grpc_utils_unit_tests = [
     "internal/populate_grpc_options_test.cc",
     "internal/resumable_streaming_read_rpc_test.cc",
     "internal/retry_loop_test.cc",
+    "internal/routing_matcher_test.cc",
     "internal/streaming_read_rpc_logging_test.cc",
     "internal/streaming_read_rpc_test.cc",
     "internal/streaming_write_rpc_logging_test.cc",

--- a/google/cloud/internal/routing_matcher.h
+++ b/google/cloud/internal/routing_matcher.h
@@ -17,9 +17,10 @@
 
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
+#include <functional>
 #include <regex>
 #include <string>
-#include <unordered_map>
+#include <vector>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/routing_matcher.h
+++ b/google/cloud/internal/routing_matcher.h
@@ -1,0 +1,70 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ROUTING_MATCHER_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ROUTING_MATCHER_H
+
+#include "google/cloud/version.h"
+#include "absl/types/optional.h"
+#include <regex>
+#include <string>
+#include <unordered_map>
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+/**
+ * A helper class used by our `MetadataDecorator`s to match and extract routing
+ * keys from a proto.
+ */
+template <typename Request>
+struct RoutingMatcher {
+  // Includes an equals sign. e.g. "key="
+  std::string routing_key;
+
+  struct Pattern {
+    std::function<std::string const&(Request const&)> field_getter;
+    absl::optional<std::regex> re;
+  };
+  std::vector<Pattern> patterns;
+
+  // If a match is found for this routing_key, append "routing_key=value" to
+  // the `params` vector.
+  void AppendParam(Request const& request, std::vector<std::string>& params) {
+    std::smatch match;
+    for (auto const& pattern : patterns) {
+      auto const& field = pattern.field_getter(request);
+      if (field.empty()) continue;
+      // When the optional regex is not engaged, it is implied that we should
+      // match the whole field.
+      if (!pattern.re) {
+        params.push_back(routing_key + field);
+        return;
+      }
+      if (std::regex_match(field, match, *pattern.re)) {
+        params.push_back(routing_key + match[1].str());
+        return;
+      }
+    }
+  }
+};
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ROUTING_MATCHER_H

--- a/google/cloud/internal/routing_matcher_test.cc
+++ b/google/cloud/internal/routing_matcher_test.cc
@@ -14,8 +14,6 @@
 
 #include "google/cloud/internal/routing_matcher.h"
 #include <gmock/gmock.h>
-#include <regex>
-#include <unordered_map>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/internal/routing_matcher_test.cc
+++ b/google/cloud/internal/routing_matcher_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/routing_matcher.h"
+#include <gmock/gmock.h>
+#include <regex>
+#include <unordered_map>
+
+namespace google {
+namespace cloud {
+namespace internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+using ::testing::UnorderedElementsAre;
+
+// Simulate a protobuf message with two string fields: `foo` and `bar`.
+struct TestRequest {
+  std::string const& foo() const { return foo_; };
+  std::string const& bar() const { return bar_; };
+
+  std::string foo_;
+  std::string bar_;
+};
+
+TEST(RoutingMatcher, NoAppendIfNoMatch) {
+  auto matcher = RoutingMatcher<TestRequest>{
+      "routing_id=",
+      {
+          {[](TestRequest const& request) -> std::string const& {
+             return request.foo();
+           },
+           std::regex{"baz/([^/]+)"}},
+      }};
+
+  std::vector<std::string> params = {"previous"};
+  auto request = TestRequest{"foo/foo", "bar/bar"};
+  matcher.AppendParam(request, params);
+  EXPECT_THAT(params, UnorderedElementsAre("previous"));
+}
+
+TEST(RoutingMatcher, MatchesAll) {
+  auto matcher = RoutingMatcher<TestRequest>{
+      "routing_id=",
+      {
+          {[](TestRequest const& request) -> std::string const& {
+             return request.foo();
+           },
+           absl::nullopt},
+      }};
+
+  std::vector<std::string> params = {"previous"};
+  auto request = TestRequest{"foo/foo", "bar/bar"};
+  matcher.AppendParam(request, params);
+  EXPECT_THAT(params, UnorderedElementsAre("previous", "routing_id=foo/foo"));
+}
+
+TEST(RoutingMatcher, EmptyFieldIsSkipped) {
+  auto matcher = RoutingMatcher<TestRequest>{
+      "routing_id=",
+      {
+          {[](TestRequest const& request) -> std::string const& {
+             return request.foo();
+           },
+           absl::nullopt},
+          {[](TestRequest const& request) -> std::string const& {
+             return request.bar();
+           },
+           std::regex{"bar/([^/]+)"}},
+      }};
+
+  std::vector<std::string> params = {"previous"};
+  auto request = TestRequest{"", "bar/bar"};
+  matcher.AppendParam(request, params);
+  EXPECT_THAT(params, UnorderedElementsAre("previous", "routing_id=bar"));
+}
+
+TEST(RoutingMatcher, FirstNonEmptyMatchIsUsed) {
+  auto matcher = RoutingMatcher<TestRequest>{
+      "routing_id=",
+      {
+          {[](TestRequest const& request) -> std::string const& {
+             return request.foo();
+           },
+           std::regex{"foo/([^/]+)"}},
+          {[](TestRequest const& request) -> std::string const& {
+             return request.bar();
+           },
+           std::regex{"bar/([^/]+)"}},
+      }};
+
+  std::vector<std::string> params = {"previous"};
+  auto request = TestRequest{"foo/foo", "bar/bar"};
+  matcher.AppendParam(request, params);
+  EXPECT_THAT(params, UnorderedElementsAre("previous", "routing_id=foo"));
+}
+
+}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace internal
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/routing_matcher_test.cc
+++ b/google/cloud/internal/routing_matcher_test.cc
@@ -19,8 +19,8 @@
 
 namespace google {
 namespace cloud {
-namespace internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
 namespace {
 
 using ::testing::UnorderedElementsAre;
@@ -107,7 +107,7 @@ TEST(RoutingMatcher, FirstNonEmptyMatchIsUsed) {
 }
 
 }  // namespace
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Part of the work for #9121

For context, this is how the `RoutingMatcher` class will be used:
https://github.com/dbolduc/google-cloud-cpp/blob/b173e447940dc3d6ae71d00f9b570e6c5262058d/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc#L113-L158

And if you were curious, this branch has the full implementation:
https://github.com/googleapis/google-cloud-cpp/compare/main...dbolduc:wip-routing-parameters?expand=1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9353)
<!-- Reviewable:end -->
