### PR TITLE
impl(generator): service `HasExplicitRoutingMethod()` helper

### DIFF
--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -23,6 +23,7 @@
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/printer.h"
 #include <google/api/client.pb.h>
+#include <google/api/routing.pb.h>
 #include <google/protobuf/descriptor.h>
 #include <unordered_map>
 
@@ -153,6 +154,13 @@ bool ServiceCodeGenerator::HasBidirStreamingMethod() const {
   return std::any_of(methods_.begin(), methods_.end(),
                      [](google::protobuf::MethodDescriptor const& m) {
                        return IsBidirStreaming(m);
+                     });
+}
+
+bool ServiceCodeGenerator::HasExplicitRoutingMethod() const {
+  return std::any_of(methods_.begin(), methods_.end(),
+                     [](google::protobuf::MethodDescriptor const& m) {
+                       return m.options().HasExtension(google::api::routing);
                      });
 }
 

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -145,6 +145,12 @@ class ServiceCodeGenerator : public GeneratorInterface {
   bool HasBidirStreamingMethod() const;
 
   /**
+   * Determines if the service contains at least one RPC with a
+   * google.api.routing annotation.
+   */
+  bool HasExplicitRoutingMethod() const;
+
+  /**
    * Determines if any of the method signatures has any Protocol Buffer
    * Well-Known Types per
    * https://developers.google.com/protocol-buffers/docs/reference/google.protobuf


### PR DESCRIPTION
Part of the work for #9121 

I will use this to conditionally include `RoutingMatcher` and `absl::StrJoin` in the metadata decorator cc files.