### PR TITLE
test(storage): make benchmark more memory efficient

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -38,13 +38,12 @@ std::string ExtractPeer(
   return p == headers.end() ? std::string{"unknown"} : p->second;
 }
 
-using SharedContents = std::shared_ptr<std::string>;
-
 class UploadObject : public ThroughputExperiment {
  public:
   explicit UploadObject(google::cloud::storage::Client client,
                         ExperimentTransport transport,
-                        SharedContents random_data, bool prefer_insert)
+                        std::shared_ptr<std::string> random_data,
+                        bool prefer_insert)
       : client_(std::move(client)),
         transport_(transport),
         random_data_(std::move(random_data)),
@@ -138,7 +137,7 @@ class UploadObject : public ThroughputExperiment {
  private:
   google::cloud::storage::Client client_;
   ExperimentTransport transport_;
-  SharedContents random_data_;
+  std::shared_ptr<std::string> random_data_;
   bool prefer_insert_;
 };
 


### PR DESCRIPTION
The benchmark was allocating a (constant) buffer of random data to
upload on each thread. The default size of this buffer is 64 MiB.
This is a good default, as around 64 MiB the performance plateaus.
We also are starting to run benchmarks with 64 and more threads,
and each thread has several buffers (gRPC, DirectPath, XML, Json,
each gets a different buffer) that quickly pushes memory consumption
too high.  Better to share the buffer across all these threads.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9358)
<!-- Reviewable:end -->
