### PR TITLE
impl(spanner): fix the handling of PartialResultSet.resume_token

### DIFF
--- a/google/cloud/spanner/internal/logging_result_set_reader.cc
+++ b/google/cloud/spanner/internal/logging_result_set_reader.cc
@@ -28,9 +28,15 @@ void LoggingResultSetReader::TryCancel() {
   GCP_LOG(DEBUG) << __func__ << "() >> (void)";
 }
 
-absl::optional<PartialResultSet> LoggingResultSetReader::Read() {
-  GCP_LOG(DEBUG) << __func__ << "() << (void)";
-  auto result = impl_->Read();
+absl::optional<PartialResultSet> LoggingResultSetReader::Read(
+    absl::optional<std::string> const& resume_token) {
+  if (resume_token) {
+    GCP_LOG(DEBUG) << __func__ << "() << \""
+                   << DebugString(*resume_token, tracing_options_) << "\"";
+  } else {
+    GCP_LOG(DEBUG) << __func__ << "() << (unresumable)";
+  }
+  auto result = impl_->Read(resume_token);
   if (!result) {
     GCP_LOG(DEBUG) << __func__ << "() >> (optional-with-no-value)";
   } else {

--- a/google/cloud/spanner/internal/logging_result_set_reader.h
+++ b/google/cloud/spanner/internal/logging_result_set_reader.h
@@ -34,7 +34,8 @@ class LoggingResultSetReader : public PartialResultSetReader {
   ~LoggingResultSetReader() override = default;
 
   void TryCancel() override;
-  absl::optional<PartialResultSet> Read() override;
+  absl::optional<PartialResultSet> Read(
+      absl::optional<std::string> const& resume_token) override;
   Status Finish() override;
 
  private:

--- a/google/cloud/spanner/internal/partial_result_set_resume.h
+++ b/google/cloud/spanner/internal/partial_result_set_resume.h
@@ -48,12 +48,13 @@ class PartialResultSetResume : public PartialResultSetReader {
         idempotency_(idempotency),
         retry_policy_prototype_(std::move(retry_policy)),
         backoff_policy_prototype_(std::move(backoff_policy)),
-        child_(factory_(last_resume_token_)) {}
+        child_(factory_(std::string{})) {}
 
   ~PartialResultSetResume() override = default;
 
   void TryCancel() override;
-  absl::optional<PartialResultSet> Read() override;
+  absl::optional<PartialResultSet> Read(
+      absl::optional<std::string> const& resume_token) override;
   Status Finish() override;
 
  private:
@@ -61,7 +62,6 @@ class PartialResultSetResume : public PartialResultSetReader {
   google::cloud::Idempotency idempotency_;
   std::unique_ptr<spanner::RetryPolicy> retry_policy_prototype_;
   std::unique_ptr<spanner::BackoffPolicy> backoff_policy_prototype_;
-  std::string last_resume_token_;
   std::unique_ptr<PartialResultSetReader> child_;
   absl::optional<Status> last_status_;
 };

--- a/google/cloud/spanner/internal/partial_result_set_resume_test.cc
+++ b/google/cloud/spanner/internal/partial_result_set_resume_test.cc
@@ -117,7 +117,7 @@ TEST(PartialResultSetResume, Success) {
   auto v = reader->Read("");
   ASSERT_TRUE(v.has_value());
   EXPECT_THAT(v->result, IsProtoEqual(response));
-  v = reader->Read("test-token-0");
+  v = reader->Read("resume-after-2");
   ASSERT_FALSE(v.has_value());
   auto status = reader->Finish();
   EXPECT_STATUS_OK(status);

--- a/google/cloud/spanner/internal/partial_result_set_source.cc
+++ b/google/cloud/spanner/internal/partial_result_set_source.cc
@@ -14,185 +14,242 @@
 
 #include "google/cloud/spanner/internal/partial_result_set_source.h"
 #include "google/cloud/spanner/internal/merge_chunk.h"
+#include "google/cloud/spanner/options.h"
 #include "google/cloud/log.h"
+#include "absl/container/fixed_array.h"
 
 namespace google {
 namespace cloud {
 namespace spanner_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+namespace {
+
+using Values = google::protobuf::RepeatedPtrField<google::protobuf::Value>;
+
+// Efficiently move values from one repeated field to another. Starts at
+// index `start`, but always clears all of `src`. This is worth optimizing
+// because it is on the primary path for getting bulk data to the user.
+void ExtractSubrangeAndAppend(Values& src, int start, Values& dst) {
+  auto* const src_arena = src.GetArena();
+  auto* const dst_arena = dst.GetArena();
+  // Note: I've tested both branches of this conditional, but we probably
+  // need some mechanism to exercise both in ongoing automated tests.
+  if (dst_arena == src_arena || src_arena == nullptr) {
+    auto add_allocated = (dst_arena == src_arena)
+                             ? &Values::UnsafeArenaAddAllocated
+                             : &Values::AddAllocated;
+    auto const n_values = src.size() - start;
+    absl::FixedArray<google::protobuf::Value*> values(n_values);
+    src.UnsafeArenaExtractSubrange(start, n_values, values.data());
+    for (auto* value : values) {
+      (dst.*add_allocated)(value);
+    }
+  } else {
+    while (start != src.size()) {
+      dst.Add(std::move(*src.Mutable(start++)));
+    }
+  }
+  src.Clear();
+}
+
+}  // namespace
+
 StatusOr<std::unique_ptr<ResultSourceInterface>> PartialResultSetSource::Create(
     std::unique_ptr<PartialResultSetReader> reader) {
   std::unique_ptr<PartialResultSetSource> source(
       new PartialResultSetSource(std::move(reader)));
 
-  // Do the first read so the metadata is immediately available.
+  // Do an initial read from the stream to determine the fate of the factory.
   auto status = source->ReadFromStream();
-  if (!status.ok()) {
-    return status;
-  }
 
-  // The first response must contain metadata.
+  // If the initial read finished the stream, and `Finish()` failed, then
+  // creating the `PartialResultSetSource` should fail with the same error.
+  if (source->state_ == kFinished && !status.ok()) return status;
+
+  // Otherwise we require that the first response contains the metadata.
+  // Without it, creating the `PartialResultSetSource` should fail.
   if (!source->metadata_) {
-    return Status(StatusCode::kInternal, "response contained no metadata");
+    return Status(StatusCode::kInternal,
+                  "PartialResultSetSource response contained no metadata");
   }
 
   return {std::move(source)};
 }
 
-StatusOr<spanner::Row> PartialResultSetSource::NextRow() {
-  if (finished_) {
-    return spanner::Row();
+PartialResultSetSource::PartialResultSetSource(
+    std::unique_ptr<PartialResultSetReader> reader)
+    : options_(internal::CurrentOptions()), reader_(std::move(reader)) {
+  if (options_.has<spanner::StreamingResumabilityBufferSizeOption>()) {
+    values_space_limit_ =
+        options_.get<spanner::StreamingResumabilityBufferSizeOption>();
   }
-
-  // TODO(#8523): This assumes that we can yield a row as soon as we have
-  // all of its columns, which would not be the case if we (1) want to be
-  // able to resume interrupted streams, and (2) do not yet have a resume
-  // token that is "past" the row. That is, we should not yield a row that
-  // might be replayed. Given that we want to support resumption, for now
-  // we assume we always have a resume token that is "past" any completed
-  // row, but that needs to be verified.
-
-  while (buffer_.empty() || buffer_.size() < columns_->size()) {
-    auto status = ReadFromStream();
-    if (!status.ok()) {
-      return status;
-    }
-    if (finished_) {
-      if (chunk_) {
-        return Status(StatusCode::kInternal,
-                      "incomplete chunked_value at end of stream");
-      }
-      if (!buffer_.empty()) {
-        return Status(StatusCode::kInternal, "incomplete row at end of stream");
-      }
-      return spanner::Row();
-    }
-  }
-
-  auto const& fields = metadata_->row_type().fields();
-  if (fields.empty()) {
-    return Status(StatusCode::kInternal,
-                  "response metadata is missing row type information");
-  }
-
-  std::vector<spanner::Value> values;
-  values.reserve(fields.size());
-  auto iter = buffer_.begin();
-  for (auto const& field : fields) {
-    values.push_back(FromProto(field.type(), std::move(*iter)));
-    ++iter;
-  }
-  buffer_.erase(buffer_.begin(), iter);
-  return RowFriend::MakeRow(std::move(values), columns_);
 }
 
 PartialResultSetSource::~PartialResultSetSource() {
-  if (!finished_) {
-    // If there is actual data in the streaming RPC Finish() can deadlock, so
-    // before trying to read the final status we need to cancel the streaming
-    // RPC.
-    internal::OptionsSpan span(options_);
+  internal::OptionsSpan span(options_);
+  if (state_ == kReading) {
+    // Finish() can deadlock if there is still data in the streaming RPC,
+    // so before trying to read the final status we need to cancel.
     reader_->TryCancel();
-    // The user didn't iterate over all the data; finish the stream on their
-    // behalf, but we have no way to communicate error status.
-    auto finish_status = reader_->Finish();
-    if (!finish_status.ok() && finish_status.code() != StatusCode::kCancelled) {
-      GCP_LOG(WARNING) << "Finish() failed in destructor: " << finish_status;
+    state_ = kEndOfStream;
+  }
+  if (state_ == kEndOfStream) {
+    // The user didn't iterate over all the data, so finish the stream on
+    // their behalf, although we have no way to communicate error status.
+    auto status = reader_->Finish();
+    if (!status.ok() && status.code() != StatusCode::kCancelled) {
+      GCP_LOG(WARNING)
+          << "PartialResultSetSource: Finish() failed in destructor: "
+          << status;
     }
+    state_ = kFinished;
   }
 }
 
+StatusOr<spanner::Row> PartialResultSetSource::NextRow() {
+  while (rows_.empty()) {
+    if (state_ == kFinished) return spanner::Row();
+    internal::OptionsSpan span(options_);
+    auto status = ReadFromStream();
+    if (!status.ok()) return status;
+  }
+  auto row = std::move(rows_.front());
+  rows_.pop_front();
+  return row;
+}
+
 Status PartialResultSetSource::ReadFromStream() {
-  internal::OptionsSpan span(options_);
-  auto result_set = reader_->Read();
-  if (!result_set) {
-    // Read() returns false for end of stream, whether we read all the data or
-    // encountered an error. Finish() tells us the status.
-    finished_ = true;
-    return reader_->Finish();
+  absl::optional<PartialResultSet> result_set;
+  if (state_ == kFinished || !rows_.empty()) {
+    return Status(StatusCode::kInternal, "PartialResultSetSource state error");
+  }
+  if (state_ == kReading) {
+    result_set = reader_->Read(resume_token_);
+    if (!result_set) state_ = kEndOfStream;
+  }
+  if (state_ == kEndOfStream) {
+    // If we have no buffered data, we're done.
+    if (values_.empty()) {
+      state_ = kFinished;
+      return reader_->Finish();
+    }
+    // Otherwise, proceed with a `PartialResultSet` using a fake resume
+    // token to flush the buffer. The service does not appear to yield
+    // a resume token in its final response, despite it completing a row.
+    result_set = PartialResultSet{{}, false};
+    result_set->result.set_resume_token("<end-of-stream>");
   }
 
   if (result_set->result.has_metadata()) {
-    // If we got metadata more than once, log it, but use the first one.
+    // If we get metadata more than once, log it, but use the first one.
     if (metadata_) {
-      GCP_LOG(WARNING) << "Unexpectedly received two sets of metadata";
+      GCP_LOG(WARNING) << "PartialResultSetSource: Additional metadata";
     } else {
       metadata_ = std::move(*result_set->result.mutable_metadata());
-      // Copies the column names into a shared_ptr that will be shared with
+      // Copy the column names into a vector that will be shared with
       // every Row object returned from NextRow().
       columns_ = std::make_shared<std::vector<std::string>>();
+      columns_->reserve(metadata_->row_type().fields_size());
       for (auto const& field : metadata_->row_type().fields()) {
         columns_->push_back(field.name());
       }
     }
   }
-
   if (result_set->result.has_stats()) {
-    // If we got stats more than once, log it, but use the last one.
+    // If we get stats more than once, log it, but use the last one.
     if (stats_) {
-      GCP_LOG(WARNING) << "Unexpectedly received two sets of stats";
+      GCP_LOG(WARNING) << "PartialResultSetSource: Additional stats";
     }
     stats_ = std::move(*result_set->result.mutable_stats());
   }
 
   // If reader_->Read() resulted in a new PartialResultSetReader (i.e., it
-  // used the last resume_token to resume an interrupted stream), then we
-  // must clear the buffered partial-row data as it will be replayed.
+  // used the token to resume an interrupted stream), then we must discard
+  // any buffered data as it will be replayed.
   if (result_set->resumption) {
-    buffer_.clear();
-    chunk_ = {};
-  }
-
-  auto& new_values = *result_set->result.mutable_values();
-
-  // Merge values if necessary, as described in:
-  // https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.PartialResultSet
-  //
-  // As an example, if we receive the following 4 responses (assume the values
-  // are all `string_value`s of type `STRING`):
-  //
-  // ```
-  // { { values: ["A", "B", "C1"] }  chunked_value: true }
-  // { { values: ["C2", "D", "E1"] } chunked_value: true }
-  // { { values: ["E2"] },           chunked_value: true }
-  // { { values: ["E3", "F"] }       chunked_value: false }
-  // ```
-  //
-  // The final values yielded are: `A`, `B`, `C1C2`, `D`, `E1E2E3`, `F`.
-  //
-  // n.b. One value can span more than two responses (the `E1E2E3` case above);
-  // the code "just works" without needing to treat that as a special-case.
-  if (chunk_) {
-    if (new_values.empty()) {
+    if (!resume_token_) {
+      // The reader claims to have resumed the stream even though we said it
+      // should not. That leaves us in the untenable position of possibly
+      // having returned data that will be replayed, so fail the stream now.
       return Status(StatusCode::kInternal,
-                    "PartialResultSet contained no values "
-                    "to merge with prior chunked_value");
+                    "PartialResultSetSource reader resumed the stream"
+                    " despite our having asked it not to");
     }
-    auto& front = new_values[0];
-    auto merge_status = MergeChunk(*chunk_, std::move(front));
-    if (!merge_status.ok()) {
-      return merge_status;
-    }
-    using std::swap;
-    swap(*chunk_, front);
-    chunk_ = {};
+    values_back_incomplete_ = false;
+    values_.Clear();
   }
 
-  if (result_set->result.chunked_value()) {
-    if (new_values.empty()) {
-      return Status(StatusCode::kInternal,
-                    "PartialResultSet had chunked_value "
-                    "set true but contained no values");
+  // If the final value in the previous `PartialResultSet` was incomplete,
+  // it must be combined with the first value from the new set. And then
+  // we move everything remaining from the new set to the end of `values_`.
+  if (!result_set->result.values().empty()) {
+    auto& new_values = *result_set->result.mutable_values();
+    int append_start = 0;
+    if (values_back_incomplete_) {
+      auto& first = *new_values.Mutable(append_start++);
+      auto status = MergeChunk(*values_.rbegin(), std::move(first));
+      if (!status.ok()) return status;
     }
-    chunk_ = std::move(new_values[new_values.size() - 1]);
-    new_values.RemoveLast();
+    ExtractSubrangeAndAppend(new_values, append_start, values_);
+    values_back_incomplete_ = result_set->result.chunked_value();
   }
 
-  // Moves all the remaining in new_values to buffer_
-  for (auto& value_proto : new_values) {
-    buffer_.push_back(std::move(value_proto));
+  // Deliver whatever rows we can muster.
+  auto const n_values = values_.size() - (values_back_incomplete_ ? 1 : 0);
+  auto const n_columns = columns_ ? static_cast<int>(columns_->size()) : 0;
+  auto n_rows = n_columns ? n_values / n_columns : 0;
+  if (n_columns == 0 && !values_.empty()) {
+    return Status(StatusCode::kInternal,
+                  "PartialResultSetSource metadata is missing row type");
   }
+
+  // If we didn't receive a resume token, and have not exceeded our buffer
+  // limit, then we choose to `Read()` again so as to maintain resumability.
+  if (result_set->result.resume_token().empty()) {
+    if (values_.SpaceUsedExcludingSelfLong() < values_space_limit_) {
+      return {};  // OK
+    }
+  }
+
+  // If we did receive a resume token then everything should be deliverable,
+  // and we'll be able to resume the stream at this point after a breakage.
+  // Otherwise, if we deliver anything at all, we must disable resumability.
+  if (!result_set->result.resume_token().empty()) {
+    resume_token_ = result_set->result.resume_token();
+    if (n_rows * n_columns != values_.size()) {
+      if (state_ != kEndOfStream) {
+        return Status(StatusCode::kInternal,
+                      "PartialResultSetSource reader produced a resume token"
+                      " that is not on a row boundary");
+      }
+      if (n_rows == 0) {
+        return Status(StatusCode::kInternal,
+                      "PartialResultSetSource stream ended at a point"
+                      " that is not on a row boundary");
+      }
+    }
+  } else if (n_rows != 0) {
+    resume_token_ = absl::nullopt;
+  }
+
+  // Combine the available values into new elements of `rows_`.
+  int values_pos = 0;
+  std::vector<spanner::Value> values;
+  values.reserve(n_columns);
+  for (; n_rows != 0; --n_rows) {
+    for (auto const& field : metadata_->row_type().fields()) {
+      auto& value = *values_.Mutable(values_pos++);
+      values.push_back(FromProto(field.type(), std::move(value)));
+    }
+    rows_.push_back(RowFriend::MakeRow(std::move(values), columns_));
+    values.clear();
+  }
+
+  // If we didn't combine all the values, leave the remainder for next time.
+  auto* rem_values = result_set->result.mutable_values();
+  ExtractSubrangeAndAppend(values_, values_pos, *rem_values);
+  values_.Swap(rem_values);
 
   return {};  // OK
 }

--- a/google/cloud/spanner/options.h
+++ b/google/cloud/spanner/options.h
@@ -46,6 +46,8 @@
 #include "google/cloud/spanner/version.h"
 #include "google/cloud/options.h"
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <map>
 #include <memory>
 
@@ -202,6 +204,16 @@ struct ReadIndexNameOption {
  */
 struct ReadRowLimitOption {
   using Type = std::int64_t;
+};
+
+/**
+ * Option for `google::cloud::Options` to set a limit on how much data will
+ * be buffered to guarantee resumability of a streaming read or SQL query.
+ * If the limit is exceeded, and the stream is subsequently interrupted before
+ * a new resumption point can be established, the read/query will fail.
+ */
+struct StreamingResumabilityBufferSizeOption {
+  using Type = std::size_t;
 };
 
 /**

--- a/google/cloud/spanner/testing/mock_partial_result_set_reader.h
+++ b/google/cloud/spanner/testing/mock_partial_result_set_reader.h
@@ -28,8 +28,8 @@ class MockPartialResultSetReader
     : public spanner_internal::PartialResultSetReader {
  public:
   MOCK_METHOD(void, TryCancel, (), (override));
-  MOCK_METHOD(absl::optional<spanner_internal::PartialResultSet>, Read, (),
-              (override));
+  MOCK_METHOD(absl::optional<spanner_internal::PartialResultSet>, Read,
+              (absl::optional<std::string> const& resume_token), (override));
   MOCK_METHOD(Status, Finish, (), (override));
 };
 


### PR DESCRIPTION
The service only adds a `resume_token` when the `PartialResultSet` ends
with a completed row (except when the `PartialResultSet` also completes
the stream, in which case the `resume_token` remains empty). Therefore,
`resume_token` and `chunked_value` are mutually exclusive.

This means the library has to buffer rows completed within a non-token
`PartialResultSet` if it is to maintain resumability. This mainly affects
the algorithm and data used by `PartialResultSetSource::ReadFromStream()`.
For example, the storage of the token moves from `PartialResultSetResume`
to `PartialResultSetSource`, and the latter gains a `deque` of complete,
but undeliverable rows.

Introduce the `StreamingResumabilityBufferSizeOption` to control the size
of the buffer. If this size is exceeded, complete rows will be delivered
to the user, which makes the stream non-resumable until a new `resume_token`
is received.

Correct the `ConnectionImplTest.ReadSuccess` test case, which was checking
that we did the wrong thing. :-)

Add new `PartialResultSetResume` test cases for stream resumption.

Loop within the `PartialResultSetSourceTest.MultipleResponses` test to
validate that different buffering limits do not affect a complete stream.

Fixes #8523.

While we're here, canonicalize the shape of protobuf text in tests, which
includes giving resume tokens meaningful content, and also include some
additional expectations that `BeginTransaction()` is not called.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9359)
<!-- Reviewable:end -->
