### PR TITLE
impl(generator): process the `RoutingRule` proto

### DIFF
--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -552,7 +552,7 @@ absl::optional<ResourceRoutingInfo> ParseResourceRoutingHeader(
 ExplicitRoutingInfo ParseExplicitRoutingHeader(
     google::protobuf::MethodDescriptor const& method) {
   ExplicitRoutingInfo info;
-  if (!method.options().HasExtension(google::api::routing)) return {};
+  if (!method.options().HasExtension(google::api::routing)) return info;
   google::api::RoutingRule rule =
       method.options().GetExtension(google::api::routing);
 

--- a/generator/internal/descriptor_utils.h
+++ b/generator/internal/descriptor_utils.h
@@ -99,6 +99,64 @@ struct ResourceRoutingInfo {
 absl::optional<ResourceRoutingInfo> ParseResourceRoutingHeader(
     google::protobuf::MethodDescriptor const& method);
 
+/// Our representation for a `google.api.RoutingParameter` message.
+struct RoutingParameter {
+  /**
+   * A processed `field` string from a `RoutingParameter` proto.
+   *
+   * It has potentially been modified to avoid naming conflicts (e.g. a proto
+   * field named "namespace" will be stored here as "namespace_").
+   *
+   * We will generate code like: `"request." + field_name + "();"` in our
+   * metadata decorator to access the field's value.
+   */
+  std::string field_name;
+
+  /**
+   * A processed `path_template` string from a `RoutingParameter` proto.
+   *
+   * It is translated for use as a `std::regex`. We make the following
+   * substitutions, simultaneously:
+   *   - "**"    => ".*"
+   *   - "*"     => "[^/]+"
+   *   - "{foo=" => "("
+   *   - "}"     => ")"
+   *
+   * Note that we do not store the routing parameter key ("foo" in this example)
+   * in this struct. It is instead stored as a key in the `ExplicitRoutingInfo`
+   * map.
+   */
+  std::string pattern;
+};
+
+/**
+ * A data structure to represent the logic of a `google.api.RoutingRule`, in a
+ * form that facilitates code generation.
+ *
+ * The keys of the map are the extracted routing param keys. They map to an
+ * ordered list of matching rules. For this object, the first match will win.
+ */
+using ExplicitRoutingInfo =
+    std::unordered_map<std::string, std::vector<RoutingParameter>>;
+
+/**
+ * Parses the explicit resource routing info as defined in the
+ * google.api.routing annotation.
+ *
+ * This method processes the `google.api.RoutingRule` proto. It groups the
+ * `google.api.RoutingParameters` by the extracted routing parameter key.
+ *
+ * Each `google.api.RoutingParameter` message is translated into a form that is
+ * easier for our generator to work with (see `RoutingParameter` above).
+ *
+ * We reverse the order of the `RoutingParameter`s. The rule (as defined in
+ * go/actools-dynamic-routing-proposal) is that "last wins". We would like to
+ * order them such that "first wins", so we can stop iterating when we have
+ * found a match.
+ */
+ExplicitRoutingInfo ParseExplicitRoutingHeader(
+    google::protobuf::MethodDescriptor const& method);
+
 }  // namespace generator_internal
 }  // namespace cloud
 }  // namespace google

--- a/generator/internal/descriptor_utils_test.cc
+++ b/generator/internal/descriptor_utils_test.cc
@@ -36,10 +36,16 @@ using ::google::cloud::testing_util::StatusIs;
 using ::google::protobuf::DescriptorPool;
 using ::google::protobuf::FileDescriptor;
 using ::google::protobuf::FileDescriptorProto;
+using ::testing::AllOf;
+using ::testing::ElementsAre;
 using ::testing::Eq;
+using ::testing::Field;
 using ::testing::HasSubstr;
+using ::testing::Matcher;
 using ::testing::Not;
+using ::testing::Pair;
 using ::testing::Return;
+using ::testing::UnorderedElementsAre;
 
 class StringSourceTree : public google::protobuf::compiler::SourceTree {
  public:
@@ -904,6 +910,248 @@ TEST_F(PrintMethodTest, ExactlyOnePattern) {
   auto result = PrintMethod(*service_file_descriptor->service(0)->method(0),
                             printer, {}, patterns, "some_file", 42);
   EXPECT_THAT(result, IsOk());
+}
+
+// We factor out the protobuf mumbo jumbo to keep the tests concise and
+// self-contained. The protobuf objects must be in scope for the duration of a
+// test. To achieve this, we pass in a `test` lambda which is invoked in this
+// method.
+void RunRoutingTest(std::string const& service_proto,
+                    std::function<void(FileDescriptor const*)> const& test) {
+  auto constexpr kServiceBoilerPlate = R"""(
+syntax = "proto3";
+package google.protobuf;
+import "google/api/routing.proto";
+)""";
+
+  auto constexpr kRoutingProto = R"""(
+syntax = "proto3";
+package google.api;
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MethodOptions {
+  google.api.RoutingRule routing = 72295729;
+}
+message RoutingRule {
+  repeated RoutingParameter routing_parameters = 2;
+}
+message RoutingParameter {
+  string field = 1;
+  string path_template = 2;
+}
+)""";
+
+  StringSourceTree source_tree(std::map<std::string, std::string>{
+      {"google/api/routing.proto", kRoutingProto},
+      {"google/cloud/foo/service.proto", kServiceBoilerPlate + service_proto}});
+  google::protobuf::compiler::SourceTreeDescriptorDatabase source_tree_db(
+      &source_tree);
+  google::protobuf::SimpleDescriptorDatabase simple_db;
+  FileDescriptorProto file_proto;
+  // we need descriptor.proto to be accessible by the pool
+  // since our test file imports it
+  FileDescriptorProto::descriptor()->file()->CopyTo(&file_proto);
+  simple_db.Add(file_proto);
+  google::protobuf::MergedDescriptorDatabase merged_db(&simple_db,
+                                                       &source_tree_db);
+  AbortingErrorCollector collector;
+  DescriptorPool pool(&merged_db, &collector);
+
+  // Run the test
+  test(pool.FindFileByName("google/cloud/foo/service.proto"));
+}
+
+Matcher<RoutingParameter const&> RP(std::string const& field_name,
+                                    std::string const& pattern) {
+  return AllOf(Field(&RoutingParameter::field_name, field_name),
+               Field(&RoutingParameter::pattern, pattern));
+}
+
+TEST(ParseExplicitRoutingHeaderTest, NoRouting) {
+  auto constexpr kProto = R"""(
+message Foo {
+  string foo = 1;
+  string bar = 2;
+}
+
+service Service0 {
+  rpc Method0(Foo) returns (Foo) {}
+}
+)""";
+
+  RunRoutingTest(kProto, [](FileDescriptor const* fd) {
+    auto const& method = *fd->service(0)->method(0);
+    auto info = ParseExplicitRoutingHeader(method);
+    EXPECT_THAT(info, UnorderedElementsAre());
+  });
+}
+
+TEST(ParseExplicitRoutingHeaderTest, Regex) {
+  auto constexpr kProto = R"""(
+message Foo {
+  string foo = 1;
+  string bar = 2;
+}
+
+service Service0 {
+  rpc Method0(Foo) returns (Foo) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "foo"
+        path_template: "projects/*/{routing_key=instances/*}/**"
+      }
+    };
+  }
+}
+)""";
+
+  RunRoutingTest(kProto, [](FileDescriptor const* fd) {
+    auto const& method = *fd->service(0)->method(0);
+    auto info = ParseExplicitRoutingHeader(method);
+    EXPECT_THAT(
+        info,
+        UnorderedElementsAre(Pair(
+            "routing_key",
+            ElementsAre(RP("foo", "projects/[^/]+/(instances/[^/]+)/.*")))));
+  });
+}
+
+TEST(ParseExplicitRoutingHeaderTest, NoPathTemplate) {
+  auto constexpr kProto = R"""(
+message Foo {
+  string foo = 1;
+  string bar = 2;
+}
+
+service Service0 {
+  rpc Method0(Foo) returns (Foo) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "foo"
+      }
+    };
+  }
+}
+)""";
+
+  RunRoutingTest(kProto, [](FileDescriptor const* fd) {
+    auto const& method = *fd->service(0)->method(0);
+    auto info = ParseExplicitRoutingHeader(method);
+    // When the path template is not present, we should use the field name as
+    // the routing parameter key, and our regex should have one capture group
+    // that matches all.
+    EXPECT_THAT(info, UnorderedElementsAre(
+                          Pair("foo", ElementsAre(RP("foo", "(.*)")))));
+  });
+}
+
+TEST(ParseExplicitRoutingHeaderTest, OrderReversed) {
+  auto constexpr kProto = R"""(
+message Foo {
+  string foo = 1;
+  string bar = 2;
+}
+
+service Service0 {
+  rpc Method0(Foo) returns (Foo) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "foo"
+        path_template: "{routing_key=foo-path-1}"
+      }
+      routing_parameters {
+        field: "bar"
+        path_template: "{routing_key=bar-path-2}"
+      }
+      routing_parameters {
+        field: "foo"
+        path_template: "{routing_key=foo-path-3}"
+      }
+    };
+  }
+}
+)""";
+
+  RunRoutingTest(kProto, [](FileDescriptor const* fd) {
+    auto const& method = *fd->service(0)->method(0);
+    auto info = ParseExplicitRoutingHeader(method);
+    EXPECT_THAT(
+        info, UnorderedElementsAre(
+                  Pair("routing_key", ElementsAre(RP("foo", "(foo-path-3)"),
+                                                  RP("bar", "(bar-path-2)"),
+                                                  RP("foo", "(foo-path-1)")))));
+  });
+}
+
+TEST(ParseExplicitRoutingHeaderTest, GroupsByRoutingKey) {
+  auto constexpr kProto = R"""(
+message Foo {
+  string foo = 1;
+  string bar = 2;
+}
+
+service Service0 {
+  rpc Method0(Foo) returns (Foo) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "foo"
+        path_template: "{routing_key1=foo-path-1}"
+      }
+      routing_parameters {
+        field: "foo"
+        path_template: "{routing_key2=foo-path-2}"
+      }
+      routing_parameters {
+        field: "bar"
+        path_template: "{routing_key1=bar-path-3}"
+      }
+      routing_parameters {
+        field: "bar"
+        path_template: "{routing_key2=bar-path-4}"
+      }
+    };
+  }
+}
+)""";
+
+  RunRoutingTest(kProto, [](FileDescriptor const* fd) {
+    auto const& method = *fd->service(0)->method(0);
+    auto info = ParseExplicitRoutingHeader(method);
+    EXPECT_THAT(
+        info,
+        UnorderedElementsAre(
+            Pair("routing_key1", ElementsAre(RP("bar", "(bar-path-3)"),
+                                             RP("foo", "(foo-path-1)"))),
+            Pair("routing_key2", ElementsAre(RP("bar", "(bar-path-4)"),
+                                             RP("foo", "(foo-path-2)")))));
+  });
+}
+
+TEST(ParseExplicitRoutingHeaderTest, HandlesFieldNameConflict) {
+  auto constexpr kProto = R"""(
+message Foo {
+  string namespace = 1;
+}
+
+service Service0 {
+  rpc Method0(Foo) returns (Foo) {
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "namespace"
+      }
+    };
+  }
+}
+)""";
+
+  RunRoutingTest(kProto, [](FileDescriptor const* fd) {
+    auto const& method = *fd->service(0)->method(0);
+    auto info = ParseExplicitRoutingHeader(method);
+    // Note that while the field name has been modified so that it does not
+    // conflict with the C++ keyword, the routing key must not change.
+    EXPECT_THAT(info, UnorderedElementsAre(Pair(
+                          "namespace", ElementsAre(RP("namespace_", "(.*)")))));
+  });
 }
 
 }  // namespace


### PR DESCRIPTION
Part of the work for #9121 

Our metadata generator will interact with the `ExplicitRoutingInfo` data struct in order to generate the code. We use this intermediate object instead of generating code directly from the `google.api.RoutingRule` because the translation is complex enough to warrant unit testing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9360)
<!-- Reviewable:end -->
