### PR TITLE
test(storage): control benchmark pacing

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -384,6 +384,11 @@ void RunThread(ThroughputOptions const& options, std::string const& bucket_name,
     }
     auto client = provider(ExperimentTransport::kJson);
     (void)client.DeleteObject(bucket_name, object_name);
+    // If needed, pace the benchmark so each thread generates only so many
+    // samples each second.
+    auto const pace = start + options.minimum_sample_delay;
+    auto const now = std::chrono::steady_clock::now();
+    if (pace > now) std::this_thread::sleep_for(pace - now);
   }
 }
 

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -186,9 +186,10 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options](std::string const& val) {
          absl::Duration d;
          if (absl::ParseDuration(val, &d)) {
+           options.minimum_sample_delay = absl::ToChronoMilliseconds(d);
+         } else {
            options.minimum_sample_delay = std::chrono::milliseconds(-1);
          }
-         options.minimum_sample_delay = absl::ToChronoMilliseconds(d);
        }},
   };
   auto usage = BuildUsage(desc, argv[0]);
@@ -322,7 +323,7 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
     return make_status(os);
   }
 
-  if (options.minimum_sample_delay < std::chrono::milliseconds(-1)) {
+  if (options.minimum_sample_delay < std::chrono::milliseconds(0)) {
     std::ostringstream os;
     os << "Invalid value for --minimum-sample-delay";
     return make_status(os);

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/benchmarks/throughput_options.h"
 #include "absl/strings/str_split.h"
+#include "absl/time/time.h"
 #include <sstream>
 
 namespace google {
@@ -177,6 +178,18 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options](std::string const& val) {
          options.download_stall_timeout = ParseDuration(val);
        }},
+      {"--minimum-sample-delay",
+       "configure the minimum time between samples."
+       " Sometimes we only want to collect a few samples per second."
+       " This can make the data resulting from a multi-day run more"
+       " manageable.",
+       [&options](std::string const& val) {
+         absl::Duration d;
+         if (absl::ParseDuration(val, &d)) {
+           options.minimum_sample_delay = std::chrono::milliseconds(-1);
+         }
+         options.minimum_sample_delay = absl::ToChronoMilliseconds(d);
+       }},
   };
   auto usage = BuildUsage(desc, argv[0]);
 
@@ -306,6 +319,12 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
   if (options.enabled_md5.empty()) {
     std::ostringstream os;
     os << "No MD5 settings configured for benchmark.";
+    return make_status(os);
+  }
+
+  if (options.minimum_sample_delay < std::chrono::milliseconds(-1)) {
+    std::ostringstream os;
+    os << "Invalid value for --minimum-sample-delay";
     return make_status(os);
   }
 

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -58,6 +58,7 @@ struct ThroughputOptions {
   std::string direct_path_endpoint = "google-c2p:///storage.googleapis.com";
   std::chrono::seconds transfer_stall_timeout{};
   std::chrono::seconds download_stall_timeout{};
+  std::chrono::milliseconds minimum_sample_delay{};
 };
 
 google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -220,6 +220,11 @@ TEST(ThroughputOptions, Validate) {
       "--region=r",
       "--minimum-sample-delay=-2ms",
   }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-sample-delay=-1ms",
+  }));
 }
 
 }  // namespace

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -55,6 +55,7 @@ TEST(ThroughputOptions, Basic) {
       "--direct-path-endpoint=test-only-direct-path",
       "--transfer-stall-timeout=86400s",
       "--download-stall-timeout=86401s",
+      "--minimum-sample-delay=250ms",
   });
   ASSERT_STATUS_OK(options);
   EXPECT_EQ("test-project", options->project_id);
@@ -87,6 +88,7 @@ TEST(ThroughputOptions, Basic) {
   EXPECT_EQ("test-only-direct-path", options->direct_path_endpoint);
   EXPECT_EQ(std::chrono::seconds(86400), options->transfer_stall_timeout);
   EXPECT_EQ(std::chrono::seconds(86401), options->download_stall_timeout);
+  EXPECT_EQ(std::chrono::milliseconds(250), options->minimum_sample_delay);
 }
 
 TEST(ThroughputOptions, Description) {
@@ -212,6 +214,11 @@ TEST(ThroughputOptions, Validate) {
       "self-test",
       "--region=r",
       "--thread-count=-2",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-sample-delay=-2ms",
   }));
 }
 


### PR DESCRIPTION
Sometimes we only want to get a few samples per second or per minute.
For example, if we are running the benchmark for multiple days getting
hundreds of samples per second can be overwhelming. With this change the
user can control the maximum sampling rate.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9364)
<!-- Reviewable:end -->
