### PR TITLE
chore(renovate): configure protobuf versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -32,6 +32,12 @@
       "versioningTemplate": "loose"
     }
   ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["com_google_protobuf"],
+      "versioning": "loose"
+    }
+  ],
   "ignoreDeps": [
     "boringssl",
     "com_google_googleapis"


### PR DESCRIPTION
Protobuf no longer uses something that Renovate can handle by default.

As usual, one cannot test these changes so we will have to see if they work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9365)
<!-- Reviewable:end -->
