### PR TITLE
deflake(pubsub): make time-triggered `Write()` events less likely

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -877,7 +877,11 @@ TEST(StreamingSubscriptionBatchSourceTest, ExactlyOnceIncludesDeadline) {
   }
 
   auto shutdown = std::make_shared<SessionShutdownManager>();
-  auto uut = MakeTestBatchSource(background.cq(), shutdown, mock);
+  auto uut = MakeTestBatchSource(
+      background.cq(), shutdown, mock,
+      // Make the hold time long enough such that we can ignore the chances of a
+      // timer triggering in the test.
+      std::chrono::milliseconds(500));
 
   auto done = shutdown->Start({});
   uut->Start([](StatusOr<google::pubsub::v1::StreamingPullResponse> const&) {});


### PR DESCRIPTION
The unit test depends on not having time-triggered `Write()` calls. I
cannot figure out a way to disable them, but increasing the timeout
makes them less likely.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9366)
<!-- Reviewable:end -->
