### PR TITLE
feat(generator): support explicit routing headers

### DIFF
--- a/generator/integration_tests/BUILD.bazel
+++ b/generator/integration_tests/BUILD.bazel
@@ -30,6 +30,7 @@ proto_library(
         "@com_google_googleapis//google/api:client_proto",
         "@com_google_googleapis//google/api:field_behavior_proto",
         "@com_google_googleapis//google/api:resource_proto",
+        "@com_google_googleapis//google/api:routing_proto",
         "@com_google_googleapis//google/iam/v1:iam_policy_proto",
         "@com_google_googleapis//google/iam/v1:policy_proto",
         "@com_google_googleapis//google/longrunning:operations_proto",

--- a/generator/integration_tests/CMakeLists.txt
+++ b/generator/integration_tests/CMakeLists.txt
@@ -39,6 +39,7 @@ target_link_libraries(
            google-cloud-cpp::api_client_protos
            google-cloud-cpp::api_field_behavior_protos
            google-cloud-cpp::api_resource_protos
+           google-cloud-cpp::api_routing_protos
            google-cloud-cpp::iam_v1_iam_policy_protos
            google-cloud-cpp::iam_v1_policy_protos
            google-cloud-cpp::longrunning_operations_protos

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -142,6 +142,18 @@ GoldenKitchenSinkClient::AsyncAppendRows(ExperimentalTag tag, Options opts) {
   return connection_->AsyncAppendRows(std::move(tag));
 }
 
+Status
+GoldenKitchenSinkClient::ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  return connection_->ExplicitRouting1(request);
+}
+
+Status
+GoldenKitchenSinkClient::ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts) {
+  internal::OptionsSpan span(internal::MergeOptions(std::move(opts), options_));
+  return connection_->ExplicitRouting2(request);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden
 }  // namespace cloud

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -110,10 +110,10 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L975}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L992}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L935}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L975}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L952}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L992}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
@@ -121,13 +121,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L935}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L952}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L975}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L992}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L935}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L975}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L952}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L992}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
@@ -154,10 +154,10 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1017}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1034}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1017}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1001}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1034}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
@@ -165,13 +165,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L984}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L1001}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1017}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1034}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1017}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1001}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1034}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
@@ -204,10 +204,10 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1056}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1073}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1023}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1056}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1040}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1073}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
@@ -221,13 +221,13 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1023}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1040}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1056}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1073}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1023}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1056}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1040}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1073}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1059}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1076}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options opts = {});
@@ -254,12 +254,12 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1059}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1076}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1059}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1076}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
@@ -280,10 +280,10 @@ class GoldenKitchenSinkClient {
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1317}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1334}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1285}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1317}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1302}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1334}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names, Options opts = {});
@@ -292,13 +292,13 @@ class GoldenKitchenSinkClient {
   /// Streaming read of log entries as they are ingested. Until the stream is
   /// terminated, it will continue reading logs.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1285}
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1302}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1317}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1334}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1285}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1317}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1302}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1334}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options opts = {});
@@ -316,10 +316,10 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1389}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1406}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1357}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1389}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1374}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1406}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
@@ -327,13 +327,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1357}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1374}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1389}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1406}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1357}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1389}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1374}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1406}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
@@ -384,11 +384,11 @@ class GoldenKitchenSinkClient {
   ///    x-goog-request-params:
   ///    table_location=instances/instance_bar&routing_id=prof_qux
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1396}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1413}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1396}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1413}
   ///
   Status
   ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
@@ -397,11 +397,11 @@ class GoldenKitchenSinkClient {
   /// We use this RPC to verify the special case where a routing parameter key
   /// does not require a regex in order to match the correct value.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1396}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1413}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1396}
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1413}
   ///
   Status
   ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/golden_kitchen_sink_client.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.h
@@ -110,10 +110,10 @@ class GoldenKitchenSinkClient {
   ///  hour.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L905}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L975}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L865}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L905}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L935}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L975}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(std::string const& name, std::vector<std::string> const& delegates, std::vector<std::string> const& scope, google::protobuf::Duration const& lifetime, Options opts = {});
@@ -121,13 +121,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OAuth 2.0 access token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L865}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenRequest,generator/integration_tests/test.proto#L935}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L905}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateAccessTokenResponse,generator/integration_tests/test.proto#L975}
   ///
-  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L865}
-  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L905}
+  /// [google.test.admin.database.v1.GenerateAccessTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L935}
+  /// [google.test.admin.database.v1.GenerateAccessTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L975}
   ///
   StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
   GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request, Options opts = {});
@@ -154,10 +154,10 @@ class GoldenKitchenSinkClient {
   ///  token will contain `email` and `email_verified` claims.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L947}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1017}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1017}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(std::string const& name, std::vector<std::string> const& delegates, std::string const& audience, bool include_email, Options opts = {});
@@ -165,13 +165,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Generates an OpenID Connect ID token for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L914}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GenerateIdTokenRequest,generator/integration_tests/test.proto#L984}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L947}
+  /// @return @googleapis_link{google::test::admin::database::v1::GenerateIdTokenResponse,generator/integration_tests/test.proto#L1017}
   ///
-  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L914}
-  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L947}
+  /// [google.test.admin.database.v1.GenerateIdTokenRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L984}
+  /// [google.test.admin.database.v1.GenerateIdTokenResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1017}
   ///
   StatusOr<google::test::admin::database::v1::GenerateIdTokenResponse>
   GenerateIdToken(google::test::admin::database::v1::GenerateIdTokenRequest const& request, Options opts = {});
@@ -204,10 +204,10 @@ class GoldenKitchenSinkClient {
   ///  See [LogEntry][google.logging.v2.LogEntry]. Test delimiter$
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L986}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1056}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L986}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1023}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1056}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(std::string const& log_name, std::map<std::string, std::string> const& labels, Options opts = {});
@@ -221,13 +221,13 @@ class GoldenKitchenSinkClient {
   /// different resources (projects, organizations, billing accounts or
   /// folders)
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L953}
+  /// @param request @googleapis_link{google::test::admin::database::v1::WriteLogEntriesRequest,generator/integration_tests/test.proto#L1023}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L986}
+  /// @return @googleapis_link{google::test::admin::database::v1::WriteLogEntriesResponse,generator/integration_tests/test.proto#L1056}
   ///
-  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L953}
-  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L986}
+  /// [google.test.admin.database.v1.WriteLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1023}
+  /// [google.test.admin.database.v1.WriteLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1056}
   ///
   StatusOr<google::test::admin::database::v1::WriteLogEntriesResponse>
   WriteLogEntries(google::test::admin::database::v1::WriteLogEntriesRequest const& request, Options opts = {});
@@ -245,7 +245,7 @@ class GoldenKitchenSinkClient {
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L989}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1059}
   ///
   StreamRange<std::string>
   ListLogs(std::string const& parent, Options opts = {});
@@ -254,12 +254,12 @@ class GoldenKitchenSinkClient {
   /// Lists the logs in projects, organizations, folders, or billing accounts.
   /// Only logs that have entries are listed.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L989}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListLogsRequest,generator/integration_tests/test.proto#L1059}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return std::string
   ///
-  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L989}
+  /// [google.test.admin.database.v1.ListLogsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1059}
   ///
   StreamRange<std::string>
   ListLogs(google::test::admin::database::v1::ListLogsRequest request, Options opts = {});
@@ -280,10 +280,10 @@ class GoldenKitchenSinkClient {
   ///      "folders/[FOLDER_ID]/locations/[LOCATION_ID]/buckets/[BUCKET_ID]/views/[VIEW_ID]"
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1247}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1317}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1215}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1247}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1285}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1317}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(std::vector<std::string> const& resource_names, Options opts = {});
@@ -292,13 +292,13 @@ class GoldenKitchenSinkClient {
   /// Streaming read of log entries as they are ingested. Until the stream is
   /// terminated, it will continue reading logs.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1215}
+  /// @param request @googleapis_link{google::test::admin::database::v1::TailLogEntriesRequest,generator/integration_tests/test.proto#L1285}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1247}
+  /// @return @googleapis_link{google::test::admin::database::v1::TailLogEntriesResponse,generator/integration_tests/test.proto#L1317}
   ///
-  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1215}
-  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1247}
+  /// [google.test.admin.database.v1.TailLogEntriesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1285}
+  /// [google.test.admin.database.v1.TailLogEntriesResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1317}
   ///
   StreamRange<google::test::admin::database::v1::TailLogEntriesResponse>
   TailLogEntries(google::test::admin::database::v1::TailLogEntriesRequest const& request, Options opts = {});
@@ -316,10 +316,10 @@ class GoldenKitchenSinkClient {
   ///  is provided, all keys are returned.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1319}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1389}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1287}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1319}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1357}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1389}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(std::string const& name, std::vector<google::test::admin::database::v1::ListServiceAccountKeysRequest::KeyType> const& key_types, Options opts = {});
@@ -327,13 +327,13 @@ class GoldenKitchenSinkClient {
   ///
   /// Lists every [ServiceAccountKey][google.iam.admin.v1.ServiceAccountKey] for a service account.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1287}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysRequest,generator/integration_tests/test.proto#L1357}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1319}
+  /// @return @googleapis_link{google::test::admin::database::v1::ListServiceAccountKeysResponse,generator/integration_tests/test.proto#L1389}
   ///
-  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1287}
-  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1319}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1357}
+  /// [google.test.admin.database.v1.ListServiceAccountKeysResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L1389}
   ///
   StatusOr<google::test::admin::database::v1::ListServiceAccountKeysResponse>
   ListServiceAccountKeys(google::test::admin::database::v1::ListServiceAccountKeysRequest const& request, Options opts = {});
@@ -365,6 +365,46 @@ class GoldenKitchenSinkClient {
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
   AsyncAppendRows(ExperimentalTag, Options opts = {});
+
+  ///
+  /// An RPC to test that explicit routing headers are supported.
+  ///
+  /// We copy the most testing example given in the `google.api.routing` proto:
+  /// https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L353-L385
+  ///
+  /// Our integration test should verify that, given the message:
+  ///
+  ///    {
+  ///      table_name: projects/proj_foo/instances/instance_bar/table/table_baz
+  ///      app_profile_id: profiles/prof_qux
+  ///    }
+  ///
+  /// ... our metadata decorator sets:
+  ///
+  ///    x-goog-request-params:
+  ///    table_location=instances/instance_bar&routing_id=prof_qux
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1396}
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  ///
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1396}
+  ///
+  Status
+  ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
+
+  ///
+  /// We use this RPC to verify the special case where a routing parameter key
+  /// does not require a regex in order to match the correct value.
+  ///
+  /// @param request @googleapis_link{google::test::admin::database::v1::ExplicitRoutingRequest,generator/integration_tests/test.proto#L1396}
+  /// @param opts Optional. Override the class-level options, such as retry and
+  ///     backoff policies.
+  ///
+  /// [google.test.admin.database.v1.ExplicitRoutingRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L1396}
+  ///
+  Status
+  ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request, Options opts = {});
 
  private:
   std::shared_ptr<GoldenKitchenSinkConnection> connection_;

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -91,6 +91,18 @@ GoldenKitchenSinkConnection::AsyncAppendRows(ExperimentalTag) {
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
+Status
+GoldenKitchenSinkConnection::ExplicitRouting1(
+    google::test::admin::database::v1::ExplicitRoutingRequest const&) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
+Status
+GoldenKitchenSinkConnection::ExplicitRouting2(
+    google::test::admin::database::v1::ExplicitRoutingRequest const&) {
+  return Status(StatusCode::kUnimplemented, "not implemented");
+}
+
 std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -89,6 +89,12 @@ class GoldenKitchenSinkConnection {
       google::test::admin::database::v1::AppendRowsRequest,
       google::test::admin::database::v1::AppendRowsResponse>>
   AsyncAppendRows(ExperimentalTag);
+
+  virtual Status
+  ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request);
+
+  virtual Status
+  ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request);
 };
 
 /**

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.cc
@@ -68,6 +68,16 @@ class DefaultGoldenKitchenSinkConnectionIdempotencyPolicy : public GoldenKitchen
   DoNothing(google::protobuf::Empty const&) override {
     return Idempotency::kIdempotent;
   }
+
+  Idempotency
+  ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const&) override {
+    return Idempotency::kNonIdempotent;
+  }
+
+  Idempotency
+  ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const&) override {
+    return Idempotency::kNonIdempotent;
+  }
 };
 }  // namespace
 

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection_idempotency_policy.h
@@ -54,6 +54,12 @@ class GoldenKitchenSinkConnectionIdempotencyPolicy {
 
   virtual google::cloud::Idempotency
   DoNothing(google::protobuf::Empty const& request) = 0;
+
+  virtual google::cloud::Idempotency
+  ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request) = 0;
+
+  virtual google::cloud::Idempotency
+  ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request) = 0;
 };
 
 std::unique_ptr<GoldenKitchenSinkConnectionIdempotencyPolicy>

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -95,10 +95,10 @@ class GoldenThingAdminClient {
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L386}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L400}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent, Options opts = {});
@@ -106,13 +106,13 @@ class GoldenThingAdminClient {
   ///
   /// Lists Cloud Test databases.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L386}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L400}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L386}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L400}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options opts = {});
@@ -136,10 +136,10 @@ class GoldenThingAdminClient {
   ///  database ID must be enclosed in backticks (`` ` ``).
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L418}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L432}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement, Options opts = {});
@@ -154,13 +154,13 @@ class GoldenThingAdminClient {
   /// [response][google.longrunning.Operation.response] field type is
   /// [Database][google.test.admin.database.v1.Database], if successful.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L418}
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L432}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L418}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L432}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options opts = {});
@@ -172,10 +172,10 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L466}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name, Options opts = {});
@@ -183,13 +183,13 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L452}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L466}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L466}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts = {});
@@ -207,10 +207,10 @@ class GoldenThingAdminClient {
   /// @param statements  Required. DDL statements to be applied to the database.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L515}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L529}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L479}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L515}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L493}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L529}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options opts = {});
@@ -224,13 +224,13 @@ class GoldenThingAdminClient {
   /// [metadata][google.longrunning.Operation.metadata] field type is
   /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L479}
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L493}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L515}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L529}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L479}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L515}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L493}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L529}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options opts = {});
@@ -244,7 +244,7 @@ class GoldenThingAdminClient {
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L546}
   ///
   Status
   DropDatabase(std::string const& database, Options opts = {});
@@ -254,11 +254,11 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L532}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L546}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L546}
   ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts = {});
@@ -271,10 +271,10 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database whose schema we wish to get.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L554}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L568}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L543}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L554}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L557}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L568}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database, Options opts = {});
@@ -284,13 +284,13 @@ class GoldenThingAdminClient {
   /// DDL statements. This method does not show pending schema updates, those may
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L543}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L557}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L554}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L568}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L543}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L554}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L557}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L568}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options opts = {});
@@ -673,10 +673,10 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L643}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L657}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options opts = {});
@@ -700,13 +700,13 @@ class GoldenThingAdminClient {
   /// initiated, without waiting for the optimize operation associated with the
   /// first restore to complete.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L643}
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L657}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L643}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L657}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts = {});
@@ -727,7 +727,7 @@ class GoldenThingAdminClient {
   ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L562}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L576}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -743,12 +743,12 @@ class GoldenThingAdminClient {
   /// include those that have completed/failed/canceled within the last 7 days,
   /// and pending operations.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L562}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L576}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L562}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L576}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -804,13 +804,13 @@ class GoldenThingAdminClient {
   ///
   /// Tests longrunning operations without routing headers
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L643}
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L657}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L643}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L657}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts = {});
@@ -822,10 +822,10 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L466}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name, Options opts = {});
@@ -833,13 +833,13 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L452}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L466}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L352}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L466}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L352}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts = {});
@@ -853,7 +853,7 @@ class GoldenThingAdminClient {
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L546}
   ///
   future<Status>
   AsyncDropDatabase(std::string const& database, Options opts = {});
@@ -863,11 +863,11 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L532}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L546}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L546}
   ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/golden_thing_admin_client.h
+++ b/generator/integration_tests/golden/golden_thing_admin_client.h
@@ -95,10 +95,10 @@ class GoldenThingAdminClient {
   ///  Values are of the form `projects/<project>/instances/<instance>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L386}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(std::string const& parent, Options opts = {});
@@ -106,13 +106,13 @@ class GoldenThingAdminClient {
   ///
   /// Lists Cloud Test databases.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L385}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabasesRequest,generator/integration_tests/test.proto#L386}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L385}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.ListDatabasesRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L386}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   StreamRange<google::test::admin::database::v1::Database>
   ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request, Options opts = {});
@@ -136,10 +136,10 @@ class GoldenThingAdminClient {
   ///  database ID must be enclosed in backticks (`` ` ``).
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L418}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(std::string const& parent, std::string const& create_statement, Options opts = {});
@@ -154,13 +154,13 @@ class GoldenThingAdminClient {
   /// [response][google.longrunning.Operation.response] field type is
   /// [Database][google.test.admin.database.v1.Database], if successful.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L417}
+  /// @param request @googleapis_link{google::test::admin::database::v1::CreateDatabaseRequest,generator/integration_tests/test.proto#L418}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L417}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.CreateDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L418}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   CreateDatabase(google::test::admin::database::v1::CreateDatabaseRequest const& request, Options opts = {});
@@ -172,10 +172,10 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(std::string const& name, Options opts = {});
@@ -183,13 +183,13 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L452}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   StatusOr<google::test::admin::database::v1::Database>
   GetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts = {});
@@ -207,10 +207,10 @@ class GoldenThingAdminClient {
   /// @param statements  Required. DDL statements to be applied to the database.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L515}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L479}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L515}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(std::string const& database, std::vector<std::string> const& statements, Options opts = {});
@@ -224,13 +224,13 @@ class GoldenThingAdminClient {
   /// [metadata][google.longrunning.Operation.metadata] field type is
   /// [UpdateDatabaseDdlMetadata][google.test.admin.database.v1.UpdateDatabaseDdlMetadata].  The operation has no response.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L478}
+  /// @param request @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlRequest,generator/integration_tests/test.proto#L479}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L514}
+  /// @return @googleapis_link{google::test::admin::database::v1::UpdateDatabaseDdlMetadata,generator/integration_tests/test.proto#L515}
   ///
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L478}
-  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L514}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L479}
+  /// [google.test.admin.database.v1.UpdateDatabaseDdlMetadata]: @googleapis_reference_link{generator/integration_tests/test.proto#L515}
   ///
   future<StatusOr<google::test::admin::database::v1::UpdateDatabaseDdlMetadata>>
   UpdateDatabaseDdl(google::test::admin::database::v1::UpdateDatabaseDdlRequest const& request, Options opts = {});
@@ -244,7 +244,7 @@ class GoldenThingAdminClient {
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
   ///
   Status
   DropDatabase(std::string const& database, Options opts = {});
@@ -254,11 +254,11 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L532}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
   ///
   Status
   DropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts = {});
@@ -271,10 +271,10 @@ class GoldenThingAdminClient {
   /// @param database  Required. The database whose schema we wish to get.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L554}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L543}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L554}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(std::string const& database, Options opts = {});
@@ -284,13 +284,13 @@ class GoldenThingAdminClient {
   /// DDL statements. This method does not show pending schema updates, those may
   /// be queried using the [Operations][google.longrunning.Operations] API.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L542}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlRequest,generator/integration_tests/test.proto#L543}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L553}
+  /// @return @googleapis_link{google::test::admin::database::v1::GetDatabaseDdlResponse,generator/integration_tests/test.proto#L554}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L542}
-  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L553}
+  /// [google.test.admin.database.v1.GetDatabaseDdlRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L543}
+  /// [google.test.admin.database.v1.GetDatabaseDdlResponse]: @googleapis_reference_link{generator/integration_tests/test.proto#L554}
   ///
   StatusOr<google::test::admin::database::v1::GetDatabaseDdlResponse>
   GetDatabaseDdl(google::test::admin::database::v1::GetDatabaseDdlRequest const& request, Options opts = {});
@@ -673,10 +673,10 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/backups/<backup>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L643}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(std::string const& parent, std::string const& database_id, std::string const& backup, Options opts = {});
@@ -700,13 +700,13 @@ class GoldenThingAdminClient {
   /// initiated, without waiting for the optimize operation associated with the
   /// first restore to complete.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L642}
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L643}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L643}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   RestoreDatabase(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts = {});
@@ -727,7 +727,7 @@ class GoldenThingAdminClient {
   ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L562}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -743,12 +743,12 @@ class GoldenThingAdminClient {
   /// include those that have completed/failed/canceled within the last 7 days,
   /// and pending operations.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L561}
+  /// @param request @googleapis_link{google::test::admin::database::v1::ListDatabaseOperationsRequest,generator/integration_tests/test.proto#L562}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   /// @return @googleapis_link{google::longrunning::Operation,google/longrunning/operations.proto#L128}
   ///
-  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L561}
+  /// [google.test.admin.database.v1.ListDatabaseOperationsRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L562}
   /// [google.longrunning.Operation]: @googleapis_reference_link{google/longrunning/operations.proto#L128}
   ///
   StreamRange<google::longrunning::Operation>
@@ -804,13 +804,13 @@ class GoldenThingAdminClient {
   ///
   /// Tests longrunning operations without routing headers
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L642}
+  /// @param request @googleapis_link{google::test::admin::database::v1::RestoreDatabaseRequest,generator/integration_tests/test.proto#L643}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L642}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.RestoreDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L643}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   LongRunningWithoutRouting(google::test::admin::database::v1::RestoreDatabaseRequest const& request, Options opts = {});
@@ -822,10 +822,10 @@ class GoldenThingAdminClient {
   ///  `projects/<project>/instances/<instance>/databases/<database>`.
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(std::string const& name, Options opts = {});
@@ -833,13 +833,13 @@ class GoldenThingAdminClient {
   ///
   /// Gets the state of a Cloud Test database.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L451}
+  /// @param request @googleapis_link{google::test::admin::database::v1::GetDatabaseRequest,generator/integration_tests/test.proto#L452}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
-  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L337}
+  /// @return @googleapis_link{google::test::admin::database::v1::Database,generator/integration_tests/test.proto#L338}
   ///
-  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L451}
-  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L337}
+  /// [google.test.admin.database.v1.GetDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L452}
+  /// [google.test.admin.database.v1.Database]: @googleapis_reference_link{generator/integration_tests/test.proto#L338}
   ///
   future<StatusOr<google::test::admin::database::v1::Database>>
   AsyncGetDatabase(google::test::admin::database::v1::GetDatabaseRequest const& request, Options opts = {});
@@ -853,7 +853,7 @@ class GoldenThingAdminClient {
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
   ///
   future<Status>
   AsyncDropDatabase(std::string const& database, Options opts = {});
@@ -863,11 +863,11 @@ class GoldenThingAdminClient {
   /// Completed backups for the database will be retained according to their
   /// `expire_time`.
   ///
-  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L531}
+  /// @param request @googleapis_link{google::test::admin::database::v1::DropDatabaseRequest,generator/integration_tests/test.proto#L532}
   /// @param opts Optional. Override the class-level options, such as retry and
   ///     backoff policies.
   ///
-  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L531}
+  /// [google.test.admin.database.v1.DropDatabaseRequest]: @googleapis_reference_link{generator/integration_tests/test.proto#L532}
   ///
   future<Status>
   AsyncDropDatabase(google::test::admin::database::v1::DropDatabaseRequest const& request, Options opts = {});

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.cc
@@ -121,6 +121,22 @@ GoldenKitchenSinkAuth::WriteObject(
   return child_->WriteObject(std::move(context));
 }
 
+Status GoldenKitchenSinkAuth::ExplicitRouting1(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ExplicitRouting1(context, request);
+}
+
+Status GoldenKitchenSinkAuth::ExplicitRouting2(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->ExplicitRouting2(context, request);
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkAuth::AsyncTailLogEntries(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_auth_decorator.h
@@ -79,6 +79,14 @@ class GoldenKitchenSinkAuth : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::WriteObjectResponse>> WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  Status ExplicitRouting1(
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
+  Status ExplicitRouting2(
+      grpc::ClientContext& context,
+      google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::TailLogEntriesResponse>>
   AsyncTailLogEntries(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
@@ -147,6 +147,30 @@ GoldenKitchenSinkConnectionImpl::DoNothing(google::protobuf::Empty const& reques
       request, __func__);
 }
 
+Status
+GoldenKitchenSinkConnectionImpl::ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  return google::cloud::internal::RetryLoop(
+      retry_policy(), backoff_policy(),
+      idempotency_policy()->ExplicitRouting1(request),
+      [this](grpc::ClientContext& context,
+          google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+        return stub_->ExplicitRouting1(context, request);
+      },
+      request, __func__);
+}
+
+Status
+GoldenKitchenSinkConnectionImpl::ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  return google::cloud::internal::RetryLoop(
+      retry_policy(), backoff_policy(),
+      idempotency_policy()->ExplicitRouting2(request),
+      [this](grpc::ClientContext& context,
+          google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+        return stub_->ExplicitRouting2(context, request);
+      },
+      request, __func__);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace golden_internal
 }  // namespace cloud

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.h
@@ -80,6 +80,12 @@ class GoldenKitchenSinkConnectionImpl
       google::test::admin::database::v1::AppendRowsResponse>>
   AsyncAppendRows(ExperimentalTag) override;
 
+  Status
+  ExplicitRouting1(google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
+  Status
+  ExplicitRouting2(google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
  private:
   std::unique_ptr<golden::GoldenKitchenSinkRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.cc
@@ -169,6 +169,30 @@ GoldenKitchenSinkLogging::WriteObject(
   return stream;
 }
 
+Status
+GoldenKitchenSinkLogging::ExplicitRouting1(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+        return child_->ExplicitRouting1(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
+Status
+GoldenKitchenSinkLogging::ExplicitRouting2(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  return google::cloud::internal::LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+        return child_->ExplicitRouting2(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::test::admin::database::v1::TailLogEntriesResponse>>
 GoldenKitchenSinkLogging::AsyncTailLogEntries(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_logging_decorator.h
@@ -80,6 +80,14 @@ class GoldenKitchenSinkLogging : public GoldenKitchenSinkStub {
    WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  Status ExplicitRouting1(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
+  Status ExplicitRouting2(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::TailLogEntriesResponse>>
   AsyncTailLogEntries(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -18,7 +18,9 @@
 
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/internal/routing_matcher.h"
 #include "google/cloud/status_or.h"
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
@@ -106,6 +108,74 @@ GoldenKitchenSinkMetadata::WriteObject(
     std::unique_ptr<grpc::ClientContext> context) {
   SetMetadata(*context);
   return child_->WriteObject(std::move(context));
+}
+
+Status
+GoldenKitchenSinkMetadata::ExplicitRouting1(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_location_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::ExplicitRoutingRequest>{
+      "table_location=", {
+      {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
+        return request.table_name();
+      },
+      std::regex{"(regions/[^/]+/zones/[^/]+)/tables/[^/]+", std::regex::optimize}},
+      {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
+        return request.table_name();
+      },
+      std::regex{"projects/[^/]+/(instances/[^/]+)/tables/[^/]+", std::regex::optimize}},
+      }};
+  }();
+  table_location_matcher->AppendParam(request, params);
+
+  static auto* routing_id_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::ExplicitRoutingRequest>{
+      "routing_id=", {
+      {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
+        return request.app_profile_id();
+      },
+      std::regex{"profiles/([^/]+)", std::regex::optimize}},
+      {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
+        return request.app_profile_id();
+      },
+      absl::nullopt},
+      {[](google::test::admin::database::v1::ExplicitRoutingRequest const& request) -> std::string const& {
+        return request.table_name();
+      },
+      std::regex{"(projects/[^/]+)/.*", std::regex::optimize}},
+      }};
+  }();
+  routing_id_matcher->AppendParam(request, params);
+
+  if (!params.empty()) {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
+  return child_->ExplicitRouting1(context, request);
+}
+
+Status
+GoldenKitchenSinkMetadata::ExplicitRouting2(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+  std::vector<std::string> params;
+  params.reserve(1);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("no_regex_needed=" + request.app_profile_id());
+  } else if (!request.table_name().empty()) {
+    params.push_back("no_regex_needed=" + request.table_name());
+  } else if (!request.no_regex_needed().empty()) {
+    params.push_back("no_regex_needed=" + request.no_regex_needed());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
+  return child_->ExplicitRouting2(context, request);
 }
 
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.cc
@@ -71,7 +71,18 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<google::test::admin::d
 GoldenKitchenSinkMetadata::TailLogEntries(
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  SetMetadata(*context);
+  std::vector<std::string> params;
+  params.reserve(1);
+
+  if (!request.filter().empty()) {
+    params.push_back("filter=" + request.filter());
+  }
+
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->TailLogEntries(std::move(context), request);
 }
 
@@ -151,7 +162,9 @@ GoldenKitchenSinkMetadata::ExplicitRouting1(
   }();
   routing_id_matcher->AppendParam(request, params);
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
     SetMetadata(context, absl::StrJoin(params, "&"));
   }
   return child_->ExplicitRouting1(context, request);
@@ -172,7 +185,9 @@ GoldenKitchenSinkMetadata::ExplicitRouting2(
     params.push_back("no_regex_needed=" + request.no_regex_needed());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
     SetMetadata(context, absl::StrJoin(params, "&"));
   }
   return child_->ExplicitRouting2(context, request);
@@ -184,7 +199,18 @@ GoldenKitchenSinkMetadata::AsyncTailLogEntries(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::TailLogEntriesRequest const& request) {
-  SetMetadata(*context);
+  std::vector<std::string> params;
+  params.reserve(1);
+
+  if (!request.filter().empty()) {
+    params.push_back("filter=" + request.filter());
+  }
+
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncTailLogEntries(cq, std::move(context), request);
 }
 

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_metadata_decorator.h
@@ -76,6 +76,14 @@ class GoldenKitchenSinkMetadata : public GoldenKitchenSinkStub {
   WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
 
+  Status ExplicitRouting1(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
+  Status ExplicitRouting2(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::TailLogEntriesResponse>>
   AsyncTailLogEntries(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.cc
@@ -146,6 +146,32 @@ DefaultGoldenKitchenSinkStub::WriteObject(
     std::move(context), std::move(response), std::move(stream));
 }
 
+Status
+DefaultGoldenKitchenSinkStub::ExplicitRouting1(
+  grpc::ClientContext& client_context,
+  google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+    google::protobuf::Empty response;
+    auto status =
+        grpc_stub_->ExplicitRouting1(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
+}
+
+Status
+DefaultGoldenKitchenSinkStub::ExplicitRouting2(
+  grpc::ClientContext& client_context,
+  google::test::admin::database::v1::ExplicitRoutingRequest const& request) {
+    google::protobuf::Empty response;
+    auto status =
+        grpc_stub_->ExplicitRouting2(&client_context, request, &response);
+    if (!status.ok()) {
+      return google::cloud::MakeStatusFromRpcError(status);
+    }
+    return google::cloud::Status();
+}
+
 std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
     google::test::admin::database::v1::TailLogEntriesResponse>>
 DefaultGoldenKitchenSinkStub::AsyncTailLogEntries(

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_stub.h
@@ -83,6 +83,14 @@ class GoldenKitchenSinkStub {
   WriteObject(
       std::unique_ptr<grpc::ClientContext> context) = 0;
 
+  virtual Status ExplicitRouting1(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) = 0;
+
+  virtual Status ExplicitRouting2(
+    grpc::ClientContext& context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) = 0;
+
   virtual std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::TailLogEntriesResponse>>
   AsyncTailLogEntries(
@@ -150,6 +158,16 @@ class DefaultGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
       google::test::admin::database::v1::WriteObjectResponse>>
   WriteObject(
       std::unique_ptr<grpc::ClientContext> context) override;
+
+  Status
+  ExplicitRouting1(
+    grpc::ClientContext& client_context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
+
+  Status
+  ExplicitRouting2(
+    grpc::ClientContext& client_context,
+    google::test::admin::database::v1::ExplicitRoutingRequest const& request) override;
 
   std::unique_ptr<::google::cloud::internal::AsyncStreamingReadRpc<
       google::test::admin::database::v1::TailLogEntriesResponse>>

--- a/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.cc
@@ -18,7 +18,9 @@
 
 #include "generator/integration_tests/golden/internal/golden_thing_admin_metadata_decorator.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/internal/routing_matcher.h"
 #include "google/cloud/status_or.h"
 #include <generator/integration_tests/test.grpc.pb.h>
 #include <memory>
@@ -71,7 +73,47 @@ Status
 GoldenThingAdminMetadata::DropDatabase(
     grpc::ClientContext& context,
     google::test::admin::database::v1::DropDatabaseRequest const& request) {
-  SetMetadata(context, "database=" + request.database());
+  std::vector<std::string> params;
+  params.reserve(3);
+
+  static auto* project_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::DropDatabaseRequest>{
+      "project=", {
+      {[](google::test::admin::database::v1::DropDatabaseRequest const& request) -> std::string const& {
+        return request.database();
+      },
+      std::regex{"(projects/[^/]+)/instances/[^/]+/databases/[^/]+", std::regex::optimize}},
+      }};
+  }();
+  project_matcher->AppendParam(request, params);
+
+  static auto* instance_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::DropDatabaseRequest>{
+      "instance=", {
+      {[](google::test::admin::database::v1::DropDatabaseRequest const& request) -> std::string const& {
+        return request.database();
+      },
+      std::regex{"projects/[^/]+/(instances/[^/]+)/databases/[^/]+", std::regex::optimize}},
+      }};
+  }();
+  instance_matcher->AppendParam(request, params);
+
+  static auto* database_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::DropDatabaseRequest>{
+      "database=", {
+      {[](google::test::admin::database::v1::DropDatabaseRequest const& request) -> std::string const& {
+        return request.database();
+      },
+      std::regex{"projects/[^/]+/instances/[^/]+/(databases/[^/]+)", std::regex::optimize}},
+      }};
+  }();
+  database_matcher->AppendParam(request, params);
+
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
   return child_->DropDatabase(context, request);
 }
 
@@ -196,7 +238,47 @@ GoldenThingAdminMetadata::AsyncDropDatabase(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::test::admin::database::v1::DropDatabaseRequest const& request) {
-  SetMetadata(*context, "database=" + request.database());
+  std::vector<std::string> params;
+  params.reserve(3);
+
+  static auto* project_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::DropDatabaseRequest>{
+      "project=", {
+      {[](google::test::admin::database::v1::DropDatabaseRequest const& request) -> std::string const& {
+        return request.database();
+      },
+      std::regex{"(projects/[^/]+)/instances/[^/]+/databases/[^/]+", std::regex::optimize}},
+      }};
+  }();
+  project_matcher->AppendParam(request, params);
+
+  static auto* instance_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::DropDatabaseRequest>{
+      "instance=", {
+      {[](google::test::admin::database::v1::DropDatabaseRequest const& request) -> std::string const& {
+        return request.database();
+      },
+      std::regex{"projects/[^/]+/(instances/[^/]+)/databases/[^/]+", std::regex::optimize}},
+      }};
+  }();
+  instance_matcher->AppendParam(request, params);
+
+  static auto* database_matcher = []{
+    return new google::cloud::internal::RoutingMatcher<google::test::admin::database::v1::DropDatabaseRequest>{
+      "database=", {
+      {[](google::test::admin::database::v1::DropDatabaseRequest const& request) -> std::string const& {
+        return request.database();
+      },
+      std::regex{"projects/[^/]+/instances/[^/]+/(databases/[^/]+)", std::regex::optimize}},
+      }};
+  }();
+  database_matcher->AppendParam(request, params);
+
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncDropDatabase(cq, std::move(context), request);
 }
 

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_connection.h
@@ -78,6 +78,14 @@ class MockGoldenKitchenSinkConnection : public golden::GoldenKitchenSinkConnecti
       ::google::cloud::AsyncStreamingReadWriteRpc<
           google::test::admin::database::v1::AppendRowsRequest, google::test::admin::database::v1::AppendRowsResponse>>),
       AsyncAppendRows, (ExperimentalTag), (override));
+
+  MOCK_METHOD(Status,
+  ExplicitRouting1,
+  (google::test::admin::database::v1::ExplicitRoutingRequest const& request), (override));
+
+  MOCK_METHOD(Status,
+  ExplicitRouting2,
+  (google::test::admin::database::v1::ExplicitRoutingRequest const& request), (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -106,6 +106,16 @@ class MockGoldenKitchenSinkStub : public GoldenKitchenSinkStub {
     (google::cloud::CompletionQueue const& cq,
      std::unique_ptr<grpc::ClientContext> context),
     (override));
+
+  MOCK_METHOD(Status, ExplicitRouting1,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::ExplicitRoutingRequest const&),
+              (override));
+
+  MOCK_METHOD(Status, ExplicitRouting2,
+              (grpc::ClientContext&,
+               ::google::test::admin::database::v1::ExplicitRoutingRequest const&),
+              (override));
 };
 
 class MockTailLogEntriesStreamingReadRpc

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -324,6 +324,8 @@ TEST_F(MetadataDecoratorTest, ExplicitRouting) {
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            ExplicitRoutingRequest const&) {
+        // Even though IsContextMDValid can do this work for us, let's spell out
+        // what we expect to find in the routing header.
         auto headers = GetMetadata(context);
         auto it = headers.find("x-goog-request-params");
         EXPECT_NE(it, headers.end());
@@ -354,6 +356,8 @@ TEST_F(MetadataDecoratorTest, ExplicitRoutingDoesNotSendEmptyParams) {
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            ExplicitRoutingRequest const&) {
+        // Even though IsContextMDValid can do this work for us, let's spell out
+        // what we expect to find in the routing header.
         auto headers = GetMetadata(context);
         auto it = headers.find("x-goog-request-params");
         EXPECT_EQ(it, headers.end());
@@ -372,6 +376,8 @@ TEST_F(MetadataDecoratorTest, ExplicitRoutingNoRegexNeeded) {
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
                            ExplicitRoutingRequest const&) {
+        // Even though IsContextMDValid can do this work for us, let's spell out
+        // what we expect to find in the routing header.
         auto headers = GetMetadata(context);
         auto it = headers.find("x-goog-request-params");
         EXPECT_NE(it, headers.end());

--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_stub_test.cc
@@ -276,6 +276,52 @@ class MockGrpcGoldenKitchenSinkStub : public ::google::test::admin::database::
                ::google::test::admin::database::v1::WriteObjectResponse*,
                ::grpc::CompletionQueue*),
               (override));
+  MOCK_METHOD(
+      ::grpc::Status, ExplicitRouting1,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::ExplicitRoutingRequest const&
+           request,
+       ::google::protobuf::Empty* response),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      AsyncExplicitRouting1Raw,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::ExplicitRoutingRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      PrepareAsyncExplicitRouting1Raw,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::ExplicitRoutingRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::Status, ExplicitRouting2,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::ExplicitRoutingRequest const&
+           request,
+       ::google::protobuf::Empty* response),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      AsyncExplicitRouting2Raw,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::ExplicitRoutingRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
+      (override));
+  MOCK_METHOD(
+      ::grpc::ClientAsyncResponseReaderInterface<::google::protobuf::Empty>*,
+      PrepareAsyncExplicitRouting2Raw,
+      (::grpc::ClientContext * context,
+       ::google::test::admin::database::v1::ExplicitRoutingRequest const&
+           request,
+       ::grpc::CompletionQueue* cq),
+      (override));
 };
 
 class GoldenKitchenSinkStubTest : public ::testing::Test {

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -20,6 +20,7 @@ import "google/api/annotations.proto";
 import "google/api/client.proto";
 import "google/api/field_behavior.proto";
 import "google/api/resource.proto";
+import "google/api/routing.proto";
 import "google/iam/v1/iam_policy.proto";
 import "google/iam/v1/policy.proto";
 import "google/longrunning/operations.proto";
@@ -844,6 +845,75 @@ service GoldenKitchenSink {
 
   // A much simplified version of the WriteObject method in google.storage.v2.Storage
   rpc WriteObject(stream WriteObjectRequest) returns (WriteObjectResponse) {}
+
+  // An RPC to test that explicit routing headers are supported.
+  //
+  // We copy the most testing example given in the `google.api.routing` proto:
+  // https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L353-L385
+  //
+  // Our integration test should verify that, given the message:
+  //
+  //    {
+  //      table_name: projects/proj_foo/instances/instance_bar/table/table_baz
+  //      app_profile_id: profiles/prof_qux
+  //    }
+  //
+  // ... our metadata decorator sets:
+  //
+  //    x-goog-request-params:
+  //    table_location=instances/instance_bar&routing_id=prof_qux
+  rpc ExplicitRouting1(ExplicitRoutingRequest) returns (google.protobuf.Empty) {
+    // This is ignored, in favor of the google.api.routing rule.
+    option (google.api.http) = {
+      post: "/v1/{table_name=projects/**}:explicitRouting1"
+      body: "*"
+    };
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "table_name"
+        path_template: "projects/*/{table_location=instances/*}/tables/*"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{table_location=regions/*/zones/*}/tables/*"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{routing_id=projects/*}/**"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "{routing_id=**}"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "profiles/{routing_id=*}"
+      }
+    };
+  }
+
+  // We use this RPC to verify the special case where a routing parameter key
+  // does not require a regex in order to match the correct value.
+  rpc ExplicitRouting2(ExplicitRoutingRequest) returns (google.protobuf.Empty) {
+    // This is ignored, in favor of the google.api.routing rule.
+    option (google.api.http) = {
+      post: "/v1/{table_name=projects/**}:explicitRouting2"
+      body: "*"
+    };
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "no_regex_needed"
+      }
+      routing_parameters {
+        field: "table_name"
+        path_template: "{no_regex_needed=**}"
+      }
+      routing_parameters {
+        field: "app_profile_id"
+        path_template: "{no_regex_needed=**}"
+      }
+    };
+  }
 }
 
 message AppendRowsRequest {
@@ -1319,4 +1389,25 @@ message ListServiceAccountKeysRequest {
 message ListServiceAccountKeysResponse {
   // The public keys for the service account.
   repeated string keys = 1;
+}
+
+// We use the following message for our integration test, as defined here:
+// https://github.com/googleapis/googleapis/blob/f46dc249e1987a6bef1a70a371e8288ea4c17481/google/api/routing.proto#L40-L53
+message ExplicitRoutingRequest {
+  // The name of the Table
+  // Values can be of the following formats:
+  // - `projects/<project>/tables/<table>`
+  // - `projects/<project>/instances/<instance>/tables/<table>`
+  // - `region/<region>/zones/<zone>/tables/<table>`
+  string table_name = 1;
+
+  // This value specifies routing for replication.
+  // It can be in the following formats:
+  // - `profiles/<profile_id>`
+  // - a legacy `profile_id` that can be any string
+  string app_profile_id = 2;
+
+  // We use this field to demonstrate the special case for routing parameter
+  // keys which do not require a regex in order to match the correct value.
+  string no_regex_needed = 3;
 }

--- a/generator/integration_tests/test.proto
+++ b/generator/integration_tests/test.proto
@@ -118,6 +118,20 @@ service GoldenThingAdmin {
     option (google.api.http) = {
       delete: "/v1/{database=projects/*/instances/*/databases/*}"
     };
+    option (google.api.routing) = {
+      routing_parameters {
+        field: "database"
+        path_template: "{project=projects/*}/instances/*/databases/*"
+      }
+      routing_parameters {
+        field: "database"
+        path_template: "projects/*/{instance=instances/*}/databases/*"
+      }
+      routing_parameters {
+        field: "database"
+        path_template: "projects/*/instances/*/{database=databases/*}"
+      }
+    };
     option (google.api.method_signature) = "database";
   }
 
@@ -803,6 +817,9 @@ service GoldenKitchenSink {
     option (google.api.http) = {
       post: "/v2/entries:tail"
       body: "*"
+    };
+    option (google.api.routing) = {
+      routing_parameters { field: "filter" }
     };
     option (google.api.method_signature) = "resource_names";
   }

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -20,6 +20,7 @@
 #include "generator/internal/predicate_utils.h"
 #include "generator/internal/printer.h"
 #include <google/protobuf/descriptor.h>
+#include <algorithm>
 
 namespace google {
 namespace cloud {
@@ -32,14 +33,64 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
                             ContextType context_type) {
   std::string const context = context_type == kPointer ? "*context" : "context";
 
-  if (HasRoutingHeader(method)) {
-    return "  SetMetadata(" + context +
-           ", \"$method_request_param_key$=\" + "
-           "request.$method_request_param_value$);";
+  auto info = ParseExplicitRoutingHeader(method);
+  // If there are no explicit routing headers, we fall back to the routing as
+  // defined by the google.api.http annotation
+  if (info.empty()) {
+    if (HasRoutingHeader(method)) {
+      return "  SetMetadata(" + context +
+             ", \"$method_request_param_key$=\" + "
+             "request.$method_request_param_value$);";
+    }
+    // If the method does not have a `google.api.routing` or `google.api.http`
+    // annotation, we do not send the "x-goog-request-params" header.
+    return "  SetMetadata(" + context + ");";
   }
-  // If the method does not have a `google.api.http` annotation, we do not send
-  // the "x-goog-request-params" header.
-  return "  SetMetadata(" + context + ");";
+
+  // clang-format off
+  std::string text;
+  text += "  std::vector<std::string> params;\n";
+  text += "  params.reserve(" + std::to_string(info.size()) + ");\n\n";
+  for (auto const& kv : info) {
+    // In the simplest (and probably most common) cases where no regular
+    // expression matching is needed for a given routing parameter key, we skip
+    // the static loading of `RoutingMatcher`s and simply use if statements.
+    if (std::all_of(
+            kv.second.begin(), kv.second.end(),
+            [](RoutingParameter const& rp) { return rp.pattern == "(.*)"; })) {
+      for (auto i = 0; i != kv.second.size(); ++i){
+        auto const& field = kv.second[i].field_name;
+        text += i == 0 ? "  " : " else ";
+        text += "if (!request." + field + "().empty()) {\n";
+        text += "    params.push_back(\"" + kv.first + "=\" + request." + field + "());\n";
+        text += "  }";
+      }
+      text += "\n\n";
+      continue;
+    }
+    text += "  static auto* " + kv.first + "_matcher = []{\n";
+    text += "    return new google::cloud::internal::RoutingMatcher<$request_type$>{\n";
+    text += "      \"" + kv.first + "=\", {\n";
+    for (auto const& rp : kv.second) {
+      text += "      {[]($request_type$ const& request) -> std::string const& {\n";
+      text += "        return request." + rp.field_name + "();\n";
+      text += "      },\n";
+      // In the special match-all case, we do not bother to set a regex.
+      if (rp.pattern == "(.*)") {
+        text += "      absl::nullopt},\n";
+      } else {
+        text += "      std::regex{\"" + rp.pattern + "\", std::regex::optimize}},\n";
+      }
+    }
+    text += "      }};\n";
+    text += "  }();\n";
+    text += "  " + kv.first + "_matcher->AppendParam(request, params);\n\n";
+  }
+  text += "  if (!params.empty()) {\n";
+  text += "    SetMetadata(" + context + ", absl::StrJoin(params, \"&\"));\n";
+  text += "  }";
+  return text;
+  // clang-format on
 }
 
 }  // namespace
@@ -222,10 +273,15 @@ Status MetadataDecoratorGenerator::GenerateCc() {
 
   // includes
   CcPrint("\n");
-  CcLocalIncludes({vars("metadata_header_path"),
-                   "google/cloud/internal/api_client_header.h",
-                   "google/cloud/common_options.h",
-                   "google/cloud/status_or.h"});
+  CcLocalIncludes(
+      {vars("metadata_header_path"),
+       HasExplicitRoutingMethod()
+           ? "google/cloud/internal/absl_str_join_quiet.h"
+           : "",
+       "google/cloud/internal/api_client_header.h",
+       HasExplicitRoutingMethod() ? "google/cloud/internal/routing_matcher.h"
+                                  : "",
+       "google/cloud/common_options.h", "google/cloud/status_or.h"});
   CcSystemIncludes({vars("proto_grpc_header_path"), "memory"});
 
   auto result = CcOpenNamespaces(NamespaceType::kInternal);

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -58,12 +58,13 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
     if (std::all_of(
             kv.second.begin(), kv.second.end(),
             [](RoutingParameter const& rp) { return rp.pattern == "(.*)"; })) {
-      for (auto i = 0; i != kv.second.size(); ++i){
-        auto const& field = kv.second[i].field_name;
-        text += i == 0 ? "  " : " else ";
-        text += "if (!request." + field + "().empty()) {\n";
-        text += "    params.push_back(\"" + kv.first + "=\" + request." + field + "());\n";
+      bool initial_if = true;
+      for (auto const& rp : kv.second){
+        text += initial_if ? "  " : " else ";
+        text += "if (!request." + rp.field_name + "().empty()) {\n";
+        text += "    params.push_back(\"" + kv.first + "=\" + request." + rp.field_name + "());\n";
         text += "  }";
+        initial_if = false;
       }
       text += "\n\n";
       continue;

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -58,13 +58,13 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
     if (std::all_of(
             kv.second.begin(), kv.second.end(),
             [](RoutingParameter const& rp) { return rp.pattern == "(.*)"; })) {
-      bool initial_if = true;
+      auto const* sep = "  ";
       for (auto const& rp : kv.second){
-        text += initial_if ? "  " : " else ";
+        text += sep;
         text += "if (!request." + rp.field_name + "().empty()) {\n";
         text += "    params.push_back(\"" + kv.first + "=\" + request." + rp.field_name + "());\n";
         text += "  }";
-        initial_if = false;
+        sep = " else ";
       }
       text += "\n\n";
       continue;
@@ -87,7 +87,9 @@ std::string SetMetadataText(google::protobuf::MethodDescriptor const& method,
     text += "  }();\n";
     text += "  " + kv.first + "_matcher->AppendParam(request, params);\n\n";
   }
-  text += "  if (!params.empty()) {\n";
+  text += "  if (params.empty()) {\n";
+  text += "    SetMetadata(" + context + ");\n";
+  text += "  } else {\n";
   text += "    SetMetadata(" + context + ", absl::StrJoin(params, \"&\"));\n";
   text += "  }";
   return text;

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -18,7 +18,9 @@
 
 #include "google/cloud/bigtable/internal/bigtable_metadata_decorator.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/api_client_header.h"
+#include "google/cloud/internal/routing_matcher.h"
 #include "google/cloud/status_or.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
 #include <memory>
@@ -38,7 +40,29 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
 BigtableMetadata::ReadRows(
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::ReadRowsRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::ReadRowsRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::ReadRowsRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->ReadRows(std::move(context), request);
 }
 
@@ -47,14 +71,58 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
 BigtableMetadata::SampleRowKeys(
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::SampleRowKeysRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::SampleRowKeysRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->SampleRowKeys(std::move(context), request);
 }
 
 StatusOr<google::bigtable::v2::MutateRowResponse> BigtableMetadata::MutateRow(
     grpc::ClientContext& context,
     google::bigtable::v2::MutateRowRequest const& request) {
-  SetMetadata(context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::MutateRowRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::MutateRowRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
   return child_->MutateRow(context, request);
 }
 
@@ -63,7 +131,29 @@ std::unique_ptr<google::cloud::internal::StreamingReadRpc<
 BigtableMetadata::MutateRows(
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::MutateRowsRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::MutateRowsRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::MutateRowsRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->MutateRows(std::move(context), request);
 }
 
@@ -71,7 +161,29 @@ StatusOr<google::bigtable::v2::CheckAndMutateRowResponse>
 BigtableMetadata::CheckAndMutateRow(
     grpc::ClientContext& context,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  SetMetadata(context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::CheckAndMutateRowRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::CheckAndMutateRowRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
   return child_->CheckAndMutateRow(context, request);
 }
 
@@ -79,7 +191,29 @@ StatusOr<google::bigtable::v2::PingAndWarmResponse>
 BigtableMetadata::PingAndWarm(
     grpc::ClientContext& context,
     google::bigtable::v2::PingAndWarmRequest const& request) {
-  SetMetadata(context, "name=" + request.name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::PingAndWarmRequest>{
+        "name=",
+        {
+            {[](google::bigtable::v2::PingAndWarmRequest const& request)
+                 -> std::string const& { return request.name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
   return child_->PingAndWarm(context, request);
 }
 
@@ -87,7 +221,29 @@ StatusOr<google::bigtable::v2::ReadModifyWriteRowResponse>
 BigtableMetadata::ReadModifyWriteRow(
     grpc::ClientContext& context,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  SetMetadata(context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::ReadModifyWriteRowRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::ReadModifyWriteRowRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(context, absl::StrJoin(params, "&"));
+  }
   return child_->ReadModifyWriteRow(context, request);
 }
 
@@ -97,7 +253,29 @@ BigtableMetadata::AsyncReadRows(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::ReadRowsRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::ReadRowsRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::ReadRowsRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncReadRows(cq, std::move(context), request);
 }
 
@@ -107,7 +285,29 @@ BigtableMetadata::AsyncSampleRowKeys(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::SampleRowKeysRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::SampleRowKeysRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::SampleRowKeysRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncSampleRowKeys(cq, std::move(context), request);
 }
 
@@ -116,7 +316,29 @@ BigtableMetadata::AsyncMutateRow(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::MutateRowRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::MutateRowRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::MutateRowRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncMutateRow(cq, std::move(context), request);
 }
 
@@ -126,7 +348,29 @@ BigtableMetadata::AsyncMutateRows(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::MutateRowsRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::MutateRowsRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::MutateRowsRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncMutateRows(cq, std::move(context), request);
 }
 
@@ -135,7 +379,29 @@ BigtableMetadata::AsyncCheckAndMutateRow(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::CheckAndMutateRowRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::CheckAndMutateRowRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::CheckAndMutateRowRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncCheckAndMutateRow(cq, std::move(context), request);
 }
 
@@ -144,7 +410,29 @@ BigtableMetadata::AsyncReadModifyWriteRow(
     google::cloud::CompletionQueue& cq,
     std::unique_ptr<grpc::ClientContext> context,
     google::bigtable::v2::ReadModifyWriteRowRequest const& request) {
-  SetMetadata(*context, "table_name=" + request.table_name());
+  std::vector<std::string> params;
+  params.reserve(2);
+
+  static auto* table_name_matcher = [] {
+    return new google::cloud::internal::RoutingMatcher<
+        google::bigtable::v2::ReadModifyWriteRowRequest>{
+        "table_name=",
+        {
+            {[](google::bigtable::v2::ReadModifyWriteRowRequest const& request)
+                 -> std::string const& { return request.table_name(); },
+             std::regex{"(projects/[^/]+/instances/[^/]+/tables/[^/]+)",
+                        std::regex::optimize}},
+        }};
+  }();
+  table_name_matcher->AppendParam(request, params);
+
+  if (!request.app_profile_id().empty()) {
+    params.push_back("app_profile_id=" + request.app_profile_id());
+  }
+
+  if (!params.empty()) {
+    SetMetadata(*context, absl::StrJoin(params, "&"));
+  }
   return child_->AsyncReadModifyWriteRow(cq, std::move(context), request);
 }
 

--- a/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
+++ b/google/cloud/bigtable/internal/bigtable_metadata_decorator.cc
@@ -60,7 +60,9 @@ BigtableMetadata::ReadRows(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->ReadRows(std::move(context), request);
@@ -91,7 +93,9 @@ BigtableMetadata::SampleRowKeys(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->SampleRowKeys(std::move(context), request);
@@ -120,7 +124,9 @@ StatusOr<google::bigtable::v2::MutateRowResponse> BigtableMetadata::MutateRow(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
     SetMetadata(context, absl::StrJoin(params, "&"));
   }
   return child_->MutateRow(context, request);
@@ -151,7 +157,9 @@ BigtableMetadata::MutateRows(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->MutateRows(std::move(context), request);
@@ -181,7 +189,9 @@ BigtableMetadata::CheckAndMutateRow(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
     SetMetadata(context, absl::StrJoin(params, "&"));
   }
   return child_->CheckAndMutateRow(context, request);
@@ -211,7 +221,9 @@ BigtableMetadata::PingAndWarm(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
     SetMetadata(context, absl::StrJoin(params, "&"));
   }
   return child_->PingAndWarm(context, request);
@@ -241,7 +253,9 @@ BigtableMetadata::ReadModifyWriteRow(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(context);
+  } else {
     SetMetadata(context, absl::StrJoin(params, "&"));
   }
   return child_->ReadModifyWriteRow(context, request);
@@ -273,7 +287,9 @@ BigtableMetadata::AsyncReadRows(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->AsyncReadRows(cq, std::move(context), request);
@@ -305,7 +321,9 @@ BigtableMetadata::AsyncSampleRowKeys(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->AsyncSampleRowKeys(cq, std::move(context), request);
@@ -336,7 +354,9 @@ BigtableMetadata::AsyncMutateRow(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->AsyncMutateRow(cq, std::move(context), request);
@@ -368,7 +388,9 @@ BigtableMetadata::AsyncMutateRows(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->AsyncMutateRows(cq, std::move(context), request);
@@ -399,7 +421,9 @@ BigtableMetadata::AsyncCheckAndMutateRow(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->AsyncCheckAndMutateRow(cq, std::move(context), request);
@@ -430,7 +454,9 @@ BigtableMetadata::AsyncReadModifyWriteRow(
     params.push_back("app_profile_id=" + request.app_profile_id());
   }
 
-  if (!params.empty()) {
+  if (params.empty()) {
+    SetMetadata(*context);
+  } else {
     SetMetadata(*context, absl::StrJoin(params, "&"));
   }
   return child_->AsyncReadModifyWriteRow(cq, std::move(context), request);


### PR DESCRIPTION
Fixes #9121 

The first and last commits are interesting. The middle two are not.

We do not pass our variables through `service_method_vars`. It is easier to work with the data directly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9368)
<!-- Reviewable:end -->
