### PR TITLE
test(storage): cleanup benchmark options

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -87,7 +87,6 @@ class UploadObject : public ThroughputExperiment {
                               config.object_size,
                               config.object_size,
                               config.app_buffer_size,
-                              config.lib_buffer_size,
                               config.enable_crc32c,
                               config.enable_md5,
                               usage.elapsed_time,
@@ -124,7 +123,6 @@ class UploadObject : public ThroughputExperiment {
                             config.object_size,
                             config.object_size,
                             config.app_buffer_size,
-                            config.lib_buffer_size,
                             config.enable_crc32c,
                             config.enable_md5,
                             usage.elapsed_time,
@@ -184,7 +182,6 @@ class DownloadObject : public ThroughputExperiment {
                             config.object_size,
                             transfer_size,
                             config.app_buffer_size,
-                            config.lib_buffer_size,
                             config.enable_crc32c,
                             config.enable_md5,
                             usage.elapsed_time,
@@ -279,7 +276,6 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
                             config.object_size,
                             config.object_size,
                             config.app_buffer_size,
-                            config.lib_buffer_size,
                             config.enable_crc32c,
                             config.enable_md5,
                             usage.elapsed_time,
@@ -350,7 +346,6 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
                             config.object_size,
                             bytes_received,
                             config.app_buffer_size,
-                            /*lib_buffer_size=*/0,
                             /*crc_enabled=*/false,
                             /*md5_enabled=*/false,
                             usage.elapsed_time,
@@ -371,7 +366,7 @@ std::vector<std::unique_ptr<ThroughputExperiment>> CreateUploadExperiments(
     ThroughputOptions const& options, ClientProvider const& provider) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto contents = std::make_shared<std::string>(
-      MakeRandomData(generator, options.maximum_write_size));
+      MakeRandomData(generator, options.maximum_write_buffer_size));
 
   std::vector<std::unique_ptr<ThroughputExperiment>> result;
   for (auto l : options.libs) {

--- a/google/cloud/storage/benchmarks/throughput_experiment.h
+++ b/google/cloud/storage/benchmarks/throughput_experiment.h
@@ -31,7 +31,6 @@ struct ThroughputExperimentConfig {
   OpType op;
   std::int64_t object_size;
   std::size_t app_buffer_size;
-  std::size_t lib_buffer_size;
   bool enable_crc32c;
   bool enable_md5;
 };

--- a/google/cloud/storage/benchmarks/throughput_experiment_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment_test.cc
@@ -58,7 +58,7 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   ASSERT_STATUS_OK(client);
 
   ThroughputOptions options;
-  options.minimum_write_size = 1 * kMiB;
+  options.minimum_write_buffer_size = 1 * kMiB;
   options.libs = {GetParam().library};
   options.transports = {GetParam().transport};
 
@@ -66,10 +66,9 @@ TEST_P(ThroughputExperimentIntegrationTest, Upload) {
   auto experiments = CreateUploadExperiments(options, provider);
   for (auto& e : experiments) {
     auto object_name = MakeRandomObjectName();
-    ThroughputExperimentConfig config{
-        OpType::kOpInsert,       16 * kKiB, 1 * kMiB, 4 * kMiB,
-        /*enable_crc32c=*/false,
-        /*enable_md5=*/false};
+    ThroughputExperimentConfig config{OpType::kOpInsert, 16 * kKiB, 1 * kMiB,
+                                      /*enable_crc32c=*/false,
+                                      /*enable_md5=*/false};
     auto result = e->Run(bucket_name_, object_name, config);
     ASSERT_STATUS_OK(result.status);
     auto status = client->DeleteObject(bucket_name_, object_name);
@@ -85,7 +84,7 @@ TEST_P(ThroughputExperimentIntegrationTest, Download) {
   ASSERT_STATUS_OK(client);
 
   ThroughputOptions options;
-  options.minimum_write_size = 1 * kMiB;
+  options.minimum_write_buffer_size = 1 * kMiB;
   options.libs = {GetParam().library};
   options.transports = {GetParam().transport};
 
@@ -96,10 +95,9 @@ TEST_P(ThroughputExperimentIntegrationTest, Download) {
     auto object_name = MakeRandomObjectName();
 
     auto constexpr kObjectSize = 16 * kKiB;
-    ThroughputExperimentConfig config{
-        OpType::kOpRead0,        kObjectSize, 1 * kMiB, 4 * kMiB,
-        /*enable_crc32c=*/false,
-        /*enable_md5=*/false};
+    ThroughputExperimentConfig config{OpType::kOpRead0, kObjectSize, 1 * kMiB,
+                                      /*enable_crc32c=*/false,
+                                      /*enable_md5=*/false};
 
     auto contents = MakeRandomData(kObjectSize);
     auto insert =

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -78,33 +78,33 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&options](std::string const& val) {
          options.maximum_object_size = ParseSize(val);
        }},
-      {"--minimum-write-size",
+      {"--minimum-write-buffer-size",
        "configure the minimum buffer size for write() calls",
        [&options](std::string const& val) {
-         options.minimum_write_size = ParseBufferSize(val);
+         options.minimum_write_buffer_size = ParseBufferSize(val);
        }},
-      {"--maximum-write-size",
+      {"--maximum-write-buffer-size",
        "configure the maximum buffer size for write() calls",
        [&options](std::string const& val) {
-         options.maximum_write_size = ParseBufferSize(val);
+         options.maximum_write_buffer_size = ParseBufferSize(val);
        }},
-      {"--write-quantum", "quantize the buffer sizes for write() calls",
+      {"--write-buffer-quantum", "quantize the buffer sizes for write() calls",
        [&options](std::string const& val) {
-         options.write_quantum = ParseBufferSize(val);
+         options.write_buffer_quantum = ParseBufferSize(val);
        }},
-      {"--minimum-read-size",
+      {"--minimum-read-buffer-size",
        "configure the minimum buffer size for read() calls",
        [&options](std::string const& val) {
-         options.minimum_read_size = ParseBufferSize(val);
+         options.minimum_read_buffer_size = ParseBufferSize(val);
        }},
-      {"--maximum-read-size",
+      {"--maximum-read-buffer-size",
        "configure the maximum buffer size for read() calls",
        [&options](std::string const& val) {
-         options.maximum_read_size = ParseBufferSize(val);
+         options.maximum_read_buffer_size = ParseBufferSize(val);
        }},
-      {"--read-quantum", "quantize the buffer sizes for read() calls",
+      {"--read-buffer-quantum", "quantize the buffer sizes for read() calls",
        [&options](std::string const& val) {
-         options.read_quantum = ParseBufferSize(val);
+         options.read_buffer_quantum = ParseBufferSize(val);
        }},
       {"--duration", "continue the test for at least this amount of time",
        [&options](std::string const& val) {
@@ -229,33 +229,35 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
     return make_status(os);
   }
 
-  if (options.minimum_write_size > options.maximum_write_size) {
+  if (options.minimum_write_buffer_size > options.maximum_write_buffer_size) {
     std::ostringstream os;
-    os << "Invalid range for write size [" << options.minimum_write_size << ','
-       << options.maximum_write_size << "]";
+    os << "Invalid range for write buffer size ["
+       << options.minimum_write_buffer_size << ','
+       << options.maximum_write_buffer_size << "]";
     return make_status(os);
   }
-  if (options.write_quantum <= 0 ||
-      options.write_quantum > options.minimum_write_size) {
+  if (options.write_buffer_quantum <= 0 ||
+      options.write_buffer_quantum > options.minimum_write_buffer_size) {
     std::ostringstream os;
-    os << "Invalid value for --write-quantum (" << options.write_quantum
-       << "), it should be in the [1," << options.minimum_write_size
-       << "] range";
+    os << "Invalid value for --write-buffer-quantum ("
+       << options.write_buffer_quantum << "), it should be in the [1,"
+       << options.minimum_write_buffer_size << "] range";
     return make_status(os);
   }
 
-  if (options.minimum_read_size > options.maximum_read_size) {
+  if (options.minimum_read_buffer_size > options.maximum_read_buffer_size) {
     std::ostringstream os;
-    os << "Invalid range for read size [" << options.minimum_read_size << ','
-       << options.maximum_read_size << "]";
+    os << "Invalid range for read buffer size ["
+       << options.minimum_read_buffer_size << ','
+       << options.maximum_read_buffer_size << "]";
     return make_status(os);
   }
-  if (options.read_quantum <= 0 ||
-      options.read_quantum > options.minimum_read_size) {
+  if (options.read_buffer_quantum <= 0 ||
+      options.read_buffer_quantum > options.minimum_read_buffer_size) {
     std::ostringstream os;
-    os << "Invalid value for --read-quantum (" << options.read_quantum
-       << "), it should be in the [1," << options.minimum_read_size
-       << "] range";
+    os << "Invalid value for --read-buffer-quantum ("
+       << options.read_buffer_quantum << "), it should be in the [1,"
+       << options.minimum_read_buffer_size << "] range";
     return make_status(os);
   }
 

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -35,12 +35,13 @@ struct ThroughputOptions {
   int direct_path_channel_count = 0;
   std::int64_t minimum_object_size = 32 * kMiB;
   std::int64_t maximum_object_size = 256 * kMiB;
-  std::size_t minimum_write_size = 16 * kMiB;
-  std::size_t maximum_write_size = 64 * kMiB;
-  std::size_t write_quantum = 256 * kKiB;
-  std::size_t minimum_read_size = 4 * kMiB;
-  std::size_t maximum_read_size = 8 * kMiB;
-  std::size_t read_quantum = 1 * kMiB;
+  // Control the size of the read and write buffers in the application.
+  std::size_t minimum_write_buffer_size = 16 * kMiB;
+  std::size_t maximum_write_buffer_size = 64 * kMiB;
+  std::size_t write_buffer_quantum = 256 * kKiB;
+  std::size_t minimum_read_buffer_size = 4 * kMiB;
+  std::size_t maximum_read_buffer_size = 8 * kMiB;
+  std::size_t read_buffer_quantum = 1 * kMiB;
   std::int32_t minimum_sample_count = 0;
   std::int32_t maximum_sample_count = std::numeric_limits<std::int32_t>::max();
   std::vector<ExperimentLibrary> libs = {

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -36,12 +36,12 @@ TEST(ThroughputOptions, Basic) {
       "--direct-path-channel-count=2",
       "--minimum-object-size=16KiB",
       "--maximum-object-size=32KiB",
-      "--minimum-write-size=16KiB",
-      "--maximum-write-size=128KiB",
-      "--write-quantum=16KiB",
-      "--minimum-read-size=32KiB",
-      "--maximum-read-size=256KiB",
-      "--read-quantum=32KiB",
+      "--minimum-write-buffer-size=16KiB",
+      "--maximum-write-buffer-size=128KiB",
+      "--write-buffer-quantum=16KiB",
+      "--minimum-read-buffer-size=32KiB",
+      "--maximum-read-buffer-size=256KiB",
+      "--read-buffer-quantum=32KiB",
       "--duration=1s",
       "--minimum-sample-count=1",
       "--maximum-sample-count=2",
@@ -64,12 +64,12 @@ TEST(ThroughputOptions, Basic) {
   EXPECT_EQ(2, options->direct_path_channel_count);
   EXPECT_EQ(16 * kKiB, options->minimum_object_size);
   EXPECT_EQ(32 * kKiB, options->maximum_object_size);
-  EXPECT_EQ(16 * kKiB, options->minimum_write_size);
-  EXPECT_EQ(128 * kKiB, options->maximum_write_size);
-  EXPECT_EQ(16 * kKiB, options->write_quantum);
-  EXPECT_EQ(32 * kKiB, options->minimum_read_size);
-  EXPECT_EQ(256 * kKiB, options->maximum_read_size);
-  EXPECT_EQ(32 * kKiB, options->read_quantum);
+  EXPECT_EQ(16 * kKiB, options->minimum_write_buffer_size);
+  EXPECT_EQ(128 * kKiB, options->maximum_write_buffer_size);
+  EXPECT_EQ(16 * kKiB, options->write_buffer_quantum);
+  EXPECT_EQ(32 * kKiB, options->minimum_read_buffer_size);
+  EXPECT_EQ(256 * kKiB, options->maximum_read_buffer_size);
+  EXPECT_EQ(32 * kKiB, options->read_buffer_quantum);
   EXPECT_EQ(1, options->duration.count());
   EXPECT_EQ(1, options->minimum_sample_count);
   EXPECT_EQ(2, options->maximum_sample_count);

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -45,7 +45,6 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
      << ',' << r.object_size                   //
      << ',' << r.transfer_size                 //
      << ',' << r.app_buffer_size               //
-     << ',' << r.lib_buffer_size               //
      << ',' << r.crc_enabled                   //
      << ',' << r.md5_enabled                   //
      << ',' << r.elapsed_time.count()          //
@@ -59,7 +58,7 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
 
 void PrintThroughputResultHeader(std::ostream& os) {
   os << "Library,Transport,Op,Start,ObjectSize,TransferSize,AppBufferSize"
-     << ",LibBufferSize,Crc32cEnabled,MD5Enabled"
+     << ",Crc32cEnabled,MD5Enabled"
      << ",ElapsedTimeUs,CpuTimeUs,Peer,Notes,StatusCode,Status\n";
 }
 

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -73,8 +73,6 @@ struct ThroughputResult {
   std::int64_t transfer_size;
   /// The size of the application buffer (for .read() or .write() calls).
   std::size_t app_buffer_size;
-  /// The size of the library buffers (if any).
-  std::size_t lib_buffer_size;
   /// True if the CRC32C checksums are enabled in this experiment.
   bool crc_enabled;
   /// True if the MD5 hashes are enabled in this experiment.

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -75,7 +75,7 @@ TEST(ThroughputResult, HeaderMatches) {
       ExperimentLibrary::kCppClient, ExperimentTransport::kGrpc, kOpInsert,
       std::chrono::system_clock::now(),
       /*object_size=*/5 * kMiB, /*transfer_size=*/3 * kMiB,
-      /*app_buffer_size=*/2 * kMiB, /*lib_buffer_size=*/4 * kMiB,
+      /*app_buffer_size=*/2 * kMiB,
       /*crc_enabled=*/true, /*md5_enabled=*/false,
       std::chrono::microseconds(234000), std::chrono::microseconds(345000),
       Status{StatusCode::kOutOfRange, "OOR-status-message"}, "peer", "notes"});
@@ -98,7 +98,6 @@ TEST(ThroughputResult, HeaderMatches) {
   EXPECT_THAT(*line, HasSubstr("," + std::to_string(5 * kMiB) + ","));
   EXPECT_THAT(*line, HasSubstr("," + std::to_string(3 * kMiB) + ","));
   EXPECT_THAT(*line, HasSubstr("," + std::to_string(2 * kMiB) + ","));
-  EXPECT_THAT(*line, HasSubstr("," + std::to_string(4 * kMiB) + ","));
   EXPECT_THAT(*line, HasSubstr(",1,"));  // crc_enabled==true
   EXPECT_THAT(*line, HasSubstr(",0,"));  // md5_enabled==false
   EXPECT_THAT(*line, HasSubstr(",234000,"));


### PR DESCRIPTION
Rename the options controlling the read and write buffer sizes to match
what they do. Remove the parameters related to the library
buffer sizes. We bypass these buffers, so they have no effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9370)
<!-- Reviewable:end -->
