### PR TITLE
impl: fix build for Windows+x86

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -100,7 +100,8 @@ std::string DebugString(Status const& status, TracingOptions const& options) {
 }
 
 std::string DebugString(std::string s, TracingOptions const& options) {
-  std::size_t const pos = options.truncate_string_field_longer_than();
+  auto const pos =
+      static_cast<std::size_t>(options.truncate_string_field_longer_than());
   if (s.size() > pos) s.replace(pos, std::string::npos, "...<truncated>...");
   return s;
 }


### PR DESCRIPTION
Add a cast to the `int64_t`-to-`size_t` conversion from #9351.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9371)
<!-- Reviewable:end -->
