### PR TITLE
feat(bigtable): add `AppProfileIdOption`

### DIFF
--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -52,6 +52,15 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
+ * The application profile id needed for using the replication API.
+ *
+ * @see https://cloud.google.com/bigtable/docs/app-profiles
+ */
+struct AppProfileIdOption {
+  using Type = std::string;
+};
+
+/**
  * The endpoint for data operations.
  *
  * @deprecated Please use `google::cloud::EndpointOption` instead.

--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -52,9 +52,23 @@ namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * The application profile id needed for using the replication API.
+ * The application profile id.
  *
- * @see https://cloud.google.com/bigtable/docs/app-profiles
+ * An application profile, or app profile, stores settings that tell your Cloud
+ * Bigtable instance how to handle incoming requests from an application. When
+ * an applications connects to a Bigtable instance, it can specify an app
+ * profile, and Bigtable uses that app profile for requests that the application
+ * sends over that connection.
+ *
+ * This option is always used in conjunction with a `bigtable::Table`. The app
+ * profile belongs to the table's instance, with an id given by the value of
+ * this option.
+ *
+ * @see https://cloud.google.com/bigtable/docs/app-profiles for an overview of
+ *     app profiles.
+ *
+ * @see https://cloud.google.com/bigtable/docs/replication-overview#app-profiles
+ *     for how app profiles are used to achieve replication.
  */
 struct AppProfileIdOption {
   using Type = std::string;

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -24,6 +24,7 @@
 #include "google/cloud/bigtable/internal/legacy_async_row_reader.h"
 #include "google/cloud/bigtable/mutation_branch.h"
 #include "google/cloud/bigtable/mutations.h"
+#include "google/cloud/bigtable/options.h"
 #include "google/cloud/bigtable/read_modify_write_rule.h"
 #include "google/cloud/bigtable/resource_names.h"
 #include "google/cloud/bigtable/row_key_sample.h"
@@ -34,10 +35,10 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "absl/meta/type_traits.h"
-#include "options.h"
 #include <string>
 #include <vector>
 

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -37,6 +37,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "absl/meta/type_traits.h"
+#include "options.h"
 #include <string>
 #include <vector>
 
@@ -53,8 +54,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 // public.
 bigtable::Table MakeTable(std::shared_ptr<bigtable::DataConnection> conn,
                           std::string project_id, std::string instance_id,
-                          std::string app_profile_id, std::string table_id,
-                          Options options = {});
+                          std::string table_id, Options options = {});
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable_internal
@@ -953,12 +953,11 @@ class Table {
  private:
   friend Table bigtable_internal::MakeTable(
       std::shared_ptr<bigtable::DataConnection>, std::string, std::string,
-      std::string, std::string, Options);
+      std::string, Options);
   explicit Table(std::shared_ptr<bigtable::DataConnection> conn,
                  std::string project_id, std::string instance_id,
-                 std::string app_profile_id, std::string table_id,
-                 Options options = {})
-      : app_profile_id_(std::move(app_profile_id)),
+                 std::string table_id, Options options = {})
+      : app_profile_id_(options.get<AppProfileIdOption>()),
         project_id_(std::move(project_id)),
         instance_id_(std::move(instance_id)),
         table_name_(TableName(project_id_, instance_id_, table_id)),
@@ -1051,12 +1050,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 inline bigtable::Table MakeTable(std::shared_ptr<bigtable::DataConnection> conn,
                                  std::string project_id,
-                                 std::string instance_id,
-                                 std::string app_profile_id,
-                                 std::string table_id, Options options) {
+                                 std::string instance_id, std::string table_id,
+                                 Options options) {
   return bigtable::Table(std::move(conn), std::move(project_id),
-                         std::move(instance_id), std::move(app_profile_id),
-                         std::move(table_id), std::move(options));
+                         std::move(instance_id), std::move(table_id),
+                         std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -157,10 +157,9 @@ void TableIntegrationTest::SetUp() {
 bigtable::Table TableIntegrationTest::GetTable(
     std::string const& implementation) {
   if (implementation == "with-data-connection") {
-    return bigtable_internal::MakeTable(data_connection_,
-                                        TableTestEnvironment::project_id(),
-                                        TableTestEnvironment::instance_id(), "",
-                                        TableTestEnvironment::table_id());
+    return bigtable_internal::MakeTable(
+        data_connection_, TableTestEnvironment::project_id(),
+        TableTestEnvironment::instance_id(), TableTestEnvironment::table_id());
   }
   return bigtable::Table(data_client_, TableTestEnvironment::table_id());
 }

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -527,7 +527,7 @@ TEST_P(DataIntegrationTest, TableApplyWithLogging) {
     if (GetParam() == "with-data-connection") {
       auto conn = MakeDataConnection(options);
       return bigtable_internal::MakeTable(std::move(conn), project_id(),
-                                          instance_id(), "", table_id);
+                                          instance_id(), table_id);
     }
     auto data_client = MakeDataClient(project_id(), instance_id(), options);
     return Table(std::move(data_client), table_id);

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -72,7 +72,7 @@ class SampleRowsIntegrationTest
     auto table = bigtable_internal::MakeTable(
         MakeDataConnection(Options{}.set<TracingComponentsOption>({"rpc"})),
         TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
-        "", TableTestEnvironment::table_id());
+        TableTestEnvironment::table_id());
 
     int constexpr kBatchCount = 10;
     int constexpr kBatchSize = 5000;
@@ -107,16 +107,14 @@ class SampleRowsIntegrationTest
 TEST_F(SampleRowsIntegrationTest, SyncWithDataConnection) {
   auto table = bigtable_internal::MakeTable(
       MakeDataConnection(), TableTestEnvironment::project_id(),
-      TableTestEnvironment::instance_id(), "",
-      TableTestEnvironment::table_id());
+      TableTestEnvironment::instance_id(), TableTestEnvironment::table_id());
   VerifySamples(table.SampleRows());
 };
 
 TEST_F(SampleRowsIntegrationTest, AsyncWithDataConnection) {
   auto table = bigtable_internal::MakeTable(
       MakeDataConnection(), TableTestEnvironment::project_id(),
-      TableTestEnvironment::instance_id(), "",
-      TableTestEnvironment::table_id());
+      TableTestEnvironment::instance_id(), TableTestEnvironment::table_id());
   auto fut = table.AsyncSampleRows();
   VerifySamples(fut.get());
 };


### PR DESCRIPTION
Part of the work for #9349 

For now, if the `AppProfileIdOption` is supplied to the `Table` constructor, we copy the value into `Table::app_profile_id_`, and pass that along to the Connection when a call is made.

In a follow up PR, I will modify the Connection API to drop the `app_profile_id` argument from its calls, and instead look for the value in `CurrentOptions()`. I think I will drop `Table::app_profile_id_` in that PR as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9382)
<!-- Reviewable:end -->
