### PR TITLE
refactor(testing_util): prepare metadata validation to handle explicit routing

### DIFF
--- a/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_kitchen_sink_metadata_decorator_test.cc
@@ -56,9 +56,8 @@ class MetadataDecoratorTest : public ::testing::Test {
     return Status(StatusCode::kUnavailable, "try-again");
   }
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request,
         google::cloud::internal::ApiClientHeader("generator"));

--- a/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -45,10 +45,12 @@ class MetadataDecoratorTest : public ::testing::Test {
         StatusOr<google::longrunning::Operation>(TransientError()));
   }
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader("generator"));
+        context, method, request,
+        google::cloud::internal::ApiClientHeader("generator"));
   }
 
   std::shared_ptr<MockGoldenThingAdminStub> mock_;
@@ -61,10 +63,12 @@ TEST_F(MetadataDecoratorTest, GetDatabase) {
   EXPECT_CALL(*mock_, GetDatabase)
       .WillOnce(
           [this](grpc::ClientContext& context,
-                 google::test::admin::database::v1::GetDatabaseRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(context,
-                                              "google.test.admin.database.v1."
-                                              "GoldenThingAdmin.GetDatabase"));
+                 google::test::admin::database::v1::GetDatabaseRequest const&
+                     request) {
+            IsContextMDValid(context,
+                             "google.test.admin.database.v1."
+                             "GoldenThingAdmin.GetDatabase",
+                             request);
             return TransientError();
           });
 
@@ -80,13 +84,13 @@ TEST_F(MetadataDecoratorTest, GetDatabase) {
 TEST_F(MetadataDecoratorTest, ListDatabases) {
   EXPECT_CALL(*mock_, ListDatabases)
       .WillOnce(
-          [this](
-              grpc::ClientContext& context,
-              google::test::admin::database::v1::ListDatabasesRequest const&) {
-            EXPECT_STATUS_OK(
-                IsContextMDValid(context,
-                                 "google.test.admin.database.v1."
-                                 "GoldenThingAdmin.ListDatabases"));
+          [this](grpc::ClientContext& context,
+                 google::test::admin::database::v1::ListDatabasesRequest const&
+                     request) {
+            IsContextMDValid(context,
+                             "google.test.admin.database.v1."
+                             "GoldenThingAdmin.ListDatabases",
+                             request);
             return TransientError();
           });
 
@@ -101,14 +105,14 @@ TEST_F(MetadataDecoratorTest, ListDatabases) {
 TEST_F(MetadataDecoratorTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
       .WillOnce(
-          [this](
-              google::cloud::CompletionQueue&,
-              std::unique_ptr<grpc::ClientContext> context,
-              google::test::admin::database::v1::CreateDatabaseRequest const&) {
-            EXPECT_STATUS_OK(
-                IsContextMDValid(*context,
-                                 "google.test.admin.database.v1."
-                                 "GoldenThingAdmin.CreateDatabase"));
+          [this](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::CreateDatabaseRequest const&
+                     request) {
+            IsContextMDValid(*context,
+                             "google.test.admin.database.v1."
+                             "GoldenThingAdmin.CreateDatabase",
+                             request);
             return LongrunningTransientError();
           });
 
@@ -123,16 +127,18 @@ TEST_F(MetadataDecoratorTest, CreateDatabase) {
 
 TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::test::admin::database::v1::
-                           UpdateDatabaseDdlRequest const&) {
-        EXPECT_STATUS_OK(
+      .WillOnce(
+          [this](
+              google::cloud::CompletionQueue&,
+              std::unique_ptr<grpc::ClientContext> context,
+              google::test::admin::database::v1::UpdateDatabaseDdlRequest const&
+                  request) {
             IsContextMDValid(*context,
                              "google.test.admin.database.v1."
-                             "GoldenThingAdmin.UpdateDatabaseDdl"));
-        return LongrunningTransientError();
-      });
+                             "GoldenThingAdmin.UpdateDatabaseDdl",
+                             request);
+            return LongrunningTransientError();
+          });
 
   GoldenThingAdminMetadata stub(mock_);
   CompletionQueue cq;
@@ -147,12 +153,13 @@ TEST_F(MetadataDecoratorTest, UpdateDatabaseDdl) {
 TEST_F(MetadataDecoratorTest, DropDatabase) {
   EXPECT_CALL(*mock_, DropDatabase)
       .WillOnce(
-          [this](
-              grpc::ClientContext& context,
-              google::test::admin::database::v1::DropDatabaseRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
+          [this](grpc::ClientContext& context,
+                 google::test::admin::database::v1::DropDatabaseRequest const&
+                     request) {
+            IsContextMDValid(
                 context,
-                "google.test.admin.database.v1.GoldenThingAdmin.DropDatabase"));
+                "google.test.admin.database.v1.GoldenThingAdmin.DropDatabase",
+                request);
             return TransientError();
           });
 
@@ -167,14 +174,16 @@ TEST_F(MetadataDecoratorTest, DropDatabase) {
 
 TEST_F(MetadataDecoratorTest, GetDatabaseDdl) {
   EXPECT_CALL(*mock_, GetDatabaseDdl)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::test::admin::database::v1::
-                           GetDatabaseDdlRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context,
-            "google.test.admin.database.v1.GoldenThingAdmin.GetDatabaseDdl"));
-        return TransientError();
-      });
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::test::admin::database::v1::GetDatabaseDdlRequest const&
+                     request) {
+            IsContextMDValid(
+                context,
+                "google.test.admin.database.v1.GoldenThingAdmin.GetDatabaseDdl",
+                request);
+            return TransientError();
+          });
 
   GoldenThingAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -188,10 +197,11 @@ TEST_F(MetadataDecoratorTest, GetDatabaseDdl) {
 TEST_F(MetadataDecoratorTest, SetIamPolicy) {
   EXPECT_CALL(*mock_, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::SetIamPolicyRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
+                       google::iam::v1::SetIamPolicyRequest const& request) {
+        IsContextMDValid(
             context,
-            "google.test.admin.database.v1.GoldenThingAdmin.SetIamPolicy"));
+            "google.test.admin.database.v1.GoldenThingAdmin.SetIamPolicy",
+            request);
         return TransientError();
       });
 
@@ -207,10 +217,11 @@ TEST_F(MetadataDecoratorTest, SetIamPolicy) {
 TEST_F(MetadataDecoratorTest, GetIamPolicy) {
   EXPECT_CALL(*mock_, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::GetIamPolicyRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
+                       google::iam::v1::GetIamPolicyRequest const& request) {
+        IsContextMDValid(
             context,
-            "google.test.admin.database.v1.GoldenThingAdmin.GetIamPolicy"));
+            "google.test.admin.database.v1.GoldenThingAdmin.GetIamPolicy",
+            request);
         return TransientError();
       });
 
@@ -225,14 +236,15 @@ TEST_F(MetadataDecoratorTest, GetIamPolicy) {
 
 TEST_F(MetadataDecoratorTest, TestIamPermissions) {
   EXPECT_CALL(*mock_, TestIamPermissions)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::TestIamPermissionsRequest const&) {
-        EXPECT_STATUS_OK(
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::iam::v1::TestIamPermissionsRequest const& request) {
             IsContextMDValid(context,
                              "google.test.admin.database.v1."
-                             "GoldenThingAdmin.TestIamPermissions"));
-        return TransientError();
-      });
+                             "GoldenThingAdmin.TestIamPermissions",
+                             request);
+            return TransientError();
+          });
 
   GoldenThingAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -246,13 +258,14 @@ TEST_F(MetadataDecoratorTest, TestIamPermissions) {
 TEST_F(MetadataDecoratorTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
       .WillOnce(
-          [this](
-              google::cloud::CompletionQueue&,
-              std::unique_ptr<grpc::ClientContext> context,
-              google::test::admin::database::v1::CreateBackupRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
+          [this](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::CreateBackupRequest const&
+                     request) {
+            IsContextMDValid(
                 *context,
-                "google.test.admin.database.v1.GoldenThingAdmin.CreateBackup"));
+                "google.test.admin.database.v1.GoldenThingAdmin.CreateBackup",
+                request);
             return LongrunningTransientError();
           });
 
@@ -267,14 +280,15 @@ TEST_F(MetadataDecoratorTest, CreateBackup) {
 
 TEST_F(MetadataDecoratorTest, GetBackup) {
   EXPECT_CALL(*mock_, GetBackup)
-      .WillOnce(
-          [this](grpc::ClientContext& context,
-                 google::test::admin::database::v1::GetBackupRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
-                context,
-                "google.test.admin.database.v1.GoldenThingAdmin.GetBackup"));
-            return TransientError();
-          });
+      .WillOnce([this](
+                    grpc::ClientContext& context,
+                    google::test::admin::database::v1::GetBackupRequest const&
+                        request) {
+        IsContextMDValid(
+            context, "google.test.admin.database.v1.GoldenThingAdmin.GetBackup",
+            request);
+        return TransientError();
+      });
 
   GoldenThingAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -288,12 +302,13 @@ TEST_F(MetadataDecoratorTest, GetBackup) {
 TEST_F(MetadataDecoratorTest, UpdateBackup) {
   EXPECT_CALL(*mock_, UpdateBackup)
       .WillOnce(
-          [this](
-              grpc::ClientContext& context,
-              google::test::admin::database::v1::UpdateBackupRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
+          [this](grpc::ClientContext& context,
+                 google::test::admin::database::v1::UpdateBackupRequest const&
+                     request) {
+            IsContextMDValid(
                 context,
-                "google.test.admin.database.v1.GoldenThingAdmin.UpdateBackup"));
+                "google.test.admin.database.v1.GoldenThingAdmin.UpdateBackup",
+                request);
             return TransientError();
           });
 
@@ -309,12 +324,13 @@ TEST_F(MetadataDecoratorTest, UpdateBackup) {
 TEST_F(MetadataDecoratorTest, DeleteBackup) {
   EXPECT_CALL(*mock_, DeleteBackup)
       .WillOnce(
-          [this](
-              grpc::ClientContext& context,
-              google::test::admin::database::v1::DeleteBackupRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
+          [this](grpc::ClientContext& context,
+                 google::test::admin::database::v1::DeleteBackupRequest const&
+                     request) {
+            IsContextMDValid(
                 context,
-                "google.test.admin.database.v1.GoldenThingAdmin.DeleteBackup"));
+                "google.test.admin.database.v1.GoldenThingAdmin.DeleteBackup",
+                request);
             return TransientError();
           });
 
@@ -331,10 +347,12 @@ TEST_F(MetadataDecoratorTest, ListBackups) {
   EXPECT_CALL(*mock_, ListBackups)
       .WillOnce(
           [this](grpc::ClientContext& context,
-                 google::test::admin::database::v1::ListBackupsRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
+                 google::test::admin::database::v1::ListBackupsRequest const&
+                     request) {
+            IsContextMDValid(
                 context,
-                "google.test.admin.database.v1.GoldenThingAdmin.ListBackups"));
+                "google.test.admin.database.v1.GoldenThingAdmin.ListBackups",
+                request);
             return TransientError();
           });
 
@@ -351,10 +369,11 @@ TEST_F(MetadataDecoratorTest, RestoreDatabase) {
       .WillOnce([this](google::cloud::CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
                        google::test::admin::database::v1::
-                           RestoreDatabaseRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
+                           RestoreDatabaseRequest const& request) {
+        IsContextMDValid(
             *context,
-            "google.test.admin.database.v1.GoldenThingAdmin.RestoreDatabase"));
+            "google.test.admin.database.v1.GoldenThingAdmin.RestoreDatabase",
+            request);
         return LongrunningTransientError();
       });
 
@@ -371,11 +390,11 @@ TEST_F(MetadataDecoratorTest, ListDatabaseOperations) {
   EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
-                           ListDatabaseOperationsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.test.admin.database.v1.GoldenThingAdmin."
-                             "ListDatabaseOperations"));
+                           ListDatabaseOperationsRequest const& request) {
+        IsContextMDValid(context,
+                         "google.test.admin.database.v1.GoldenThingAdmin."
+                         "ListDatabaseOperations",
+                         request);
         return TransientError();
       });
 
@@ -391,11 +410,11 @@ TEST_F(MetadataDecoratorTest, ListBackupOperations) {
   EXPECT_CALL(*mock_, ListBackupOperations)
       .WillOnce([this](grpc::ClientContext& context,
                        google::test::admin::database::v1::
-                           ListBackupOperationsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.test.admin.database.v1."
-                             "GoldenThingAdmin.ListBackupOperations"));
+                           ListBackupOperationsRequest const& request) {
+        IsContextMDValid(context,
+                         "google.test.admin.database.v1."
+                         "GoldenThingAdmin.ListBackupOperations",
+                         request);
         return TransientError();
       });
 
@@ -412,10 +431,12 @@ TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
       .WillOnce(
           [this](google::cloud::CompletionQueue&,
                  std::unique_ptr<grpc::ClientContext> context,
-                 google::test::admin::database::v1::GetDatabaseRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(*context,
-                                              "google.test.admin.database.v1."
-                                              "GoldenThingAdmin.GetDatabase"));
+                 google::test::admin::database::v1::GetDatabaseRequest const&
+                     request) {
+            IsContextMDValid(*context,
+                             "google.test.admin.database.v1."
+                             "GoldenThingAdmin.GetDatabase",
+                             request);
             return make_ready_future(
                 StatusOr<google::test::admin::database::v1::Database>(
                     TransientError()));
@@ -434,13 +455,14 @@ TEST_F(MetadataDecoratorTest, AsyncGetDatabase) {
 TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
   EXPECT_CALL(*mock_, AsyncDropDatabase)
       .WillOnce(
-          [this](
-              google::cloud::CompletionQueue&,
-              std::unique_ptr<grpc::ClientContext> context,
-              google::test::admin::database::v1::DropDatabaseRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(*context,
-                                              "google.test.admin.database.v1."
-                                              "GoldenThingAdmin.DropDatabase"));
+          [this](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::test::admin::database::v1::DropDatabaseRequest const&
+                     request) {
+            IsContextMDValid(*context,
+                             "google.test.admin.database.v1."
+                             "GoldenThingAdmin.DropDatabase",
+                             request);
             return make_ready_future(TransientError());
           });
 
@@ -456,16 +478,18 @@ TEST_F(MetadataDecoratorTest, AsyncDropDatabase) {
 
 TEST_F(MetadataDecoratorTest, LongRunningWithoutRouting) {
   EXPECT_CALL(*mock_, AsyncLongRunningWithoutRouting)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::test::admin::database::v1::
-                           RestoreDatabaseRequest const&) {
-        EXPECT_STATUS_OK(
+      .WillOnce(
+          [this](
+              google::cloud::CompletionQueue&,
+              std::unique_ptr<grpc::ClientContext> context,
+              google::test::admin::database::v1::RestoreDatabaseRequest const&
+                  request) {
             IsContextMDValid(*context,
                              "google.test.admin.database.v1.GoldenThingAdmin."
-                             "LongRunningWithoutRouting"));
-        return LongrunningTransientError();
-      });
+                             "LongRunningWithoutRouting",
+                             request);
+            return LongrunningTransientError();
+          });
 
   GoldenThingAdminMetadata stub(mock_);
   CompletionQueue cq;
@@ -478,11 +502,12 @@ TEST_F(MetadataDecoratorTest, LongRunningWithoutRouting) {
 
 TEST_F(MetadataDecoratorTest, GetOperation) {
   EXPECT_CALL(*mock_, AsyncGetOperation)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::longrunning::GetOperationRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.longrunning.Operations.GetOperation"));
+      .WillOnce([this](
+                    google::cloud::CompletionQueue&,
+                    std::unique_ptr<grpc::ClientContext> context,
+                    google::longrunning::GetOperationRequest const& request) {
+        IsContextMDValid(*context, "google.longrunning.Operations.GetOperation",
+                         request);
         return LongrunningTransientError();
       });
 
@@ -497,13 +522,15 @@ TEST_F(MetadataDecoratorTest, GetOperation) {
 
 TEST_F(MetadataDecoratorTest, CancelOperation) {
   EXPECT_CALL(*mock_, AsyncCancelOperation)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::longrunning::CancelOperationRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.longrunning.Operations.CancelOperation"));
-        return make_ready_future(TransientError());
-      });
+      .WillOnce(
+          [this](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            IsContextMDValid(*context,
+                             "google.longrunning.Operations.CancelOperation",
+                             request);
+            return make_ready_future(TransientError());
+          });
 
   GoldenThingAdminMetadata stub(mock_);
   CompletionQueue cq;

--- a/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_metadata_decorator_test.cc
@@ -45,9 +45,8 @@ class MetadataDecoratorTest : public ::testing::Test {
         StatusOr<google::longrunning::Operation>(TransientError()));
   }
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request,
         google::cloud::internal::ApiClientHeader("generator"));

--- a/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc
@@ -53,9 +53,8 @@ using ::testing::Return;
 
 class BigtableStubFactory : public ::testing::Test {
  protected:
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request,
         google::cloud::internal::ApiClientHeader("generator"));

--- a/google/cloud/bigtable/internal/legacy_async_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_async_row_reader_test.cc
@@ -73,9 +73,9 @@ class TableAsyncReadRowsTest : public bigtable::testing::TableTestFixture {
                       grpc::ClientContext* context,
                       btproto::ReadRowsRequest const& r,
                       grpc::CompletionQueue*) {
-          EXPECT_STATUS_OK(validate_metadata_fixture_.IsContextMDValid(
-              *context, "google.bigtable.v2.Bigtable.ReadRows",
-              google::cloud::internal::ApiClientHeader()));
+          validate_metadata_fixture_.IsContextMDValid(
+              *context, "google.bigtable.v2.Bigtable.ReadRows", r,
+              google::cloud::internal::ApiClientHeader());
           (*request_expectations_ptr)(r);
           return std::unique_ptr<
               MockClientAsyncReaderInterface<btproto::ReadRowsResponse>>(

--- a/google/cloud/bigtable/internal/legacy_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader_test.cc
@@ -193,9 +193,9 @@ TEST_F(LegacyRowReaderTest, ReadOneRowAppProfileId) {
       .WillOnce([expected_id](grpc::ClientContext* context,
                               ReadRowsRequest const& req) {
         ValidateMetadataFixture fixture;
-        EXPECT_STATUS_OK(fixture.IsContextMDValid(
-            *context, "google.bigtable.v2.Bigtable.ReadRows",
-            google::cloud::internal::ApiClientHeader()));
+        fixture.IsContextMDValid(*context,
+                                 "google.bigtable.v2.Bigtable.ReadRows", req,
+                                 google::cloud::internal::ApiClientHeader());
         EXPECT_EQ(expected_id, req.app_profile_id());
         auto stream = absl::make_unique<MockReadRowsReader>(
             "google.bigtable.v2.Bigtable.ReadRows");

--- a/google/cloud/bigtable/mutation_batcher_test.cc
+++ b/google/cloud/bigtable/mutation_batcher_test.cc
@@ -172,8 +172,8 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
                         grpc::ClientContext* context,
                         btproto::MutateRowsRequest const& r,
                         grpc::CompletionQueue*) {
-            EXPECT_STATUS_OK(IsContextMDValid(
-                *context, "google.bigtable.v2.Bigtable.MutateRows"));
+            IsContextMDValid(*context, "google.bigtable.v2.Bigtable.MutateRows",
+                             r);
             EXPECT_EQ(exchange.req.size(), r.entries_size());
             for (std::size_t i = 0; i != exchange.req.size(); ++i) {
               google::bigtable::v2::MutateRowsRequest::Entry expected;
@@ -247,10 +247,11 @@ class MutationBatcherTest : public bigtable::testing::TableTestFixture {
 
   std::size_t NumOperationsOutstanding() { return cq_impl_->size(); }
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   std::unique_ptr<MutationBatcher> batcher_;

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -34,10 +34,11 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {
  protected:
   TableApplyTest() : TableTestFixture(CompletionQueue{}) {}
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   std::function<grpc::Status(grpc::ClientContext* context,
@@ -45,10 +46,10 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {
                              google::bigtable::v2::MutateRowResponse*)>
   CreateMutateRowMock(grpc::Status const& status) {
     return [this, status](grpc::ClientContext* context,
-                          google::bigtable::v2::MutateRowRequest const&,
+                          google::bigtable::v2::MutateRowRequest const& request,
                           google::bigtable::v2::MutateRowResponse*) {
-      EXPECT_STATUS_OK(
-          IsContextMDValid(*context, "google.bigtable.v2.Bigtable.MutateRow"));
+      IsContextMDValid(*context, "google.bigtable.v2.Bigtable.MutateRow",
+                       request);
       return status;
     };
   }

--- a/google/cloud/bigtable/table_apply_test.cc
+++ b/google/cloud/bigtable/table_apply_test.cc
@@ -34,9 +34,8 @@ class TableApplyTest : public bigtable::testing::TableTestFixture {
  protected:
   TableApplyTest() : TableTestFixture(CompletionQueue{}) {}
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -32,9 +32,8 @@ class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
  protected:
   TableCheckAndMutateRowTest() : TableTestFixture(CompletionQueue{}) {}
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/bigtable/table_check_and_mutate_row_test.cc
+++ b/google/cloud/bigtable/table_check_and_mutate_row_test.cc
@@ -32,10 +32,11 @@ class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
  protected:
   TableCheckAndMutateRowTest() : TableTestFixture(CompletionQueue{}) {}
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   std::function<
@@ -43,11 +44,12 @@ class TableCheckAndMutateRowTest : public bigtable::testing::TableTestFixture {
                    google::bigtable::v2::CheckAndMutateRowRequest const&,
                    google::bigtable::v2::CheckAndMutateRowResponse*)>
   CreateCheckAndMutateMock(grpc::Status const& status) {
-    return [this, status](grpc::ClientContext* context,
-                          google::bigtable::v2::CheckAndMutateRowRequest const&,
-                          google::bigtable::v2::CheckAndMutateRowResponse*) {
-      EXPECT_STATUS_OK(IsContextMDValid(
-          *context, "google.bigtable.v2.Bigtable.CheckAndMutateRow"));
+    return [this, status](
+               grpc::ClientContext* context,
+               google::bigtable::v2::CheckAndMutateRowRequest const& request,
+               google::bigtable::v2::CheckAndMutateRowResponse*) {
+      IsContextMDValid(
+          *context, "google.bigtable.v2.Bigtable.CheckAndMutateRow", request);
       return status;
     };
   }

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -33,9 +33,8 @@ class TableReadRowTest : public bigtable::testing::TableTestFixture {
  protected:
   TableReadRowTest() : TableTestFixture(CompletionQueue{}) {}
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/bigtable/table_readrow_test.cc
+++ b/google/cloud/bigtable/table_readrow_test.cc
@@ -33,10 +33,11 @@ class TableReadRowTest : public bigtable::testing::TableTestFixture {
  protected:
   TableReadRowTest() : TableTestFixture(CompletionQueue{}) {}
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
  private:
@@ -68,8 +69,7 @@ TEST_F(TableReadRowTest, ReadRowSimple) {
             .WillOnce(Return(false));
         EXPECT_CALL(*stream, Finish).WillOnce(Return(grpc::Status::OK));
 
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows"));
+        IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows", req);
         EXPECT_EQ(1, req.rows().row_keys_size());
         EXPECT_EQ("r1", req.rows().row_keys(0));
         EXPECT_EQ(1, req.rows_limit());
@@ -93,8 +93,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
         EXPECT_CALL(*stream, Read).WillOnce(Return(false));
         EXPECT_CALL(*stream, Finish).WillOnce(Return(grpc::Status::OK));
 
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows"));
+        IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows", req);
         EXPECT_EQ(1, req.rows().row_keys_size());
         EXPECT_EQ("r1", req.rows().row_keys(0));
         EXPECT_EQ(1, req.rows_limit());
@@ -110,7 +109,7 @@ TEST_F(TableReadRowTest, ReadRowMissing) {
 TEST_F(TableReadRowTest, UnrecoverableFailure) {
   EXPECT_CALL(*client_, ReadRows)
       .WillRepeatedly([this](grpc::ClientContext* context,
-                             btproto::ReadRowsRequest const&) {
+                             btproto::ReadRowsRequest const& request) {
         auto stream = absl::make_unique<MockReadRowsReader>(
             "google.bigtable.v2.Bigtable.ReadRows");
         EXPECT_CALL(*stream, Read).WillRepeatedly(Return(false));
@@ -118,8 +117,8 @@ TEST_F(TableReadRowTest, UnrecoverableFailure) {
             .WillRepeatedly(Return(
                 grpc::Status(grpc::StatusCode::PERMISSION_DENIED, "uh oh")));
 
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows"));
+        IsContextMDValid(*context, "google.bigtable.v2.Bigtable.ReadRows",
+                         request);
         return stream;
       });
 

--- a/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
+++ b/google/cloud/bigtable/testing/mock_async_failing_rpc_factory.h
@@ -57,8 +57,9 @@ struct MockAsyncFailingRpcFactory {
                                             grpc::ClientContext* context,
                                             RequestType const& request,
                                             grpc::CompletionQueue*) {
-      EXPECT_STATUS_OK(validate_metadata_fixture_.IsContextMDValid(
-          *context, method, google::cloud::internal::ApiClientHeader()));
+      validate_metadata_fixture_.IsContextMDValid(
+          *context, method, request,
+          google::cloud::internal::ApiClientHeader());
       RequestType expected;
       // Cannot use ASSERT_TRUE() here, it has an embedded "return;"
       EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(

--- a/google/cloud/bigtable/testing/mock_response_reader.h
+++ b/google/cloud/bigtable/testing/mock_response_reader.h
@@ -63,9 +63,10 @@ class MockResponseReader : public grpc::ClientReaderInterface<Response> {
    */
   std::function<UniquePtr(grpc::ClientContext*, Request const&)>
   MakeMockReturner() {
-    return [this](grpc::ClientContext* context, Request const&) {
-      EXPECT_STATUS_OK(validate_metadata_fixture_.IsContextMDValid(
-          *context, method_, google::cloud::internal::ApiClientHeader()));
+    return [this](grpc::ClientContext* context, Request const& request) {
+      validate_metadata_fixture_.IsContextMDValid(
+          *context, method_, request,
+          google::cloud::internal::ApiClientHeader());
       return UniquePtr(this);
     };
   }

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -49,9 +49,8 @@ class MockMinimalIamCredentialsStub : public MinimalIamCredentialsStub {
 
 class MinimalIamCredentialsStubTest : public ::testing::Test {
  protected:
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/internal/minimal_iam_credentials_stub_test.cc
+++ b/google/cloud/internal/minimal_iam_credentials_stub_test.cc
@@ -49,10 +49,11 @@ class MockMinimalIamCredentialsStub : public MinimalIamCredentialsStub {
 
 class MinimalIamCredentialsStubTest : public ::testing::Test {
  protected:
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   static Status TransientError() {
@@ -134,10 +135,11 @@ TEST_F(MinimalIamCredentialsStubTest,
   EXPECT_CALL(*mock, AsyncGenerateAccessToken)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       GenerateAccessTokenRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
+                       GenerateAccessTokenRequest const& request) {
+        IsContextMDValid(
             *context,
-            "google.iam.credentials.v1.IAMCredentials.GenerateAccessToken"));
+            "google.iam.credentials.v1.IAMCredentials.GenerateAccessToken",
+            request);
         GenerateAccessTokenResponse response;
         response.set_access_token("test-only-token");
         return make_ready_future(make_status_or(response));

--- a/google/cloud/pubsub/internal/publisher_metadata_test.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata_test.cc
@@ -36,9 +36,8 @@ using ::testing::Pair;
 
 class PublisherMetadataTest : public ::testing::Test {
  protected:
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/pubsub/internal/publisher_metadata_test.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata_test.cc
@@ -36,10 +36,11 @@ using ::testing::Pair;
 
 class PublisherMetadataTest : public ::testing::Test {
  protected:
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   void ValidateNoUserProject(grpc::ClientContext& context) {
@@ -66,9 +67,9 @@ TEST_F(PublisherMetadataTest, CreateTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, CreateTopic)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::Topic const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Publisher.CreateTopic"));
+                       google::pubsub::v1::Topic const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Publisher.CreateTopic",
+                         request);
         return make_status_or(google::pubsub::v1::Topic{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -97,9 +98,9 @@ TEST_F(PublisherMetadataTest, GetTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, GetTopic)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::GetTopicRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context, "google.pubsub.v1.Publisher.GetTopic"));
+                       google::pubsub::v1::GetTopicRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Publisher.GetTopic",
+                         request);
         return make_status_or(google::pubsub::v1::Topic{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -128,9 +129,9 @@ TEST_F(PublisherMetadataTest, UpdateTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, UpdateTopic)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::UpdateTopicRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Publisher.UpdateTopic"));
+                       google::pubsub::v1::UpdateTopicRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Publisher.UpdateTopic",
+                         request);
         return make_status_or(google::pubsub::v1::Topic{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -160,9 +161,9 @@ TEST_F(PublisherMetadataTest, ListTopics) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, ListTopics)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ListTopicsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context, "google.pubsub.v1.Publisher.ListTopics"));
+                       google::pubsub::v1::ListTopicsRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Publisher.ListTopics",
+                         request);
         return make_status_or(google::pubsub::v1::ListTopicsResponse{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -191,9 +192,9 @@ TEST_F(PublisherMetadataTest, DeleteTopic) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, DeleteTopic)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::DeleteTopicRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Publisher.DeleteTopic"));
+                       google::pubsub::v1::DeleteTopicRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Publisher.DeleteTopic",
+                         request);
         return Status{};
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -221,12 +222,15 @@ TEST_F(PublisherMetadataTest, DeleteTopic) {
 TEST_F(PublisherMetadataTest, DetachSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, DetachSubscription)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::DetachSubscriptionRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Publisher.DetachSubscription"));
-        return make_status_or(google::pubsub::v1::DetachSubscriptionResponse{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::DetachSubscriptionRequest const& request) {
+            IsContextMDValid(context,
+                             "google.pubsub.v1.Publisher.DetachSubscription",
+                             request);
+            return make_status_or(
+                google::pubsub::v1::DetachSubscriptionResponse{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::DetachSubscriptionRequest const&) {
         ValidateNoUserProject(context);
@@ -253,14 +257,15 @@ TEST_F(PublisherMetadataTest, DetachSubscription) {
 TEST_F(PublisherMetadataTest, ListTopicSubscriptions) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, ListTopicSubscriptions)
-      .WillOnce(
-          [this](grpc::ClientContext& context,
-                 google::pubsub::v1::ListTopicSubscriptionsRequest const&) {
-            EXPECT_STATUS_OK(IsContextMDValid(
-                context, "google.pubsub.v1.Publisher.ListTopicSubscriptions"));
-            return make_status_or(
-                google::pubsub::v1::ListTopicSubscriptionsResponse{});
-          })
+      .WillOnce([this](grpc::ClientContext& context,
+                       google::pubsub::v1::ListTopicSubscriptionsRequest const&
+                           request) {
+        IsContextMDValid(context,
+                         "google.pubsub.v1.Publisher.ListTopicSubscriptions",
+                         request);
+        return make_status_or(
+            google::pubsub::v1::ListTopicSubscriptionsResponse{});
+      })
       .WillOnce(
           [this](grpc::ClientContext& context,
                  google::pubsub::v1::ListTopicSubscriptionsRequest const&) {
@@ -290,12 +295,15 @@ TEST_F(PublisherMetadataTest, ListTopicSubscriptions) {
 TEST_F(PublisherMetadataTest, ListTopicSnapshots) {
   auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
   EXPECT_CALL(*mock, ListTopicSnapshots)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ListTopicSnapshotsRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Publisher.ListTopicSnapshots"));
-        return make_status_or(google::pubsub::v1::ListTopicSnapshotsResponse{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::ListTopicSnapshotsRequest const& request) {
+            IsContextMDValid(context,
+                             "google.pubsub.v1.Publisher.ListTopicSnapshots",
+                             request);
+            return make_status_or(
+                google::pubsub::v1::ListTopicSnapshotsResponse{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::ListTopicSnapshotsRequest const&) {
         ValidateNoUserProject(context);
@@ -323,9 +331,9 @@ TEST_F(PublisherMetadataTest, AsyncPublish) {
   EXPECT_CALL(*mock, AsyncPublish)
       .WillOnce([this](google::cloud::CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       google::pubsub::v1::PublishRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context, "google.pubsub.v1.Publisher.Publish"));
+                       google::pubsub::v1::PublishRequest const& request) {
+        IsContextMDValid(*context, "google.pubsub.v1.Publisher.Publish",
+                         request);
         return make_ready_future(
             make_status_or(google::pubsub::v1::PublishResponse{}));
       })

--- a/google/cloud/pubsub/internal/schema_metadata_test.cc
+++ b/google/cloud/pubsub/internal/schema_metadata_test.cc
@@ -37,9 +37,8 @@ using ::testing::Pair;
 
 class SchemaMetadataTest : public ::testing::Test {
  protected:
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/pubsub/internal/schema_metadata_test.cc
+++ b/google/cloud/pubsub/internal/schema_metadata_test.cc
@@ -37,10 +37,11 @@ using ::testing::Pair;
 
 class SchemaMetadataTest : public ::testing::Test {
  protected:
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   void ValidateNoUserProject(grpc::ClientContext& context) {
@@ -67,10 +68,9 @@ TEST_F(SchemaMetadataTest, CreateSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, CreateSchema)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::CreateSchemaRequest const&) {
-        EXPECT_THAT(IsContextMDValid(
-                        context, "google.pubsub.v1.SchemaService.CreateSchema"),
-                    IsOk());
+                       google::pubsub::v1::CreateSchemaRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.SchemaService.CreateSchema",
+                         request);
         return make_status_or(google::pubsub::v1::Schema{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -99,10 +99,9 @@ TEST_F(SchemaMetadataTest, GetSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, GetSchema)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::GetSchemaRequest const&) {
-        EXPECT_THAT(IsContextMDValid(
-                        context, "google.pubsub.v1.SchemaService.GetSchema"),
-                    IsOk());
+                       google::pubsub::v1::GetSchemaRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.SchemaService.GetSchema",
+                         request);
         return make_status_or(google::pubsub::v1::Schema{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -131,10 +130,9 @@ TEST_F(SchemaMetadataTest, ListSchemas) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, ListSchemas)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ListSchemasRequest const&) {
-        EXPECT_THAT(IsContextMDValid(
-                        context, "google.pubsub.v1.SchemaService.ListSchemas"),
-                    IsOk());
+                       google::pubsub::v1::ListSchemasRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.SchemaService.ListSchemas",
+                         request);
         return make_status_or(google::pubsub::v1::ListSchemasResponse{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -163,10 +161,9 @@ TEST_F(SchemaMetadataTest, DeleteSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, DeleteSchema)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::DeleteSchemaRequest const&) {
-        EXPECT_THAT(IsContextMDValid(
-                        context, "google.pubsub.v1.SchemaService.DeleteSchema"),
-                    IsOk());
+                       google::pubsub::v1::DeleteSchemaRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.SchemaService.DeleteSchema",
+                         request);
         return Status{};
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -194,12 +191,11 @@ TEST_F(SchemaMetadataTest, DeleteSchema) {
 TEST_F(SchemaMetadataTest, ValidateSchema) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, ValidateSchema)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ValidateSchemaRequest const&) {
-        EXPECT_THAT(
-            IsContextMDValid(context,
-                             "google.pubsub.v1.SchemaService.ValidateSchema"),
-            IsOk());
+      .WillOnce([this](
+                    grpc::ClientContext& context,
+                    google::pubsub::v1::ValidateSchemaRequest const& request) {
+        IsContextMDValid(
+            context, "google.pubsub.v1.SchemaService.ValidateSchema", request);
         return make_status_or(google::pubsub::v1::ValidateSchemaResponse{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -227,12 +223,11 @@ TEST_F(SchemaMetadataTest, ValidateSchema) {
 TEST_F(SchemaMetadataTest, ValidateMessage) {
   auto mock = std::make_shared<pubsub_testing::MockSchemaStub>();
   EXPECT_CALL(*mock, ValidateMessage)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ValidateMessageRequest const&) {
-        EXPECT_THAT(
-            IsContextMDValid(context,
-                             "google.pubsub.v1.SchemaService.ValidateMessage"),
-            IsOk());
+      .WillOnce([this](
+                    grpc::ClientContext& context,
+                    google::pubsub::v1::ValidateMessageRequest const& request) {
+        IsContextMDValid(
+            context, "google.pubsub.v1.SchemaService.ValidateMessage", request);
         return make_status_or(google::pubsub::v1::ValidateMessageResponse{});
       })
       .WillOnce([this](grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_metadata_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_test.cc
@@ -36,10 +36,11 @@ using ::testing::Pair;
 
 class SubscriberMetadataTest : public ::testing::Test {
  protected:
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   void ValidateNoUserProject(grpc::ClientContext& context) {
@@ -66,9 +67,9 @@ TEST_F(SubscriberMetadataTest, CreateSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, CreateSubscription)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::Subscription const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.CreateSubscription"));
+                       google::pubsub::v1::Subscription const& request) {
+        IsContextMDValid(
+            context, "google.pubsub.v1.Subscriber.CreateSubscription", request);
         return make_status_or(google::pubsub::v1::Subscription{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -97,10 +98,11 @@ TEST_F(SubscriberMetadataTest, CreateSubscription) {
 TEST_F(SubscriberMetadataTest, GetSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, GetSubscription)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::GetSubscriptionRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.GetSubscription"));
+      .WillOnce([this](
+                    grpc::ClientContext& context,
+                    google::pubsub::v1::GetSubscriptionRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Subscriber.GetSubscription",
+                         request);
         return make_status_or(google::pubsub::v1::Subscription{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -129,12 +131,14 @@ TEST_F(SubscriberMetadataTest, GetSubscription) {
 TEST_F(SubscriberMetadataTest, UpdateSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, UpdateSubscription)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::UpdateSubscriptionRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.UpdateSubscription"));
-        return make_status_or(google::pubsub::v1::Subscription{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::UpdateSubscriptionRequest const& request) {
+            IsContextMDValid(context,
+                             "google.pubsub.v1.Subscriber.UpdateSubscription",
+                             request);
+            return make_status_or(google::pubsub::v1::Subscription{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::UpdateSubscriptionRequest const&) {
         ValidateNoUserProject(context);
@@ -161,12 +165,15 @@ TEST_F(SubscriberMetadataTest, UpdateSubscription) {
 TEST_F(SubscriberMetadataTest, ListSubscriptions) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, ListSubscriptions)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ListSubscriptionsRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.ListSubscriptions"));
-        return make_status_or(google::pubsub::v1::ListSubscriptionsResponse{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::ListSubscriptionsRequest const& request) {
+            IsContextMDValid(context,
+                             "google.pubsub.v1.Subscriber.ListSubscriptions",
+                             request);
+            return make_status_or(
+                google::pubsub::v1::ListSubscriptionsResponse{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::ListSubscriptionsRequest const&) {
         ValidateNoUserProject(context);
@@ -192,12 +199,14 @@ TEST_F(SubscriberMetadataTest, ListSubscriptions) {
 TEST_F(SubscriberMetadataTest, DeleteSubscription) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSubscription)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::DeleteSubscriptionRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.DeleteSubscription"));
-        return Status{};
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::DeleteSubscriptionRequest const& request) {
+            IsContextMDValid(context,
+                             "google.pubsub.v1.Subscriber.DeleteSubscription",
+                             request);
+            return Status{};
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::DeleteSubscriptionRequest const&) {
         ValidateNoUserProject(context);
@@ -224,12 +233,14 @@ TEST_F(SubscriberMetadataTest, DeleteSubscription) {
 TEST_F(SubscriberMetadataTest, ModifyPushConfig) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, ModifyPushConfig)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ModifyPushConfigRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.ModifyPushConfig"));
-        return Status{};
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::ModifyPushConfigRequest const& request) {
+            IsContextMDValid(context,
+                             "google.pubsub.v1.Subscriber.ModifyPushConfig",
+                             request);
+            return Status{};
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::ModifyPushConfigRequest const&) {
         ValidateNoUserProject(context);
@@ -256,13 +267,14 @@ TEST_F(SubscriberMetadataTest, ModifyPushConfig) {
 TEST_F(SubscriberMetadataTest, AsyncStreamingPull) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncStreamingPull)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::pubsub::v1::StreamingPullRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.pubsub.v1.Subscriber.StreamingPull"));
-        return absl::make_unique<pubsub_testing::MockAsyncPullStream>();
-      })
+      .WillOnce(
+          [this](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::pubsub::v1::StreamingPullRequest const& request) {
+            IsContextMDValid(
+                *context, "google.pubsub.v1.Subscriber.StreamingPull", request);
+            return absl::make_unique<pubsub_testing::MockAsyncPullStream>();
+          })
       .WillOnce([this](google::cloud::CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
                        google::pubsub::v1::StreamingPullRequest const&) {
@@ -294,9 +306,9 @@ TEST_F(SubscriberMetadataTest, AsyncAcknowledge) {
   EXPECT_CALL(*mock, AsyncAcknowledge)
       .WillOnce([this](google::cloud::CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       google::pubsub::v1::AcknowledgeRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.pubsub.v1.Subscriber.Acknowledge"));
+                       google::pubsub::v1::AcknowledgeRequest const& request) {
+        IsContextMDValid(*context, "google.pubsub.v1.Subscriber.Acknowledge",
+                         request);
         return make_ready_future(Status{});
       })
       .WillOnce([this](google::cloud::CompletionQueue&,
@@ -328,13 +340,15 @@ TEST_F(SubscriberMetadataTest, AsyncAcknowledge) {
 TEST_F(SubscriberMetadataTest, AsyncModifyAckDeadline) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, AsyncModifyAckDeadline)
-      .WillOnce([this](google::cloud::CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::pubsub::v1::ModifyAckDeadlineRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.pubsub.v1.Subscriber.ModifyAckDeadline"));
-        return make_ready_future(Status{});
-      })
+      .WillOnce(
+          [this](google::cloud::CompletionQueue&,
+                 std::unique_ptr<grpc::ClientContext> context,
+                 google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+            IsContextMDValid(*context,
+                             "google.pubsub.v1.Subscriber.ModifyAckDeadline",
+                             request);
+            return make_ready_future(Status{});
+          })
       .WillOnce([this](google::cloud::CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
                        google::pubsub::v1::ModifyAckDeadlineRequest const&) {
@@ -364,12 +378,13 @@ TEST_F(SubscriberMetadataTest, AsyncModifyAckDeadline) {
 TEST_F(SubscriberMetadataTest, CreateSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, CreateSnapshot)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::CreateSnapshotRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.CreateSnapshot"));
-        return make_status_or(google::pubsub::v1::Snapshot{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::CreateSnapshotRequest const& request) {
+            IsContextMDValid(
+                context, "google.pubsub.v1.Subscriber.CreateSnapshot", request);
+            return make_status_or(google::pubsub::v1::Snapshot{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::CreateSnapshotRequest const&) {
         ValidateNoUserProject(context);
@@ -397,9 +412,9 @@ TEST_F(SubscriberMetadataTest, GetSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, GetSnapshot)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::GetSnapshotRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.GetSnapshot"));
+                       google::pubsub::v1::GetSnapshotRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Subscriber.GetSnapshot",
+                         request);
         return make_status_or(google::pubsub::v1::Snapshot{});
       })
       .WillOnce([this](grpc::ClientContext& context,
@@ -428,12 +443,13 @@ TEST_F(SubscriberMetadataTest, GetSnapshot) {
 TEST_F(SubscriberMetadataTest, ListSnapshots) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, ListSnapshots)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::ListSnapshotsRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.ListSnapshots"));
-        return make_status_or(google::pubsub::v1::ListSnapshotsResponse{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::ListSnapshotsRequest const& request) {
+            IsContextMDValid(
+                context, "google.pubsub.v1.Subscriber.ListSnapshots", request);
+            return make_status_or(google::pubsub::v1::ListSnapshotsResponse{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::ListSnapshotsRequest const&) {
         ValidateNoUserProject(context);
@@ -459,12 +475,13 @@ TEST_F(SubscriberMetadataTest, ListSnapshots) {
 TEST_F(SubscriberMetadataTest, UpdateSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, UpdateSnapshot)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::UpdateSnapshotRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.UpdateSnapshot"));
-        return make_status_or(google::pubsub::v1::Snapshot{});
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::UpdateSnapshotRequest const& request) {
+            IsContextMDValid(
+                context, "google.pubsub.v1.Subscriber.UpdateSnapshot", request);
+            return make_status_or(google::pubsub::v1::Snapshot{});
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::UpdateSnapshotRequest const&) {
         ValidateNoUserProject(context);
@@ -491,12 +508,13 @@ TEST_F(SubscriberMetadataTest, UpdateSnapshot) {
 TEST_F(SubscriberMetadataTest, DeleteSnapshot) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, DeleteSnapshot)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::DeleteSnapshotRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.DeleteSnapshot"));
-        return Status{};
-      })
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::pubsub::v1::DeleteSnapshotRequest const& request) {
+            IsContextMDValid(
+                context, "google.pubsub.v1.Subscriber.DeleteSnapshot", request);
+            return Status{};
+          })
       .WillOnce([this](grpc::ClientContext& context,
                        google::pubsub::v1::DeleteSnapshotRequest const&) {
         ValidateNoUserProject(context);
@@ -524,9 +542,8 @@ TEST_F(SubscriberMetadataTest, Seek) {
   auto mock = std::make_shared<pubsub_testing::MockSubscriberStub>();
   EXPECT_CALL(*mock, Seek)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::pubsub::v1::SeekRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context, "google.pubsub.v1.Subscriber.Seek"));
+                       google::pubsub::v1::SeekRequest const& request) {
+        IsContextMDValid(context, "google.pubsub.v1.Subscriber.Seek", request);
         return make_status_or(google::pubsub::v1::SeekResponse{});
       })
       .WillOnce([this](grpc::ClientContext& context,

--- a/google/cloud/pubsub/internal/subscriber_metadata_test.cc
+++ b/google/cloud/pubsub/internal/subscriber_metadata_test.cc
@@ -36,9 +36,8 @@ using ::testing::Pair;
 
 class SubscriberMetadataTest : public ::testing::Test {
  protected:
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/pubsub/publisher_connection_test.cc
+++ b/google/cloud/pubsub/publisher_connection_test.cc
@@ -80,9 +80,9 @@ TEST(PublisherConnectionTest, Metadata) {
                           std::unique_ptr<grpc::ClientContext> context,
                           google::pubsub::v1::PublishRequest const& request) {
         google::cloud::testing_util::ValidateMetadataFixture fixture;
-        EXPECT_STATUS_OK(fixture.IsContextMDValid(
-            *context, "google.pubsub.v1.Publisher.Publish",
-            google::cloud::internal::ApiClientHeader()));
+        fixture.IsContextMDValid(*context, "google.pubsub.v1.Publisher.Publish",
+                                 request,
+                                 google::cloud::internal::ApiClientHeader());
         google::pubsub::v1::PublishResponse response;
         for (auto const& m : request.messages()) {
           response.add_message_ids("ack-" + m.message_id());

--- a/google/cloud/pubsub/schema_admin_connection_test.cc
+++ b/google/cloud/pubsub/schema_admin_connection_test.cc
@@ -68,14 +68,13 @@ TEST(SchemaAdminConnectionTest, Create) {
   EXPECT_CALL(*mock, CreateSchema(_, IsProtoEqual(request)))
       .WillOnce(Return(Status(StatusCode::kUnavailable, "try-again")))
       .WillOnce([&](grpc::ClientContext& context,
-                    google::pubsub::v1::CreateSchemaRequest const&) {
+                    google::pubsub::v1::CreateSchemaRequest const& request) {
         // Use this test to also verify the metadata decorator is automatically
         // configured.
         google::cloud::testing_util::ValidateMetadataFixture fixture;
-        EXPECT_THAT(fixture.IsContextMDValid(
-                        context, "google.pubsub.v1.SchemaService.CreateSchema",
-                        google::cloud::internal::ApiClientHeader()),
-                    IsOk());
+        fixture.IsContextMDValid(
+            context, "google.pubsub.v1.SchemaService.CreateSchema", request,
+            google::cloud::internal::ApiClientHeader());
         return make_status_or(response);
       });
 

--- a/google/cloud/pubsub/subscriber_connection_test.cc
+++ b/google/cloud/pubsub/subscriber_connection_test.cc
@@ -223,9 +223,9 @@ TEST(SubscriberConnectionTest, MakeSubscriberConnectionSetupsMetadata) {
               std::unique_ptr<grpc::ClientContext> context,
               google::pubsub::v1::StreamingPullRequest const& request) {
             ValidateMetadataFixture fixture;
-            EXPECT_STATUS_OK(fixture.IsContextMDValid(
-                *context, "google.pubsub.v1.Subscriber.Pull",
-                google::cloud::internal::ApiClientHeader()));
+            fixture.IsContextMDValid(
+                *context, "google.pubsub.v1.Subscriber.Pull", request,
+                google::cloud::internal::ApiClientHeader());
             return FakeAsyncStreamingPull(cq, std::move(context), request);
           });
 

--- a/google/cloud/pubsub/subscription_admin_connection_test.cc
+++ b/google/cloud/pubsub/subscription_admin_connection_test.cc
@@ -78,9 +78,9 @@ TEST(SubscriptionAdminConnectionTest, CreateWithMetadata) {
       .WillOnce([&](grpc::ClientContext& context,
                     google::pubsub::v1::Subscription const& request) {
         testing_util::ValidateMetadataFixture fixture;
-        EXPECT_STATUS_OK(fixture.IsContextMDValid(
-            context, "google.pubsub.v1.Subscriber.CreateSubscription",
-            google::cloud::internal::ApiClientHeader()));
+        fixture.IsContextMDValid(
+            context, "google.pubsub.v1.Subscriber.CreateSubscription", request,
+            google::cloud::internal::ApiClientHeader());
         EXPECT_EQ(subscription.FullName(), request.name());
         return make_status_or(request);
       });

--- a/google/cloud/pubsub/topic_admin_connection_test.cc
+++ b/google/cloud/pubsub/topic_admin_connection_test.cc
@@ -73,9 +73,9 @@ TEST(TopicAdminConnectionTest, Metadata) {
       .WillOnce([&](grpc::ClientContext& context,
                     google::pubsub::v1::Topic const& request) {
         ::google::cloud::testing_util::ValidateMetadataFixture fixture;
-        EXPECT_STATUS_OK(fixture.IsContextMDValid(
-            context, "google.pubsub.v1.Publisher.CreateTopic",
-            google::cloud::internal::ApiClientHeader()));
+        fixture.IsContextMDValid(
+            context, "google.pubsub.v1.Publisher.CreateTopic", request,
+            google::cloud::internal::ApiClientHeader());
         return make_status_or(request);
       });
 

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -42,10 +42,11 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   static Status TransientError() {
@@ -60,11 +61,11 @@ TEST_F(DatabaseAdminMetadataTest, CreateDatabase) {
   EXPECT_CALL(*mock_, AsyncCreateDatabase)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gsad::v1::CreateDatabaseRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "CreateDatabase"));
+                       gsad::v1::CreateDatabaseRequest const& request) {
+        IsContextMDValid(*context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "CreateDatabase",
+                         request);
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -85,11 +86,11 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
   EXPECT_CALL(*mock_, AsyncUpdateDatabaseDdl)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gsad::v1::UpdateDatabaseDdlRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "UpdateDatabaseDdl"));
+                       gsad::v1::UpdateDatabaseDdlRequest const& request) {
+        IsContextMDValid(*context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "UpdateDatabaseDdl",
+                         request);
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -111,11 +112,11 @@ TEST_F(DatabaseAdminMetadataTest, UpdateDatabase) {
 TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
   EXPECT_CALL(*mock_, DropDatabase)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::DropDatabaseRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "DropDatabase"));
+                       gsad::v1::DropDatabaseRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "DropDatabase",
+                         request);
         return TransientError();
       });
 
@@ -135,11 +136,11 @@ TEST_F(DatabaseAdminMetadataTest, DropDatabase) {
 TEST_F(DatabaseAdminMetadataTest, ListDatabases) {
   EXPECT_CALL(*mock_, ListDatabases)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::ListDatabasesRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "ListDatabases"));
+                       gsad::v1::ListDatabasesRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "ListDatabases",
+                         request);
         return TransientError();
       });
 
@@ -158,11 +159,11 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
   EXPECT_CALL(*mock_, AsyncRestoreDatabase)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gsad::v1::RestoreDatabaseRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "RestoreDatabase"));
+                       gsad::v1::RestoreDatabaseRequest const& request) {
+        IsContextMDValid(*context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "RestoreDatabase",
+                         request);
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -182,11 +183,11 @@ TEST_F(DatabaseAdminMetadataTest, RestoreDatabase) {
 TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
   EXPECT_CALL(*mock_, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::GetIamPolicyRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "GetIamPolicy"));
+                       google::iam::v1::GetIamPolicyRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "GetIamPolicy",
+                         request);
         return TransientError();
       });
 
@@ -206,11 +207,11 @@ TEST_F(DatabaseAdminMetadataTest, GetIamPolicy) {
 TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
   EXPECT_CALL(*mock_, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::SetIamPolicyRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "SetIamPolicy"));
+                       google::iam::v1::SetIamPolicyRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "SetIamPolicy",
+                         request);
         return TransientError();
       });
 
@@ -235,14 +236,15 @@ TEST_F(DatabaseAdminMetadataTest, SetIamPolicy) {
 
 TEST_F(DatabaseAdminMetadataTest, TestIamPermissions) {
   EXPECT_CALL(*mock_, TestIamPermissions)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::TestIamPermissionsRequest const&) {
-        EXPECT_STATUS_OK(
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::iam::v1::TestIamPermissionsRequest const& request) {
             IsContextMDValid(context,
                              "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "TestIamPermissions"));
-        return TransientError();
-      });
+                             "TestIamPermissions",
+                             request);
+            return TransientError();
+          });
 
   DatabaseAdminMetadata stub(mock_);
   grpc::ClientContext context;
@@ -261,11 +263,11 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
   EXPECT_CALL(*mock_, AsyncCreateBackup)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gsad::v1::CreateBackupRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "CreateBackup"));
+                       gsad::v1::CreateBackupRequest const& request) {
+        IsContextMDValid(*context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "CreateBackup",
+                         request);
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -285,11 +287,11 @@ TEST_F(DatabaseAdminMetadataTest, CreateBackup) {
 TEST_F(DatabaseAdminMetadataTest, GetBackup) {
   EXPECT_CALL(*mock_, GetBackup)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::GetBackupRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "GetBackup"));
+                       gsad::v1::GetBackupRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "GetBackup",
+                         request);
         return TransientError();
       });
 
@@ -309,11 +311,11 @@ TEST_F(DatabaseAdminMetadataTest, GetBackup) {
 TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
   EXPECT_CALL(*mock_, DeleteBackup)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::DeleteBackupRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "DeleteBackup"));
+                       gsad::v1::DeleteBackupRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "DeleteBackup",
+                         request);
         return TransientError();
       });
 
@@ -333,11 +335,11 @@ TEST_F(DatabaseAdminMetadataTest, DeleteBackup) {
 TEST_F(DatabaseAdminMetadataTest, ListBackups) {
   EXPECT_CALL(*mock_, ListBackups)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::ListBackupsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "ListBackups"));
+                       gsad::v1::ListBackupsRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "ListBackups",
+                         request);
         return TransientError();
       });
 
@@ -355,11 +357,11 @@ TEST_F(DatabaseAdminMetadataTest, ListBackups) {
 TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
   EXPECT_CALL(*mock_, UpdateBackup)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::UpdateBackupRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "UpdateBackup"));
+                       gsad::v1::UpdateBackupRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "UpdateBackup",
+                         request);
         return TransientError();
       });
 
@@ -379,11 +381,11 @@ TEST_F(DatabaseAdminMetadataTest, UpdateBackup) {
 TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
   EXPECT_CALL(*mock_, ListBackupOperations)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::ListBackupOperationsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "ListBackupOperations"));
+                       gsad::v1::ListBackupOperationsRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "ListBackupOperations",
+                         request);
         return TransientError();
       });
 
@@ -401,11 +403,11 @@ TEST_F(DatabaseAdminMetadataTest, ListBackupOperations) {
 TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
   EXPECT_CALL(*mock_, ListDatabaseOperations)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsad::v1::ListDatabaseOperationsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.database.v1.DatabaseAdmin."
-                             "ListDatabaseOperations"));
+                       gsad::v1::ListDatabaseOperationsRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.database.v1.DatabaseAdmin."
+                         "ListDatabaseOperations",
+                         request);
         return TransientError();
       });
 
@@ -422,14 +424,15 @@ TEST_F(DatabaseAdminMetadataTest, ListDatabaseOperations) {
 
 TEST_F(DatabaseAdminMetadataTest, GetOperation) {
   EXPECT_CALL(*mock_, AsyncGetOperation)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::longrunning::GetOperationRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.longrunning.Operations.GetOperation"));
-        return make_ready_future(
-            StatusOr<google::longrunning::Operation>(TransientError()));
-      });
+      .WillOnce(
+          [this](CompletionQueue&, std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::GetOperationRequest const& request) {
+            IsContextMDValid(*context,
+                             "google.longrunning.Operations.GetOperation",
+                             request);
+            return make_ready_future(
+                StatusOr<google::longrunning::Operation>(TransientError()));
+          });
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;
@@ -442,13 +445,14 @@ TEST_F(DatabaseAdminMetadataTest, GetOperation) {
 
 TEST_F(DatabaseAdminMetadataTest, CancelOperation) {
   EXPECT_CALL(*mock_, AsyncCancelOperation)
-      .WillOnce([this](CompletionQueue&,
-                       std::unique_ptr<grpc::ClientContext> context,
-                       google::longrunning::CancelOperationRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            *context, "google.longrunning.Operations.CancelOperation"));
-        return make_ready_future(TransientError());
-      });
+      .WillOnce(
+          [this](CompletionQueue&, std::unique_ptr<grpc::ClientContext> context,
+                 google::longrunning::CancelOperationRequest const& request) {
+            IsContextMDValid(*context,
+                             "google.longrunning.Operations.CancelOperation",
+                             request);
+            return make_ready_future(TransientError());
+          });
 
   DatabaseAdminMetadata stub(mock_);
   CompletionQueue cq;

--- a/google/cloud/spanner/internal/database_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/database_admin_metadata_test.cc
@@ -42,9 +42,8 @@ class DatabaseAdminMetadataTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -41,9 +41,8 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader());
   }

--- a/google/cloud/spanner/internal/instance_admin_metadata_test.cc
+++ b/google/cloud/spanner/internal/instance_admin_metadata_test.cc
@@ -41,10 +41,11 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 
   void TearDown() override {}
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader());
+        context, method, request, google::cloud::internal::ApiClientHeader());
   }
 
   static Status TransientError() {
@@ -58,11 +59,11 @@ class InstanceAdminMetadataTest : public ::testing::Test {
 TEST_F(InstanceAdminMetadataTest, GetInstance) {
   EXPECT_CALL(*mock_, GetInstance)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsai::v1::GetInstanceRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "GetInstance"));
+                       gsai::v1::GetInstanceRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "GetInstance",
+                         request);
         return TransientError();
       });
 
@@ -80,11 +81,11 @@ TEST_F(InstanceAdminMetadataTest, GetInstance) {
 TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
   EXPECT_CALL(*mock_, GetInstanceConfig)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsai::v1::GetInstanceConfigRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "GetInstanceConfig"));
+                       gsai::v1::GetInstanceConfigRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "GetInstanceConfig",
+                         request);
         return TransientError();
       });
 
@@ -100,11 +101,11 @@ TEST_F(InstanceAdminMetadataTest, GetInstanceConfig) {
 TEST_F(InstanceAdminMetadataTest, ListInstanceConfigs) {
   EXPECT_CALL(*mock_, ListInstanceConfigs)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsai::v1::ListInstanceConfigsRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "ListInstanceConfigs"));
+                       gsai::v1::ListInstanceConfigsRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "ListInstanceConfigs",
+                         request);
         return TransientError();
       });
 
@@ -120,11 +121,11 @@ TEST_F(InstanceAdminMetadataTest, CreateInstance) {
   EXPECT_CALL(*mock_, AsyncCreateInstance)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gsai::v1::CreateInstanceRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "CreateInstance"));
+                       gsai::v1::CreateInstanceRequest const& request) {
+        IsContextMDValid(*context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "CreateInstance",
+                         request);
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -143,11 +144,11 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
   EXPECT_CALL(*mock_, AsyncUpdateInstance)
       .WillOnce([this](CompletionQueue&,
                        std::unique_ptr<grpc::ClientContext> context,
-                       gsai::v1::UpdateInstanceRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(*context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "UpdateInstance"));
+                       gsai::v1::UpdateInstanceRequest const& request) {
+        IsContextMDValid(*context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "UpdateInstance",
+                         request);
         return make_ready_future(
             StatusOr<google::longrunning::Operation>(TransientError()));
       });
@@ -167,11 +168,11 @@ TEST_F(InstanceAdminMetadataTest, UpdateInstance) {
 TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
   EXPECT_CALL(*mock_, DeleteInstance)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsai::v1::DeleteInstanceRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "DeleteInstance"));
+                       gsai::v1::DeleteInstanceRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "DeleteInstance",
+                         request);
         return TransientError();
       });
 
@@ -189,11 +190,11 @@ TEST_F(InstanceAdminMetadataTest, DeleteInstance) {
 TEST_F(InstanceAdminMetadataTest, ListInstances) {
   EXPECT_CALL(*mock_, ListInstances)
       .WillOnce([this](grpc::ClientContext& context,
-                       gsai::v1::ListInstancesRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "ListInstances"));
+                       gsai::v1::ListInstancesRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "ListInstances",
+                         request);
         return TransientError();
       });
 
@@ -208,11 +209,11 @@ TEST_F(InstanceAdminMetadataTest, ListInstances) {
 TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
   EXPECT_CALL(*mock_, GetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::GetIamPolicyRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "GetIamPolicy"));
+                       google::iam::v1::GetIamPolicyRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "GetIamPolicy",
+                         request);
         return TransientError();
       });
 
@@ -230,11 +231,11 @@ TEST_F(InstanceAdminMetadataTest, GetIamPolicy) {
 TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
   EXPECT_CALL(*mock_, SetIamPolicy)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::SetIamPolicyRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context,
-                             "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "SetIamPolicy"));
+                       google::iam::v1::SetIamPolicyRequest const& request) {
+        IsContextMDValid(context,
+                         "google.spanner.admin.instance.v1.InstanceAdmin."
+                         "SetIamPolicy",
+                         request);
         return TransientError();
       });
 
@@ -251,14 +252,15 @@ TEST_F(InstanceAdminMetadataTest, SetIamPolicy) {
 
 TEST_F(InstanceAdminMetadataTest, TestIamPermissions) {
   EXPECT_CALL(*mock_, TestIamPermissions)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::iam::v1::TestIamPermissionsRequest const&) {
-        EXPECT_STATUS_OK(
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::iam::v1::TestIamPermissionsRequest const& request) {
             IsContextMDValid(context,
                              "google.spanner.admin.instance.v1.InstanceAdmin."
-                             "TestIamPermissions"));
-        return TransientError();
-      });
+                             "TestIamPermissions",
+                             request);
+            return TransientError();
+          });
 
   InstanceAdminMetadata stub(mock_);
   grpc::ClientContext context;

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -58,9 +58,8 @@ class MetadataSpannerStubTest : public ::testing::Test {
     EXPECT_EQ(TransientError(), status);
   }
 
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request, google::cloud::internal::ApiClientHeader(),
         db_.FullName());

--- a/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
+++ b/google/cloud/spanner/internal/metadata_spanner_stub_test.cc
@@ -58,10 +58,11 @@ class MetadataSpannerStubTest : public ::testing::Test {
     EXPECT_EQ(TransientError(), status);
   }
 
-  Status IsContextMDValid(grpc::ClientContext& context,
-                          std::string const& method) {
+  template <typename Request>
+  void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
+                        Request const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
-        context, method, google::cloud::internal::ApiClientHeader(),
+        context, method, request, google::cloud::internal::ApiClientHeader(),
         db_.FullName());
   }
 
@@ -75,9 +76,9 @@ class MetadataSpannerStubTest : public ::testing::Test {
                      std::string const& rpc_name,
                      MemberFunction member_function) {
     call.WillOnce(
-        [this, rpc_name](grpc::ClientContext& context, Request const&) {
-          EXPECT_STATUS_OK(IsContextMDValid(
-              context, "google.spanner.v1.Spanner." + rpc_name));
+        [this, rpc_name](grpc::ClientContext& context, Request const& request) {
+          IsContextMDValid(context, "google.spanner.v1.Spanner." + rpc_name,
+                           request);
           return TransientError();
         });
 
@@ -140,12 +141,13 @@ TEST_F(MetadataSpannerStubTest, UserProject) {
 
 TEST_F(MetadataSpannerStubTest, CreateSession) {
   EXPECT_CALL(*mock_, CreateSession)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::CreateSessionRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.spanner.v1.Spanner.CreateSession"));
-        return TransientError();
-      });
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::spanner::v1::CreateSessionRequest const& request) {
+            IsContextMDValid(context, "google.spanner.v1.Spanner.CreateSession",
+                             request);
+            return TransientError();
+          });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
@@ -157,12 +159,15 @@ TEST_F(MetadataSpannerStubTest, CreateSession) {
 
 TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
   EXPECT_CALL(*mock_, BatchCreateSessions)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::BatchCreateSessionsRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.spanner.v1.Spanner.BatchCreateSessions"));
-        return TransientError();
-      });
+      .WillOnce(
+          [this](
+              grpc::ClientContext& context,
+              google::spanner::v1::BatchCreateSessionsRequest const& request) {
+            IsContextMDValid(context,
+                             "google.spanner.v1.Spanner.BatchCreateSessions",
+                             request);
+            return TransientError();
+          });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
@@ -176,9 +181,9 @@ TEST_F(MetadataSpannerStubTest, BatchCreateSessions) {
 TEST_F(MetadataSpannerStubTest, GetSession) {
   EXPECT_CALL(*mock_, GetSession)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::GetSessionRequest const&) {
-        EXPECT_STATUS_OK(
-            IsContextMDValid(context, "google.spanner.v1.Spanner.GetSession"));
+                       google::spanner::v1::GetSessionRequest const& request) {
+        IsContextMDValid(context, "google.spanner.v1.Spanner.GetSession",
+                         request);
         return TransientError();
       });
 
@@ -198,12 +203,13 @@ TEST_F(MetadataSpannerStubTest, GetSession) {
 
 TEST_F(MetadataSpannerStubTest, ListSessions) {
   EXPECT_CALL(*mock_, ListSessions)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::ListSessionsRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.spanner.v1.Spanner.ListSessions"));
-        return TransientError();
-      });
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::spanner::v1::ListSessionsRequest const& request) {
+            IsContextMDValid(context, "google.spanner.v1.Spanner.ListSessions",
+                             request);
+            return TransientError();
+          });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
@@ -215,12 +221,13 @@ TEST_F(MetadataSpannerStubTest, ListSessions) {
 
 TEST_F(MetadataSpannerStubTest, DeleteSession) {
   EXPECT_CALL(*mock_, DeleteSession)
-      .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::DeleteSessionRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.spanner.v1.Spanner.DeleteSession"));
-        return TransientError();
-      });
+      .WillOnce(
+          [this](grpc::ClientContext& context,
+                 google::spanner::v1::DeleteSessionRequest const& request) {
+            IsContextMDValid(context, "google.spanner.v1.Spanner.DeleteSession",
+                             request);
+            return TransientError();
+          });
 
   MetadataSpannerStub stub(mock_, db_.FullName());
   grpc::ClientContext context;
@@ -243,9 +250,9 @@ TEST_F(MetadataSpannerStubTest, ExecuteSql) {
 TEST_F(MetadataSpannerStubTest, ExecuteStreamingSql) {
   EXPECT_CALL(*mock_, ExecuteStreamingSql)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::ExecuteSqlRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.spanner.v1.Spanner.ExecuteStreamingSql"));
+                       google::spanner::v1::ExecuteSqlRequest const& request) {
+        IsContextMDValid(
+            context, "google.spanner.v1.Spanner.ExecuteStreamingSql", request);
         return std::unique_ptr<grpc::ClientReaderInterface<
             google::spanner::v1::PartialResultSet>>{};
       });
@@ -271,9 +278,9 @@ TEST_F(MetadataSpannerStubTest, ExecuteBatchDml) {
 TEST_F(MetadataSpannerStubTest, StreamingRead) {
   EXPECT_CALL(*mock_, StreamingRead)
       .WillOnce([this](grpc::ClientContext& context,
-                       google::spanner::v1::ReadRequest const&) {
-        EXPECT_STATUS_OK(IsContextMDValid(
-            context, "google.spanner.v1.Spanner.StreamingRead"));
+                       google::spanner::v1::ReadRequest const& request) {
+        IsContextMDValid(context, "google.spanner.v1.Spanner.StreamingRead",
+                         request);
         return std::unique_ptr<grpc::ClientReaderInterface<
             google::spanner::v1::PartialResultSet>>{};
       });

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -52,9 +52,8 @@ using ::testing::Return;
 
 class StorageStubFactory : public ::testing::Test {
  protected:
-  template <typename Request>
   void IsContextMDValid(grpc::ClientContext& context, std::string const& method,
-                        Request const& request) {
+                        google::protobuf::Message const& request) {
     return validate_metadata_fixture_.IsContextMDValid(
         context, method, request,
         google::cloud::internal::ApiClientHeader("generator"));

--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -18,7 +18,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
-#include <gmock/gmock.h>
+#include <google/protobuf/message.h>
 #include <grpcpp/generic/async_generic_service.h>
 #include <grpcpp/grpcpp.h>
 #include <map>
@@ -76,8 +76,9 @@ class ValidateMetadataFixture {
    *
    * @return an OK status if the `context` is properly set up
    */
-  Status IsContextMDValid(
+  void IsContextMDValid(
       grpc::ClientContext& context, std::string const& method,
+      google::protobuf::Message const& request,
       std::string const& api_client_header,
       absl::optional<std::string> const& resource_name = {},
       absl::optional<std::string> const& resource_prefix_header = {});


### PR DESCRIPTION
Part of the work for #9373 

**REVIEWER**: the actual refactor is in the second commit, which is mostly moving things from the source to the header. The first commit contains updates to all the tests.

For my next trick, I am adding a templated `Request` parameter to `IsContextMDValid`, and dropping the return value. Explicit routing looks into the contents of a request so we will need this information.

The case of streaming writes is weird because there is no request when we add metadata to the `grpc::ClientContext`. So we just send empty requests in our tests. Note that `BigQueryWriteClient::AppendRows` would not pass this test. (This has been true forever. I opened #9381 to address it).

Also, make the error message for the metadata matcher more informative (like it used to be).
```
Value of: actual
Expected: contains at least one element that has a first field that is equal to "table_name", and has a second field that matches the pattern: "projects/*/instances/*/tables/*"
  Actual: { ("table_name", "proijslkfj/ps/snfinstces/sles/slk") }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9383)
<!-- Reviewable:end -->
