### PR TITLE
test: validate explicit routing

### DIFF
--- a/google/cloud/testing_util/BUILD.bazel
+++ b/google/cloud/testing_util/BUILD.bazel
@@ -80,6 +80,7 @@ cc_library(
         "@com_github_grpc_grpc//:grpc++",
         "@com_google_googleapis//:googleapis_system_includes",
         "@com_google_googleapis//google/api:annotations_cc_proto",
+        "@com_google_googleapis//google/api:routing_cc_proto",
         "@com_google_googletest//:gtest_main",
         "@com_google_protobuf//:protobuf",
     ],

--- a/google/cloud/testing_util/google_cloud_cpp_testing_grpc.cmake
+++ b/google/cloud/testing_util/google_cloud_cpp_testing_grpc.cmake
@@ -28,8 +28,11 @@ add_library(
     validate_metadata.h)
 target_link_libraries(
     google_cloud_cpp_testing_grpc
-    PUBLIC google-cloud-cpp::grpc_utils google-cloud-cpp::common
-           google-cloud-cpp::api_annotations_protos protobuf::libprotobuf
+    PUBLIC google-cloud-cpp::grpc_utils
+           google-cloud-cpp::common
+           google-cloud-cpp::api_annotations_protos
+           google-cloud-cpp::api_routing_protos
+           protobuf::libprotobuf
            GTest::gmock)
 google_cloud_cpp_add_common_options(google_cloud_cpp_testing_grpc)
 


### PR DESCRIPTION
Fixes #9373

Note that any test in Bigtable (the only service with explicit routing for which we have a library) which sets an app profile id will now fail the context metadata check. There is apparently exactly one such test, so we implement a temporary workaround.

My plan is to add more such tests by also setting the app profile id in the `bigtable_stub_factory_test.cc`.
 But this will have to wait until after the generator has explicit routing support.
https://github.com/googleapis/google-cloud-cpp/blob/91aae8c5bbd5182534ba716a07a3d5a1a3bdade0/google/cloud/bigtable/internal/bigtable_stub_factory_test.cc#L117-L119

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9385)
<!-- Reviewable:end -->
