### PR TITLE
fix(bigtable)!: pass app profile id to connection as options

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -43,53 +43,52 @@ std::vector<FailedMutation> MakeUnimplementedFailedMutations(std::size_t n) {
 
 DataConnection::~DataConnection() = default;
 
-Status DataConnection::Apply(
-    // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, SingleRowMutation) {
+// NOLINTNEXTLINE(performance-unnecessary-value-param)
+Status DataConnection::Apply(std::string const&, SingleRowMutation) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 future<Status> DataConnection::AsyncApply(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, SingleRowMutation) {
+    std::string const&, SingleRowMutation) {
   return make_ready_future(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
 std::vector<FailedMutation> DataConnection::BulkApply(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, BulkMutation mut) {
+    std::string const&, BulkMutation mut) {
   return MakeUnimplementedFailedMutations(mut.size());
 }
 
 future<std::vector<FailedMutation>> DataConnection::AsyncBulkApply(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, BulkMutation mut) {
+    std::string const&, BulkMutation mut) {
   return make_ready_future(MakeUnimplementedFailedMutations(mut.size()));
 }
 
 RowReader DataConnection::ReadRows(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, RowSet, std::int64_t, Filter) {
+    std::string const&, RowSet, std::int64_t, Filter) {
   return MakeRowReader(std::make_shared<bigtable_internal::StatusOnlyRowReader>(
       Status(StatusCode::kUnimplemented, "not implemented")));
 }
 
 StatusOr<std::pair<bool, Row>> DataConnection::ReadRow(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, std::string, Filter) {
+    std::string const&, std::string, Filter) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 StatusOr<MutationBranch> DataConnection::CheckAndMutateRow(
-    std::string const&, std::string const&,
+    std::string const&,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string, Filter, std::vector<Mutation>, std::vector<Mutation>) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 future<StatusOr<MutationBranch>> DataConnection::AsyncCheckAndMutateRow(
-    std::string const&, std::string const&,
+    std::string const&,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string, Filter, std::vector<Mutation>, std::vector<Mutation>) {
   return make_ready_future<StatusOr<MutationBranch>>(
@@ -97,12 +96,12 @@ future<StatusOr<MutationBranch>> DataConnection::AsyncCheckAndMutateRow(
 }
 
 StatusOr<std::vector<RowKeySample>> DataConnection::SampleRows(
-    std::string const&, std::string const&) {
+    std::string const&) {
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
 future<StatusOr<std::vector<RowKeySample>>> DataConnection::AsyncSampleRows(
-    std::string const&, std::string const&) {
+    std::string const&) {
   return make_ready_future<StatusOr<std::vector<RowKeySample>>>(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
@@ -121,17 +120,16 @@ future<StatusOr<Row>> DataConnection::AsyncReadModifyWriteRow(
 }
 
 void DataConnection::AsyncReadRows(
-    std::string const&, std::string const&,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::function<future<bool>(Row)>, std::function<void(Status)> on_finish,
+    std::string const&, std::function<future<bool>(Row)>,
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    RowSet, std::int64_t, Filter) {
+    std::function<void(Status)> on_finish, RowSet, std::int64_t, Filter) {
   on_finish(Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
 future<StatusOr<std::pair<bool, Row>>> DataConnection::AsyncReadRow(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
-    std::string const&, std::string const&, std::string, Filter) {
+    std::string const&, std::string, Filter) {
   return make_ready_future<StatusOr<std::pair<bool, Row>>>(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }

--- a/google/cloud/bigtable/data_connection.h
+++ b/google/cloud/bigtable/data_connection.h
@@ -52,44 +52,39 @@ class DataConnection {
 
   virtual Options options() { return Options{}; }
 
-  virtual Status Apply(std::string const& app_profile_id,
-                       std::string const& table_name, SingleRowMutation mut);
+  virtual Status Apply(std::string const& table_name, SingleRowMutation mut);
 
-  virtual future<Status> AsyncApply(std::string const& app_profile_id,
-                                    std::string const& table_name,
+  virtual future<Status> AsyncApply(std::string const& table_name,
                                     SingleRowMutation mut);
 
-  virtual std::vector<FailedMutation> BulkApply(
-      std::string const& app_profile_id, std::string const& table_name,
-      BulkMutation mut);
+  virtual std::vector<FailedMutation> BulkApply(std::string const& table_name,
+                                                BulkMutation mut);
 
   virtual future<std::vector<FailedMutation>> AsyncBulkApply(
-      std::string const& app_profile_id, std::string const& table_name,
-      BulkMutation mut);
+      std::string const& table_name, BulkMutation mut);
 
-  virtual RowReader ReadRows(std::string const& app_profile_id,
-                             std::string const& table_name, RowSet row_set,
+  virtual RowReader ReadRows(std::string const& table_name, RowSet row_set,
                              std::int64_t rows_limit, Filter filter);
 
-  virtual StatusOr<std::pair<bool, Row>> ReadRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, Filter filter);
+  virtual StatusOr<std::pair<bool, Row>> ReadRow(std::string const& table_name,
+                                                 std::string row_key,
+                                                 Filter filter);
 
   virtual StatusOr<MutationBranch> CheckAndMutateRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
+      std::string const& table_name, std::string row_key, Filter filter,
+      std::vector<Mutation> true_mutations,
       std::vector<Mutation> false_mutations);
 
   virtual future<StatusOr<MutationBranch>> AsyncCheckAndMutateRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
+      std::string const& table_name, std::string row_key, Filter filter,
+      std::vector<Mutation> true_mutations,
       std::vector<Mutation> false_mutations);
 
   virtual StatusOr<std::vector<RowKeySample>> SampleRows(
-      std::string const& app_profile_id, std::string const& table_name);
+      std::string const& table_name);
 
   virtual future<StatusOr<std::vector<RowKeySample>>> AsyncSampleRows(
-      std::string const& app_profile_id, std::string const& table_name);
+      std::string const& table_name);
 
   virtual StatusOr<Row> ReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request);
@@ -97,16 +92,14 @@ class DataConnection {
   virtual future<StatusOr<Row>> AsyncReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request);
 
-  virtual void AsyncReadRows(std::string const& app_profile_id,
-                             std::string const& table_name,
+  virtual void AsyncReadRows(std::string const& table_name,
                              std::function<future<bool>(Row)> on_row,
                              std::function<void(Status)> on_finish,
                              RowSet row_set, std::int64_t rows_limit,
                              Filter filter);
 
   virtual future<StatusOr<std::pair<bool, Row>>> AsyncReadRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, Filter filter);
+      std::string const& table_name, std::string row_key, Filter filter);
 };
 
 /**

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -41,49 +41,41 @@ class DataConnectionImpl : public bigtable::DataConnection {
 
   Options options() override { return options_; }
 
-  Status Apply(std::string const& app_profile_id, std::string const& table_name,
+  Status Apply(std::string const& table_name,
                bigtable::SingleRowMutation mut) override;
 
-  future<Status> AsyncApply(std::string const& app_profile_id,
-                            std::string const& table_name,
+  future<Status> AsyncApply(std::string const& table_name,
                             bigtable::SingleRowMutation mut) override;
 
   std::vector<bigtable::FailedMutation> BulkApply(
-      std::string const& app_profile_id, std::string const& table_name,
-      bigtable::BulkMutation mut) override;
+      std::string const& table_name, bigtable::BulkMutation mut) override;
 
   future<std::vector<bigtable::FailedMutation>> AsyncBulkApply(
-      std::string const& app_profile_id, std::string const& table_name,
-      bigtable::BulkMutation mut) override;
+      std::string const& table_name, bigtable::BulkMutation mut) override;
 
-  bigtable::RowReader ReadRows(std::string const& app_profile_id,
-                               std::string const& table_name,
+  bigtable::RowReader ReadRows(std::string const& table_name,
                                bigtable::RowSet row_set,
                                std::int64_t rows_limit,
                                bigtable::Filter filter) override;
 
   StatusOr<std::pair<bool, bigtable::Row>> ReadRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, bigtable::Filter filter) override;
+      std::string const& table_name, std::string row_key,
+      bigtable::Filter filter) override;
 
   StatusOr<bigtable::MutationBranch> CheckAndMutateRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, bigtable::Filter filter,
-      std::vector<bigtable::Mutation> true_mutations,
+      std::string const& table_name, std::string row_key,
+      bigtable::Filter filter, std::vector<bigtable::Mutation> true_mutations,
       std::vector<bigtable::Mutation> false_mutations) override;
 
   future<StatusOr<bigtable::MutationBranch>> AsyncCheckAndMutateRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, bigtable::Filter filter,
-      std::vector<bigtable::Mutation> true_mutations,
+      std::string const& table_name, std::string row_key,
+      bigtable::Filter filter, std::vector<bigtable::Mutation> true_mutations,
       std::vector<bigtable::Mutation> false_mutations) override;
 
   StatusOr<std::vector<bigtable::RowKeySample>> SampleRows(
-      std::string const& app_profile_id,
       std::string const& table_name) override;
 
   future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows(
-      std::string const& app_profile_id,
       std::string const& table_name) override;
 
   StatusOr<bigtable::Row> ReadModifyWriteRow(
@@ -92,18 +84,21 @@ class DataConnectionImpl : public bigtable::DataConnection {
   future<StatusOr<bigtable::Row>> AsyncReadModifyWriteRow(
       google::bigtable::v2::ReadModifyWriteRowRequest request) override;
 
-  void AsyncReadRows(std::string const& app_profile_id,
-                     std::string const& table_name,
+  void AsyncReadRows(std::string const& table_name,
                      std::function<future<bool>(bigtable::Row)> on_row,
                      std::function<void(Status)> on_finish,
                      bigtable::RowSet row_set, std::int64_t rows_limit,
                      bigtable::Filter filter) override;
 
   future<StatusOr<std::pair<bool, bigtable::Row>>> AsyncReadRow(
-      std::string const& app_profile_id, std::string const& table_name,
-      std::string row_key, bigtable::Filter filter) override;
+      std::string const& table_name, std::string row_key,
+      bigtable::Filter filter) override;
 
  private:
+  static std::string const& app_profile_id() {
+    return internal::CurrentOptions().get<bigtable::AppProfileIdOption>();
+  }
+
   std::unique_ptr<bigtable::DataRetryPolicy> retry_policy() {
     auto const& options = internal::CurrentOptions();
     if (options.has<bigtable::DataRetryPolicyOption>()) {

--- a/google/cloud/bigtable/mocks/mock_data_connection.h
+++ b/google/cloud/bigtable/mocks/mock_data_connection.h
@@ -37,61 +37,51 @@ class MockDataConnection : public bigtable::DataConnection {
   MOCK_METHOD(Options, options, (), (override));
 
   MOCK_METHOD(Status, Apply,
-              (std::string const& app_profile_id, std::string const& table_name,
-               bigtable::SingleRowMutation mut),
+              (std::string const& table_name, bigtable::SingleRowMutation mut),
               (override));
 
   MOCK_METHOD(future<Status>, AsyncApply,
-              (std::string const& app_profile_id, std::string const& table_name,
-               bigtable::SingleRowMutation mut),
+              (std::string const& table_name, bigtable::SingleRowMutation mut),
               (override));
 
   MOCK_METHOD(std::vector<bigtable::FailedMutation>, BulkApply,
-              (std::string const& app_profile_id, std::string const& table_name,
-               bigtable::BulkMutation mut),
+              (std::string const& table_name, bigtable::BulkMutation mut),
               (override));
 
   MOCK_METHOD(future<std::vector<bigtable::FailedMutation>>, AsyncBulkApply,
-              (std::string const& app_profile_id, std::string const& table_name,
-               bigtable::BulkMutation mut),
+              (std::string const& table_name, bigtable::BulkMutation mut),
               (override));
 
   MOCK_METHOD(bigtable::RowReader, ReadRows,
-              (std::string const& app_profile_id, std::string const& table_name,
-               bigtable::RowSet row_set, std::int64_t rows_limit,
-               bigtable::Filter filter),
+              (std::string const& table_name, bigtable::RowSet row_set,
+               std::int64_t rows_limit, bigtable::Filter filter),
               (override));
 
   MOCK_METHOD((StatusOr<std::pair<bool, bigtable::Row>>), ReadRow,
-              (std::string const& app_profile_id, std::string const& table_name,
-               std::string row_key, bigtable::Filter filter),
+              (std::string const& table_name, std::string row_key,
+               bigtable::Filter filter),
               (override));
 
   MOCK_METHOD(StatusOr<bigtable::MutationBranch>, CheckAndMutateRow,
-              (std::string const& app_profile_id, std::string const& table_name,
-               std::string row_key, bigtable::Filter filter,
+              (std::string const& table_name, std::string row_key,
+               bigtable::Filter filter,
                std::vector<bigtable::Mutation> true_mutations,
                std::vector<bigtable::Mutation> false_mutations),
               (override));
 
   MOCK_METHOD(future<StatusOr<bigtable::MutationBranch>>,
               AsyncCheckAndMutateRow,
-              (std::string const& app_profile_id, std::string const& table_name,
-               std::string row_key, bigtable::Filter filter,
+              (std::string const& table_name, std::string row_key,
+               bigtable::Filter filter,
                std::vector<bigtable::Mutation> true_mutations,
                std::vector<bigtable::Mutation> false_mutations),
               (override));
 
   MOCK_METHOD(StatusOr<std::vector<bigtable::RowKeySample>>, SampleRows,
-              (std::string const& app_profile_id,
-               std::string const& table_name),
-              (override));
+              (std::string const& table_name), (override));
 
   MOCK_METHOD(future<StatusOr<std::vector<bigtable::RowKeySample>>>,
-              AsyncSampleRows,
-              (std::string const& app_profile_id,
-               std::string const& table_name),
-              (override));
+              AsyncSampleRows, (std::string const& table_name), (override));
 
   MOCK_METHOD(StatusOr<bigtable::Row>, ReadModifyWriteRow,
               (google::bigtable::v2::ReadModifyWriteRowRequest request),
@@ -102,15 +92,15 @@ class MockDataConnection : public bigtable::DataConnection {
               (override));
 
   MOCK_METHOD(void, AsyncReadRows,
-              (std::string const& app_profile_id, std::string const& table_name,
+              (std::string const& table_name,
                std::function<future<bool>(bigtable::Row)> on_row,
                std::function<void(Status)> on_finish, bigtable::RowSet row_set,
                std::int64_t rows_limit, bigtable::Filter filter),
               (override));
 
   MOCK_METHOD((future<StatusOr<std::pair<bool, bigtable::Row>>>), AsyncReadRow,
-              (std::string const& app_profile_id, std::string const& table_name,
-               std::string row_key, bigtable::Filter filter),
+              (std::string const& table_name, std::string row_key,
+               bigtable::Filter filter),
               (override));
 };
 

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -129,6 +129,7 @@ Table TestTable(std::shared_ptr<MockDataConnection> mock) {
 void CheckCurrentOptions() {
   auto const& options = google::cloud::internal::CurrentOptions();
   EXPECT_TRUE(options.has<TestOption>());
+  EXPECT_EQ(kAppProfileId, options.get<AppProfileIdOption>());
 }
 
 TEST(TableTest, ConnectionConstructor) {
@@ -156,11 +157,9 @@ TEST(TableTest, AppProfileId) {
 TEST(TableTest, Apply) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, Apply)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
+      .WillOnce([](std::string const& table_name,
                    bigtable::SingleRowMutation const& mut) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ(mut.row_key(), "row");
         return PermanentError();
@@ -174,11 +173,9 @@ TEST(TableTest, Apply) {
 TEST(TableTest, AsyncApply) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncApply)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
+      .WillOnce([](std::string const& table_name,
                    bigtable::SingleRowMutation const& mut) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ(mut.row_key(), "row");
         return make_ready_future(PermanentError());
@@ -194,11 +191,9 @@ TEST(TableTest, BulkApply) {
 
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, BulkApply)
-      .WillOnce([&expected](std::string const& app_profile_id,
-                            std::string const& table_name,
+      .WillOnce([&expected](std::string const& table_name,
                             bigtable::BulkMutation const& mut) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ(mut.size(), 2);
         return expected;
@@ -215,11 +210,9 @@ TEST(TableTest, AsyncBulkApply) {
 
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncBulkApply)
-      .WillOnce([&expected](std::string const& app_profile_id,
-                            std::string const& table_name,
+      .WillOnce([&expected](std::string const& table_name,
                             bigtable::BulkMutation const& mut) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ(mut.size(), 2);
         return make_ready_future(expected);
@@ -234,12 +227,10 @@ TEST(TableTest, AsyncBulkApply) {
 TEST(TableTest, ReadRows) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, ReadRows)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
+      .WillOnce([](std::string const& table_name,
                    bigtable::RowSet const& row_set, std::int64_t rows_limit,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_THAT(row_set, IsTestRowSet());
         EXPECT_EQ(rows_limit, RowReader::NO_ROWS_LIMIT);
@@ -257,12 +248,10 @@ TEST(TableTest, ReadRows) {
 TEST(TableTest, ReadRowsWithRowLimit) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, ReadRows)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
+      .WillOnce([](std::string const& table_name,
                    bigtable::RowSet const& row_set, std::int64_t rows_limit,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_THAT(row_set, IsTestRowSet());
         EXPECT_EQ(rows_limit, 42);
@@ -280,11 +269,9 @@ TEST(TableTest, ReadRowsWithRowLimit) {
 TEST(TableTest, ReadRow) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, ReadRow)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name, std::string const& row_key,
+      .WillOnce([](std::string const& table_name, std::string const& row_key,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ("row", row_key);
         EXPECT_THAT(filter, IsTestFilter());
@@ -299,13 +286,11 @@ TEST(TableTest, ReadRow) {
 TEST(TableTest, CheckAndMutateRow) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, CheckAndMutateRow)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name, std::string const& row_key,
+      .WillOnce([](std::string const& table_name, std::string const& row_key,
                    Filter const& filter,
                    std::vector<Mutation> const& true_mutations,
                    std::vector<Mutation> const& false_mutations) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ("row", row_key);
         EXPECT_THAT(filter, IsTestFilter());
@@ -327,13 +312,11 @@ TEST(TableTest, CheckAndMutateRow) {
 TEST(TableTest, AsyncCheckAndMutateRow) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncCheckAndMutateRow)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name, std::string const& row_key,
+      .WillOnce([](std::string const& table_name, std::string const& row_key,
                    Filter const& filter,
                    std::vector<Mutation> const& true_mutations,
                    std::vector<Mutation> const& false_mutations) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ("row", row_key);
         EXPECT_THAT(filter, IsTestFilter());
@@ -356,14 +339,11 @@ TEST(TableTest, AsyncCheckAndMutateRow) {
 
 TEST(TableTest, SampleRows) {
   auto mock = std::make_shared<MockDataConnection>();
-  EXPECT_CALL(*mock, SampleRows)
-      .WillOnce(
-          [](std::string const& app_profile_id, std::string const& table_name) {
-            CheckCurrentOptions();
-            EXPECT_EQ(kAppProfileId, app_profile_id);
-            EXPECT_EQ(kTableName, table_name);
-            return PermanentError();
-          });
+  EXPECT_CALL(*mock, SampleRows).WillOnce([](std::string const& table_name) {
+    CheckCurrentOptions();
+    EXPECT_EQ(kTableName, table_name);
+    return PermanentError();
+  });
 
   auto table = TestTable(std::move(mock));
   auto samples = table.SampleRows();
@@ -373,14 +353,12 @@ TEST(TableTest, SampleRows) {
 TEST(TableTest, AsyncSampleRows) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncSampleRows)
-      .WillOnce(
-          [](std::string const& app_profile_id, std::string const& table_name) {
-            CheckCurrentOptions();
-            EXPECT_EQ(kAppProfileId, app_profile_id);
-            EXPECT_EQ(kTableName, table_name);
-            return make_ready_future<StatusOr<std::vector<RowKeySample>>>(
-                PermanentError());
-          });
+      .WillOnce([](std::string const& table_name) {
+        CheckCurrentOptions();
+        EXPECT_EQ(kTableName, table_name);
+        return make_ready_future<StatusOr<std::vector<RowKeySample>>>(
+            PermanentError());
+      });
 
   auto table = TestTable(std::move(mock));
   auto samples = table.AsyncSampleRows().get();
@@ -392,7 +370,6 @@ TEST(TableTest, ReadModifyWriteRow) {
   EXPECT_CALL(*mock, ReadModifyWriteRow)
       .WillOnce([](v2::ReadModifyWriteRowRequest const& request) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_THAT(request.rules(),
                     ElementsAre(MatchRule(TestAppendRule()),
@@ -411,7 +388,6 @@ TEST(TableTest, AsyncReadModifyWriteRow) {
   EXPECT_CALL(*mock, AsyncReadModifyWriteRow)
       .WillOnce([](v2::ReadModifyWriteRowRequest const& request) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, request.app_profile_id());
         EXPECT_EQ(kTableName, request.table_name());
         EXPECT_THAT(request.rules(),
                     ElementsAre(MatchRule(TestAppendRule()),
@@ -428,14 +404,12 @@ TEST(TableTest, AsyncReadModifyWriteRow) {
 TEST(TableTest, AsyncReadRows) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncReadRows)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
+      .WillOnce([](std::string const& table_name,
                    std::function<future<bool>(bigtable::Row)> const& on_row,
                    std::function<void(Status)> const& on_finish,
                    bigtable::RowSet const& row_set, std::int64_t rows_limit,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_THAT(row_set, IsTestRowSet());
         EXPECT_EQ(RowReader::NO_ROWS_LIMIT, rows_limit);
@@ -471,14 +445,12 @@ TEST(TableTest, AsyncReadRows) {
 TEST(TableTest, AsyncReadRowsWithRowLimit) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncReadRows)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name,
+      .WillOnce([](std::string const& table_name,
                    std::function<future<bool>(bigtable::Row)> const& on_row,
                    std::function<void(Status)> const& on_finish,
                    bigtable::RowSet const& row_set, std::int64_t rows_limit,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_THAT(row_set, IsTestRowSet());
         EXPECT_EQ(42, rows_limit);
@@ -514,7 +486,7 @@ TEST(TableTest, AsyncReadRowsWithRowLimit) {
 TEST(TableTest, AsyncReadRowsAcceptsMoveOnlyTypes) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncReadRows)
-      .WillOnce([](Unused, Unused,
+      .WillOnce([](Unused,
                    std::function<future<bool>(bigtable::Row)> const& on_row,
                    std::function<void(Status)> const& on_finish, Unused, Unused,
                    Unused) {
@@ -548,11 +520,9 @@ TEST(TableTest, AsyncReadRowsAcceptsMoveOnlyTypes) {
 TEST(TableTest, AsyncReadRow) {
   auto mock = std::make_shared<MockDataConnection>();
   EXPECT_CALL(*mock, AsyncReadRow)
-      .WillOnce([](std::string const& app_profile_id,
-                   std::string const& table_name, std::string const& row_key,
+      .WillOnce([](std::string const& table_name, std::string const& row_key,
                    bigtable::Filter const& filter) {
         CheckCurrentOptions();
-        EXPECT_EQ(kAppProfileId, app_profile_id);
         EXPECT_EQ(kTableName, table_name);
         EXPECT_EQ("row", row_key);
         EXPECT_THAT(filter, IsTestFilter());


### PR DESCRIPTION
Fixes #9349 

This tedious PR does two things:
1. stores the app profile in `Table::options_` instead of `Table::app_profile_id_`. (Note that `options_` is already passed in an `OptionsSpan` for each RPC). Legacy uses of `app_profile_id_` become `app_profile_id()`.
2. drops `std::string const& app_profile_id` from the Connection methods. We set up`OptionsSpan`s in the Connection unit tests so we can verify that all RPCs set a request's `app_profile_id` field.

While this is a breaking change at HEAD, the methods are less than 2 weeks old and have not been included in a release yet. The upside of this change is that the method signature of the Connection is closer to that of the Table. And it's nice to have one less field to type.

My apologies for not validating the Table API surface before writing all the connection code.

Also, I decided not to perpetuate the `if-call-options-use-call-options-else-use-conn-options` logic. As @devbww pointed out earlier, the connection options are set once. They are merged into the client options. The client options are merged into the call options. So it must be the case that either the call options have a given option, or that neither the call options nor the connection options have a given option. Therefore, we should just use the call options.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9388)
<!-- Reviewable:end -->
