### PR TITLE
cleanup(pubsub): subscriber consumes `std::function<>`

### DIFF
--- a/google/cloud/pubsub/subscriber.h
+++ b/google/cloud/pubsub/subscriber.h
@@ -114,9 +114,7 @@ class Subscriber {
    * @par Example
    * @snippet samples.cc subscribe
    *
-   * @param cb the callable invoked when messages are received. This must be
-   *     usable to construct a
-   *     `std::function<void(pubsub::Message, pubsub::AckHandler)>`.
+   * @param cb the callable invoked when messages are received.
    * @return a future that is satisfied when the session will no longer receive
    *     messages. For example, because there was an unrecoverable error trying
    *     to receive data. Calling `.cancel()` in this object will (eventually)
@@ -125,10 +123,8 @@ class Subscriber {
    * [std-function-link]:
    * https://en.cppreference.com/w/cpp/utility/functional/function
    */
-  template <typename Callable>
-  future<Status> Subscribe(Callable&& cb) {
-    std::function<void(Message, AckHandler)> f(std::forward<Callable>(cb));
-    return connection_->Subscribe({std::move(f)});
+  future<Status> Subscribe(std::function<void(Message, AckHandler)> cb) {
+    return connection_->Subscribe({std::move(cb)});
   }
 
  private:


### PR DESCRIPTION
We used to consume any object that could be converted to a
`std::function<>` of the right type. Consuming the `std::function<>`
will allow us to overload on the function type. We expect applications
using exactly-once delivery will consume a different `AckHandler` which
includes error messages.

Part of the work for #9327

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9395)
<!-- Reviewable:end -->
