### PR TITLE
impl(pubsub): exactly-once delivery retries lease extensions

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -623,10 +623,10 @@ std::unique_ptr<pubsub_testing::MockAsyncPullStream> MakeExactlyOnceStream(
   return stream;
 }
 
-// Wait until the exactly once stream is ready.  Refactors some repetitive code.
+// Wait until the exactly-once stream is ready.  Refactors some repetitive code.
 // The promise returned here will trigger a `Write()` and `Read()` call
-// corresponding to the initial update of the stream's deadline (as this is a
-// exactly once stream), and the loop for `Read()`.
+// corresponding to the initial update of the stream's deadline (as this is an
+// exactly-once stream), and the loop for `Read()`.
 promise<bool> WaitForExactlyOnceStreamInitialRunAsync(
     AsyncSequencer<bool>& aseq) {
   auto start = aseq.PopFrontWithName();


### PR DESCRIPTION
This finally uses the lease extensions on a subscription with
exactly-once delivery enabled.

Part of the work for #9327

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9396)
<!-- Reviewable:end -->
