### PR TITLE
cleanup(bigtable): ergonomic string ctor for TableResource

### DIFF
--- a/google/cloud/bigtable/table_resource.cc
+++ b/google/cloud/bigtable/table_resource.cc
@@ -26,8 +26,9 @@ TableResource::TableResource(InstanceResource instance, std::string table_id)
 
 TableResource::TableResource(std::string project_id, std::string instance_id,
                              std::string table_id)
-    : instance_(Project(std::move(project_id)), std::move(instance_id)),
-      table_id_(std::move(table_id)) {}
+    : TableResource(InstanceResource(Project(std::move(project_id)),
+                                     std::move(instance_id)),
+                    std::move(table_id)) {}
 
 std::string TableResource::FullName() const {
   return instance_.FullName() + "/tables/" + table_id_;

--- a/google/cloud/bigtable/table_resource.cc
+++ b/google/cloud/bigtable/table_resource.cc
@@ -24,6 +24,11 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TableResource::TableResource(InstanceResource instance, std::string table_id)
     : instance_(std::move(instance)), table_id_(std::move(table_id)) {}
 
+TableResource::TableResource(std::string project_id, std::string instance_id,
+                             std::string table_id)
+    : instance_(Project(std::move(project_id)), std::move(instance_id)),
+      table_id_(std::move(table_id)) {}
+
 std::string TableResource::FullName() const {
   return instance_.FullName() + "/tables/" + table_id_;
 }

--- a/google/cloud/bigtable/table_resource.h
+++ b/google/cloud/bigtable/table_resource.h
@@ -49,6 +49,16 @@ class TableResource {
    */
   TableResource(InstanceResource instance, std::string table_id);
 
+  /**
+   * Constructs a TableResource object identified by the given IDs.
+   *
+   * This is equivalent to first constructing an `InstanceResource` from the
+   * given @p project_id and @p instance_id arguments and then calling the
+   * `TableResource(InstanceResource, std::string)` constructor.
+   */
+  TableResource(std::string project_id, std::string instance_id,
+                std::string table_id);
+
   /// Returns the `InstanceResource` containing this table.
   InstanceResource const& instance() const { return instance_; }
 

--- a/google/cloud/bigtable/table_resource_test.cc
+++ b/google/cloud/bigtable/table_resource_test.cc
@@ -51,6 +51,12 @@ TEST(TableResource, Basics) {
   EXPECT_EQ("t2", tr2.table_id());
   EXPECT_EQ(in2, tr2.instance());
   EXPECT_EQ("projects/p2/instances/i2/tables/t2", tr2.FullName());
+
+  TableResource tr_string_ctor("p1", "i1", "t1");
+  EXPECT_EQ(tr_string_ctor, tr);
+  EXPECT_EQ("t1", tr_string_ctor.table_id());
+  EXPECT_EQ(in, tr_string_ctor.instance());
+  EXPECT_EQ("projects/p1/instances/i1/tables/t1", tr_string_ctor.FullName());
 }
 
 TEST(TableResource, OutputStream) {


### PR DESCRIPTION
I am sorry, but writing code like `TableResource(InstanceResource(Project("p"), "i"), "t)"` is just too painful for me. I am sure it would be painful for our customers too.

So add a constructor that accepts strings. `TableResource("p", "i", "t")`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9397)
<!-- Reviewable:end -->
