### PR TITLE
test(storage): more tweaks to ranged reads

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -378,8 +378,9 @@ void RunThread(ThroughputOptions const& options, std::string const& bucket_name,
     // to be larger than the object sizes. The larger this read range size is,
     // the higher the proportion of full range reads.
     if (offset == 0 && size == object_size) return absl::nullopt;
-    // The REST API has a quirk: reading the last 0 bytes returns all the bytes,
-    // just read the *first* 0 bytes in that case.
+    // The REST API has a quirk: reading the last 0 bytes returns all the bytes.
+    // Just read the *first* 0 bytes in that case. Note that `size == 0` is
+    // implied by the initialization to `min(object_size - offset, ...)`.
     if (offset == object_size) return std::make_pair(0, 0);
     return std::make_pair(offset, size);
   };

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -25,7 +25,7 @@ namespace {
 Status ValidateQuantizedRange(std::string const& name, std::int64_t minimum,
                               std::int64_t maximum, std::int64_t quantum) {
   using ::google::cloud::StatusCode;
-  if (minimum > maximum) {
+  if (minimum > maximum || minimum < 0 || maximum < 0) {
     std::ostringstream os;
     os << "Invalid range for " << name << " [" << minimum << ',' << maximum
        << "]";


### PR DESCRIPTION
The benchmark would perform a range read with 50% probability, but some
ranged reads were "full" as the range was larger than the object. I
found it hard to reason about this, so now only the range size controls
whether the read is full or not.

I also rediscovered a quirk of the JSON API, that it is better avoided:
reading the last 0 bytes actually returns all the bytes. Maybe we should
fix this in the client library itself, for now just avoid running into
it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9400)
<!-- Reviewable:end -->
