### PR TITLE
chore(renovate): configure Abseil versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,7 @@
   ],
   "packageRules": [
     {
-      "matchPackageNames": ["com_google_protobuf"],
+      "matchPackageNames": ["com_google_protobuf", "com_google_absl"],
       "versioning": "loose"
     }
   ],


### PR DESCRIPTION
Apparently renovate bot cannot handle Abseil's versions with the default
configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9401)
<!-- Reviewable:end -->
