### PR TITLE
feat(bigtable): modern `Table` constructor

### DIFF
--- a/google/cloud/bigtable/options.h
+++ b/google/cloud/bigtable/options.h
@@ -145,17 +145,17 @@ using DataLimitedErrorCountRetryPolicy =
     ::google::cloud::internal::LimitedErrorCountRetryPolicy<
         bigtable::internal::SafeGrpcRetry>;
 
-/// Option to use with `google::cloud::Options`.
+/// Option to configure the retry policy used by `Table`.
 struct DataRetryPolicyOption {
   using Type = std::shared_ptr<DataRetryPolicy>;
 };
 
-/// Option to use with `google::cloud::Options`.
+/// Option to configure the backoff policy used by `Table`.
 struct DataBackoffPolicyOption {
   using Type = std::shared_ptr<BackoffPolicy>;
 };
 
-/// Option to use with `google::cloud::Options`.
+/// Option to configure the idempotency policy used by `Table`.
 struct IdempotentMutationPolicyOption {
   using Type = std::shared_ptr<bigtable::IdempotentMutationPolicy>;
 };

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -45,21 +45,6 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable_internal {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-// Make a `Table` that is implemented by a `DataConnection`, instead of a
-// `DataClient`. We will use this in tests while the `DataConnection` is under
-// development.
-//
-// TODO(#8860) - remove this when we make the `DataConnection` constructor
-// public.
-bigtable::Table MakeTable(std::shared_ptr<bigtable::DataConnection> conn,
-                          std::string project_id, std::string instance_id,
-                          std::string table_id, Options options = {});
-
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_internal
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
@@ -194,6 +179,31 @@ class Table {
   struct ValidPolicies : absl::conjunction<ValidPolicy<Policies>...> {};
 
  public:
+  /**
+   * Constructs a `Table` object.
+   *
+   * @param conn the connection to the Cloud Bigtable service. See
+   *     `MakeDataConnection()` for how to create a connection. To mock the
+   *     behavior of `Table` in your tests, use a
+   *     `bigtable_mocks::MockDataConnection`.
+   * @param tr identifies the table resource by its project, instance, and table
+   *     ids.
+   * @param options Configuration options for the table. Use
+   *     `AppProfileIdOption` to supply an app profile for the `Table`
+   *     operations. Or configure retry / backoff / idempotency policies with
+   *     the options enumerated in `DataPolicyOptionList`.
+   */
+  explicit Table(std::shared_ptr<bigtable::DataConnection> conn,
+                 TableResource tr, Options options = {})
+      : table_(std::move(tr)),
+        table_name_(table_.FullName()),
+        metadata_update_policy_(
+            MetadataUpdatePolicy(table_name_, MetadataParamTypes::TABLE_NAME)),
+        connection_(std::move(conn)),
+        options_(google::cloud::internal::MergeOptions(
+            std::move(options),
+            internal::DefaultDataOptions(connection_->options()))) {}
+
   /**
    * Constructor with default policies.
    *
@@ -960,22 +970,6 @@ class Table {
                                                       Filter filter);
 
  private:
-  friend Table bigtable_internal::MakeTable(
-      std::shared_ptr<bigtable::DataConnection>, std::string, std::string,
-      std::string, Options);
-  explicit Table(std::shared_ptr<bigtable::DataConnection> conn,
-                 std::string project_id, std::string instance_id,
-                 std::string table_id, Options options = {})
-      : table_(std::move(project_id), std::move(instance_id),
-               std::move(table_id)),
-        table_name_(table_.FullName()),
-        metadata_update_policy_(
-            MetadataUpdatePolicy(table_name_, MetadataParamTypes::TABLE_NAME)),
-        connection_(std::move(conn)),
-        options_(google::cloud::internal::MergeOptions(
-            std::move(options),
-            internal::DefaultDataOptions(connection_->options()))) {}
-
   /**
    * Send request ReadModifyWriteRowRequest to modify the row and get it back
    */
@@ -1049,20 +1043,6 @@ class Table {
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
-namespace bigtable_internal {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-inline bigtable::Table MakeTable(std::shared_ptr<bigtable::DataConnection> conn,
-                                 std::string project_id,
-                                 std::string instance_id, std::string table_id,
-                                 Options options) {
-  return bigtable::Table(std::move(conn), std::move(project_id),
-                         std::move(instance_id), std::move(table_id),
-                         std::move(options));
-}
-
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/table_test.cc
+++ b/google/cloud/bigtable/table_test.cc
@@ -122,8 +122,9 @@ Options TableOptions() {
 
 Table TestTable(std::shared_ptr<MockDataConnection> mock) {
   EXPECT_CALL(*mock, options).WillRepeatedly(Return(Options{}));
-  return bigtable_internal::MakeTable(std::move(mock), kProjectId, kInstanceId,
-                                      kTableId, TableOptions());
+  return Table(std::move(mock),
+               TableResource(kProjectId, kInstanceId, kTableId),
+               TableOptions());
 }
 
 void CheckCurrentOptions() {
@@ -134,8 +135,8 @@ void CheckCurrentOptions() {
 
 TEST(TableTest, ConnectionConstructor) {
   auto conn = std::make_shared<MockDataConnection>();
-  auto table = bigtable_internal::MakeTable(std::move(conn), kProjectId,
-                                            kInstanceId, kTableId);
+  auto table =
+      Table(std::move(conn), TableResource(kProjectId, kInstanceId, kTableId));
   EXPECT_EQ(kProjectId, table.project_id());
   EXPECT_EQ(kInstanceId, table.instance_id());
   EXPECT_EQ(kTableId, table.table_id());
@@ -144,13 +145,11 @@ TEST(TableTest, ConnectionConstructor) {
 
 TEST(TableTest, AppProfileId) {
   auto conn = std::make_shared<MockDataConnection>();
-  auto table =
-      bigtable_internal::MakeTable(conn, kProjectId, kInstanceId, kTableId);
+  auto table = Table(conn, TableResource(kProjectId, kInstanceId, kTableId));
   EXPECT_EQ("", table.app_profile_id());
 
-  table = bigtable_internal::MakeTable(
-      conn, kProjectId, kInstanceId, kTableId,
-      Options{}.set<AppProfileIdOption>(kAppProfileId));
+  table = Table(conn, TableResource(kProjectId, kInstanceId, kTableId),
+                Options{}.set<AppProfileIdOption>(kAppProfileId));
   EXPECT_EQ(kAppProfileId, table.app_profile_id());
 }
 

--- a/google/cloud/bigtable/testing/table_integration_test.cc
+++ b/google/cloud/bigtable/testing/table_integration_test.cc
@@ -157,9 +157,10 @@ void TableIntegrationTest::SetUp() {
 bigtable::Table TableIntegrationTest::GetTable(
     std::string const& implementation) {
   if (implementation == "with-data-connection") {
-    return bigtable_internal::MakeTable(
-        data_connection_, TableTestEnvironment::project_id(),
-        TableTestEnvironment::instance_id(), TableTestEnvironment::table_id());
+    return Table(data_connection_,
+                 TableResource(TableTestEnvironment::project_id(),
+                               TableTestEnvironment::instance_id(),
+                               TableTestEnvironment::table_id()));
   }
   return bigtable::Table(data_client_, TableTestEnvironment::table_id());
 }

--- a/google/cloud/bigtable/tests/data_integration_test.cc
+++ b/google/cloud/bigtable/tests/data_integration_test.cc
@@ -526,8 +526,8 @@ TEST_P(DataIntegrationTest, TableApplyWithLogging) {
   auto make_table = [&](Options const& options) {
     if (GetParam() == "with-data-connection") {
       auto conn = MakeDataConnection(options);
-      return bigtable_internal::MakeTable(std::move(conn), project_id(),
-                                          instance_id(), table_id);
+      return Table(std::move(conn),
+                   TableResource(project_id(), instance_id(), table_id));
     }
     auto data_client = MakeDataClient(project_id(), instance_id(), options);
     return Table(std::move(data_client), table_id);

--- a/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
+++ b/google/cloud/bigtable/tests/table_sample_rows_integration_test.cc
@@ -69,10 +69,11 @@ class SampleRowsIntegrationTest
   static void SetUpTestSuite() {
     // Create kBatchSize * kBatchCount rows. Use a special client with tracing
     // disabled because it simply generates too much data.
-    auto table = bigtable_internal::MakeTable(
+    auto table = Table(
         MakeDataConnection(Options{}.set<TracingComponentsOption>({"rpc"})),
-        TableTestEnvironment::project_id(), TableTestEnvironment::instance_id(),
-        TableTestEnvironment::table_id());
+        TableResource(TableTestEnvironment::project_id(),
+                      TableTestEnvironment::instance_id(),
+                      TableTestEnvironment::table_id()));
 
     int constexpr kBatchCount = 10;
     int constexpr kBatchSize = 5000;
@@ -105,16 +106,18 @@ class SampleRowsIntegrationTest
 };
 
 TEST_F(SampleRowsIntegrationTest, SyncWithDataConnection) {
-  auto table = bigtable_internal::MakeTable(
-      MakeDataConnection(), TableTestEnvironment::project_id(),
-      TableTestEnvironment::instance_id(), TableTestEnvironment::table_id());
+  auto table = Table(MakeDataConnection(),
+                     TableResource(TableTestEnvironment::project_id(),
+                                   TableTestEnvironment::instance_id(),
+                                   TableTestEnvironment::table_id()));
   VerifySamples(table.SampleRows());
 };
 
 TEST_F(SampleRowsIntegrationTest, AsyncWithDataConnection) {
-  auto table = bigtable_internal::MakeTable(
-      MakeDataConnection(), TableTestEnvironment::project_id(),
-      TableTestEnvironment::instance_id(), TableTestEnvironment::table_id());
+  auto table = Table(MakeDataConnection(),
+                     TableResource(TableTestEnvironment::project_id(),
+                                   TableTestEnvironment::instance_id(),
+                                   TableTestEnvironment::table_id()));
   auto fut = table.AsyncSampleRows();
   VerifySamples(fut.get());
 };


### PR DESCRIPTION
Fixes #8860
Technically this fixes #6465 which fixes #1161. Although we should probably update our [credentials sample](https://github.com/googleapis/google-cloud-cpp/blob/c8a4920f64e5fdafb180d9ae1e30bcf4f7bbb3ff/google/cloud/bigtable/examples/bigtable_grpc_credentials.cc). (I think of that task as #7434).

Release the `Table` constructor that accepts a `DataConnection`. Yay, we are close to having a good mocking story. and a good credentials story. (I say close because there is still the pesky legacy API which does not have these things and lives alongside the "new shinny").

For now I just list the relevant options in the constructor's documentation. I would like to link to examples of how the `Options` are used. But the examples must exist first. (#9309 tracks this work).

I would also like to provide guidance on how to mock the `Table` calls in this constructor's documentation. (which is blocked on #9308).

I think this feature warrants a detailed CHANGELOG entry, but I am going to wait until the other modernization work is done before writing the post.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9403)
<!-- Reviewable:end -->
