### PR TITLE
cleanup: include algorithm for std::any_of

### DIFF
--- a/generator/internal/predicate_utils.h
+++ b/generator/internal/predicate_utils.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/optional.h"
 #include <google/protobuf/descriptor.h>
+#include <algorithm>
 #include <functional>
 #include <vector>
 

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -25,6 +25,7 @@
 #include <google/api/client.pb.h>
 #include <google/api/routing.pb.h>
 #include <google/protobuf/descriptor.h>
+#include <algorithm>
 #include <unordered_map>
 
 namespace google {

--- a/google/cloud/pubsub/internal/exactly_once_policies.cc
+++ b/google/cloud/pubsub/internal/exactly_once_policies.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/internal/exactly_once_policies.h"
 #include "absl/memory/memory.h"
+#include <algorithm>
 
 namespace google {
 namespace cloud {


### PR DESCRIPTION
At least one of these was breaking a downstream consumer of the
repo, where incidental inclusions don't happen in the same way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9406)
<!-- Reviewable:end -->
