### PR TITLE
cleanup(pubsub): use fully-qualified google::protobuf types

### DIFF
--- a/google/cloud/pubsub/snapshot_builder.h
+++ b/google/cloud/pubsub/snapshot_builder.h
@@ -60,7 +60,8 @@ class SnapshotBuilder {
   ///@{
   SnapshotBuilder& add_label(std::string const& key,
                              std::string const& value) & {
-    using value_type = protobuf::Map<std::string, std::string>::value_type;
+    using value_type =
+        google::protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
     paths_.insert("labels");
     return *this;

--- a/google/cloud/pubsub/subscription_builder.h
+++ b/google/cloud/pubsub/subscription_builder.h
@@ -268,7 +268,8 @@ class SubscriptionBuilder {
 
   SubscriptionBuilder& add_label(std::string const& key,
                                  std::string const& value) & {
-    using value_type = protobuf::Map<std::string, std::string>::value_type;
+    using value_type =
+        google::protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
     paths_.insert("labels");
     return *this;

--- a/google/cloud/pubsub/topic_builder.h
+++ b/google/cloud/pubsub/topic_builder.h
@@ -52,7 +52,8 @@ class TopicBuilder {
   /// @name Setters for each protocol buffer field.
   ///@{
   TopicBuilder& add_label(std::string const& key, std::string const& value) & {
-    using value_type = protobuf::Map<std::string, std::string>::value_type;
+    using value_type =
+        google::protobuf::Map<std::string, std::string>::value_type;
     proto_.mutable_labels()->insert(value_type(key, value));
     paths_.insert("labels");
     return *this;


### PR DESCRIPTION
This makes it easier to do any downstream mapping of names
in environments with non-standard protobuf namespaces.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9407)
<!-- Reviewable:end -->
