### PR TITLE
cleanup(bigtable): prefer DataConnection API in benchmarks, tests

### DIFF
--- a/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
+++ b/google/cloud/bigtable/admin/integration_tests/table_admin_integration_test.cc
@@ -303,8 +303,9 @@ TEST_F(TableAdminIntegrationTest, WaitForConsistencyCheck) {
 
   // We need to mutate the data in the table and then wait for those mutations
   // to propagate to both clusters. First create a `bigtable::Table` object.
-  auto data_client = bigtable::MakeDataClient(project_id(), id);
-  bigtable::Table table(data_client, random_table_id);
+  auto table = bigtable::Table(
+      bigtable::MakeDataConnection(),
+      bigtable::TableResource(project_id(), id, random_table_id));
 
   // Insert some cells into the table.
   std::string const row_key1 = "check-consistency-row1";

--- a/google/cloud/bigtable/benchmarks/benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/benchmark.cc
@@ -123,14 +123,16 @@ void Benchmark::DeleteTable() {
   }
 }
 
-std::shared_ptr<bigtable::DataClient> Benchmark::MakeDataClient() {
-  return bigtable::MakeDataClient(options_.project_id, options_.instance_id,
-                                  opts_);
+Table Benchmark::MakeTable() const {
+  auto table_opts = Options{}.set<AppProfileIdOption>(options_.app_profile_id);
+  return Table(MakeDataConnection(opts_),
+               TableResource(options_.project_id, options_.instance_id,
+                             options_.table_id),
+               std::move(table_opts));
 }
 
 google::cloud::StatusOr<BenchmarkResult> Benchmark::PopulateTable() {
-  bigtable::Table table(MakeDataClient(), options_.app_profile_id,
-                        options_.table_id);
+  auto table = MakeTable();
   std::cout << "# Populating table " << options_.table_id << " " << std::flush;
   std::vector<std::future<google::cloud::StatusOr<BenchmarkResult>>> tasks;
   auto upload_start = std::chrono::steady_clock::now();

--- a/google/cloud/bigtable/benchmarks/benchmark.h
+++ b/google/cloud/bigtable/benchmarks/benchmark.h
@@ -62,8 +62,8 @@ class Benchmark {
   /// Populate the table with initial data.
   google::cloud::StatusOr<BenchmarkResult> PopulateTable();
 
-  /// Return a `bigtable::DataClient` configured for this benchmark.
-  std::shared_ptr<bigtable::DataClient> MakeDataClient();
+  /// Return a `bigtable::Table` configured for this benchmark.
+  Table MakeTable() const;
 
   /// Create a random key.
   std::string MakeRandomKey(google::cloud::internal::DefaultPRNG& gen) const;

--- a/google/cloud/bigtable/benchmarks/embedded_server_test.cc
+++ b/google/cloud/bigtable/benchmarks/embedded_server_test.cc
@@ -75,8 +75,8 @@ TEST(EmbeddedServer, TableApply) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataClient("fake-project", "fake-instance", options),
-              "fake-table");
+  Table table(MakeDataConnection(options),
+              TableResource("fake-project", "fake-instance", "fake-table"));
 
   SingleRowMutation mutation("row1",
                              {SetCell("fam", "col", milliseconds(0), "val"),
@@ -100,8 +100,8 @@ TEST(EmbeddedServer, TableBulkApply) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataClient("fake-project", "fake-instance", options),
-              "fake-table");
+  Table table(MakeDataConnection(options),
+              TableResource("fake-project", "fake-instance", "fake-table"));
 
   BulkMutation bulk;
   bulk.emplace_back(SingleRowMutation(
@@ -127,8 +127,8 @@ TEST(EmbeddedServer, ReadRows1) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataClient("fake-project", "fake-instance", options),
-              "fake-table");
+  Table table(MakeDataConnection(options),
+              TableResource("fake-project", "fake-instance", "fake-table"));
 
   EXPECT_EQ(0, server->read_rows_count());
   auto reader = table.ReadRows(RowSet("row1"), 1, Filter::PassAllFilter());
@@ -149,8 +149,8 @@ TEST(EmbeddedServer, ReadRows100) {
           .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
           .set<EndpointOption>(server->address());
 
-  Table table(MakeDataClient("fake-project", "fake-instance", options),
-              "fake-table");
+  Table table(MakeDataConnection(options),
+              TableResource("fake-project", "fake-instance", "fake-table"));
 
   EXPECT_EQ(0, server->read_rows_count());
   auto reader = table.ReadRows(RowSet(RowRange::StartingAt("foo")), 100,

--- a/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/endurance_benchmark.cc
@@ -62,8 +62,8 @@ using bigtable::benchmarks::ParseArgs;
 
 /// Run an iteration of the test, returns the number of operations.
 google::cloud::StatusOr<long> RunBenchmark(  // NOLINT(google-runtime-int)
-    bigtable::benchmarks::Benchmark& benchmark, std::string app_profile_id,
-    std::string const& table_id, std::chrono::seconds test_duration);
+    bigtable::benchmarks::Benchmark const& benchmark,
+    std::chrono::seconds test_duration);
 
 }  // anonymous namespace
 
@@ -91,8 +91,7 @@ int main(int argc, char* argv[]) {
       launch_policy = std::launch::deferred;
     }
     tasks.emplace_back(std::async(launch_policy, RunBenchmark,
-                                  std::ref(benchmark), options->app_profile_id,
-                                  options->table_id, options->test_duration));
+                                  std::ref(benchmark), options->test_duration));
   }
 
   // Wait for the threads and combine all the results.
@@ -149,13 +148,11 @@ OperationResult RunOneReadRow(bigtable::Table& table,
 }
 
 google::cloud::StatusOr<long> RunBenchmark(  // NOLINT(google-runtime-int)
-    bigtable::benchmarks::Benchmark& benchmark, std::string app_profile_id,
-    std::string const& table_id, std::chrono::seconds test_duration) {
+    bigtable::benchmarks::Benchmark const& benchmark,
+    std::chrono::seconds test_duration) {
   BenchmarkResult partial = {};
 
-  auto data_client = benchmark.MakeDataClient();
-  bigtable::Table table(std::move(data_client), std::move(app_profile_id),
-                        table_id);
+  auto table = benchmark.MakeTable();
 
   auto generator = google::cloud::internal::MakeDefaultPRNG();
 

--- a/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
+++ b/google/cloud/bigtable/benchmarks/mutation_batcher_throughput_benchmark.cc
@@ -192,11 +192,10 @@ int main(int argc, char* argv[]) {
   }
 
   auto table = cbt::Table(
-      cbt::MakeDataClient(
-          options->project_id, options->instance_id,
+      cbt::MakeDataConnection(
           Options{}.set<google::cloud::GrpcBackgroundThreadPoolSizeOption>(
               options->max_batches)),
-      table_id);
+      cbt::TableResource(options->project_id, options->instance_id, table_id));
 
   std::cout << "# Project ID: " << options->project_id
             << "\n# Instance ID: " << options->instance_id

--- a/google/cloud/bigtable/tests/admin_integration_test.cc
+++ b/google/cloud/bigtable/tests/admin_integration_test.cc
@@ -257,8 +257,8 @@ TEST_F(AdminIntegrationTest, WaitForConsistencyCheck) {
 
   // We need to mutate the data in the table and then wait for those mutations
   // to propagate to both clusters. First create a `bigtable::Table` object.
-  auto data_client = bigtable::MakeDataClient(project_id(), id);
-  bigtable::Table table(data_client, random_table_id);
+  auto table = Table(MakeDataConnection(),
+                     TableResource(project_id(), id, random_table_id));
 
   // Insert some cells into the table.
   std::string const row_key1 = "check-consistency-row1";


### PR DESCRIPTION
Part of the work for #9309 

I took the opportunity to simplify `benchmark.h` by returning a `Table` instead of a `DataClient` to be made into a `Table`.

Everything else should be straight forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9409)
<!-- Reviewable:end -->
