### PR TITLE
cleanup(bigtable): prefer `DataConnection` in sample code/docs

### DIFF
--- a/google/cloud/bigtable/doc/bigtable-hello-world.dox
+++ b/google/cloud/bigtable/doc/bigtable-hello-world.dox
@@ -59,7 +59,7 @@ Create a table with [BigtableTableAdminClient::CreateTable()][TableAdmin-CreateT
 ## Connecting to Cloud Bigtable to read and write data
 
 To read and write data, connect to Cloud Bigtable using
-`bigtable::MakeDataClient()`:
+`bigtable::MakeDataConnection()`:
 
 @snippet bigtable_hello_world.cc connect data
 

--- a/google/cloud/bigtable/examples/bigtable_examples_common.cc
+++ b/google/cloud/bigtable/examples/bigtable_examples_common.cc
@@ -53,7 +53,8 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
-        google::cloud::bigtable::MakeDataClient(argv[0], argv[1]), argv[2]);
+        google::cloud::bigtable::MakeDataConnection(),
+        google::cloud::bigtable::TableResource(argv[0], argv[1], argv[2]));
     argv.erase(argv.begin(), argv.begin() + 3);
     function(table, argv);
   };
@@ -117,7 +118,8 @@ Commands::value_type MakeCommandEntry(std::string const& name,
       throw Usage{std::move(os).str()};
     }
     google::cloud::bigtable::Table table(
-        google::cloud::bigtable::MakeDataClient(argv[0], argv[1]), argv[2]);
+        google::cloud::bigtable::MakeDataConnection(),
+        google::cloud::bigtable::TableResource(argv[0], argv[1], argv[2]));
     google::cloud::CompletionQueue cq;
     std::thread t([&cq] { cq.Run(); });
     AutoShutdownCQ shutdown(cq, std::move(t));

--- a/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_app_profile.cc
@@ -43,10 +43,11 @@ void HelloWorldAppProfile(std::vector<std::string> const& argv) {
   std::string const& profile_id = argv[3];
 
   // Create an object to access the Cloud Bigtable Data API.
-  auto data_client = cbt::MakeDataClient(project_id, instance_id);
+  auto connection = cbt::MakeDataConnection();
 
   // Use the default profile to write some data.
-  cbt::Table write(data_client, table_id);
+  cbt::Table write(connection,
+                   cbt::TableResource(project_id, instance_id, table_id));
 
   // Modify (and create if necessary) a row.
   std::vector<std::string> greetings{"Hello World!", "Hello Cloud Bigtable!",
@@ -75,7 +76,11 @@ void HelloWorldAppProfile(std::vector<std::string> const& argv) {
 
   // Access Cloud Bigtable using a different profile
   //! [read with app profile]
-  cbt::Table read(data_client, profile_id, table_id);
+  auto options =
+      google::cloud::Options{}.set<cbt::AppProfileIdOption>(profile_id);
+  cbt::Table read(connection,
+                  cbt::TableResource(project_id, instance_id, table_id),
+                  options);
 
   google::cloud::StatusOr<std::pair<bool, cbt::Row>> result =
       read.ReadRow("key-0", cbt::Filter::ColumnRangeClosed("fam", "c0", "c0"));

--- a/google/cloud/bigtable/examples/bigtable_hello_world.cc
+++ b/google/cloud/bigtable/examples/bigtable_hello_world.cc
@@ -65,7 +65,8 @@ void BigtableHelloWorld(std::vector<std::string> const& argv) {
 
   // Create an object to access the Cloud Bigtable Data API.
   //! [connect data]
-  cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id);
+  cbt::Table table(cbt::MakeDataConnection(),
+                   cbt::TableResource(project_id, instance_id, table_id));
   //! [connect data] [END bigtable_hw_create_table]
 
   // Modify (and create if necessary) a row.

--- a/google/cloud/bigtable/examples/data_async_snippets.cc
+++ b/google/cloud/bigtable/examples/data_async_snippets.cc
@@ -349,8 +349,11 @@ void RunAll(std::vector<std::string> const& argv) {
                                   table_id, std::move(t));
   if (!schema) throw std::runtime_error(schema.status().message());
 
-  cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id,
-                   cbt::AlwaysRetryMutationPolicy());
+  using ::google::cloud::Options;
+  cbt::Table table(cbt::MakeDataConnection(),
+                   cbt::TableResource(project_id, instance_id, table_id),
+                   Options{}.set<cbt::IdempotentMutationPolicyOption>(
+                       cbt::AlwaysRetryMutationPolicy().clone()));
 
   std::cout << "\nRunning the AsyncApply() example" << std::endl;
   AsyncApply(table, {"row-0001"});

--- a/google/cloud/bigtable/examples/data_filter_snippets.cc
+++ b/google/cloud/bigtable/examples/data_filter_snippets.cc
@@ -579,7 +579,8 @@ void RunAll(std::vector<std::string> const& argv) {
                                   table_id, std::move(t));
   if (!schema) throw std::runtime_error(schema.status().message());
 
-  cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id);
+  cbt::Table table(cbt::MakeDataConnection(),
+                   cbt::TableResource(project_id, instance_id, table_id));
 
   std::cout << "\nPreparing data for multiple examples" << std::endl;
   InsertTestData(table, {});

--- a/google/cloud/bigtable/examples/read_snippets.cc
+++ b/google/cloud/bigtable/examples/read_snippets.cc
@@ -14,11 +14,11 @@
 
 #include "google/cloud/bigtable/examples/bigtable_examples_common.h"
 #include "google/cloud/bigtable/resource_names.h"
-#include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
-#include "google/cloud/bigtable/testing/random_names.h"
 //! [bigtable includes]
 #include "google/cloud/bigtable/table.h"
 //! [bigtable includes]
+#include "google/cloud/bigtable/testing/cleanup_stale_resources.h"
+#include "google/cloud/bigtable/testing/random_names.h"
 #include "google/cloud/internal/format_time_point.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
@@ -145,7 +145,8 @@ void ReadKeysSet(std::vector<std::string> argv) {
   }
 
   google::cloud::bigtable::Table table(
-      google::cloud::bigtable::MakeDataClient(argv[0], argv[1]), argv[2]);
+      google::cloud::bigtable::MakeDataConnection(),
+      google::cloud::bigtable::TableResource(argv[0], argv[1], argv[2]));
   argv.erase(argv.begin(), argv.begin() + 3);
 
   // [START bigtable_read_keys_set]
@@ -369,7 +370,8 @@ void RunAll(std::vector<std::string> const& argv) {
                                   table_id, std::move(t));
   if (!schema) throw std::runtime_error(schema.status().message());
 
-  cbt::Table table(cbt::MakeDataClient(project_id, instance_id), table_id);
+  cbt::Table table(cbt::MakeDataConnection(),
+                   cbt::TableResource(project_id, instance_id, table_id));
 
   std::cout << "Preparing data for read examples" << std::endl;
   PrepareReadSamples(table);

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -192,6 +192,15 @@ class Table {
    *     `AppProfileIdOption` to supply an app profile for the `Table`
    *     operations. Or configure retry / backoff / idempotency policies with
    *     the options enumerated in `DataPolicyOptionList`.
+   *
+   * @par Example Using AppProfile
+   * @snippet bigtable_hello_app_profile.cc read with app profile
+   *
+   * @par Idempotency Policy Example
+   * @snippet data_snippets.cc apply relaxed idempotency
+   *
+   * @par Modified Retry Policy Example
+   * @snippet data_snippets.cc apply custom retry
    */
   explicit Table(std::shared_ptr<bigtable::DataConnection> conn,
                  TableResource tr, Options options = {})
@@ -224,12 +233,6 @@ class Table {
    * API.
    * @param table_id the table id within the instance defined by client.  The
    *     full table name is `client->instance_name() + '/tables/' + table_id`.
-   *
-   * @par Example
-   * @snippet bigtable_hello_app_profile.cc cbt namespace
-   *
-   * @par Example Using AppProfile
-   * @snippet bigtable_hello_app_profile.cc read with app profile
    */
   Table(std::shared_ptr<DataClient> client, std::string app_profile_id,
         std::string const& table_id)
@@ -294,12 +297,6 @@ class Table {
    * @see SafeIdempotentMutationPolicy, AlwaysRetryMutationPolicy,
    *     ExponentialBackoffPolicy, LimitedErrorCountRetryPolicy,
    *     LimitedTimeRetryPolicy.
-   *
-   * @par Idempotency Policy Example
-   * @snippet data_snippets.cc apply relaxed idempotency
-   *
-   * @par Modified Retry Policy Example
-   * @snippet data_snippets.cc apply custom retry
    */
   template <
       typename... Policies,
@@ -357,12 +354,6 @@ class Table {
    * @see SafeIdempotentMutationPolicy, AlwaysRetryMutationPolicy,
    *     ExponentialBackoffPolicy, LimitedErrorCountRetryPolicy,
    *     LimitedTimeRetryPolicy.
-   *
-   * @par Idempotency Policy Example
-   * @snippet data_snippets.cc apply relaxed idempotency
-   *
-   * @par Modified Retry Policy Example
-   * @snippet data_snippets.cc apply custom retry
    */
   template <
       typename... Policies,


### PR DESCRIPTION
Part of the work for #9309 

Update our sample code to use the new API. Move references to the code samples in `table.h` from the `DataClient` ctor to the `DataConnection` ctor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9410)
<!-- Reviewable:end -->
