### PR TITLE
ci: fix gcc-7.3 trigger names

### DIFF
--- a/ci/cloudbuild/triggers/gcc-7.3-ci.yaml
+++ b/ci/cloudbuild/triggers/gcc-7.3-ci.yaml
@@ -4,7 +4,7 @@ github:
   owner: googleapis
   push:
     branch: ^(master|main|v\d+\..*)$
-name: gcc-7.3-ci
+name: gcc-7-3-ci
 substitutions:
   _BUILD_NAME: gcc-7.3
   _DISTRO: centos-7

--- a/ci/cloudbuild/triggers/gcc-7.3-pr.yaml
+++ b/ci/cloudbuild/triggers/gcc-7.3-pr.yaml
@@ -5,7 +5,7 @@ github:
   pullRequest:
     branch: ^(master|main|v\d+\..*)$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
-name: gcc-7.3-pr
+name: gcc-7-3-pr
 substitutions:
   _BUILD_NAME: gcc-7.3
   _DISTRO: centos-7


### PR DESCRIPTION
TIL: trigger names cannot contain periods. I think keeping the file names as they are is less confusing w.r.t. the build name, and the version of GCC and so on.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9412)
<!-- Reviewable:end -->
