### PR TITLE
feat(bigtable): dynamic routing of Data API requests

### DIFF
--- a/google/cloud/bigtable/metadata_update_policy.cc
+++ b/google/cloud/bigtable/metadata_update_policy.cc
@@ -50,5 +50,20 @@ void MetadataUpdatePolicy::Setup(grpc::ClientContext& context) const {
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+bigtable::MetadataUpdatePolicy MakeMetadataUpdatePolicy(
+    std::string const& table_name, std::string const& app_profile_id) {
+  // The rule is the same for all RPCs in the Data API. We always include the
+  // table name. We append an app profile id only if one was provided.
+  return bigtable::MetadataUpdatePolicy(
+      table_name +
+          (app_profile_id.empty() ? "" : "&app_profile_id=" + app_profile_id),
+      bigtable::MetadataParamTypes::TABLE_NAME);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/bigtable/metadata_update_policy.h
+++ b/google/cloud/bigtable/metadata_update_policy.h
@@ -104,6 +104,18 @@ class MetadataUpdatePolicy {
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Returns a `MetadataUpdatePolicy` that implements the explicit routing
+ * specification in `bigtable.proto`.
+ */
+bigtable::MetadataUpdatePolicy MakeMetadataUpdatePolicy(
+    std::string const& table_name, std::string const& app_profile_id);
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -182,7 +182,7 @@ future<std::vector<FailedMutation>> Table::AsyncBulkApply(BulkMutation mut) {
   return internal::AsyncRetryBulkApply::Create(
       cq, clone_rpc_retry_policy(), clone_rpc_backoff_policy(),
       *mutation_policy, clone_metadata_update_policy(), client_,
-      app_profile_id(), table_name(), std::move(mut));
+      app_profile_id(), table_name_, std::move(mut));
 }
 
 RowReader Table::ReadRows(RowSet row_set, Filter filter) {


### PR DESCRIPTION
Fixes #9123 

Add a method that lets us configure `MetadataUpdatePolicy` that takes in a `table_name` and an `app_profile_id`. (Essentially hardcoding what the generator does). We piggyback off an existing constructor, because I did not feel like dealing with private friends. (Obviously, I was not going to grow the API and add a public constructor).

Inside `Table`, our app profile id is stored in `Table::options_`. We make sure that `metadata_update_policy_` is defined after `options_` so we can use the `app_profile_id()` accessor in our constructors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9414)
<!-- Reviewable:end -->
