### PR TITLE
cleanup: heed abseil-string-find-startswith clang-tidy

### DIFF
--- a/google/cloud/pubsub/internal/exactly_once_policies.cc
+++ b/google/cloud/pubsub/internal/exactly_once_policies.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/pubsub/internal/exactly_once_policies.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/match.h"
 #include <algorithm>
 
 namespace google {
@@ -47,7 +48,8 @@ bool ExactlyOnceRetryPolicy::IsPermanentFailure(Status const& status) const {
   if (ExactlyOnceRetryable(code)) return false;
   auto const& metadata = status.error_info().metadata();
   return !std::any_of(metadata.begin(), metadata.end(), [this](auto const& kv) {
-    return kv.first == ack_id_ && kv.second.rfind("TRANSIENT_FAILURE_", 0) == 0;
+    return kv.first == ack_id_ &&
+           absl::StartsWith(kv.second, "TRANSIENT_FAILURE_");
   });
 }
 

--- a/google/cloud/pubsub/internal/extend_leases_with_retry.cc
+++ b/google/cloud/pubsub/internal/extend_leases_with_retry.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/pubsub/internal/exactly_once_policies.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/log.h"
+#include "absl/strings/match.h"
 #include <algorithm>
 #include <memory>
 
@@ -39,7 +40,7 @@ google::pubsub::v1::ModifyAckDeadlineRequest UpdateRequest(
     auto const& m = status.error_info().metadata();
     auto f = m.find(ack_id);
     auto const permanent =
-        f == m.end() || f->second.rfind("TRANSIENT_FAILURE_", 0) != 0;
+        f == m.end() || !absl::StartsWith(f->second, "TRANSIENT_FAILURE_");
     if (permanent) {
       GCP_LOG(WARNING)
           << "permanent failure trying to extend the lease for ack_id="


### PR DESCRIPTION
Some downstream users enable this clang-tidy, so we might as well take
its advice.

https://clang.llvm.org/extra/clang-tidy/checks/abseil/string-find-startswith.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9416)
<!-- Reviewable:end -->
