### PR TITLE
cleanup: enable abseil warnings in clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,6 +45,7 @@
 #
 Checks: >
   -*,
+  abseil-*,
   bugprone-*,
   google-*,
   misc-*,

--- a/examples/gcs2cbt.cc
+++ b/examples/gcs2cbt.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
 #include <condition_variable>
 #include <fstream>
@@ -207,11 +208,11 @@ The options are:
     std::string argument(argv[1]);
     argv.erase(argv.begin() + 1);
     if (argument == "--help") {
-    } else if (0 == argument.find(separator_option)) {
+    } else if (absl::StartsWith(argument, separator_option)) {
       options.separator = argument.substr(separator_option.size())[0];
-    } else if (0 == argument.find(key_option)) {
+    } else if (absl::StartsWith(argument, key_option)) {
       options.keys.push_back(std::stoi(argument.substr(key_option.size())) - 1);
-    } else if (0 == argument.find(keys_separator_option)) {
+    } else if (absl::StartsWith(argument, keys_separator_option)) {
       options.keys_separator = argument.substr(keys_separator_option.size());
     } else {
       return argument;

--- a/examples/grpc_credential_types.cc
+++ b/examples/grpc_credential_types.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/log.h"
 #include "google/cloud/project.h"
 #include "google/cloud/testing_util/example_driver.h"
+#include "absl/strings/match.h"
 #include "absl/strings/str_split.h"
 #include "absl/time/time.h"  // NOLINT(modernize-deprecated-headers)
 #include <curl/curl.h>
@@ -214,7 +215,7 @@ void UseIdTokenGrpc(google::cloud::iam::IAMCredentialsClient client,
     if (!token) throw std::runtime_error(token.status().message());
 
     auto const prefix = std::string{"https://"};
-    if (url.rfind(prefix, 0) != 0) {
+    if (!absl::StartsWith(url, prefix)) {
       throw std::runtime_error("Invalid URL" + url);
     }
     auto endpoint = url.substr(prefix.length()) + ":443";

--- a/generator/internal/descriptor_utils.cc
+++ b/generator/internal/descriptor_utils.cc
@@ -480,9 +480,8 @@ void SetRetryStatusCodeExpression(VarsDictionary& vars) {
   std::set<std::string> codes = absl::StrSplit(iter->second, ',');
 
   auto append_status_code = [&](std::string const& status_code) {
-    absl::StrAppend(
-        &retry_status_code_expression,
-        absl::StrCat(" && status.code() != StatusCode::", status_code));
+    absl::StrAppend(&retry_status_code_expression,
+                    " && status.code() != StatusCode::", status_code);
   };
 
   for (auto const& code : codes) {

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -72,7 +72,7 @@ std::map<std::string, std::string> ScaffoldVars(
   for (auto const& api : index["apis"]) {
     if (!api.contains("directory")) continue;
     auto const directory = api["directory"].get<std::string>() + "/";
-    if (service.service_proto_path().rfind(directory, 0) != 0) continue;
+    if (!absl::StartsWith(service.service_proto_path(), directory)) continue;
     vars.emplace("title", api.value("title", ""));
     vars.emplace("description", api.value("description", ""));
     vars.emplace("directory", api.value("directory", ""));

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/status_or.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
+#include "absl/strings/match.h"
 #include "generator/generator.h"
 #include "generator/generator_config.pb.h"
 #include "generator/internal/scaffold_generator.h"
@@ -72,7 +73,7 @@ std::string Dirname(std::string const& path) {
 std::vector<std::string> Parents(std::string path) {
   std::vector<std::string> p;
   p.push_back(path);
-  while (path.find('/') != std::string::npos) {
+  while (absl::StrContains(path, '/')) {
     path = Dirname(path);
     p.push_back(path);
   }

--- a/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
+++ b/google/cloud/bigtable/examples/bigtable_instance_admin_snippets.cc
@@ -764,7 +764,7 @@ void TestIamPermissions(std::vector<std::string> const& argv) {
   }
   auto it = argv.cbegin();
   auto const resource_name = *it++;
-  if (resource_name.rfind("projects/", 0) != 0) {
+  if (!absl::StartsWith(resource_name, "projects/")) {
     throw Usage{usage +
                 "\nresource-name should be fully qualified. For example: "
                 "'projects/my-project/instances/my-instance'"};

--- a/google/cloud/bigtable/tests/instance_admin_emulator.cc
+++ b/google/cloud/bigtable/tests/instance_admin_emulator.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/bigtable/internal/prefix_range_end.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/match.h"
 #include <google/bigtable/admin/v2/bigtable_instance_admin.grpc.pb.h>
 #include <google/longrunning/operations.grpc.pb.h>
 #include <google/protobuf/text_format.h>
@@ -106,7 +107,7 @@ class InstanceAdminEmulator final
 
     std::string prefix = request->parent() + "/instances/";
     for (auto const& kv : instances_) {
-      if (0 == kv.first.find(prefix)) {
+      if (absl::StartsWith(kv.first, prefix)) {
         *response->add_instances() = kv.second;
       }
     }
@@ -385,7 +386,7 @@ class InstanceAdminEmulator final
 
     auto const& parent = request->parent();
     for (auto const& kv : app_profiles_) {
-      if (0 == kv.first.find(parent)) {
+      if (absl::StartsWith(kv.first, parent)) {
         *response->add_app_profiles() = kv.second;
       }
     }

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -43,7 +43,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 char const* InitialQueryParameterSeparator(std::string const& url) {
-  if (url.find('?') != std::string::npos) return "&";
+  if (absl::StrContains(url, '?')) return "&";
   return "?";
 }
 

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -43,7 +43,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 char const* InitialQueryParameterSeparator(std::string const& url) {
-  if (absl::StrContains(url, '?')) return "&";
+  // Abseil <= 20200923 does not implement StrContains(.., char)
+  // NOLINTNEXTLINE(abseil-string-find-str-contains)
+  if (url.find('?') != std::string::npos) return "&";
   return "?";
 }
 

--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/log.h"
+#include "absl/strings/match.h"
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
 #include <algorithm>
@@ -86,7 +87,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
                  [](char x) { return x == '/' ? ' ' : x; });
   // LibreSSL seems to be using semantic versioning, so just check the major
   // version.
-  if (expected_prefix.rfind("LibreSSL 2", 0) == 0) {
+  if (absl::StartsWith(expected_prefix, "LibreSSL 2")) {
     expected_prefix = "LibreSSL 2";
   }
 #ifdef OPENSSL_VERSION
@@ -98,7 +99,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   // that the major version matches (e.g. LibreSSL), and (b) because the
   // `openssl_v` string sometimes reads `OpenSSL 1.1.0 May 2018` while the
   // string reported by libcurl would be `OpenSSL/1.1.0`, sigh...
-  if (openssl_v.rfind(expected_prefix, 0) != 0) {
+  if (!absl::StartsWith(openssl_v, expected_prefix)) {
     std::ostringstream os;
     os << "Mismatched versions of OpenSSL linked in libcurl vs. the version"
        << " linked by the Google Cloud Storage C++ library.\n"
@@ -180,8 +181,8 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
   //    https://curl.haxx.se/libcurl/c/threadsafe.html
   // Only these library prefixes require special configuration for using safely
   // with multiple threads.
-  return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 ||
-          curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
+  return (absl::StartsWith(curl_ssl_id, "OpenSSL/1.0") ||
+          absl::StartsWith(curl_ssl_id, "LibreSSL/2"));
 }
 
 long VersionToCurlCode(std::string const& v) {  // NOLINT(google-runtime-int)

--- a/google/cloud/pubsub/benchmarks/endurance.cc
+++ b/google/cloud/pubsub/benchmarks/endurance.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/command_line_parsing.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/match.h"
 #include <chrono>
 #include <iostream>
 #include <limits>
@@ -450,7 +451,7 @@ void PublisherTask(Config const& config, ExperimentFlowControl& flow_control,
       publisher = make_publisher();
     }
     auto message = flow_control.GenerateMessage(task);
-    auto const shutdown = message.data().rfind("shutdown:", 0) == 0;
+    auto const shutdown = absl::StartsWith(message.data(), "shutdown:");
     last_publish = publisher.Publish(std::move(message))
                        .then([&flow_control](future<StatusOr<std::string>> f) {
                          flow_control.Published(f.get().ok());

--- a/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_extra_integration_test.cc
@@ -31,6 +31,7 @@
 #include "google/cloud/kms_key_name.h"
 #include "google/cloud/testing_util/integration_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -62,10 +63,10 @@ std::string const& ProjectId() {
 
 bool RunSlowBackupTests() {
   static bool run_slow_backup_tests =
-      google::cloud::internal::GetEnv(
-          "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-          .value_or("")
-          .find("backup") != std::string::npos;
+      absl::StrContains(google::cloud::internal::GetEnv(
+                            "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
+                            .value_or(""),
+                        "backup");
   return run_slow_backup_tests;
 }
 

--- a/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/backup_integration_test.cc
@@ -14,13 +14,11 @@
 
 #include "google/cloud/spanner/admin/database_admin_client.h"
 #include "google/cloud/spanner/admin/database_admin_options.h"
-#include "google/cloud/spanner/admin/instance_admin_client.h"
 #include "google/cloud/spanner/backoff_policy.h"
 #include "google/cloud/spanner/backup.h"
 #include "google/cloud/spanner/client.h"
 #include "google/cloud/spanner/polling_policy.h"
 #include "google/cloud/spanner/retry_policy.h"
-#include "google/cloud/spanner/testing/instance_location.h"
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/spanner/timestamp.h"
@@ -30,10 +28,10 @@
 #include "google/cloud/kms_key_name.h"
 #include "google/cloud/testing_util/integration_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
 #include <chrono>
-#include <regex>
 #include <sstream>
 #include <string>
 
@@ -51,10 +49,10 @@ std::string const& ProjectId() {
 
 bool RunSlowBackupTests() {
   static bool run_slow_backup_tests =
-      google::cloud::internal::GetEnv(
-          "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-          .value_or("")
-          .find("backup") != std::string::npos;
+      absl::StrContains(google::cloud::internal::GetEnv(
+                            "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
+                            .value_or(""),
+                        "backup");
   return run_slow_backup_tests;
 }
 

--- a/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/instance_admin_integration_test.cc
@@ -56,10 +56,10 @@ std::string const& InstanceId() {
 }
 
 bool RunSlowInstanceTests() {
-  static bool run_slow_instance_tests =
+  static bool run_slow_instance_tests = absl::StrContains(
       internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-          .value_or("")
-          .find("instance") != std::string::npos;
+          .value_or(""),
+      "instance");
   return run_slow_instance_tests;
 }
 

--- a/google/cloud/spanner/benchmarks/benchmarks_config.cc
+++ b/google/cloud/spanner/benchmarks/benchmarks_config.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/compiler_info.h"
 #include "google/cloud/internal/getenv.h"
+#include "absl/strings/match.h"
 #include <functional>
 #include <sstream>
 
@@ -121,13 +122,13 @@ google::cloud::StatusOr<Config> ParseArgs(std::vector<std::string> args) {
     std::string const& arg = *i;
     bool found = false;
     for (auto const& flag : flags) {
-      if (arg.rfind(flag.flag_name, 0) != 0) continue;
+      if (!absl::StartsWith(arg, flag.flag_name)) continue;
       found = true;
       flag.parser(config, arg.substr(flag.flag_name.size()));
 
       break;
     }
-    if (!found && arg.rfind("--", 0) == 0) {
+    if (!found && absl::StartsWith(arg, "--")) {
       return invalid_argument("Unexpected command-line flag " + arg);
     }
   }

--- a/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_extra_integration_test.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/integration_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -57,10 +58,10 @@ std::string const& ProjectId() {
 
 bool RunSlowBackupTests() {
   static bool run_slow_backup_tests =
-      google::cloud::internal::GetEnv(
-          "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-          .value_or("")
-          .find("backup") != std::string::npos;
+      absl::StrContains(google::cloud::internal::GetEnv(
+                            "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
+                            .value_or(""),
+                        "backup");
   return run_slow_backup_tests;
 }
 

--- a/google/cloud/spanner/integration_tests/backup_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/backup_integration_test.cc
@@ -21,11 +21,11 @@
 #include "google/cloud/spanner/testing/pick_random_instance.h"
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/spanner/timestamp.h"
-#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/testing_util/integration_test.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include "absl/strings/match.h"
 #include "absl/time/time.h"
 #include <gmock/gmock.h>
 #include <chrono>
@@ -47,10 +47,10 @@ std::string const& ProjectId() {
 
 bool RunSlowBackupTests() {
   static bool run_slow_backup_tests =
-      google::cloud::internal::GetEnv(
-          "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-          .value_or("")
-          .find("backup") != std::string::npos;
+      absl::StrContains(google::cloud::internal::GetEnv(
+                            "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
+                            .value_or(""),
+                        "backup");
   return run_slow_backup_tests;
 }
 

--- a/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/instance_admin_integration_test.cc
@@ -59,10 +59,10 @@ std::string const& InstanceId() {
 }
 
 bool RunSlowInstanceTests() {
-  static bool run_slow_instance_tests =
+  static bool run_slow_instance_tests = absl::StrContains(
       internal::GetEnv("GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
-          .value_or("")
-          .find("instance") != std::string::npos;
+          .value_or(""),
+      "instance");
   return run_slow_instance_tests;
 }
 

--- a/google/cloud/spanner/internal/status_utils.cc
+++ b/google/cloud/spanner/internal/status_utils.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/spanner/internal/status_utils.h"
 #include "google/cloud/grpc_error_delegate.h"
 #include "google/cloud/internal/status_payload_keys.h"
+#include "absl/strings/match.h"
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 #include <google/spanner/v1/spanner.pb.h>
@@ -45,7 +46,7 @@ bool IsSessionNotFound(google::cloud::Status const& status) {
 
   // Without an attached `ResourceInfo` (which should never happen outside
   // of tests), we fallback to looking at the `Status` message.
-  return status.message().find("Session not found") != std::string::npos;
+  return absl::StrContains(status.message(), "Session not found");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/samples/samples.cc
+++ b/google/cloud/spanner/samples/samples.cc
@@ -3722,9 +3722,9 @@ void RunAllSlowInstanceTests(
           "GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS")
           .value_or("");
   auto const run_slow_backup_tests =
-      run_slow_integration_tests.find("backup") != std::string::npos;
+      absl::StrContains(run_slow_integration_tests, "backup");
   auto const run_slow_instance_tests =
-      run_slow_integration_tests.find("instance") != std::string::npos;
+      absl::StrContains(run_slow_integration_tests, "instance");
 
   if (!run_slow_instance_tests) return;
 

--- a/google/cloud/spanner/testing/pick_random_instance.cc
+++ b/google/cloud/spanner/testing/pick_random_instance.cc
@@ -18,6 +18,7 @@
 #include "google/cloud/spanner/instance.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/project.h"
+#include "absl/strings/match.h"
 #include <vector>
 
 namespace google {
@@ -46,7 +47,7 @@ StatusOr<std::string> PickRandomInstance(
   for (auto& instance : client.ListInstances(request)) {
     if (!instance) return std::move(instance).status();
     auto instance_id = instance->name().substr(instance_prefix.size());
-    if (instance_id.rfind("test-instance-", 0) != 0) {
+    if (!absl::StartsWith(instance_id, "test-instance-")) {
       auto emulator = google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST");
       if (emulator.has_value()) continue;  // server-side filter not supported
       return Status(StatusCode::kInternal,

--- a/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
+++ b/google/cloud/storage/benchmarks/benchmark_make_random_test.cc
@@ -19,6 +19,9 @@ namespace google {
 namespace cloud {
 namespace storage_benchmarks {
 namespace {
+
+using ::testing::StartsWith;
+
 TEST(StorageBenchmarksUtilsTest, MakeRandomData) {
   google::cloud::internal::DefaultPRNG generator =
       google::cloud::internal::MakeDefaultPRNG();
@@ -48,7 +51,7 @@ TEST(StorageBenchmarksUtilsTest, MakeRandomBucket) {
   auto d2 = MakeRandomBucketName(generator);
   EXPECT_NE(d1, d2);
 
-  EXPECT_EQ(0, d1.rfind(RandomBucketPrefix(), 0));
+  EXPECT_THAT(d1, StartsWith(RandomBucketPrefix()));
   EXPECT_GE(63U, d1.size());
   EXPECT_EQ(std::string::npos,
             d1.find_first_not_of("-_abcdefghijklmnopqrstuvwxyz0123456789"))

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -16,7 +16,7 @@
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/status_matchers.h"
-#include "absl/strings/str_split.h"
+#include "absl/strings/match.h"
 #include <gmock/gmock.h>
 #include <algorithm>
 
@@ -49,7 +49,7 @@ MATCHER_P(
     ++pos;
   }
   std::string status = arg.substr(pos);
-  if (status.find(substr) == std::string::npos) {
+  if (!absl::StrContains(status, substr)) {
     *result_listener << "Didn't find " << substr << " in " << status;
     return false;
   }

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -15,6 +15,7 @@
 #include "google/cloud/storage/examples/storage_examples_common.h"
 #include "google/cloud/storage/testing/random_names.h"
 #include "google/cloud/internal/getenv.h"
+#include "absl/strings/match.h"
 #include <regex>
 #include <sstream>
 
@@ -45,7 +46,7 @@ Commands::value_type CreateCommandEntry(
     std::string const& name, std::vector<std::string> const& arg_names,
     ClientCommand const& command) {
   bool allow_varargs =
-      !arg_names.empty() && arg_names.back().find("...") != std::string::npos;
+      !arg_names.empty() && absl::StrContains(arg_names.back(), "...");
   auto adapter = [=](std::vector<std::string> const& argv) {
     if ((argv.size() == 1 && argv[0] == "--help") ||
         (allow_varargs ? argv.size() < (arg_names.size() - 1)

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -17,7 +17,6 @@
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/user_agent_prefix.h"
 #include "absl/memory/memory.h"
-#include "absl/strings/match.h"
 
 namespace google {
 namespace cloud {
@@ -26,7 +25,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 char const* InitialQueryParameterSeparator(std::string const& url) {
-  if (absl::StrContains(url, '?')) return "&";
+  // Abseil <= 20200923 does not implement StrContains(.., char)
+  // NOLINTNEXTLINE(abseil-string-find-str-contains)
+  if (url.find('?') != std::string::npos) return "&";
   return "?";
 }
 }  // namespace

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/curl_request_builder.h"
-#include "google/cloud/storage/version.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/algorithm.h"
 #include "google/cloud/internal/user_agent_prefix.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/match.h"
 
 namespace google {
 namespace cloud {
@@ -26,7 +26,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 char const* InitialQueryParameterSeparator(std::string const& url) {
-  if (url.find('?') != std::string::npos) return "&";
+  if (absl::StrContains(url, '?')) return "&";
   return "?";
 }
 }  // namespace

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -88,7 +88,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
                  [](char x) { return x == '/' ? ' ' : x; });
   // LibreSSL seems to be using semantic versioning, so just check the major
   // version.
-  if (absl::StartsWith(expected_prefix, "LibreSSL 2", 0)) {
+  if (absl::StartsWith(expected_prefix, "LibreSSL 2")) {
     expected_prefix = "LibreSSL 2";
   }
 #ifdef OPENSSL_VERSION

--- a/google/cloud/storage/internal/curl_wrappers.cc
+++ b/google/cloud/storage/internal/curl_wrappers.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/storage/client_options.h"
 #include "google/cloud/storage/internal/binary_data_as_debug_string.h"
 #include "google/cloud/log.h"
+#include "absl/strings/match.h"
 #include <openssl/crypto.h>
 #include <openssl/opensslv.h>
 #include <algorithm>
@@ -87,7 +88,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
                  [](char x) { return x == '/' ? ' ' : x; });
   // LibreSSL seems to be using semantic versioning, so just check the major
   // version.
-  if (expected_prefix.rfind("LibreSSL 2", 0) == 0) {
+  if (absl::StartsWith(expected_prefix, "LibreSSL 2", 0)) {
     expected_prefix = "LibreSSL 2";
   }
 #ifdef OPENSSL_VERSION
@@ -99,7 +100,7 @@ void InitializeSslLocking(bool enable_ssl_callbacks) {
   // that the major version matches (e.g. LibreSSL), and (b) because the
   // `openssl_v` string sometimes reads `OpenSSL 1.1.0 May 2018` while the
   // string reported by libcurl would be `OpenSSL/1.1.0`, sigh...
-  if (openssl_v.rfind(expected_prefix, 0) != 0) {
+  if (!absl::StartsWith(openssl_v, expected_prefix)) {
     std::ostringstream os;
     os << "Mismatched versions of OpenSSL linked in libcurl vs. the version"
        << " linked by the Google Cloud Storage C++ library.\n"
@@ -181,8 +182,8 @@ bool SslLibraryNeedsLocking(std::string const& curl_ssl_id) {
   //    https://curl.haxx.se/libcurl/c/threadsafe.html
   // Only these library prefixes require special configuration for using safely
   // with multiple threads.
-  return (curl_ssl_id.rfind("OpenSSL/1.0", 0) == 0 ||
-          curl_ssl_id.rfind("LibreSSL/2", 0) == 0);
+  return (absl::StartsWith(curl_ssl_id, "OpenSSL/1.0") ||
+          absl::StartsWith(curl_ssl_id, "LibreSSL/2"));
 }
 
 long VersionToCurlCode(std::string const& v) {  // NOLINT(google-runtime-int)

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/time_utils.h"
 #include "absl/algorithm/container.h"
+#include "absl/strings/match.h"
 #include "absl/time/civil_time.h"
 #include <algorithm>
 #include <cctype>
@@ -144,7 +145,7 @@ BucketMetadata GrpcBucketMetadataParser::FromProto(
   // may have a project id (instead of number), we need to do some parsing. We
   // are forgiving here. It is better to drop one field rather than dropping
   // the full message.
-  if (rhs.project().rfind("projects/", 0) == 0) {
+  if (absl::StartsWith(rhs.project(), "projects/")) {
     auto s = rhs.project().substr(std::strlen("projects/"));
     char* end;
     auto number = std::strtol(s.c_str(), &end, 10);

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -30,6 +30,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/invoke_result.h"
 #include "google/cloud/log.h"
+#include "absl/strings/match.h"
 #include <crc32c/crc32c.h>
 #include <grpcpp/grpcpp.h>
 #include <algorithm>
@@ -97,8 +98,8 @@ int DefaultGrpcNumChannels(std::string const& endpoint) {
   // When using DirectPath the gRPC library already does load balancing across
   // multiple sockets, it makes little sense to perform additional load
   // balancing in the client library.
-  if (endpoint.rfind("google-c2p:///", 0) == 0 ||
-      endpoint.rfind("google-c2p-experimental:///", 0) == 0) {
+  if (absl::StartsWith(endpoint, "google-c2p:///") ||
+      absl::StartsWith(endpoint, "google-c2p-experimental:///")) {
     return 1;
   }
   // When not using DirectPath, there are limits to the bandwidth per channel,

--- a/google/cloud/storage/internal/object_requests.cc
+++ b/google/cloud/storage/internal/object_requests.cc
@@ -484,7 +484,7 @@ StatusOr<std::uint64_t> ParseRangeHeader(std::string const& range) {
   // that is the value should match `bytes=0-[0-9]+`:
   char const prefix[] = "bytes=0-";
   auto constexpr kPrefixLen = sizeof(prefix) - 1;
-  if (range.rfind(prefix, 0) != 0) {
+  if (!absl::StartsWith(range, prefix)) {
     return Status(
         StatusCode::kInternal,
         "cannot parse Range header in resumable upload response, value=" +

--- a/google/cloud/storage/internal/retry_client.cc
+++ b/google/cloud/storage/internal/retry_client.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/storage/internal/retry_object_read_source.h"
 #include "google/cloud/internal/retry_policy.h"
 #include "absl/memory/memory.h"
+#include "absl/strings/match.h"
 #include <sstream>
 #include <thread>
 
@@ -485,7 +486,7 @@ StatusOr<QueryResumableUploadResponse> RetryClient::UploadChunk(
       auto constexpr kConcurrentMessagePrefix = "Concurrent requests received.";
       auto const is_concurrent_write =
           last_status.code() == StatusCode::kAborted &&
-          last_status.message().rfind(kConcurrentMessagePrefix, 0) == 0;
+          absl::StartsWith(last_status.message(), kConcurrentMessagePrefix);
       auto const is_retryable =
           is_concurrent_write
               ? retry_policy->OnFailure(Status(StatusCode::kUnavailable, ""))

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/storage/testing/random_names.h"
 #include "google/cloud/storage/testing/remove_stale_buckets.h"
 #include "google/cloud/internal/getenv.h"
+#include "absl/strings/match.h"
 #include <nlohmann/json.hpp>
 
 namespace google {
@@ -35,14 +36,14 @@ bool UseGrpcForMetadata() {
   auto v =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG")
           .value_or("");
-  return v.find("metadata") != std::string::npos;
+  return absl::StrContains(v, "metadata");
 }
 
 bool UseGrpcForMedia() {
   auto v =
       google::cloud::internal::GetEnv("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG")
           .value_or("");
-  return v.find("media") != std::string::npos;
+  return absl::StrContains(v, "media");
 }
 
 }  // namespace

--- a/google/cloud/storage/tests/curl_download_request_integration_test.cc
+++ b/google/cloud/storage/tests/curl_download_request_integration_test.cc
@@ -281,7 +281,7 @@ TEST(CurlDownloadRequestTest, SimpleStreamReadAfterClosed) {
     delay *= 2;
   }
   ASSERT_STATUS_OK(received);
-  std::vector<std::string> lines = absl::StrSplit(*received, "\n");
+  std::vector<std::string> lines = absl::StrSplit(*received, '\n');
   auto p = std::remove(lines.begin(), lines.end(), std::string{});
   lines.erase(p, lines.end());
   EXPECT_EQ(kLineCount, lines.size());

--- a/google/cloud/testing_util/command_line_parsing.cc
+++ b/google/cloud/testing_util/command_line_parsing.cc
@@ -128,7 +128,7 @@ std::vector<std::string> OptionsParse(std::vector<OptionDescriptor> const& desc,
     // Try to match `argument` against the options in `desc`
     bool matched = false;
     for (auto const& d : desc) {
-      if (argument.rfind(d.option, 0) != 0) {
+      if (!absl::StartsWith(argument, d.option)) {
         // Not a match, keep searching
         continue;
       }

--- a/google/cloud/testing_util/validate_metadata.cc
+++ b/google/cloud/testing_util/validate_metadata.cc
@@ -125,7 +125,7 @@ RoutingHeaders FromRoutingRule(google::api::RoutingRule const& routing,
     // `nested2` are generic Messages, and `value` is the string field we are to
     // match against. We must iterate over the nested messages to get to the
     // string value.
-    std::deque<std::string> fields = absl::StrSplit(rp.field(), ".");
+    std::deque<std::string> fields = absl::StrSplit(rp.field(), '.');
     auto const& field = GetField(fields, method->input_type(), request);
 
     // We skip empty fields.


### PR DESCRIPTION
I also fixed all `str.rfind(..., 0)` instances that I could find. We are
using clang-tidy-13, which does not suggest replacing those with
`absl::StartsWith()`. We will update to clang-tidy-14 "soon", and I
want to simplify that upgrade. That also makes the imports into google
a bit easier (I hope).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9417)
<!-- Reviewable:end -->
