### PR TITLE
ci: missing export in build.sh

### DIFF
--- a/ci/cloudbuild/build.sh
+++ b/ci/cloudbuild/build.sh
@@ -179,10 +179,11 @@ fi
 CODECOV_TOKEN="$(tr -d '[:space:]' <<<"${CODECOV_TOKEN:-}")"
 LOG_LINKER_PAT="$(tr -d '[:space:]' <<<"${LOG_LINKER_PAT:-}")"
 
-export TRIGGER_TYPE
+export CODECOV_TOKEN
 export BRANCH_NAME
 export COMMIT_SHA
-export CODECOV_TOKEN
+export TRIGGER_TYPE
+export VERBOSE_FLAG
 export LOG_LINKER_PAT
 
 # --local is the most fundamental build mode, in that all other builds


### PR DESCRIPTION
When building with `--cloud=...` we need to export the
`VERBOSE_FLAG` environment variable. In most command-line builds this
is exported via the `docker run --env=...` commands, so it was hard to
detect. To make it easier to detect such problems, I reordered the
`export` commands to match the `docker run` order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9422)
<!-- Reviewable:end -->
