### PR TITLE
test(spanner): populate Instance create_time and update_time fields

### DIFF
--- a/google/cloud/spanner/instance_admin_connection_test.cc
+++ b/google/cloud/spanner/instance_admin_connection_test.cc
@@ -71,6 +71,8 @@ TEST(InstanceAdminConnectionTest, GetInstanceSuccess) {
     display_name: "test display name"
     node_count: 7
     state: CREATING
+    create_time { seconds: 1657025805 nanos: 967908745 }
+    update_time { seconds: 1657025805 nanos: 967908745 }
   )pb";
   gsai::v1::Instance expected_instance;
   ASSERT_TRUE(TextFormat::ParseFromString(kInstanceText, &expected_instance));


### PR DESCRIPTION
There are no defined samples nor suggested extra tests for the new
Spanner Instance fields, so let's at least verify that they can be
parsed from a text proto we use in a `GetInstance()` mock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9427)
<!-- Reviewable:end -->
