### PR TITLE
ci: move `checkers` build to Fedora:36

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -7,6 +7,10 @@ BasedOnStyle: Google
 DerivePointerAlignment: false
 PointerAlignment: Left
 
+# The Google Style Guide only asks for consistency w.r.t. "east const" vs.
+# "const west" alignment of cv-qualifiers. In this project we use "east const".
+QualifierAlignment: Right
+
 IncludeBlocks: Merge
 IncludeCategories:
 # Matches common headers first, but sorts them after project includes

--- a/ci/cloudbuild/dockerfiles/checkers.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/checkers.Dockerfile
@@ -17,7 +17,7 @@
 # than to the extent that certain distros offer certain versions of software
 # that the build needs. It's fine to add more deps that are needed by the
 # `checkers.sh` build.
-FROM fedora:35
+FROM fedora:36
 ARG NCPU=4
 
 RUN dnf makecache && \


### PR DESCRIPTION
This includes `clang-format` 14. I enabled the "east const" formatting,
probably the most interesting rule with this new version.

Part of the work for #8922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9428)
<!-- Reviewable:end -->
