### PR TITLE
cleanup(storage): enforce cognitive complexity limits

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -99,3 +99,4 @@ CheckOptions:
   - { key: readability-identifier-naming.StaticConstantPrefix,     value: k         }
   - { key: readability-implicit-bool-conversion.AllowIntegerConditions,  value: 1   }
   - { key: readability-implicit-bool-conversion.AllowPointerConditions,  value: 1   }
+  - { key: readability-function-cognitive-complexity.IgnoreMacros,  value: 1   }

--- a/google/cloud/storage/.clang-tidy
+++ b/google/cloud/storage/.clang-tidy
@@ -1,0 +1,5 @@
+---
+InheritParentConfig: true
+
+Checks: >
+  readability-function-cognitive-complexity


### PR DESCRIPTION
Enable the clang-tidy `readability-function-cognitive-complexity` check
(as an error) for `google/cloud/storage/`.  I think we should turn this
on everywhere, but needed to start somewhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9435)
<!-- Reviewable:end -->
