### PR TITLE
cleanup(pubsub): enable clang-tidy's cognitive complexity

### DIFF
--- a/google/cloud/pubsub/.clang-tidy
+++ b/google/cloud/pubsub/.clang-tidy
@@ -1,0 +1,5 @@
+---
+InheritParentConfig: true
+
+Checks: >
+  readability-function-cognitive-complexity


### PR DESCRIPTION
One function was a little over the limit, fix it and enable the
`readability-function-cognitive-complexity`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9445)
<!-- Reviewable:end -->
