### PR TITLE
test(storage): create bucket using configured REST endpoint

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -127,7 +127,9 @@ int main(int argc, char* argv[]) {
   }
 
   auto client_options =
-      google::cloud::Options{}.set<gcs::ProjectIdOption>(options->project_id);
+      google::cloud::Options{}
+          .set<gcs::ProjectIdOption>(options->project_id)
+          .set<gcs::RestEndpointOption>(options->rest_endpoint);
   auto client = gcs::Client(client_options);
 
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());


### PR DESCRIPTION
The benchmark was creating its temporary bucket using the default REST
endpoint.  This makes no difference when testing against production,
buckets are global and their creation is globally consistent.  But this
does not work when using a non-production environment.