### PR TITLE
fix(spanner): avoid evaluation-order issue in function arguments

### DIFF
--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -469,9 +469,10 @@ spanner::RowStream ConnectionImpl::ReadImpl(
                   tracing_options](std::string const& resume_token) mutable {
     if (!resume_token.empty()) request->set_resume_token(resume_token);
     auto context = absl::make_unique<grpc::ClientContext>();
+    auto grpc_reader = stub->StreamingRead(*context, *request);
     std::unique_ptr<PartialResultSetReader> reader =
         absl::make_unique<DefaultPartialResultSetReader>(
-            std::move(context), stub->StreamingRead(*context, *request));
+            std::move(context), std::move(grpc_reader));
     if (tracing_enabled) {
       reader = absl::make_unique<LoggingResultSetReader>(std::move(reader),
                                                          tracing_options);
@@ -688,9 +689,10 @@ ResultType ConnectionImpl::CommonQueryImpl(
                     tracing_options](std::string const& resume_token) mutable {
       if (!resume_token.empty()) request.set_resume_token(resume_token);
       auto context = absl::make_unique<grpc::ClientContext>();
+      auto grpc_reader = stub->ExecuteStreamingSql(*context, request);
       std::unique_ptr<PartialResultSetReader> reader =
           absl::make_unique<DefaultPartialResultSetReader>(
-              std::move(context), stub->ExecuteStreamingSql(*context, request));
+              std::move(context), std::move(grpc_reader));
       if (tracing_enabled) {
         reader = absl::make_unique<LoggingResultSetReader>(std::move(reader),
                                                            tracing_options);


### PR DESCRIPTION
The behavior of
```
  extern void f(std::unique_ptr<T>, T);
  std::unique_ptr<T> p = ...;
  f(std::move(p), *p);
```
is undefined, so introduce a sequence point between dereferencing
the `unique_ptr` and moving it.