### PR TITLE
impl(storage): configure gRPC ClientContext using `CurrentOptions`

### DIFF
--- a/google/cloud/storage/internal/grpc_configure_client_context.h
+++ b/google/cloud/storage/internal/grpc_configure_client_context.h
@@ -17,6 +17,7 @@
 
 #include "google/cloud/storage/internal/generic_request.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/grpc_options.h"
 #include <grpcpp/client_context.h>
 
 namespace google {
@@ -57,6 +58,9 @@ void ApplyQueryParameters(grpc::ClientContext& context, Request const& request,
     if (!prefix.empty()) field_mask = prefix + "(" + field_mask + ")";
     context.AddMetadata("x-goog-fieldmask", std::move(field_mask));
   }
+
+  google::cloud::internal::ConfigureContext(
+      context, google::cloud::internal::CurrentOptions());
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_configure_client_context_test.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context_test.cc
@@ -27,6 +27,7 @@ namespace {
 using ::google::cloud::testing_util::ValidateMetadataFixture;
 using ::testing::Contains;
 using ::testing::IsEmpty;
+using ::testing::MockFunction;
 using ::testing::Pair;
 
 class GrpcConfigureClientContext : public ::testing::Test {
@@ -99,6 +100,19 @@ TEST_F(GrpcConfigureClientContext, ApplyQueryParametersQuotaUserAndUserIp) {
     auto metadata = GetMetadata(context);
     EXPECT_THAT(metadata, Contains(Pair("x-goog-quota-user", test.expected)));
   }
+}
+
+TEST_F(GrpcConfigureClientContext, ApplyQueryParametersGrpcOptions) {
+  MockFunction<void(grpc::ClientContext&)> mock;
+  EXPECT_CALL(mock, Call);
+
+  google::cloud::internal::OptionsSpan span(
+      Options{}.set<google::cloud::internal::GrpcSetupOption>(
+          mock.AsStdFunction()));
+
+  grpc::ClientContext context;
+  ApplyQueryParameters(context,
+                       ReadObjectRangeRequest("test-bucket", "test-object"));
 }
 
 }  // namespace


### PR DESCRIPTION
Configure the `grpc::ClientContext`s created by a `storage::internal::GrpcClient` using the `CurrentOptions()`.

Note that, as of writing this, the only option that does anything is `google::cloud::internal::GrpcSetupOption`. And we do not set this option. So we are only gaining a hook for debugging. And we are doing some extra map lookups on every client call. That is not obviously great.

But, if we ever add an option for setting metadata or for setting a deadline we can have it take effect in `google::cloud::internal::ConfigureContext(..., Options)`. for gRPC. (See https://github.com/googleapis/google-cloud-cpp/issues/4926#issuecomment-1125348091 for how I see things playing out)