### PR TITLE
doc(bigtable): fix uses of `ListInstances` in docs

### DIFF
--- a/google/cloud/bigtable/doc/bigtable-samples-grpc-credentials.dox
+++ b/google/cloud/bigtable/doc/bigtable-samples-grpc-credentials.dox
@@ -31,9 +31,9 @@ Sample code to connect to an Admin API endpoint
 
 ```
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
+#include "google/cloud/project.h"
 
 int main(int argc, char* argv[]) try {
-  namespace cbt = ::google::cloud::bigtable;
   namespace cbta = ::google::cloud::bigtable_admin;
   namespace gc = ::google::cloud;
   std::string const project_id = argv[1];
@@ -51,7 +51,7 @@ int main(int argc, char* argv[]) try {
   auto client = cbta::BigtableInstanceAdminClient(
       cbta::MakeBigtableInstanceAdminConnection(
           gc::Options{}.set<gc::GrpcCredentialOption>(credentials)));
-  auto instances = client.ListInstances(cbt::InstanceName(project_id, "-"));
+  auto instances = client.ListInstances(gc::Project(project_id).FullName()));
   return 0;
 } catch (std::exception const& ex) {
   std::cerr << "Standard C++ exception raised: " << ex.what() << std::endl;


### PR DESCRIPTION
The argument to `ListInstances(std::string parent)` is a project name. I must have been thinking of the `ListClusters` API when I made these changes. Ugh.

Noticed while working on #4122. The emulator is cool with the bad resource name, but the production service rightfully yells at us.

Also, stop using an `internal` symbol in our public example code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9461)
<!-- Reviewable:end -->
