### PR TITLE
fix(assuredworkloads): reenable on windows

### DIFF
--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -34,11 +34,6 @@ cc_library(
         include = [HEADER_GLOB],
         exclude = [MOCK_HEADER_GLOB],
     ),
-    # TODO(#8198): Re-enable the Windows build.
-    target_compatible_with = select({
-        "@platforms//os:windows": ["@platforms//:incompatible"],
-        "//conditions:default": [],
-    }),
     visibility = ["//:__pkg__"],
     deps = [
         "//:common",

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -14,16 +14,6 @@
 # limitations under the License.
 # ~~~
 
-# TODO(#8198): Re-enable the macos build.
-if (WIN32)
-    message(
-        WARNING
-            "Cannot build google/cloud/assuredworkloads on Windows platforms."
-            " More details at https://github.com/googleapis/google-cloud-cpp/issues/8198"
-    )
-    return()
-endif ()
-
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "Assured Workloads API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the Assured Workloads API")


### PR DESCRIPTION
Probably fixes #8198

We require protobuf >=21.0, which handles `STATUS_PENDING`: https://github.com/protocolbuffers/protobuf/blob/d1ec41203033cb0ceea19f2b4132b65deb3c80a9/src/google/protobuf/port_def.inc#L848-L849