### PR TITLE
test: stricter routing metadata validation

### DIFF
--- a/google/cloud/bigtable/internal/legacy_row_reader_test.cc
+++ b/google/cloud/bigtable/internal/legacy_row_reader_test.cc
@@ -145,10 +145,10 @@ TEST_F(LegacyRowReaderTest, EmptyReaderHasNoRows) {
   EXPECT_CALL(*client_, ReadRows).WillOnce(stream->MakeMockReturner());
 
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   EXPECT_EQ(reader.begin(), reader.end());
@@ -170,10 +170,10 @@ TEST_F(LegacyRowReaderTest, ReadOneRow) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -237,10 +237,10 @@ TEST_F(LegacyRowReaderTest, StreamIsDrained) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -280,10 +280,10 @@ TEST_F(LegacyRowReaderTest, RetryThenSuccess) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -311,10 +311,10 @@ TEST_F(LegacyRowReaderTest, NoRetryOnPermanentError) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -356,7 +356,7 @@ TEST_F(LegacyRowReaderTest, RetrySkipsAlreadyReadRows) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet("r1", "r2"),
+      client_, kTableName, bigtable::RowSet("r1", "r2"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
       std::move(retry_policy_), std::move(backoff_policy_),
       metadata_update_policy_, std::move(parser_factory_));
@@ -412,7 +412,7 @@ TEST_F(LegacyRowReaderTest, RetrySkipsAlreadyScannedRows) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet("r1", "r2", "r3"),
+      client_, kTableName, bigtable::RowSet("r1", "r2", "r3"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
       std::move(retry_policy_), std::move(backoff_policy_),
       metadata_update_policy_, std::move(parser_factory_));
@@ -456,10 +456,10 @@ TEST_F(LegacyRowReaderTest, FailedParseIsRetried) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -504,7 +504,7 @@ TEST_F(LegacyRowReaderTest, FailedParseSkipsAlreadyReadRows) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet("r1", "r2"),
+      client_, kTableName, bigtable::RowSet("r1", "r2"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
       std::move(retry_policy_), std::move(backoff_policy_),
       metadata_update_policy_, std::move(parser_factory_));
@@ -562,7 +562,7 @@ TEST_F(LegacyRowReaderTest, FailedParseSkipsAlreadyScannedRows) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet("r1", "r2", "r3"),
+      client_, kTableName, bigtable::RowSet("r1", "r2", "r3"),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
       std::move(retry_policy_), std::move(backoff_policy_),
       metadata_update_policy_, std::move(parser_factory_));
@@ -595,10 +595,10 @@ TEST_F(LegacyRowReaderTest, FailedParseWithPermanentError) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -630,7 +630,8 @@ TEST_F(LegacyRowReaderTest, NoRetryOnEmptyRowSet) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(bigtable::RowRange::Closed("r1", "r2")),
+      client_, kTableName,
+      bigtable::RowSet(bigtable::RowRange::Closed("r1", "r2")),
       bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
       std::move(retry_policy_), std::move(backoff_policy_),
       metadata_update_policy_, std::move(parser_factory_));
@@ -652,9 +653,10 @@ TEST_F(LegacyRowReaderTest, RowLimitIsSent) {
   EXPECT_CALL(*stream, Finish()).WillOnce(Return(grpc::Status::OK));
 
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), 442, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(), 442,
+      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
+      std::move(backoff_policy_), metadata_update_policy_,
+      std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -693,9 +695,10 @@ TEST_F(LegacyRowReaderTest, RowLimitIsDecreasedOnRetry) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), 42, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(), 42,
+      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
+      std::move(backoff_policy_), metadata_update_policy_,
+      std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -727,9 +730,10 @@ TEST_F(LegacyRowReaderTest, NoRetryIfRowLimitIsReached) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), 1, bigtable::Filter::PassAllFilter(),
-      std::move(retry_policy_), std::move(backoff_policy_),
-      metadata_update_policy_, std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(), 1,
+      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
+      std::move(backoff_policy_), metadata_update_policy_,
+      std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -755,10 +759,10 @@ TEST_F(LegacyRowReaderTest, CancelDrainsStream) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();
@@ -776,10 +780,10 @@ TEST_F(LegacyRowReaderTest, CancelDrainsStream) {
 
 TEST_F(LegacyRowReaderTest, CancelBeforeBegin) {
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   // Manually cancel the call before a stream was created.
@@ -800,10 +804,10 @@ TEST_F(LegacyRowReaderTest, ConstructorDoesNotCallRpc) {
   EXPECT_CALL(*parser_factory_, CreateHook()).Times(0);
 
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 }
 
@@ -847,10 +851,10 @@ TEST_F(LegacyRowReaderTest, RetryUsesNewContext) {
 
   parser_factory_->AddParser(std::move(parser));
   auto impl = std::make_shared<LegacyRowReader>(
-      client_, "", bigtable::RowSet(), bigtable::RowReader::NO_ROWS_LIMIT,
-      bigtable::Filter::PassAllFilter(), std::move(retry_policy_),
-      std::move(backoff_policy_), metadata_update_policy_,
-      std::move(parser_factory_));
+      client_, kTableName, bigtable::RowSet(),
+      bigtable::RowReader::NO_ROWS_LIMIT, bigtable::Filter::PassAllFilter(),
+      std::move(retry_policy_), std::move(backoff_policy_),
+      metadata_update_policy_, std::move(parser_factory_));
   auto reader = MakeRowReader(std::move(impl));
 
   auto it = reader.begin();

--- a/google/cloud/testing_util/validate_metadata.h
+++ b/google/cloud/testing_util/validate_metadata.h
@@ -77,7 +77,7 @@ class ValidateMetadataFixture {
    * @return an OK status if the `context` is properly set up
    */
   void IsContextMDValid(
-      grpc::ClientContext& context, std::string const& method,
+      grpc::ClientContext& context, std::string const& method_name,
       google::protobuf::Message const& request,
       std::string const& api_client_header,
       absl::optional<std::string> const& resource_name = {},


### PR DESCRIPTION
The main change is to check for (unordered) equality of the routing header against our expectations. Previously, we were checking that the actual header is a superset of the expected headers.

We skip validation of the routing header for any client-side streams.

We do some light refactoring/renaming of method names vs method descriptors.

Then we update two bigtable tests to set realistic resource values, so the metadata is extracted properly. (Our tests were setting the table name to `""`, which is not something the library will ever do.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9475)
<!-- Reviewable:end -->
