### PR TITLE
feat(common): make the RPC log even more readable

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -34,6 +34,8 @@ std::string DebugString(google::protobuf::Message const& m,
   p.SetUseShortRepeatedPrimitives(options.use_short_repeated_primitives());
   p.SetTruncateStringFieldLongerThan(
       options.truncate_string_field_longer_than());
+  p.SetPrintMessageFieldsInIndexOrder(true);
+  p.SetExpandAny(true);
   p.PrintToString(m, &str);
   return absl::StrCat(m.GetTypeName(), " {",
                       (options.single_line_mode() ? " " : "\n"), str, "}");


### PR DESCRIPTION
- Expand google.protobuf.Any payloads rather than printing their
  serialized content.
- Print fields in the order defined in source code instead of by
  the field number.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9477)
<!-- Reviewable:end -->
