### PR TITLE
test(bigtable): run against prod for nightly build

### DIFF
--- a/ci/cloudbuild/builds/integration-daily.sh
+++ b/ci/cloudbuild/builds/integration-daily.sh
@@ -23,7 +23,7 @@
 # `ci/cloudbuild/triggers` directory. "Manual" triggers exist only within the
 # GCB UI at the time of this writing. Users with the appropriate access can run
 # this build by hand with:
-#   `ci/cloudbuild/build.sh --distro fedora-34 integration-daily --project cloud-cpp-testing-resources`
+#   `ci/cloudbuild/build.sh --distro fedora-35 --build integration-daily --cloud cloud-cpp-testing-resources`
 
 set -euo pipefail
 
@@ -45,6 +45,12 @@ export GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS="instance,backup"
 export GOOGLE_CLOUD_CPP_IAM_QUOTA_LIMITED_INTEGRATION_TESTS="yes"
 mapfile -t integration_args < <(integration::bazel_args)
 integration::bazel_with_emulators test "${args[@]}" "${integration_args[@]}"
+
+io::log_h2 "Running Bigtable integration tests (against prod)"
+bazel test "${args[@]}" "${integration_args[@]}" \
+  --test_tag_filters="integration-test" -- \
+  "//google/cloud/bigtable/..." \
+  "-//google/cloud/bigtable/examples:bigtable_grpc_credentials"
 
 io::log_h2 "Running Spanner integration tests (against prod)"
 bazel test "${args[@]}" "${integration_args[@]}" \


### PR DESCRIPTION
Fixes #4122 

Googlers can see a manual run (where the emulator and Spanner tests are commented out) [here](https://pantheon.corp.google.com/cloud-build/builds;region=us-east1/1ab1302d-f2c8-4adb-9642-27d5d4d55613;step=3?project=cloud-cpp-testing-resources).