### PR TITLE
test(spanner): extend abandoned-database retention period to 7 days

### DIFF
--- a/google/cloud/spanner/testing/cleanup_stale_databases.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.cc
@@ -28,9 +28,6 @@ Status CleanupStaleDatabases(
     google::cloud::spanner_admin::DatabaseAdminClient admin_client,
     std::string const& project_id, std::string const& instance_id,
     std::chrono::system_clock::time_point tp) {
-  // Drop any databases more than 2 days old. This automatically cleans up
-  // any databases created by a previous build that may have crashed before
-  // having a chance to cleanup.
   spanner::Instance instance(Project(project_id), instance_id);
   auto const expired = RandomDatabasePrefix(tp);
   std::regex re(RandomDatabasePrefixRegex());

--- a/google/cloud/spanner/testing/cleanup_stale_databases.h
+++ b/google/cloud/spanner/testing/cleanup_stale_databases.h
@@ -25,6 +25,10 @@ namespace cloud {
 namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+// Drop all databases whose names indicate that they were created on or
+// before the (UTC) day that contains @p `tp`. This is useful to clean
+// up databases created by previous tests that crashed before having a
+// chance to cleanup after themselves.
 Status CleanupStaleDatabases(
     google::cloud::spanner_admin::DatabaseAdminClient admin_client,
     std::string const& project_id, std::string const& instance_id,


### PR DESCRIPTION
The word is that server-side logs are kept for 7 days while a database
exists, so let's keep abandoned test databases around for at least that
long.

The immediate goal is to help in the debugging of #4758.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9479)
<!-- Reviewable:end -->
