### PR TITLE
feat: improve error messages for access token errors

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -31,6 +31,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/algorithm.h",
     "internal/api_client_header.h",
     "internal/attributes.h",
+    "internal/auth_header_error.h",
     "internal/backoff_policy.h",
     "internal/base64_transforms.h",
     "internal/big_endian.h",
@@ -88,6 +89,7 @@ google_cloud_cpp_common_hdrs = [
 google_cloud_cpp_common_srcs = [
     "credentials.cc",
     "internal/api_client_header.cc",
+    "internal/auth_header_error.cc",
     "internal/backoff_policy.cc",
     "internal/base64_transforms.cc",
     "internal/compiler_info.cc",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -45,6 +45,8 @@ add_library(
     internal/api_client_header.cc
     internal/api_client_header.h
     internal/attributes.h
+    internal/auth_header_error.cc
+    internal/auth_header_error.h
     internal/backoff_policy.cc
     internal/backoff_policy.h
     internal/base64_transforms.cc

--- a/google/cloud/internal/auth_header_error.cc
+++ b/google/cloud/internal/auth_header_error.cc
@@ -1,0 +1,37 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/internal/auth_header_error.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+Status AuthHeaderError(Status status) {
+  if (status.ok()) return status;
+  auto constexpr kText =
+      "Could not create a OAuth2 access token to authenticate the request."
+      " The request was not sent, as such an access token is required to"
+      " complete the request successfully. Learn more about Google Cloud"
+      " authentication at https://cloud.google.com/docs/authentication."
+      " The underlying error message was: ";
+  auto message = kText + status.message();
+  return Status{status.code(), message, status.error_info()};
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/internal/auth_header_error.h
+++ b/google/cloud/internal/auth_header_error.h
@@ -1,0 +1,36 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_AUTH_HEADER_ERROR_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_AUTH_HEADER_ERROR_H
+
+#include "google/cloud/status.h"
+#include "google/cloud/version.h"
+
+namespace google {
+namespace cloud {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+/**
+ * Returns a more descriptive error when we fail to create an access token.
+ */
+Status AuthHeaderError(Status status);
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_AUTH_HEADER_ERROR_H

--- a/google/cloud/internal/oauth2_authorized_user_credentials.cc
+++ b/google/cloud/internal/oauth2_authorized_user_credentials.cc
@@ -73,7 +73,8 @@ ParseAuthorizedUserRefreshResponse(rest_internal::RestResponse& response,
     auto error_payload =
         *payload +
         "Could not find all required fields in response (access_token,"
-        " id_token, expires_in, token_type).";
+        " id_token, expires_in, token_type) while trying to obtain an access"
+        " token for service account credentials.";
     return AsStatus(status_code, error_payload);
   }
   std::string header_value = access_token.value("token_type", "");

--- a/google/cloud/internal/oauth2_compute_engine_credentials.cc
+++ b/google/cloud/internal/oauth2_compute_engine_credentials.cc
@@ -74,7 +74,8 @@ ParseComputeEngineRefreshResponse(rest_internal::RestResponse& response,
     auto error_payload =
         *payload +
         "Could not find all required fields in response (access_token,"
-        " expires_in, token_type).";
+        " expires_in, token_type) while trying to obtain an access token for"
+        " compute engine credentials.";
     return Status{StatusCode::kInvalidArgument, error_payload, {}};
   }
   std::string header_value = access_token.value("token_type", "");

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -146,7 +146,8 @@ ParseServiceAccountRefreshResponse(rest_internal::RestResponse& response,
     auto error_payload =
         *payload +
         "Could not find all required fields in response (access_token,"
-        " expires_in, token_type).";
+        " expires_in, token_type) while trying to obtain an access token for"
+        " service account credentials.";
     return AsStatus(status_code, error_payload);
   }
 

--- a/google/cloud/storage/internal/curl_client.cc
+++ b/google/cloud/storage/internal/curl_client.cc
@@ -26,6 +26,7 @@
 #include "google/cloud/storage/internal/service_account_parser.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/auth_header_error.h"
 #include "google/cloud/internal/getenv.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
@@ -37,6 +38,7 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
+using ::google::cloud::internal::AuthHeaderError;
 using ::google::cloud::internal::CurrentOptions;
 
 namespace {
@@ -131,7 +133,7 @@ Status CurlClient::SetupBuilderCommon(CurlRequestBuilder& builder,
   auto const& current = CurrentOptions();
   auto auth_header =
       current.get<Oauth2CredentialsOption>()->AuthorizationHeader();
-  if (!auth_header.ok()) return std::move(auth_header).status();
+  if (!auth_header) return AuthHeaderError(std::move(auth_header).status());
   builder.SetMethod(method)
       .ApplyClientOptions(current)
       .AddHeader(auth_header.value())

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -29,6 +29,7 @@
 #include "google/cloud/storage/internal/service_account_parser.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/auth_header_error.h"
 #include "google/cloud/internal/getenv.h"
 #include "absl/memory/memory.h"
 #include "absl/strings/match.h"
@@ -42,6 +43,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 namespace rest = google::cloud::rest_internal;
+using ::google::cloud::internal::AuthHeaderError;
 using ::google::cloud::internal::CurrentOptions;
 
 namespace {
@@ -124,9 +126,7 @@ Status AddAuthorizationHeader(Options const& options,
                               RestRequestBuilder& builder) {
   auto auth_header =
       options.get<Oauth2CredentialsOption>()->AuthorizationHeader();
-  if (!auth_header.ok()) {
-    return std::move(auth_header).status();
-  }
+  if (!auth_header) return AuthHeaderError(std::move(auth_header).status());
   builder.AddHeader("Authorization", std::string(absl::StripPrefix(
                                          *auth_header, "Authorization: ")));
   return {};

--- a/google/cloud/storage/oauth2/authorized_user_credentials.cc
+++ b/google/cloud/storage/oauth2/authorized_user_credentials.cc
@@ -71,7 +71,8 @@ ParseAuthorizedUserRefreshResponse(
     auto payload =
         response.payload +
         "Could not find all required fields in response (access_token,"
-        " id_token, expires_in, token_type).";
+        " id_token, expires_in, token_type) while trying to obtain an access"
+        " token for authorized user credentials.";
     return AsStatus(storage::internal::HttpResponse{response.status_code,
                                                     payload, response.headers});
   }

--- a/google/cloud/storage/oauth2/compute_engine_credentials.cc
+++ b/google/cloud/storage/oauth2/compute_engine_credentials.cc
@@ -42,7 +42,8 @@ ParseComputeEngineRefreshResponse(
     auto payload =
         response.payload +
         "Could not find all required fields in response (access_token,"
-        " expires_in, token_type).";
+        " expires_in, token_type) while trying to obtain an access token for"
+        " compute engine credentials.";
     return AsStatus(storage::internal::HttpResponse{response.status_code,
                                                     payload, response.headers});
   }

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -254,7 +254,8 @@ ParseServiceAccountRefreshResponse(
     auto payload =
         response.payload +
         "Could not find all required fields in response (access_token,"
-        " expires_in, token_type).";
+        " expires_in, token_type) while trying to obtain an access token for"
+        " service account credentials.";
     return AsStatus(storage::internal::HttpResponse{response.status_code,
                                                     payload, response.headers});
   }


### PR DESCRIPTION
When we fail to generate an access token the errors can be very
confusing.  See for example this discussion:

https://issues.apache.org/jira/browse/ARROW-17069

This change is an attempt at making these errors less confusing. They
could be made event better if we had a specific webpage describing
client library authentication and troubleshooting, but we do not have
such a page at the moment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9485)
<!-- Reviewable:end -->
