### PR TITLE
ci: speed up cache uploads and downloads

### DIFF
--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -58,30 +58,30 @@ FALLBACK_KEY=""
 PATHS=()
 while true; do
   case "$1" in
-  --bucket_url)
-    BUCKET_URL="$2"
-    shift 2
-    ;;
-  --key)
-    KEY="$2"
-    shift 2
-    ;;
-  --fallback_key)
-    FALLBACK_KEY="$2"
-    shift 2
-    ;;
-  --path)
-    PATHS+=("$2")
-    shift 2
-    ;;
-  -h | --help)
-    print_usage
-    exit 0
-    ;;
-  --)
-    shift
-    break
-    ;;
+    --bucket_url)
+      BUCKET_URL="$2"
+      shift 2
+      ;;
+    --key)
+      KEY="$2"
+      shift 2
+      ;;
+    --fallback_key)
+      FALLBACK_KEY="$2"
+      shift 2
+      ;;
+    --path)
+      PATHS+=("$2")
+      shift 2
+      ;;
+    -h | --help)
+      print_usage
+      exit 0
+      ;;
+    --)
+      shift
+      break
+      ;;
   esac
 done
 readonly BUCKET_URL
@@ -150,14 +150,14 @@ io::log "====> ${PROGRAM_NAME}: $*"
 readonly TIMEFORMAT="==> 🕑 ${PROGRAM_NAME} completed in %R seconds"
 time {
   case "$1" in
-  save)
-    save_cache
-    ;;
-  restore)
-    restore_cache
-    ;;
-  *)
-    print_usage
-    ;;
+    save)
+      save_cache
+      ;;
+    restore)
+      restore_cache
+      ;;
+    *)
+      print_usage
+      ;;
   esac
 }

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -121,7 +121,7 @@ function save_cache() {
   tmpd="$(mktemp -d)"
   tmpf="${tmpd}/cache.tar.gz"
   tar -czf "${tmpf}" "${paths[@]}"
-  gcloud alpha storage cp "${tmpf}" "${PRIMARY_CACHE_URL}"
+  gcloud --quiet alpha storage cp "${tmpf}" "${PRIMARY_CACHE_URL}"
   gsutil stat "${PRIMARY_CACHE_URL}"
   rm "${tmpf}"
   rmdir "${tmpd}"
@@ -135,7 +135,7 @@ function restore_cache() {
   for url in "${urls[@]}"; do
     if gsutil stat "${url}"; then
       io::log "Fetching cache url ${url}"
-      gcloud alpha storage cp "${url}" - | tar -zxf - || continue
+      gcloud --quiet alpha storage cp "${url}" - | tar -zxf - || continue
       break
     fi
   done

--- a/ci/cloudbuild/cache.sh
+++ b/ci/cloudbuild/cache.sh
@@ -117,11 +117,11 @@ function save_cache() {
   fi
   io::log "Saving ( ${paths[*]} ) to ${PRIMARY_CACHE_URL}"
   du -sh "${paths[@]}"
-  # We use a temp file here so gsutil can retry failed uploads. See #6508.
+  # We use a temp file here so gcloud can retry failed uploads. See #6508.
   tmpd="$(mktemp -d)"
   tmpf="${tmpd}/cache.tar.gz"
   tar -czf "${tmpf}" "${paths[@]}"
-  gsutil cp "${tmpf}" "${PRIMARY_CACHE_URL}"
+  gcloud alpha storage cp "${tmpf}" "${PRIMARY_CACHE_URL}"
   gsutil stat "${PRIMARY_CACHE_URL}"
   rm "${tmpf}"
   rmdir "${tmpd}"
@@ -135,7 +135,7 @@ function restore_cache() {
   for url in "${urls[@]}"; do
     if gsutil stat "${url}"; then
       io::log "Fetching cache url ${url}"
-      gsutil cp "${url}" - | tar -zxf - || continue
+      gcloud alpha storage cp "${url}" - | tar -zxf - || continue
       break
     fi
   done

--- a/ci/cloudbuild/cloudbuild.yaml
+++ b/ci/cloudbuild/cloudbuild.yaml
@@ -80,7 +80,7 @@ steps:
 
   # Restores the homedir cache into /h in parallel with the previous step.
   # Won't break the build if this step fails.
-- name: 'gcr.io/cloud-builders/gsutil'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   waitFor: [ '-' ]
   entrypoint: 'bash'
   dir: '/h'
@@ -105,7 +105,7 @@ steps:
 
   # Caches some directories in the homedir, in the specified GCS bucket.
   # Won't break the build if this step fails.
-- name: 'gcr.io/cloud-builders/gsutil'
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: 'bash'
   dir: '/h'
   args:

--- a/ci/kokoro/lib/cache.sh
+++ b/ci/kokoro/lib/cache.sh
@@ -56,7 +56,7 @@ cache_download_tarball() {
 
   io::log_h2 "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
   io::log "gcloud configuration"
-  gcloud version
+  "${GCLOUD_BIN}" version
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
     "${GCLOUD_BIN}" --quiet alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
     cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"

--- a/ci/kokoro/lib/cache.sh
+++ b/ci/kokoro/lib/cache.sh
@@ -55,10 +55,10 @@ cache_download_tarball() {
   activate_service_account_keyfile "${CACHE_KEYFILE}"
 
   io::log_h2 "Downloading build cache ${FILENAME} from ${GCS_FOLDER}"
-  io::log "gsutil configuration"
-  gsutil version -l
+  io::log "gcloud configuration"
+  gcloud version
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
+    "${GCLOUD_BIN}" alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
     cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
 }
 
@@ -89,7 +89,7 @@ cache_upload_tarball() {
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    gsutil "${CACHE_GSUTIL_DEBUG:--q}" \
+    "${GCLOUD_BIN}" alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
     cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
 
   io::log "Upload completed"

--- a/ci/kokoro/lib/cache.sh
+++ b/ci/kokoro/lib/cache.sh
@@ -58,7 +58,7 @@ cache_download_tarball() {
   io::log "gcloud configuration"
   gcloud version
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    "${GCLOUD_BIN}" alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
+    "${GCLOUD_BIN}" --quiet alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
     cp "gs://${GCS_FOLDER}/${FILENAME}" "${DESTINATION}"
 }
 
@@ -89,7 +89,7 @@ cache_upload_tarball() {
   create_gcloud_config
   activate_service_account_keyfile "${CACHE_KEYFILE}"
   env "CLOUDSDK_ACTIVE_CONFIG_NAME=${GCLOUD_CONFIG}" \
-    "${GCLOUD_BIN}" alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
+    "${GCLOUD_BIN}" --quiet alpha storage "${CACHE_GSUTIL_DEBUG:--q}" \
     cp "${SOURCE_DIRECTORY}/${FILENAME}" "gs://${CACHE_FOLDER}/"
 
   io::log "Upload completed"


### PR DESCRIPTION
The (new, but well regarded) `gcloud alpha storage` commands have a
reputation of being faster than `gsutil` without requiring a lot of
tuning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9493)
<!-- Reviewable:end -->
