### PR TITLE
doc(pubsub): create BigQuery subscription sample

### DIFF
--- a/google/cloud/pubsub/samples/samples.cc
+++ b/google/cloud/pubsub/samples/samples.cc
@@ -340,6 +340,32 @@ void CreatePushSubscription(
   (std::move(client), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
 }
 
+void CreateBigQuerySubscription(
+    google::cloud::pubsub::SubscriptionAdminClient client,
+    std::vector<std::string> const& argv) {
+  //! [START pubsub_create_bigquery_subscription] [create-bigquery-subscription]
+  namespace pubsub = ::google::cloud::pubsub;
+  [](pubsub::SubscriptionAdminClient client, std::string const& project_id,
+     std::string const& topic_id, std::string const& subscription_id,
+     std::string const& table_id) {
+    auto sub = client.CreateSubscription(
+        pubsub::Topic(project_id, std::move(topic_id)),
+        pubsub::Subscription(project_id, std::move(subscription_id)),
+        pubsub::SubscriptionBuilder{}.set_bigquery_config(
+            pubsub::BigQueryConfigBuilder{}.set_table(table_id)));
+    if (sub.status().code() == google::cloud::StatusCode::kAlreadyExists) {
+      std::cout << "The subscription already exists\n";
+      return;
+    }
+    if (!sub) throw std::runtime_error(sub.status().message());
+
+    std::cout << "The subscription was successfully created: "
+              << sub->DebugString() << "\n";
+  }
+  //! [END pubsub_create_bigquery_subscription] [create-bigquery-subscription]
+  (std::move(client), argv.at(0), argv.at(1), argv.at(2), argv.at(3));
+}
+
 void CreateOrderingSubscription(
     google::cloud::pubsub::SubscriptionAdminClient client,
     std::vector<std::string> const& argv) {
@@ -1974,6 +2000,7 @@ void AutoRun(std::vector<std::string> const& argv) {
   auto const subscription_id = RandomSubscriptionId(generator);
   auto const filtered_subscription_id = RandomSubscriptionId(generator);
   auto const push_subscription_id = RandomSubscriptionId(generator);
+  auto const bigquery_subscription_id = RandomSubscriptionId(generator);
   auto const ordering_subscription_id = RandomSubscriptionId(generator);
   auto const ordering_topic_id = "ordering-" + RandomTopicId(generator);
   auto const dead_letter_subscription_id = RandomSubscriptionId(generator);
@@ -2246,6 +2273,10 @@ void AutoRun(std::vector<std::string> const& argv) {
   std::cout << "\nRunning DeleteSubscription() sample [5]" << std::endl;
   DeleteSubscription(subscription_admin_client, {project_id, subscription_id});
 
+  std::cout << "\nRunning DeleteSubscription() sample [6] " << std::endl;
+  DeleteSubscription(subscription_admin_client,
+                     {project_id, bigquery_subscription_id});
+
   std::cout << "\nRunning DeleteTopic() sample [1]" << std::endl;
   DeleteTopic(topic_admin_client, {project_id, dead_letter_topic_id});
 
@@ -2300,6 +2331,10 @@ int main(int argc, char* argv[]) {  // NOLINT(bugprone-exception-escape)
           "create-push-subscription",
           {"project-id", "topic-id", "subscription-id", "endpoint"},
           CreatePushSubscription),
+      CreateSubscriptionAdminCommand(
+          "create-bigquery-subscription",
+          {"project-id", "topic-id", "subscription-id", "table-id"},
+          CreateBigQuerySubscription),
       CreateSubscriptionAdminCommand(
           "create-ordering-subscription",
           {"project-id", "topic-id", "subscription-id"},

--- a/google/cloud/pubsub/subscription_admin_client.h
+++ b/google/cloud/pubsub/subscription_admin_client.h
@@ -85,6 +85,9 @@ class SubscriptionAdminClient {
    * @par Example: Create a Push Subscription
    * @snippet samples.cc create-push-subscription
    *
+   * @par Example: Create a BigQuery Subscription
+   * @snippet samples.cc create-bigquery-subscription
+   *
    * @param topic the topic that the subscription will attach to
    * @param subscription the name for the subscription
    * @param builder any additional configuration for the subscription


### PR DESCRIPTION
Note that this was not added to the auto samples run. The reason is that it requires a BigQuery table to exist or to be created. It looks like there isn't library support for creating tables in C++. If there is a way to do it and it is preferred that this sample be added to the auto-run samples, I can do that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9500)
<!-- Reviewable:end -->
