### PR TITLE
chore: move libraries from transition to full GA

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,14 +34,7 @@ EXPERIMENTAL_LIBRARIES = [
 ]
 
 TRANSITION_LIBRARIES = [
-    # Declared GA on 2022-06-01
-    "dataplex",
-    "dialogflow_cx",
-    "dialogflow_es",
-    # 2022-04-11
-    "logging",
     "osconfig",
-    "speech",
 ]
 
 GA_LIBRARIES = [
@@ -64,8 +57,11 @@ GA_LIBRARIES = [
     "containeranalysis",
     "datacatalog",
     "datamigration",
+    "dataplex",
     "dataproc",
     "debugger",
+    "dialogflow_cx",
+    "dialogflow_es",
     "dlp",
     "documentai",
     "eventarc",
@@ -78,6 +74,7 @@ GA_LIBRARIES = [
     "iot",
     "kms",
     "language",
+    "logging",
     "managedidentities",
     "memcache",
     "monitoring",
@@ -101,6 +98,7 @@ GA_LIBRARIES = [
     "servicemanagement",
     "serviceusage",
     "shell",
+    "speech",
     "storagetransfer",
     "talent",
     "tasks",

--- a/ci/verify_current_targets/CMakeLists.txt
+++ b/ci/verify_current_targets/CMakeLists.txt
@@ -23,12 +23,15 @@ set(common_libraries common grpc_utils)
 
 # Add GA libraries to this list, the only difference is the name of the CMake
 # targets
-set(ga_libraries # cmake-format: sortable
-                 bigquery bigtable iam pubsub spanner storage)
-
-# Add experimental (non-GA) libraries here.
-set(experimental_libraries # cmake-format: sortable
-                           logging)
+set(ga_libraries
+    # cmake-format: sortable
+    bigquery
+    bigtable
+    iam
+    logging
+    pubsub
+    spanner
+    storage)
 
 # CMake can use pkg-config to find dependencies. We recommend using CMake
 # targets, but we want to verify our pkg-config files remain usable and
@@ -43,7 +46,7 @@ function (add_test_case name)
     add_test(NAME "${name}" COMMAND "${name}")
 endfunction ()
 
-foreach (library ${common_libraries} ${ga_libraries} ${experimental_libraries})
+foreach (library ${common_libraries} ${ga_libraries})
     find_package("google_cloud_cpp_${library}" REQUIRED)
 endforeach ()
 
@@ -51,12 +54,7 @@ foreach (library ${common_libraries} ${ga_libraries})
     add_test_case(test_cmake_${library} google-cloud-cpp::${library})
 endforeach ()
 
-foreach (library ${experimental_libraries})
-    add_test_case(test_cmake_${library}
-                  google-cloud-cpp::experimental-${library})
-endforeach ()
-
-foreach (library ${common_libraries} ${ga_libraries} ${experimental_libraries})
+foreach (library ${common_libraries} ${ga_libraries})
     message("library=${library}")
     pkg_check_modules(${library} IMPORTED_TARGET REQUIRED
                       google_cloud_cpp_${library})

--- a/google/cloud/dataplex/config.cmake.in
+++ b/google/cloud/dataplex/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_dataplex-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-dataplex)
-    add_library(google-cloud-cpp::experimental-dataplex ALIAS google-cloud-cpp::dataplex)
-endif ()

--- a/google/cloud/dialogflow_cx/config.cmake.in
+++ b/google/cloud/dialogflow_cx/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_dialogflow_cx-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-dialogflow_cx)
-    add_library(google-cloud-cpp::experimental-dialogflow_cx ALIAS google-cloud-cpp::dialogflow_cx)
-endif ()

--- a/google/cloud/dialogflow_es/config.cmake.in
+++ b/google/cloud/dialogflow_es/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_dialogflow_es-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-dialogflow_es)
-    add_library(google-cloud-cpp::experimental-dialogflow_es ALIAS google-cloud-cpp::dialogflow_es)
-endif ()

--- a/google/cloud/logging/config.cmake.in
+++ b/google/cloud/logging/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_logging-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-logging)
-    add_library(google-cloud-cpp::experimental-logging ALIAS google-cloud-cpp::logging)
-endif ()

--- a/google/cloud/logging/quickstart/CMakeLists.txt
+++ b/google/cloud/logging/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-logging)
+target_link_libraries(quickstart google-cloud-cpp::logging)

--- a/google/cloud/speech/config.cmake.in
+++ b/google/cloud/speech/config.cmake.in
@@ -20,7 +20,3 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_speech-targets.cmake")
-
-if (NOT TARGET google-cloud-cpp::experimental-speech)
-    add_library(google-cloud-cpp::experimental-speech ALIAS google-cloud-cpp::speech)
-endif ()

--- a/google/cloud/speech/quickstart/CMakeLists.txt
+++ b/google/cloud/speech/quickstart/CMakeLists.txt
@@ -29,4 +29,4 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-speech)
+target_link_libraries(quickstart google-cloud-cpp::speech)


### PR DESCRIPTION
Remove experimental aliases. Use `logging` instead of `experimental-logging` in our CI.

Note that we do not move `osconfig`. (If I understand things correctly) we never moved the CMake targets into the transition state. We only define `google-cloud-cpp::experimental-osconfig`. https://github.com/googleapis/google-cloud-cpp/blob/021fceb482a2dc5782c4c1568dc0b303fcd77199/google/cloud/osconfig/CMakeLists.txt#L67-L76

I think we should keep our bazel and cmake targets in sync. I will send a follow up PR to move the osconfig cmake targets into a transition state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9504)
<!-- Reviewable:end -->
