### PR TITLE
chore(deps): fix google/benchmark SHA256

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -77,7 +77,7 @@ def google_cloud_cpp_deps():
             urls = [
                 "https://github.com/google/benchmark/archive/v1.6.2.tar.gz",
             ],
-            sha256 = "82c02e5cf17d864404973e964ff272b9d652b626861e61443e497e4f67423437",
+            sha256 = "6adf850c2be6aa15843c94ac63d0819d5bf9f5678ae41244f25a1f4bf9480827",
         )
 
     # Load the googleapis dependency.


### PR DESCRIPTION
I think this indicates the release tag got moved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9507)
<!-- Reviewable:end -->
