### PR TITLE
fix(storage): no char for `std::uniform_int_distribution`

### DIFF
--- a/google/cloud/storage/internal/invocation_id_generator.cc
+++ b/google/cloud/storage/internal/invocation_id_generator.cc
@@ -42,10 +42,11 @@ std::string InvocationIdGenerator::MakeInvocationId() {
     auto constexpr kIdBitCount = 128;
     auto constexpr kArraySize = kIdBitCount / 8;
     std::array<std::uint8_t, kArraySize> buf;
-    std::uniform_int_distribution<std::uint8_t> d(0, 255);
+    std::uniform_int_distribution<int> d(0, 255);
 
     std::lock_guard<std::mutex> lk(mu_);
-    std::generate(buf.begin(), buf.end(), [&] { return d(generator_); });
+    std::generate(buf.begin(), buf.end(),
+                  [&] { return static_cast<std::uint8_t>(d(generator_)); });
     return buf;
   }();
   o[kVersionOctet] = (o[kVersionOctet] & kVersionMask) | kVersion;


### PR DESCRIPTION
TIL: it is undefined behavior to use `std::uniform_int_distribution<>`
with `char`, `unsigned char`, and its aliases. And some platforms
enforce this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9509)
<!-- Reviewable:end -->
