### PR TITLE
chore: declare `osconfig` GA

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -34,6 +34,7 @@ EXPERIMENTAL_LIBRARIES = [
 ]
 
 TRANSITION_LIBRARIES = [
+    # Declared GA on 2022-07-18
     "osconfig",
 ]
 

--- a/google/cloud/osconfig/CMakeLists.txt
+++ b/google/cloud/osconfig/CMakeLists.txt
@@ -17,7 +17,7 @@
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "OS Config API C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the OS Config API")
-set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION} (Experimental)")
+set(DOXYGEN_PROJECT_NUMBER "${PROJECT_VERSION}")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "osconfig_internal" "osconfig_testing"
                             "examples")
 set(DOXYGEN_EXAMPLE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -66,14 +66,13 @@ target_link_libraries(
 google_cloud_cpp_add_common_options(google_cloud_cpp_osconfig)
 set_target_properties(
     google_cloud_cpp_osconfig
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-osconfig
+    PROPERTIES EXPORT_NAME google-cloud-cpp::osconfig
                VERSION "${PROJECT_VERSION}"
                SOVERSION "${PROJECT_VERSION_MAJOR}")
 target_compile_options(google_cloud_cpp_osconfig
                        PUBLIC ${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-add_library(google-cloud-cpp::experimental-osconfig ALIAS
-            google_cloud_cpp_osconfig)
+add_library(google-cloud-cpp::osconfig ALIAS google_cloud_cpp_osconfig)
 
 # Create a header-only library for the mocks. We use a CMake `INTERFACE` library
 # for these, a regular library would not work on macOS (where the library needs
@@ -92,11 +91,10 @@ add_library(google_cloud_cpp_osconfig_mocks INTERFACE)
 target_sources(google_cloud_cpp_osconfig_mocks INTERFACE ${mock_files})
 target_link_libraries(
     google_cloud_cpp_osconfig_mocks
-    INTERFACE google-cloud-cpp::experimental-osconfig GTest::gmock_main
-              GTest::gmock GTest::gtest)
-set_target_properties(
-    google_cloud_cpp_osconfig_mocks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-osconfig_mocks)
+    INTERFACE google-cloud-cpp::osconfig GTest::gmock_main GTest::gmock
+              GTest::gtest)
+set_target_properties(google_cloud_cpp_osconfig_mocks
+                      PROPERTIES EXPORT_NAME google-cloud-cpp::osconfig_mocks)
 target_include_directories(
     google_cloud_cpp_osconfig_mocks
     INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
@@ -109,7 +107,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_executable(osconfig_quickstart "quickstart/quickstart.cc")
     target_link_libraries(osconfig_quickstart
-                          PRIVATE google-cloud-cpp::experimental-osconfig)
+                          PRIVATE google-cloud-cpp::osconfig)
     google_cloud_cpp_add_common_options(osconfig_quickstart)
     add_test(
         NAME osconfig_quickstart

--- a/google/cloud/osconfig/README.md
+++ b/google/cloud/osconfig/README.md
@@ -1,16 +1,12 @@
 # OS Config API C++ Client Library
 
-:construction:
-
 This directory contains an idiomatic C++ client library for the
 [OS Config API][cloud-service-docs], a service for patch management, patch
 compliance, and configuration management on VM instances.
 
 <!-- TODO(#8139) - fix streaming read updated namespace before GA -->
 
-This library is **experimental**. Its APIs are subject to change without notice.
-
-Please note that the Google Cloud C++ client libraries do **not** follow
+While this library is **GA**, please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).
 
 ## Supported Platforms

--- a/google/cloud/osconfig/README.md
+++ b/google/cloud/osconfig/README.md
@@ -4,8 +4,6 @@ This directory contains an idiomatic C++ client library for the
 [OS Config API][cloud-service-docs], a service for patch management, patch
 compliance, and configuration management on VM instances.
 
-<!-- TODO(#8139) - fix streaming read updated namespace before GA -->
-
 While this library is **GA**, please note that the Google Cloud C++ client libraries do **not** follow
 [Semantic Versioning](https://semver.org/).
 

--- a/google/cloud/osconfig/config.cmake.in
+++ b/google/cloud/osconfig/config.cmake.in
@@ -20,3 +20,7 @@ find_dependency(google_cloud_cpp_grpc_utils)
 find_dependency(absl)
 
 include("${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_osconfig-targets.cmake")
+
+if (NOT TARGET google-cloud-cpp::experimental-osconfig)
+    add_library(google-cloud-cpp::experimental-osconfig ALIAS google-cloud-cpp::osconfig)
+endif ()

--- a/google/cloud/osconfig/doc/main.dox
+++ b/google/cloud/osconfig/doc/main.dox
@@ -6,7 +6,7 @@ An idiomatic C++ client library for the [OS Config API][cloud-service-docs],
 a service for patch management, patch compliance, and configuration
 management on VM instances.
 
-This library is **experimental**. Its APIs are subject to change without notice.
+While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]


### PR DESCRIPTION
the bazel build was moved to a transition state, but the cmake build was not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9511)
<!-- Reviewable:end -->
