### PR TITLE
ci: move `demo-fedora` build to Fedora:36

### DIFF
--- a/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
+++ b/ci/cloudbuild/dockerfiles/demo-fedora.Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora:35
+FROM fedora:36
 ARG NCPU=4
 
 ## [BEGIN packaging.md]
@@ -25,7 +25,7 @@ RUN dnf makecache && \
         openssl-devel patch unzip tar wget zip zlib-devel
 # ```
 
-# Fedora 34 includes packages for gRPC and Protobuf, but they are not
+# Fedora 36 includes packages for gRPC and Protobuf, but they are not
 # recent enough to support the protos published by Google Cloud. The indirect
 # dependencies of libcurl, Protobuf, and gRPC are recent enough for our needs.
 

--- a/ci/generate-markdown/generate-packaging.sh
+++ b/ci/generate-markdown/generate-packaging.sh
@@ -179,7 +179,7 @@ function extract() {
 # A "map" (comma separated) of dockerfile -> summary.
 DOCKER_DISTROS=(
   "demo-alpine-stable.Dockerfile,Alpine (Stable)"
-  "demo-fedora.Dockerfile,Fedora (35)"
+  "demo-fedora.Dockerfile,Fedora (36)"
   "demo-opensuse-leap.Dockerfile,openSUSE (Leap)"
   "demo-ubuntu-jammy.Dockerfile,Ubuntu (22.04 LTS - Jammy Jellyfish)"
   "demo-ubuntu-focal.Dockerfile,Ubuntu (20.04 LTS - Focal Fossa)"

--- a/doc/packaging.md
+++ b/doc/packaging.md
@@ -222,7 +222,7 @@ cmake --build cmake-out --target install
 </details>
 
 <details>
-<summary>Fedora (35)</summary>
+<summary>Fedora (36)</summary>
 <br>
 
 Install the minimal development tools:
@@ -233,7 +233,7 @@ sudo dnf install -y ccache cmake curl findutils gcc-c++ git make ninja-build \
         openssl-devel patch unzip tar wget zip zlib-devel
 ```
 
-Fedora 34 includes packages for gRPC and Protobuf, but they are not
+Fedora 36 includes packages for gRPC and Protobuf, but they are not
 recent enough to support the protos published by Google Cloud. The indirect
 dependencies of libcurl, Protobuf, and gRPC are recent enough for our needs.
 


### PR DESCRIPTION
Part of the work for #8922

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9516)
<!-- Reviewable:end -->
