### PR TITLE
fix(pubsub): missing subscription name in lease extensions

### DIFF
--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source.cc
@@ -126,6 +126,7 @@ future<Status> StreamingSubscriptionBatchSource::BulkNack(
 void StreamingSubscriptionBatchSource::ExtendLeases(
     std::vector<std::string> ack_ids, std::chrono::seconds extension) {
   google::pubsub::v1::ModifyAckDeadlineRequest request;
+  request.set_subscription(subscription_full_name_);
   request.set_ack_deadline_seconds(
       static_cast<std::int32_t>(extension.count()));
   for (auto& a : ack_ids) {

--- a/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
+++ b/google/cloud/pubsub/internal/streaming_subscription_batch_source_test.cc
@@ -522,17 +522,25 @@ TEST(StreamingSubscriptionBatchSourceTest, AckMany) {
                                             Property(&ModifyRequest::ack_ids,
                                                      ElementsAre("fake-003"))))
       .WillOnce(OnModify);
-  EXPECT_CALL(*mock, AsyncModifyAckDeadline(
-                         _, _,
-                         Property(&ModifyRequest::ack_ids,
-                                  ElementsAre("fake-004", "fake-005"))))
+  EXPECT_CALL(
+      *mock,
+      AsyncModifyAckDeadline(
+          _, _,
+          AllOf(
+              Property(&ModifyRequest::subscription,
+                       "projects/test-project/subscriptions/test-subscription"),
+              Property(&ModifyRequest::ack_ids,
+                       ElementsAre("fake-004", "fake-005")))))
       .WillOnce(OnModify);
   EXPECT_CALL(
       *mock,
       AsyncModifyAckDeadline(
           _, _,
-          AllOf(Property(&ModifyRequest::ack_ids, ElementsAre("fake-006")),
-                Property(&ModifyRequest::ack_deadline_seconds, 123))))
+          AllOf(
+              Property(&ModifyRequest::subscription,
+                       "projects/test-project/subscriptions/test-subscription"),
+              Property(&ModifyRequest::ack_ids, ElementsAre("fake-006")),
+              Property(&ModifyRequest::ack_deadline_seconds, 123))))
       .WillOnce(OnModify);
 
   auto shutdown = std::make_shared<SessionShutdownManager>();


### PR DESCRIPTION
When I changed the lease extensions to use unary RPCs (as opposed to
inline messages in the streaming pull), I neglected to include the
subscription name with the request.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9523)
<!-- Reviewable:end -->
