### PR TITLE
fix(generator): streaming writes with routing instructions

### DIFF
--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -316,6 +316,10 @@ $metadata_class_name$::$method_name$(
       continue;
     }
     if (IsBidirStreaming(method)) {
+      // Asynchronous streaming writes do not consume a request. Typically, the
+      // first `Write()` call contains any relevant data to "start" the stream.
+      // Thus, the decorator cannot add any routing instructions. The caller
+      // should initialize `context` with any such instructions.
       CcPrintMethod(method, __FILE__, __LINE__,
                     R"""(
 std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
@@ -397,13 +401,10 @@ $metadata_class_name$::Async$method_name$(
       continue;
     }
     if (IsStreamingWrite(method)) {
-      // Asynchronous streaming writes do not consume a request, typically the
+      // Asynchronous streaming writes do not consume a request. Typically, the
       // first `Write()` call contains any relevant data to "start" the stream.
       // Thus, the decorator cannot add any routing instructions. The caller
-      // should initialize `context` with any such instructions. At this time,
-      // all callers are hand-crafted, so this is just a bit more work for
-      // library developers, ut a lot less than writing the routing instructions
-      // for all RPCs.
+      // should initialize `context` with any such instructions.
       auto const definition = absl::StrCat(
           R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<

--- a/generator/internal/metadata_decorator_generator.cc
+++ b/generator/internal/metadata_decorator_generator.cc
@@ -397,6 +397,13 @@ $metadata_class_name$::Async$method_name$(
       continue;
     }
     if (IsStreamingWrite(method)) {
+      // Asynchronous streaming writes do not consume a request, typically the
+      // first `Write()` call contains any relevant data to "start" the stream.
+      // Thus, the decorator cannot add any routing instructions. The caller
+      // should initialize `context` with any such instructions. At this time,
+      // all callers are hand-crafted, so this is just a bit more work for
+      // library developers, ut a lot less than writing the routing instructions
+      // for all RPCs.
       auto const definition = absl::StrCat(
           R"""(
 std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
@@ -404,9 +411,7 @@ std::unique_ptr<::google::cloud::internal::AsyncStreamingWriteRpc<
 $metadata_class_name$::Async$method_name$(
     google::cloud::CompletionQueue const& cq,
     std::unique_ptr<grpc::ClientContext> context) {
-)""",
-          SetMetadataText(method, kPointer),
-          R"""(
+  SetMetadata(*context);
   return child_->Async$method_name$(cq, std::move(context));
 }
 )""");


### PR DESCRIPTION
The generator cannot create code to capture the routing instructions on
asynchronous streaming writes.  The generated functions do not have a
request to extract the routing instructions from.  Just inject the
basic metadata, the caller is responsible for adding the routing
instructions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9524)
<!-- Reviewable:end -->
