### PR TITLE
ci: configure MSVC 2022 builds

### DIFF
--- a/ci/kokoro/windows/bazel-debug-2022-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-debug-2022-presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2022"
+}

--- a/ci/kokoro/windows/bazel-debug-2022.cfg
+++ b/ci/kokoro/windows/bazel-debug-2022.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2022"
+}

--- a/ci/kokoro/windows/bazel-release-2022-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-release-2022-presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2022"
+}

--- a/ci/kokoro/windows/bazel-release-2022.cfg
+++ b/ci/kokoro/windows/bazel-release-2022.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2022"
+}

--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -21,8 +21,13 @@ REM Install Bazelisk.
 REM Change PATH to install the Bazelisk version we just installed
 @set PATH=C:\bin;%PATH%
 
+@REM Before MSVC 2022 the compiler is a 32-bit binary
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
-call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars32.bat"
+if %MSVC_VERSION% GEQ 2022 (
+  call "c:\Program Files\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
+) else (
+  call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
+)
 
 REM The remaining of the build script is implemented in PowerShell.
 @echo %date% %time%

--- a/ci/kokoro/windows/build-bazel.ps1
+++ b/ci/kokoro/windows/build-bazel.ps1
@@ -93,11 +93,16 @@ if ((Test-Path env:KOKORO_GFILE_DIR) -and
     $build_flags += @("--experimental_guard_against_concurrent_changes")
 }
 
-if ($BuildName -eq "bazel-release") {
+if ($BuildName -like "bazel-release-*") {
     $build_flags += ("-c", "opt")
 }
 
-$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
+# Before MSVC 2022 the compiler is a 32-bit binary
+if ("${env:MSVC_VERSION}" -ge "2022") {
+  $env:BAZEL_VC="C:\Program Files\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
+} else {
+  $env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
+}
 
 ForEach($_ in (1, 2, 3)) {
     Write-Host -ForegroundColor Yellow "`n$(Get-Date -Format o) Fetch dependencies [$_]"

--- a/ci/kokoro/windows/build-quickstart-bazel.ps1
+++ b/ci/kokoro/windows/build-quickstart-bazel.ps1
@@ -80,7 +80,12 @@ if ((Test-Path env:KOKORO_GFILE_DIR) -and
     $build_flags += @("--experimental_guard_against_concurrent_changes")
 }
 
-$env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
+# Before MSVC 2022 the compiler is a 32-bit binary
+if ("${env:MSVC_VERSION}" -ge "2022") {
+    $env:BAZEL_VC="C:\Program Files\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
+} else {
+    $env:BAZEL_VC="C:\Program Files (x86)\Microsoft Visual Studio\${env:MSVC_VERSION}\Community\VC"
+}
 
 $project_root = (Get-Item -Path ".\" -Verbose).FullName
 # If at all possible, load the configuration for the integration tests and

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -21,8 +21,13 @@ REM Install Bazelisk.
 REM Change PATH to install the Bazelisk version we just installed
 @set PATH=C:\bin;%PATH%
 
+@REM Before MSVC 2022 the compiler is a 32-bit binary
 REM Configure the environment to use MSVC %MSVC_VERSION% and then switch to PowerShell.
-call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
+if %MSVC_VERSION% GEQ 2022 (
+  call "c:\Program Files\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
+) else (
+  call "c:\Program Files (x86)\Microsoft Visual Studio\%MSVC_VERSION%\Community\VC\Auxiliary\Build\vcvars64.bat"
+)
 
 REM The remaining of the build script is implemented in PowerShell.
 @echo %date% %time%

--- a/ci/kokoro/windows/build.ps1
+++ b/ci/kokoro/windows/build.ps1
@@ -74,16 +74,7 @@ if (($BuildName -eq "cmake") -or ($BuildName -eq "cmake-debug")) {
     $env:VCPKG_TRIPLET = "x86-windows-static"
     $DependencyScript = "build-cmake-dependencies.ps1"
     $BuildScript = "build-cmake.ps1"
-} elseif (($BuildName -eq "bazel-debug") -or ($BuildName -eq "bazel")) {
-    $DependencyScript = "build-bazel-dependencies.ps1"
-    $BuildScript = "build-bazel.ps1"
-} elseif ($BuildName -eq "bazel-release") {
-    $DependencyScript = "build-bazel-dependencies.ps1"
-    $BuildScript = "build-bazel.ps1"
-} elseif ($BuildName -eq "bazel-debug-2017") {
-    $DependencyScript = "build-bazel-dependencies.ps1"
-    $BuildScript = "build-bazel.ps1"
-} elseif ($BuildName -eq "bazel-release-2017") {
+} elseif ($BuildName -like "bazel-*") {
     $DependencyScript = "build-bazel-dependencies.ps1"
     $BuildScript = "build-bazel.ps1"
 } elseif ($BuildName -eq "quickstart-bazel") {


### PR DESCRIPTION
Prepare the scripts to build with MSVC 2022. Create the configuration files for
Kokoro.

Part of the work for #4106 