### PR TITLE
test(spanner): MakeConnection() test will require a service

### DIFF
--- a/google/cloud/spanner/integration_tests/client_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/client_integration_test.cc
@@ -1001,6 +1001,17 @@ TEST_F(ClientIntegrationTest, UnifiedCredentials) {
   ASSERT_NO_FATAL_FAILURE(InsertTwoSingers());
 }
 
+/// @test Verify backwards compatibility for MakeConnection() arguments.
+TEST_F(ClientIntegrationTest, MakeConnectionOverloads) {
+  MakeConnection(GetDatabase(), ConnectionOptions());
+  MakeConnection(GetDatabase(), ConnectionOptions(), SessionPoolOptions());
+  MakeConnection(GetDatabase(), ConnectionOptions(), SessionPoolOptions(),
+                 LimitedTimeRetryPolicy(std::chrono::minutes(25)).clone(),
+                 ExponentialBackoffPolicy(std::chrono::seconds(2),
+                                          std::chrono::minutes(10), 1.5)
+                     .clone());
+}
+
 /// @test Verify the backwards compatibility `v1` namespace still exists.
 TEST_F(ClientIntegrationTest, BackwardsCompatibility) {
   auto connection = ::google::cloud::spanner::v1::MakeConnection(GetDatabase());


### PR DESCRIPTION
`ClientTest.MakeConnectionOptionalArguments` is really an integration
test in unit-test clothing.  Indeed, in the near future just creating
a database connection will start the process of filling the session
pool.  So, move it from `client_test.cc` to `client_integration_test.cc`.

Also, the purpose of the test is to ensure that the previous overloads
with `ConnectionOptions` and `SessionPoolOptions` are still available,
and not to verify any particular behavior.  So, simplify accordingly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9545)
<!-- Reviewable:end -->
