### PR TITLE
feat(spanner): default SessionPoolMinSessionsOption to a non-zero value

### DIFF
--- a/google/cloud/spanner/internal/defaults.cc
+++ b/google/cloud/spanner/internal/defaults.cc
@@ -74,6 +74,11 @@ Options DefaultOptions(Options opts) {
   }
 
   // Sets Spanner-specific options from session_pool_options.h
+  auto& num_channels = opts.lookup<GrpcNumChannelsOption>();
+  num_channels = (std::max)(num_channels, 1);
+  if (!opts.has<spanner::SessionPoolMinSessionsOption>()) {
+    opts.set<spanner::SessionPoolMinSessionsOption>(25 * num_channels);
+  }
   if (!opts.has<spanner::SessionPoolMaxSessionsPerChannelOption>()) {
     opts.set<spanner::SessionPoolMaxSessionsPerChannelOption>(100);
   }
@@ -89,8 +94,6 @@ Options DefaultOptions(Options opts) {
     opts.set<SessionPoolClockOption>(std::make_shared<Session::Clock>());
   }
   // Enforces some SessionPool constraints.
-  auto& num_channels = opts.lookup<GrpcNumChannelsOption>();
-  num_channels = (std::max)(num_channels, 1);
   auto& max_idle = opts.lookup<spanner::SessionPoolMaxIdleSessionsOption>();
   max_idle = (std::max)(max_idle, 0);
   auto& max_sessions_per_channel =

--- a/google/cloud/spanner/internal/defaults_test.cc
+++ b/google/cloud/spanner/internal/defaults_test.cc
@@ -71,7 +71,8 @@ TEST(Options, Defaults) {
               ElementsAre(gcloud_user_agent_matcher()));
   EXPECT_FALSE(opts.has<UserProjectOption>());
 
-  EXPECT_EQ(0, opts.get<SessionPoolMinSessionsOption>());
+  EXPECT_EQ(25 * opts.get<GrpcNumChannelsOption>(),
+            opts.get<SessionPoolMinSessionsOption>());
   EXPECT_EQ(100, opts.get<SessionPoolMaxSessionsPerChannelOption>());
   EXPECT_EQ(0, opts.get<SessionPoolMaxIdleSessionsOption>());
   EXPECT_EQ(ActionOnExhaustion::kBlock,

--- a/google/cloud/spanner/session_pool_options_test.cc
+++ b/google/cloud/spanner/session_pool_options_test.cc
@@ -53,7 +53,7 @@ TEST(SessionPoolOptionsTest, MaxMinSessionsConflict) {
 
 TEST(SessionPoolOptionsTest, DefaultOptions) {
   auto const opts = SessionPoolOptions{};
-  EXPECT_EQ(0, opts.min_sessions());
+  EXPECT_EQ(25 * 4, opts.min_sessions());
   EXPECT_EQ(100, opts.max_sessions_per_channel());
   EXPECT_EQ(0, opts.max_idle_sessions());
   EXPECT_EQ(ActionOnExhaustion::kBlock, opts.action_on_exhaustion());


### PR DESCRIPTION
Set the default value for `spanner::SessionPoolMinSessionsOption` to
`(25 * num_channels)`.  This means we will start the session-allocation
process at connection-creation time rather than waiting for the first
request.

The actual change is simple.  Most of the PR deals with:
- Reordering `BatchCreateSessions()` expectations to before connection
  creation.
- Expecting additional `BatchCreateSessions()` calls when the first one
  fails.

Fixes #4483.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9546)
<!-- Reviewable:end -->
