### PR TITLE
feat(GCS+gRPC): implement `DeleteResumableUpload()`

### DIFF
--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -253,6 +253,29 @@ TEST_F(GrpcClientTest, QueryResumableUpload) {
   EXPECT_EQ(response.status(), PermanentError());
 }
 
+TEST_F(GrpcClientTest, DeleteResumableUpload) {
+  auto mock = std::make_shared<testing::MockStorageStub>();
+  EXPECT_CALL(*mock, CancelResumableWrite)
+      .WillOnce(
+          [this](
+              grpc::ClientContext& context,
+              google::storage::v2::CancelResumableWriteRequest const& request) {
+            auto metadata = GetMetadata(context);
+            EXPECT_THAT(metadata,
+                        UnorderedElementsAre(
+                            Pair("x-goog-quota-user", "test-quota-user"),
+                            Pair("x-goog-fieldmask", "field1,field2")));
+            EXPECT_THAT(request.upload_id(), "test-only-upload-id");
+            return PermanentError();
+          });
+  auto client = CreateTestClient(mock);
+  auto response = client->DeleteResumableUpload(
+      DeleteResumableUploadRequest("test-only-upload-id")
+          .set_multiple_options(Fields("field1,field2"),
+                                QuotaUser("test-quota-user")));
+  EXPECT_EQ(response.status(), PermanentError());
+}
+
 TEST_F(GrpcClientTest, CreateBucket) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, CreateBucket)

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -697,6 +697,13 @@ QueryResumableUploadResponse GrpcObjectRequestParser::FromProto(
   return result;
 }
 
+google::storage::v2::CancelResumableWriteRequest
+GrpcObjectRequestParser::ToProto(DeleteResumableUploadRequest const& request) {
+  google::storage::v2::CancelResumableWriteRequest result;
+  result.set_upload_id(request.upload_session_url());
+  return result;
+}
+
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage

--- a/google/cloud/storage/internal/grpc_object_request_parser.h
+++ b/google/cloud/storage/internal/grpc_object_request_parser.h
@@ -73,6 +73,9 @@ struct GrpcObjectRequestParser {
   static QueryResumableUploadResponse FromProto(
       google::storage::v2::QueryWriteStatusResponse const& response,
       Options const& options);
+
+  static google::storage::v2::CancelResumableWriteRequest ToProto(
+      DeleteResumableUploadRequest const& request);
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -1060,6 +1060,20 @@ TEST(GrpcObjectRequestParser, QueryResumableUploadResponseWithResource) {
   EXPECT_EQ(actual.payload->size(), 123456);
 }
 
+TEST(GrpcObjectRequestParser, DeleteResumableUploadRequest) {
+  google::storage::v2::CancelResumableWriteRequest expected;
+  EXPECT_TRUE(TextFormat::ParseFromString(
+      R"pb(
+        upload_id: "test-upload-id"
+      )pb",
+      &expected));
+
+  DeleteResumableUploadRequest req("test-upload-id");
+
+  auto actual = GrpcObjectRequestParser::ToProto(req);
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/tests/CMakeLists.txt
+++ b/google/cloud/storage/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ set(storage_client_integration_tests
     grpc_hmac_key_integration_test.cc
     grpc_integration_test.cc
     grpc_object_acl_integration_test.cc
+    grpc_object_media_integration_test.cc
     grpc_object_metadata_integration_test.cc
     grpc_service_account_integration_test.cc
     key_file_integration_test.cc

--- a/google/cloud/storage/tests/grpc_object_media_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_media_integration_test.cc
@@ -1,0 +1,74 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
+#include "google/cloud/storage/testing/storage_integration_test.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/testing_util/scoped_environment.h"
+#include "google/cloud/testing_util/status_matchers.h"
+#include <crc32c/crc32c.h>
+#include <gmock/gmock.h>
+#include <vector>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+namespace {
+
+using ::google::cloud::internal::GetEnv;
+using ::google::cloud::testing_util::ScopedEnvironment;
+using ::testing::IsEmpty;
+using ::testing::Not;
+
+// When GOOGLE_CLOUD_CPP_HAVE_GRPC is not set these tests compile, but they
+// actually just run against the regular GCS REST API. That is fine.
+class GrpcObjectMediaIntegrationTest
+    : public google::cloud::storage::testing::StorageIntegrationTest {};
+
+TEST_F(GrpcObjectMediaIntegrationTest, CancelResumableUpload) {
+  ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
+                                "metadata");
+  // TODO(#5673) - restore gRPC integration tests against production
+  if (!UsingEmulator()) GTEST_SKIP();
+
+  auto const bucket_name =
+      GetEnv("GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME").value_or("");
+  ASSERT_THAT(bucket_name, Not(IsEmpty()))
+      << "GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME is not set";
+
+  auto client = MakeIntegrationTestClient();
+  ASSERT_STATUS_OK(client);
+
+  auto object_name = MakeRandomObjectName();
+
+  // Start an upload, capture its upload ID and suspend it.
+  auto os = client->WriteObject(bucket_name, object_name, IfGenerationMatch(0),
+                                NewResumableUploadSession());
+  auto const upload_id = os.resumable_session_id();
+  std::move(os).Suspend();
+
+  auto status = client->DeleteResumableUpload(upload_id);
+  EXPECT_STATUS_OK(status);
+}
+
+}  // namespace
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC

--- a/google/cloud/storage/tests/storage_client_integration_tests.bzl
+++ b/google/cloud/storage/tests/storage_client_integration_tests.bzl
@@ -33,6 +33,7 @@ storage_client_integration_tests = [
     "grpc_hmac_key_integration_test.cc",
     "grpc_integration_test.cc",
     "grpc_object_acl_integration_test.cc",
+    "grpc_object_media_integration_test.cc",
     "grpc_object_metadata_integration_test.cc",
     "grpc_service_account_integration_test.cc",
     "key_file_integration_test.cc",


### PR DESCRIPTION
This is a small function, so I added the request parser, unit tests, and
integration tests in a single PR.

Fixes #5910

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9550)
<!-- Reviewable:end -->
