### PR TITLE
fix(GCS+gRPC): more efficient `ReadObject()` stall timeouts

### DIFF
--- a/google/cloud/storage/internal/async_accumulate_read_object_test.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object_test.cc
@@ -28,7 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::internal::StreamingRpcMetadata;
-using ::google::cloud::storage::testing::MockObjectMediaStream;
+using ::google::cloud::storage::testing::MockAsyncObjectMediaStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::AsyncSequencer;
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -72,7 +72,7 @@ std::unique_ptr<
     google::cloud::internal::AsyncStreamingReadRpc<ReadObjectResponse>>
 MakeMockStreamPartial(int id, ReadObjectResponse response,
                       StatusCode code = StatusCode::kOk) {
-  auto stream = absl::make_unique<MockObjectMediaStream>();
+  auto stream = absl::make_unique<MockAsyncObjectMediaStream>();
   EXPECT_CALL(*stream, Start).WillOnce(Return(ByMove(make_ready_future(true))));
   EXPECT_CALL(*stream, Read)
       .WillOnce(Return(
@@ -108,7 +108,7 @@ TEST(AsyncAccumulateReadObjectTest, PartialSimple) {
   ReadObjectResponse r1;
   ASSERT_TRUE(TextFormat::ParseFromString(kText1, &r1));
 
-  auto mock = absl::make_unique<MockObjectMediaStream>();
+  auto mock = absl::make_unique<MockAsyncObjectMediaStream>();
   ::testing::InSequence sequence;
 
   EXPECT_CALL(*mock, Start).WillOnce(Return(ByMove(make_ready_future(true))));
@@ -139,7 +139,7 @@ TEST(AsyncAccumulateReadObjectTest, PartialStartTimeout) {
   AsyncSequencer<bool> async;
   auto cq = MakeMockedCompletionQueue(async);
 
-  auto mock = absl::make_unique<MockObjectMediaStream>();
+  auto mock = absl::make_unique<MockAsyncObjectMediaStream>();
 
   EXPECT_CALL(*mock, Start).WillRepeatedly([&] {
     return async.PushBack("Start").then([](future<bool> f) { return f.get(); });
@@ -189,7 +189,7 @@ TEST(AsyncAccumulateReadObjectTest, PartialReadTimeout) {
   AsyncSequencer<bool> async;
   auto cq = MakeMockedCompletionQueue(async);
 
-  auto mock = absl::make_unique<MockObjectMediaStream>();
+  auto mock = absl::make_unique<MockAsyncObjectMediaStream>();
 
   EXPECT_CALL(*mock, Start).WillRepeatedly([&] {
     return async.PushBack("Start").then([](future<bool> f) { return f.get(); });
@@ -249,7 +249,7 @@ TEST(AsyncAccumulateReadObjectTest, PartialFinishTimeout) {
   AsyncSequencer<bool> async;
   auto cq = MakeMockedCompletionQueue(async);
 
-  auto mock = absl::make_unique<MockObjectMediaStream>();
+  auto mock = absl::make_unique<MockAsyncObjectMediaStream>();
 
   EXPECT_CALL(*mock, Start).WillRepeatedly([&] {
     return async.PushBack("Start").then([](future<bool> f) { return f.get(); });

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -66,7 +66,7 @@ TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
 
   auto client = GrpcClient::CreateMock(
       mock, Options{}
-                .set<TransferStallTimeoutOption>(std::chrono::seconds(0))
+                .set<DownloadStallTimeoutOption>(std::chrono::seconds(0))
                 .set<GrpcCompletionQueueOption>(cq));
   // Normally the span is created by `storage::Client`, but we bypass that code
   // in this test.
@@ -102,14 +102,15 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
         return stream;
       });
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
-  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
+  EXPECT_CALL(*mock_cq,
+              MakeRelativeTimer(std::chrono::nanoseconds(configured_timeout)))
       .WillOnce(Return(ByMove(make_ready_future(
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
   auto client = GrpcClient::CreateMock(
       mock, Options{}
-                .set<TransferStallTimeoutOption>(configured_timeout)
+                .set<DownloadStallTimeoutOption>(configured_timeout)
                 .set<GrpcCompletionQueueOption>(cq));
   // Normally the span is created by `storage::Client`, but we bypass that code
   // in this test.

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -603,9 +603,8 @@ TEST_F(GrpcClientTest, GetObjectMetadata) {
 
 TEST_F(GrpcClientTest, ReadObject) {
   auto mock = std::make_shared<testing::MockStorageStub>();
-  EXPECT_CALL(*mock, AsyncReadObject)
-      .WillOnce([this](google::cloud::CompletionQueue const&,
-                       std::unique_ptr<grpc::ClientContext> context,
+  EXPECT_CALL(*mock, ReadObject)
+      .WillOnce([this](std::unique_ptr<grpc::ClientContext> context,
                        v2::ReadObjectRequest const& request) {
         auto metadata = GetMetadata(*context);
         EXPECT_THAT(metadata, UnorderedElementsAre(
@@ -613,11 +612,7 @@ TEST_F(GrpcClientTest, ReadObject) {
                                   Pair("x-goog-fieldmask", "field1,field2")));
         EXPECT_THAT(request.bucket(), "projects/_/buckets/test-bucket");
         EXPECT_THAT(request.object(), "test-object");
-        auto stream = absl::make_unique<testing::MockObjectMediaStream>();
-        EXPECT_CALL(*stream, Start)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        return std::unique_ptr<google::cloud::internal::AsyncStreamingReadRpc<
-            google::storage::v2::ReadObjectResponse>>(std::move(stream));
+        return absl::make_unique<testing::MockObjectMediaStream>();
       });
   auto client = CreateTestClient(mock);
   auto stream = client->ReadObject(

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -17,7 +17,9 @@
 
 #include "google/cloud/storage/internal/object_read_source.h"
 #include "google/cloud/storage/version.h"
-#include "google/cloud/internal/async_streaming_read_rpc.h"
+#include "google/cloud/future.h"
+#include "google/cloud/internal/streaming_read_rpc.h"
+#include "absl/functional/function_ref.h"
 #include <google/storage/v2/storage.pb.h>
 #include <functional>
 #include <string>
@@ -40,12 +42,15 @@ namespace internal {
  */
 class GrpcObjectReadSource : public ObjectReadSource {
  public:
-  using StreamingRpc = ::google::cloud::internal::AsyncStreamingReadRpc<
+  using StreamingRpc = ::google::cloud::internal::StreamingReadRpc<
       google::storage::v2::ReadObjectResponse>;
 
-  explicit GrpcObjectReadSource(
-      std::unique_ptr<StreamingRpc> stream,
-      std::chrono::milliseconds download_stall_timeout);
+  // A function to create timers. These should return a future, satisfied with
+  // `false` if the timer was canceled, and with `true` if the timer triggered.
+  using TimerSource = std::function<future<bool>()>;
+
+  explicit GrpcObjectReadSource(TimerSource timer_source,
+                                std::unique_ptr<StreamingRpc> stream);
 
   ~GrpcObjectReadSource() override = default;
 
@@ -58,13 +63,17 @@ class GrpcObjectReadSource : public ObjectReadSource {
   /// codes.
   StatusOr<ReadSourceResult> Read(char* buf, std::size_t n) override;
 
-  std::chrono::milliseconds download_stall_timeout() const {
-    return download_stall_timeout_;
-  }
-
  private:
+  using BufferManager =
+      absl::FunctionRef<std::pair<absl::string_view, std::size_t>(
+          absl::string_view)>;
+
+  void HandleResponse(ReadSourceResult& result,
+                      google::storage::v2::ReadObjectResponse response,
+                      BufferManager buffer_manager);
+
+  TimerSource timer_source_;
   std::unique_ptr<StreamingRpc> stream_;
-  std::chrono::milliseconds download_stall_timeout_;
 
   // In some cases the gRPC response may contain more data than the buffer
   // provided by the application. This buffer stores any excess results.

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -66,7 +66,7 @@ class GrpcObjectReadSource : public ObjectReadSource {
  private:
   using BufferManager =
       absl::FunctionRef<std::pair<absl::string_view, std::size_t>(
-          absl::string_view)>;
+          absl::string_view, std::size_t)>;
 
   void HandleResponse(ReadSourceResult& result,
                       google::storage::v2::ReadObjectResponse response,

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -174,7 +174,17 @@ class MockInsertStream : public google::cloud::internal::AsyncStreamingWriteRpc<
               (), (const, override));
 };
 
-class MockObjectMediaStream
+class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
+                                  google::storage::v2::ReadObjectResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD((absl::variant<Status, google::storage::v2::ReadObjectResponse>),
+              Read, (), (override));
+  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
+              (), (const, override));
+};
+
+class MockAsyncObjectMediaStream
     : public google::cloud::internal::AsyncStreamingReadRpc<
           google::storage::v2::ReadObjectResponse> {
  public:


### PR DESCRIPTION
This changes the implementation of `ReadObject()` to use the blocking
API and a watchdog timer to implement stall timeouts. If the timer
expires before the `Read()` operation completes a background thread
cancels the RPC.  If the operation completes, we cancel the timer.

Part of the work for #9558 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9554)
<!-- Reviewable:end -->
