### PR TITLE
impl: support request metadata for streaming write RPCs

### DIFF
--- a/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
+++ b/generator/integration_tests/golden/mocks/mock_golden_kitchen_sink_stub.h
@@ -134,6 +134,7 @@ public:
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD(bool, Write, (::google::test::admin::database::v1::WriteObjectRequest const&, grpc::WriteOptions), (override));
   MOCK_METHOD(StatusOr<::google::test::admin::database::v1::WriteObjectResponse>, Close, (), (override));
+  MOCK_METHOD(internal::StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 class MockTailLogEntriesAsyncStreamingReadRpc

--- a/google/cloud/internal/streaming_write_rpc.h
+++ b/google/cloud/internal/streaming_write_rpc.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_STREAMING_WRITE_RPC_H
 
+#include "google/cloud/internal/grpc_request_metadata.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <grpcpp/grpcpp.h>
@@ -54,6 +55,17 @@ class StreamingWriteRpc {
 
   /// Half-close the stream and wait for a response.
   virtual StatusOr<ResponseType> Close() = 0;
+
+  /**
+   * Return the request metadata.
+   *
+   * Request metadata is useful for troubleshooting, but may be relatively
+   * expensive to extract.  Library developers should avoid this function in
+   * the critical path.
+   *
+   * @note Only call this function once, and only after `Finish()` completes.
+   */
+  virtual StreamingRpcMetadata GetRequestMetadata() const = 0;
 };
 
 }  // namespace internal

--- a/google/cloud/internal/streaming_write_rpc_impl.h
+++ b/google/cloud/internal/streaming_write_rpc_impl.h
@@ -74,6 +74,10 @@ class StreamingWriteRpcImpl
     return std::move(*response_);
   }
 
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    return GetRequestMetadataFromContext(*context_);
+  }
+
  private:
   Status Finish() {
     auto status = MakeStatusFromRpcError(stream_->Finish());
@@ -109,6 +113,8 @@ class StreamingWriteRpcError
   bool Write(RequestType const&, grpc::WriteOptions) override { return false; }
 
   StatusOr<ResponseType> Close() override { return status_; }
+
+  StreamingRpcMetadata GetRequestMetadata() const override { return {}; }
 
  private:
   Status status_;

--- a/google/cloud/internal/streaming_write_rpc_logging.h
+++ b/google/cloud/internal/streaming_write_rpc_logging.h
@@ -73,6 +73,15 @@ class StreamingWriteRpcLogging
     return result;
   }
 
+  StreamingRpcMetadata GetRequestMetadata() const override {
+    auto prefix = std::string(__func__) + "(" + request_id_ + ")";
+    GCP_LOG(DEBUG) << prefix << " <<";
+    auto metadata = stream_->GetRequestMetadata();
+    GCP_LOG(DEBUG) << prefix << " >> metadata={"
+                   << FormatForLoggingDecorator(metadata) << "}";
+    return metadata;
+  }
+
  private:
   std::unique_ptr<StreamingWriteRpc<RequestType, ResponseType>> stream_;
   TracingOptions tracing_options_;

--- a/google/cloud/internal/streaming_write_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_logging_test.cc
@@ -33,6 +33,7 @@ using ::google::cloud::testing_util::StatusIs;
 using ::testing::AllOf;
 using ::testing::Contains;
 using ::testing::HasSubstr;
+using ::testing::Pair;
 using ::testing::Return;
 
 template <typename RequestType, typename ResponseType>
@@ -44,6 +45,7 @@ class MockStreamingWriteRpc
   MOCK_METHOD(bool, Write, (RequestType const&, grpc::WriteOptions),
               (override));
   MOCK_METHOD(StatusOr<ResponseType>, Close, (), (override));
+  MOCK_METHOD(StreamingRpcMetadata, GetRequestMetadata, (), (const, override));
 };
 
 class StreamingWriteRpcLoggingTest : public ::testing::Test {
@@ -109,6 +111,19 @@ TEST_F(StreamingWriteRpcLoggingTest, CloseWithError) {
                                     HasSubstr("(void)"))));
   EXPECT_THAT(lines, Contains(AllOf(HasSubstr("Close"), HasSubstr("test-id"),
                                     HasSubstr("try-again"))));
+}
+
+TEST_F(StreamingWriteRpcLoggingTest, GetRequestMetadata) {
+  auto mock = absl::make_unique<MockStream>();
+  EXPECT_CALL(*mock, GetRequestMetadata).WillOnce([] {
+    return StreamingRpcMetadata({{":test-only", "value"}});
+  });
+  TestedStream stream(std::move(mock), TracingOptions{}, "test-id");
+  EXPECT_THAT(stream.GetRequestMetadata(),
+              Contains(Pair(":test-only", "value")));
+  EXPECT_THAT(log_.ExtractLines(),
+              Contains(AllOf(HasSubstr("GetRequestMetadata(test-id)"),
+                             HasSubstr("{:test-only: value}"))));
 }
 
 }  // namespace


### PR DESCRIPTION
I will (eventually) need this for GCS+gRPC, so we can troubleshoot
uploads, and we can better evaluate the performance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9557)
<!-- Reviewable:end -->
