### PR TITLE
feat(common): make the RPC log even more readable

### DIFF
--- a/google/cloud/internal/log_wrapper.cc
+++ b/google/cloud/internal/log_wrapper.cc
@@ -45,7 +45,7 @@ class DurationMessagePrinter
     generator->PrintLiteral("\"");
     generator->PrintString(absl::FormatDuration(d));
     generator->PrintLiteral("\"");
-    generator->PrintLiteral(single_line_mode ? " " : "\n");
+    generator->Print(single_line_mode ? " " : "\n", 1);
   }
 };
 
@@ -63,7 +63,7 @@ class TimestampMessagePrinter
     auto t = absl::FromUnixSeconds(seconds) + absl::Nanoseconds(nanos);
     auto constexpr kFormat = "\"%E4Y-%m-%dT%H:%M:%E*SZ\"";
     generator->PrintString(absl::FormatTime(kFormat, t, absl::UTCTimeZone()));
-    generator->PrintLiteral(single_line_mode ? " " : "\n");
+    generator->Print(single_line_mode ? " " : "\n", 1);
   }
 };
 

--- a/google/cloud/internal/log_wrapper_test.cc
+++ b/google/cloud/internal/log_wrapper_test.cc
@@ -17,7 +17,9 @@
 #include "google/cloud/testing_util/scoped_log.h"
 #include "google/cloud/tracing_options.h"
 #include <google/bigtable/v2/bigtable.grpc.pb.h>
+#include <google/protobuf/duration.pb.h>
 #include <google/protobuf/text_format.h>
+#include <google/protobuf/timestamp.pb.h>
 #include <google/rpc/error_details.pb.h>
 #include <google/rpc/status.pb.h>
 #include <google/spanner/v1/mutation.pb.h>
@@ -159,6 +161,27 @@ TEST(LogWrapper, TruncateString) {
   for (auto const& c : cases) {
     EXPECT_EQ(c.expected, DebugString(c.actual, tracing_options));
   }
+}
+
+TEST(LogWrapper, Duration) {
+  google::protobuf::Duration duration;
+  duration.set_seconds((11 * 60 + 22) * 60 + 33);
+  duration.set_nanos(123456789);
+  std::string const expected =
+      R"(google.protobuf.Duration { "11h22m33.123456789s" })";
+  EXPECT_EQ(expected, DebugString(duration, TracingOptions{}.SetOptions(
+                                                "single_line_mode=on")));
+}
+
+TEST(LogWrapper, Timestamp) {
+  google::protobuf::Timestamp timestamp;
+  timestamp.set_seconds(1658470436);
+  timestamp.set_nanos(123456789);
+  std::string const expected = R"(google.protobuf.Timestamp {
+  "2022-07-22T06:13:56.123456789Z"
+})";
+  EXPECT_EQ(expected, DebugString(timestamp, TracingOptions{}.SetOptions(
+                                                 "single_line_mode=off")));
 }
 
 TEST(LogWrapper, FutureStatus) {

--- a/google/cloud/internal/streaming_read_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_read_rpc_logging_test.cc
@@ -85,8 +85,7 @@ TEST_F(StreamingReadRpcLoggingTest, Read) {
   absl::visit(ResultVisitor(), result);
   auto log_lines = log_.ExtractLines();
   EXPECT_THAT(log_lines, Contains(HasSubstr("Read")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr("seconds")));
-  EXPECT_THAT(log_lines, Contains(HasSubstr("42")));
+  EXPECT_THAT(log_lines, Contains(HasSubstr("42s")));
 
   result = reader.Read();
   absl::visit(ResultVisitor(), result);

--- a/google/cloud/internal/streaming_write_rpc_logging_test.cc
+++ b/google/cloud/internal/streaming_write_rpc_logging_test.cc
@@ -76,7 +76,7 @@ TEST_F(StreamingWriteRpcLoggingTest, Write) {
   stream.Write(request, grpc::WriteOptions{});
   auto const lines = log_.ExtractLines();
   EXPECT_THAT(lines, Contains(AllOf(HasSubstr("Write"), HasSubstr("test-id"),
-                                    HasSubstr("123456"))));
+                                    HasSubstr("1970-01-02T10:17:36Z"))));
   EXPECT_THAT(lines, Contains(AllOf(HasSubstr("Write"), HasSubstr("test-id"),
                                     HasSubstr("true"))));
 }
@@ -94,7 +94,7 @@ TEST_F(StreamingWriteRpcLoggingTest, CloseWithSuccess) {
   EXPECT_THAT(lines, Contains(AllOf(HasSubstr("Close"), HasSubstr("test-id"),
                                     HasSubstr("(void)"))));
   EXPECT_THAT(lines, Contains(AllOf(HasSubstr("Close"), HasSubstr("test-id"),
-                                    HasSubstr("123456"))));
+                                    HasSubstr("34h17m36s"))));
 }
 
 TEST_F(StreamingWriteRpcLoggingTest, CloseWithError) {


### PR DESCRIPTION
- Render google.protobuf.Duration and google.protobuf.Timestamp
  fields as descriptive strings rather than as raw numbers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9561)
<!-- Reviewable:end -->
