### PR TITLE
feat(GCS+gRPC): more efficient `InsertObject()` stall timeouts

### DIFF
--- a/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
@@ -28,7 +28,7 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-using ::google::cloud::storage::testing::MockInsertStream;
+using ::google::cloud::storage::testing::MockAsyncInsertStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ByMove;
@@ -45,7 +45,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutStart) {
       .WillOnce([&](google::cloud::CompletionQueue const&,
                     std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
+        auto stream = absl::make_unique<MockAsyncInsertStream>();
         EXPECT_CALL(*stream, Start).WillOnce([&] {
           return hold_response.get_future().then(
               [](future<void>) { return false; });
@@ -79,7 +79,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
       .WillOnce([&](google::cloud::CompletionQueue const&,
                     std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
+        auto stream = absl::make_unique<MockAsyncInsertStream>();
         EXPECT_CALL(*stream, Start)
             .WillOnce(Return(ByMove(make_ready_future(true))));
         EXPECT_CALL(*stream, Write).WillOnce([&] {
@@ -115,7 +115,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
       .WillOnce([&](google::cloud::CompletionQueue const&,
                     std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
+        auto stream = absl::make_unique<MockAsyncInsertStream>();
         EXPECT_CALL(*stream, Start)
             .WillOnce(Return(ByMove(make_ready_future(true))));
         EXPECT_CALL(*stream, Write)
@@ -153,7 +153,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutFinish) {
       .WillOnce([&](google::cloud::CompletionQueue const&,
                     std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockInsertStream>();
+        auto stream = absl::make_unique<MockAsyncInsertStream>();
         EXPECT_CALL(*stream, Start)
             .WillOnce(Return(ByMove(make_ready_future(true))));
         EXPECT_CALL(*stream, Write)

--- a/google/cloud/storage/internal/storage_stub_factory_test.cc
+++ b/google/cloud/storage/internal/storage_stub_factory_test.cc
@@ -30,7 +30,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::storage::testing::MockInsertStream;
+using ::google::cloud::storage::testing::MockAsyncInsertStream;
 using ::google::cloud::storage::testing::MockObjectMediaStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::ScopedLog;
@@ -141,7 +141,7 @@ TEST_F(StorageStubFactory, WriteObject) {
               IsContextMDValid(*context,
                                "google.storage.v2.Storage.WriteObject",
                                google::storage::v2::WriteObjectRequest{});
-              auto stream = absl::make_unique<MockInsertStream>();
+              auto stream = absl::make_unique<MockAsyncInsertStream>();
               EXPECT_CALL(*stream, Start)
                   .WillOnce(Return(ByMove(make_ready_future(true))));
               EXPECT_CALL(*stream, Finish)

--- a/google/cloud/storage/testing/mock_storage_stub.h
+++ b/google/cloud/storage/testing/mock_storage_stub.h
@@ -157,19 +157,17 @@ class MockStorageStub : public storage_internal::StorageStub {
               (override));
 };
 
-class MockInsertStream : public google::cloud::internal::AsyncStreamingWriteRpc<
+class MockInsertStream : public google::cloud::internal::StreamingWriteRpc<
                              google::storage::v2::WriteObjectRequest,
                              google::storage::v2::WriteObjectResponse> {
  public:
   MOCK_METHOD(void, Cancel, (), (override));
-  MOCK_METHOD(future<bool>, Start, (), (override));
-  MOCK_METHOD(future<bool>, Write,
+  MOCK_METHOD(bool, Write,
               (google::storage::v2::WriteObjectRequest const&,
                grpc::WriteOptions),
               (override));
-  MOCK_METHOD(future<bool>, WritesDone, (), (override));
-  MOCK_METHOD(future<StatusOr<google::storage::v2::WriteObjectResponse>>,
-              Finish, (), (override));
+  MOCK_METHOD(StatusOr<google::storage::v2::WriteObjectResponse>, Close, (),
+              (override));
   MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
               (), (const, override));
 };
@@ -180,6 +178,24 @@ class MockObjectMediaStream : public google::cloud::internal::StreamingReadRpc<
   MOCK_METHOD(void, Cancel, (), (override));
   MOCK_METHOD((absl::variant<Status, google::storage::v2::ReadObjectResponse>),
               Read, (), (override));
+  MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
+              (), (const, override));
+};
+
+class MockAsyncInsertStream
+    : public google::cloud::internal::AsyncStreamingWriteRpc<
+          google::storage::v2::WriteObjectRequest,
+          google::storage::v2::WriteObjectResponse> {
+ public:
+  MOCK_METHOD(void, Cancel, (), (override));
+  MOCK_METHOD(future<bool>, Start, (), (override));
+  MOCK_METHOD(future<bool>, Write,
+              (google::storage::v2::WriteObjectRequest const&,
+               grpc::WriteOptions),
+              (override));
+  MOCK_METHOD(future<bool>, WritesDone, (), (override));
+  MOCK_METHOD(future<StatusOr<google::storage::v2::WriteObjectResponse>>,
+              Finish, (), (override));
   MOCK_METHOD(google::cloud::internal::StreamingRpcMetadata, GetRequestMetadata,
               (), (const, override));
 };


### PR DESCRIPTION
This changes the implementation of `InsertObject()` to use the blocking
API and a watchdog timer to implement stall timeouts. If the timer
expires before the `Write()` operation completes a background thread
cancels the RPC.  If the operation completes, we cancel the timer.

Part of the work for #9558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9573)
<!-- Reviewable:end -->
