### PR TITLE
impl(rest): always discard handles via HandleFactory

### DIFF
--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -135,13 +135,13 @@ CurlHandle CurlHandle::MakeFromPool(CurlHandleFactory& factory) {
 void CurlHandle::ReturnToPool(CurlHandleFactory& factory, CurlHandle h) {
   CurlPtr tmp(nullptr, curl_easy_cleanup);
   h.handle_.swap(tmp);
-  factory.CleanupHandle(std::move(tmp), CurlHandleFactory::kKeep);
+  factory.CleanupHandle(std::move(tmp), HandleDisposition::kKeep);
 }
 
 void CurlHandle::DiscardFromPool(CurlHandleFactory& factory, CurlHandle h) {
   CurlPtr tmp(nullptr, curl_easy_cleanup);
   h.handle_.swap(tmp);
-  factory.CleanupHandle(std::move(tmp), CurlHandleFactory::kDiscard);
+  factory.CleanupHandle(std::move(tmp), HandleDisposition::kDiscard);
 }
 
 CurlHandle::CurlHandle() : handle_(MakeCurlPtr()) {

--- a/google/cloud/internal/curl_handle.cc
+++ b/google/cloud/internal/curl_handle.cc
@@ -135,7 +135,13 @@ CurlHandle CurlHandle::MakeFromPool(CurlHandleFactory& factory) {
 void CurlHandle::ReturnToPool(CurlHandleFactory& factory, CurlHandle h) {
   CurlPtr tmp(nullptr, curl_easy_cleanup);
   h.handle_.swap(tmp);
-  factory.CleanupHandle(std::move(tmp));
+  factory.CleanupHandle(std::move(tmp), CurlHandleFactory::kKeep);
+}
+
+void CurlHandle::DiscardFromPool(CurlHandleFactory& factory, CurlHandle h) {
+  CurlPtr tmp(nullptr, curl_easy_cleanup);
+  h.handle_.swap(tmp);
+  factory.CleanupHandle(std::move(tmp), CurlHandleFactory::kDiscard);
 }
 
 CurlHandle::CurlHandle() : handle_(MakeCurlPtr()) {

--- a/google/cloud/internal/curl_handle.h
+++ b/google/cloud/internal/curl_handle.h
@@ -41,6 +41,7 @@ class CurlHandle {
  public:
   static CurlHandle MakeFromPool(CurlHandleFactory& factory);
   static void ReturnToPool(CurlHandleFactory& factory, CurlHandle h);
+  static void DiscardFromPool(CurlHandleFactory& factory, CurlHandle h);
 
   explicit CurlHandle();
   ~CurlHandle();

--- a/google/cloud/internal/curl_handle_factory.cc
+++ b/google/cloud/internal/curl_handle_factory.cc
@@ -116,7 +116,7 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr h, HandleDisposition d) {
     std::unique_lock<std::mutex> lk(last_client_ip_address_mu_);
     last_client_ip_address_ = ip;
   }
-  if (d == kDiscard) return;
+  if (d == HandleDisposition::kDiscard) return;
   // Use a temporary data structure to release any excess handles *after* the
   // lock is released.
   std::vector<CurlPtr> released;
@@ -148,7 +148,7 @@ CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
 
 void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti m,
                                                  HandleDisposition d) {
-  if (!m || d == kDiscard) return;
+  if (!m || d == HandleDisposition::kDiscard) return;
   // Use a temporary data structure to release any excess handles *after* the
   // lock is released.
   std::vector<CurlMulti> released;

--- a/google/cloud/internal/curl_handle_factory.h
+++ b/google/cloud/internal/curl_handle_factory.h
@@ -28,18 +28,18 @@ namespace cloud {
 namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+enum class HandleDisposition {
+  /// The handle was used successfully. preserve it if possible.
+  kKeep,
+  /// The handle was used, but returned an error. Discard it from the pool.
+  kDiscard,
+};
+
 /**
  * Implements the Factory Pattern for CURL handles (and multi-handles).
  */
 class CurlHandleFactory {
  public:
-  enum HandleDisposition : int {
-    /// The handle was used successfully. preserve it if possible.
-    kKeep,
-    /// The handle was used, but returned an error. Discard it from the pool.
-    kDiscard,
-  };
-
   virtual ~CurlHandleFactory() = default;
 
   virtual CurlPtr CreateHandle() = 0;

--- a/google/cloud/internal/curl_handle_factory.h
+++ b/google/cloud/internal/curl_handle_factory.h
@@ -27,18 +27,26 @@ namespace google {
 namespace cloud {
 namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Implements the Factory Pattern for CURL handles (and multi-handles).
  */
 class CurlHandleFactory {
  public:
+  enum HandleDisposition : int {
+    /// The handle was used successfully. preserve it if possible.
+    kKeep,
+    /// The handle was used, but returned an error. Discard it from the pool.
+    kDiscard,
+  };
+
   virtual ~CurlHandleFactory() = default;
 
   virtual CurlPtr CreateHandle() = 0;
-  virtual void CleanupHandle(CurlPtr) = 0;
+  virtual void CleanupHandle(CurlPtr, HandleDisposition) = 0;
 
   virtual CurlMulti CreateMultiHandle() = 0;
-  virtual void CleanupMultiHandle(CurlMulti) = 0;
+  virtual void CleanupMultiHandle(CurlMulti, HandleDisposition) = 0;
 
   virtual std::string LastClientIpAddress() const = 0;
 
@@ -70,10 +78,10 @@ class DefaultCurlHandleFactory : public CurlHandleFactory {
   explicit DefaultCurlHandleFactory(Options const& o);
 
   CurlPtr CreateHandle() override;
-  void CleanupHandle(CurlPtr) override;
+  void CleanupHandle(CurlPtr, HandleDisposition) override;
 
   CurlMulti CreateMultiHandle() override;
-  void CleanupMultiHandle(CurlMulti) override;
+  void CleanupMultiHandle(CurlMulti, HandleDisposition) override;
 
   std::string LastClientIpAddress() const override {
     std::lock_guard<std::mutex> lk(mu_);
@@ -106,10 +114,10 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
   ~PooledCurlHandleFactory() override;
 
   CurlPtr CreateHandle() override;
-  void CleanupHandle(CurlPtr) override;
+  void CleanupHandle(CurlPtr, HandleDisposition) override;
 
   CurlMulti CreateMultiHandle() override;
-  void CleanupMultiHandle(CurlMulti) override;
+  void CleanupMultiHandle(CurlMulti, HandleDisposition) override;
 
   std::string LastClientIpAddress() const override {
     std::lock_guard<std::mutex> lk(last_client_ip_address_mu_);

--- a/google/cloud/internal/curl_handle_factory_benchmark.cc
+++ b/google/cloud/internal/curl_handle_factory_benchmark.cc
@@ -35,8 +35,8 @@ bool CreateAndCleanup(CurlHandleFactory& factory) {
   auto h = factory.CreateHandle();
   auto m = factory.CreateMultiHandle();
   auto const success = h && m;
-  factory.CleanupMultiHandle(std::move(m));
-  factory.CleanupHandle(std::move(h));
+  factory.CleanupMultiHandle(std::move(m), CurlHandleFactory::kKeep);
+  factory.CleanupHandle(std::move(h), CurlHandleFactory::kKeep);
   return success;
 }
 

--- a/google/cloud/internal/curl_handle_factory_benchmark.cc
+++ b/google/cloud/internal/curl_handle_factory_benchmark.cc
@@ -35,8 +35,8 @@ bool CreateAndCleanup(CurlHandleFactory& factory) {
   auto h = factory.CreateHandle();
   auto m = factory.CreateMultiHandle();
   auto const success = h && m;
-  factory.CleanupMultiHandle(std::move(m), CurlHandleFactory::kKeep);
-  factory.CleanupHandle(std::move(h), CurlHandleFactory::kKeep);
+  factory.CleanupMultiHandle(std::move(m), HandleDisposition::kKeep);
+  factory.CleanupHandle(std::move(h), HandleDisposition::kKeep);
   return success;
 }
 

--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -243,7 +243,7 @@ CurlImpl::~CurlImpl() {
 
   if (factory_) {
     CurlHandle::ReturnToPool(*factory_, std::move(handle_));
-    factory_->CleanupMultiHandle(std::move(multi_), CurlHandleFactory::kKeep);
+    factory_->CleanupMultiHandle(std::move(multi_), HandleDisposition::kKeep);
   }
 }
 
@@ -428,7 +428,7 @@ void CurlImpl::OnTransferDone() {
   // reused for any other requests.
   if (factory_) {
     CurlHandle::ReturnToPool(*factory_, std::move(handle_));
-    factory_->CleanupMultiHandle(std::move(multi_), CurlHandleFactory::kKeep);
+    factory_->CleanupMultiHandle(std::move(multi_), HandleDisposition::kKeep);
   }
 }
 
@@ -442,7 +442,7 @@ Status CurlImpl::OnTransferError(Status status) {
     // While the handle is suspect, there is probably nothing wrong with the
     // CURLM* handle, that just represents a local resource, such as data
     // structures for `epoll(7)` or `select(2)`
-    factory_->CleanupMultiHandle(std::move(multi_), CurlHandleFactory::kKeep);
+    factory_->CleanupMultiHandle(std::move(multi_), HandleDisposition::kKeep);
   }
   return status;
 }

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -116,7 +116,8 @@ CurlDownloadRequest::~CurlDownloadRequest() {
   CleanupHandles();
   if (factory_) {
     CurlHandle::ReturnToPool(*factory_, std::move(handle_));
-    factory_->CleanupMultiHandle(std::move(multi_));
+    factory_->CleanupMultiHandle(std::move(multi_),
+                                 rest_internal::CurlHandleFactory::kKeep);
   }
 }
 
@@ -300,7 +301,8 @@ void CurlDownloadRequest::OnTransferDone() {
   // reused for any other requests.
   if (factory_) {
     CurlHandle::ReturnToPool(*factory_, std::move(handle_));
-    factory_->CleanupMultiHandle(std::move(multi_));
+    factory_->CleanupMultiHandle(std::move(multi_),
+                                 rest_internal::CurlHandleFactory::kKeep);
   }
 }
 
@@ -309,12 +311,13 @@ Status CurlDownloadRequest::OnTransferError(Status status) {
   // to an invalid host, a host that is slow and trickling data, or otherwise in
   // a bad state. Release the handle, but do not return it to the pool.
   CleanupHandles();
-  auto handle = std::move(handle_);
   if (factory_) {
+    CurlHandle::DiscardFromPool(*factory_, std::move(handle_));
     // While the handle is suspect, there is probably nothing wrong with the
     // CURLM* handle, that just represents a local resource, such as data
     // structures for `epoll(7)` or `select(2)`
-    factory_->CleanupMultiHandle(std::move(multi_));
+    factory_->CleanupMultiHandle(std::move(multi_),
+                                 rest_internal::CurlHandleFactory::kKeep);
   }
   return status;
 }

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -117,7 +117,7 @@ CurlDownloadRequest::~CurlDownloadRequest() {
   if (factory_) {
     CurlHandle::ReturnToPool(*factory_, std::move(handle_));
     factory_->CleanupMultiHandle(std::move(multi_),
-                                 rest_internal::CurlHandleFactory::kKeep);
+                                 rest_internal::HandleDisposition::kKeep);
   }
 }
 
@@ -302,7 +302,7 @@ void CurlDownloadRequest::OnTransferDone() {
   if (factory_) {
     CurlHandle::ReturnToPool(*factory_, std::move(handle_));
     factory_->CleanupMultiHandle(std::move(multi_),
-                                 rest_internal::CurlHandleFactory::kKeep);
+                                 rest_internal::HandleDisposition::kKeep);
   }
 }
 
@@ -317,7 +317,7 @@ Status CurlDownloadRequest::OnTransferError(Status status) {
     // CURLM* handle, that just represents a local resource, such as data
     // structures for `epoll(7)` or `select(2)`
     factory_->CleanupMultiHandle(std::move(multi_),
-                                 rest_internal::CurlHandleFactory::kKeep);
+                                 rest_internal::HandleDisposition::kKeep);
   }
   return status;
 }

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -136,7 +136,16 @@ void CurlHandle::ReturnToPool(rest_internal::CurlHandleFactory& factory,
                               CurlHandle h) {
   rest_internal::CurlPtr tmp(nullptr, curl_easy_cleanup);
   h.handle_.swap(tmp);
-  factory.CleanupHandle(std::move(tmp));
+  factory.CleanupHandle(std::move(tmp),
+                        rest_internal::CurlHandleFactory::kKeep);
+}
+
+void CurlHandle::DiscardFromPool(rest_internal::CurlHandleFactory& factory,
+                                 CurlHandle h) {
+  rest_internal::CurlPtr tmp(nullptr, curl_easy_cleanup);
+  h.handle_.swap(tmp);
+  factory.CleanupHandle(std::move(tmp),
+                        rest_internal::CurlHandleFactory::kDiscard);
 }
 
 CurlHandle::CurlHandle() : handle_(rest_internal::MakeCurlPtr()) {

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -137,7 +137,7 @@ void CurlHandle::ReturnToPool(rest_internal::CurlHandleFactory& factory,
   rest_internal::CurlPtr tmp(nullptr, curl_easy_cleanup);
   h.handle_.swap(tmp);
   factory.CleanupHandle(std::move(tmp),
-                        rest_internal::CurlHandleFactory::kKeep);
+                        rest_internal::HandleDisposition::kKeep);
 }
 
 void CurlHandle::DiscardFromPool(rest_internal::CurlHandleFactory& factory,
@@ -145,7 +145,7 @@ void CurlHandle::DiscardFromPool(rest_internal::CurlHandleFactory& factory,
   rest_internal::CurlPtr tmp(nullptr, curl_easy_cleanup);
   h.handle_.swap(tmp);
   factory.CleanupHandle(std::move(tmp),
-                        rest_internal::CurlHandleFactory::kDiscard);
+                        rest_internal::HandleDisposition::kDiscard);
 }
 
 CurlHandle::CurlHandle() : handle_(rest_internal::MakeCurlPtr()) {

--- a/google/cloud/storage/internal/curl_handle.h
+++ b/google/cloud/storage/internal/curl_handle.h
@@ -43,6 +43,8 @@ class CurlHandle {
   static CurlHandle MakeFromPool(rest_internal::CurlHandleFactory& factory);
   static void ReturnToPool(rest_internal::CurlHandleFactory& factory,
                            CurlHandle h);
+  static void DiscardFromPool(rest_internal::CurlHandleFactory& factory,
+                              CurlHandle h);
 
   explicit CurlHandle();
   ~CurlHandle();


### PR DESCRIPTION
When a CURL* handle has an error we don't want to return it to the pool.
The error probably indicates a bad server (in the load balancer) or a
bad connection, and it is time to set up a new connection. Previously,
we just discarded the handle, how let the factory do so. In a future
PR we will use this to update counters in the factory, and adjust how
aggressively the pool releases its handles.

Part of the work for #9469

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9575)
<!-- Reviewable:end -->
