### PR TITLE
feat(GCS+gRPC): more efficient `WriteObject()` stall timeouts

### DIFF
--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -18,7 +18,7 @@
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/background_threads.h"
-#include "google/cloud/internal/async_streaming_write_rpc.h"
+#include "google/cloud/internal/streaming_write_rpc.h"
 #include <google/storage/v2/storage.pb.h>
 #include <functional>
 #include <memory>
@@ -56,7 +56,7 @@ class GrpcClient : public RawClient,
 
   ~GrpcClient() override = default;
 
-  using WriteObjectStream = ::google::cloud::internal::AsyncStreamingWriteRpc<
+  using WriteObjectStream = ::google::cloud::internal::StreamingWriteRpc<
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
 

--- a/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
@@ -17,6 +17,7 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/options.h"
 #include "google/cloud/testing_util/is_proto_equal.h"
+#include "google/cloud/testing_util/mock_completion_queue_impl.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "absl/memory/memory.h"
 #include <gmock/gmock.h>
@@ -28,76 +29,42 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-using ::google::cloud::storage::testing::MockAsyncInsertStream;
+using ::google::cloud::storage::testing::MockInsertStream;
 using ::google::cloud::storage::testing::MockStorageStub;
+using ::google::cloud::testing_util::MockCompletionQueueImpl;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::ByMove;
 using ::testing::HasSubstr;
 using ::testing::Return;
 
 /// @verify that stall timeouts are reported correctly.
-TEST(GrpcClientUploadChunkTest, StallTimeoutStart) {
-  // The mock will satisfy this promise when `Cancel()` is called.
-  promise<void> hold_response;
-
-  auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, AsyncWriteObject)
-      .WillOnce([&](google::cloud::CompletionQueue const&,
-                    std::unique_ptr<grpc::ClientContext>) {
-        ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockAsyncInsertStream>();
-        EXPECT_CALL(*stream, Start).WillOnce([&] {
-          return hold_response.get_future().then(
-              [](future<void>) { return false; });
-        });
-        EXPECT_CALL(*stream, Cancel).WillOnce([&] {
-          hold_response.set_value();
-        });
-        EXPECT_CALL(*stream, Finish)
-            .WillOnce(Return(ByMove(make_ready_future(
-                make_status_or(google::storage::v2::WriteObjectResponse{})))));
-        return stream;
-      });
-
-  auto client = GrpcClient::CreateMock(mock);
-  google::cloud::internal::OptionsSpan const span(
-      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
-  auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
-  auto response = client->UploadChunk(UploadChunkRequest(
-      "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
-  EXPECT_THAT(response,
-              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("Start()")));
-}
-
-/// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
-  // The mock will satisfy this promise when `Cancel()` is called.
-  promise<void> hold_response;
-
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, AsyncWriteObject)
-      .WillOnce([&](google::cloud::CompletionQueue const&,
-                    std::unique_ptr<grpc::ClientContext>) {
+  EXPECT_CALL(*mock, WriteObject)
+      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockAsyncInsertStream>();
-        EXPECT_CALL(*stream, Start)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        EXPECT_CALL(*stream, Write).WillOnce([&] {
-          return hold_response.get_future().then(
-              [](future<void>) { return false; });
-        });
-        EXPECT_CALL(*stream, Cancel).WillOnce([&] {
-          hold_response.set_value();
-        });
-        EXPECT_CALL(*stream, Finish)
-            .WillOnce(Return(ByMove(make_ready_future(
-                make_status_or(google::storage::v2::WriteObjectResponse{})))));
+        auto stream = absl::make_unique<MockInsertStream>();
+        EXPECT_CALL(*stream, Cancel).Times(1);
+        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+        EXPECT_CALL(*stream, Close)
+            .WillOnce(Return(
+                make_status_or(google::storage::v2::WriteObjectResponse{})));
         return stream;
       });
 
-  auto client = GrpcClient::CreateMock(mock);
+  auto const expected = std::chrono::seconds(42);
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer(std::chrono::nanoseconds(expected)))
+      .WillOnce(Return(ByMove(make_ready_future(
+          make_status_or(std::chrono::system_clock::now())))));
+  auto cq = CompletionQueue(mock_cq);
+
+  auto client = GrpcClient::CreateMock(
+      mock, Options{}
+                .set<TransferStallTimeoutOption>(expected)
+                .set<GrpcCompletionQueueOption>(cq));
   google::cloud::internal::OptionsSpan const span(
-      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+      Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
@@ -107,35 +74,35 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWrite) {
 
 /// @verify that stall timeouts are reported correctly.
 TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
-  // The mock will satisfy this promise when `Cancel()` is called.
-  promise<void> hold_response;
-
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, AsyncWriteObject)
-      .WillOnce([&](google::cloud::CompletionQueue const&,
-                    std::unique_ptr<grpc::ClientContext>) {
+  EXPECT_CALL(*mock, WriteObject)
+      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockAsyncInsertStream>();
-        EXPECT_CALL(*stream, Start)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        EXPECT_CALL(*stream, Write)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        EXPECT_CALL(*stream, WritesDone).WillOnce([&] {
-          return hold_response.get_future().then(
-              [](future<void>) { return false; });
-        });
-        EXPECT_CALL(*stream, Cancel).WillOnce([&] {
-          hold_response.set_value();
-        });
-        EXPECT_CALL(*stream, Finish)
-            .WillOnce(Return(ByMove(make_ready_future(
-                make_status_or(google::storage::v2::WriteObjectResponse{})))));
+        auto stream = absl::make_unique<MockInsertStream>();
+        EXPECT_CALL(*stream, Write).WillOnce(Return(true));
+        EXPECT_CALL(*stream, Cancel).Times(1);
+        EXPECT_CALL(*stream, Write).WillOnce(Return(false));
+        EXPECT_CALL(*stream, Close)
+            .WillOnce(Return(google::storage::v2::WriteObjectResponse{}));
         return stream;
       });
 
-  auto client = GrpcClient::CreateMock(mock);
+  auto const expected = std::chrono::seconds(42);
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer(std::chrono::nanoseconds(expected)))
+      .WillOnce(Return(ByMove(
+          make_ready_future(StatusOr<std::chrono::system_clock::time_point>(
+              Status{StatusCode::kCancelled, "test-only"})))))
+      .WillOnce(Return(ByMove(make_ready_future(
+          make_status_or(std::chrono::system_clock::now())))));
+  auto cq = CompletionQueue(mock_cq);
+
+  auto client = GrpcClient::CreateMock(
+      mock, Options{}
+                .set<TransferStallTimeoutOption>(expected)
+                .set<GrpcCompletionQueueOption>(cq));
   google::cloud::internal::OptionsSpan const span(
-      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+      Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
@@ -144,41 +111,44 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutWritesDone) {
 }
 
 /// @verify that stall timeouts are reported correctly.
-TEST(GrpcClientUploadChunkTest, StallTimeoutFinish) {
-  // The mock will satisfy this promise when `Cancel()` is called.
-  promise<void> hold_response;
-
+TEST(GrpcClientUploadChunkTest, StallTimeoutClose) {
   auto mock = std::make_shared<MockStorageStub>();
-  EXPECT_CALL(*mock, AsyncWriteObject)
-      .WillOnce([&](google::cloud::CompletionQueue const&,
-                    std::unique_ptr<grpc::ClientContext>) {
+  EXPECT_CALL(*mock, WriteObject)
+      .WillOnce([&](std::unique_ptr<grpc::ClientContext>) {
         ::testing::InSequence sequence;
-        auto stream = absl::make_unique<MockAsyncInsertStream>();
-        EXPECT_CALL(*stream, Start)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        EXPECT_CALL(*stream, Write)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        EXPECT_CALL(*stream, WritesDone)
-            .WillOnce(Return(ByMove(make_ready_future(true))));
-        EXPECT_CALL(*stream, Finish).WillOnce([&] {
-          return hold_response.get_future().then([](future<void>) {
-            return make_status_or(google::storage::v2::WriteObjectResponse{});
-          });
-        });
-        EXPECT_CALL(*stream, Cancel).WillOnce([&] {
-          hold_response.set_value();
-        });
+        auto stream = absl::make_unique<MockInsertStream>();
+        EXPECT_CALL(*stream, Write).Times(2).WillRepeatedly(Return(true));
+        EXPECT_CALL(*stream, Cancel).Times(1);
+        EXPECT_CALL(*stream, Close)
+            .WillOnce(Return(
+                make_status_or(google::storage::v2::WriteObjectResponse{})));
         return stream;
       });
 
-  auto client = GrpcClient::CreateMock(mock);
+  auto const expected = std::chrono::seconds(42);
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  EXPECT_CALL(*mock_cq, MakeRelativeTimer(std::chrono::nanoseconds(expected)))
+      .WillOnce(Return(ByMove(
+          make_ready_future(StatusOr<std::chrono::system_clock::time_point>(
+              Status{StatusCode::kCancelled, "test-only"})))))
+      .WillOnce(Return(ByMove(
+          make_ready_future(StatusOr<std::chrono::system_clock::time_point>(
+              Status{StatusCode::kCancelled, "test-only"})))))
+      .WillOnce(Return(ByMove(make_ready_future(
+          make_status_or(std::chrono::system_clock::now())))));
+  auto cq = CompletionQueue(mock_cq);
+
+  auto client = GrpcClient::CreateMock(
+      mock, Options{}
+                .set<TransferStallTimeoutOption>(expected)
+                .set<GrpcCompletionQueueOption>(cq));
   google::cloud::internal::OptionsSpan const span(
-      Options{}.set<TransferStallTimeoutOption>(std::chrono::seconds(1)));
+      Options{}.set<TransferStallTimeoutOption>(expected));
   auto const payload = std::string(UploadChunkRequest::kChunkSizeQuantum, 'A');
   auto response = client->UploadChunk(UploadChunkRequest(
       "test-only-upload-id", /*offset=*/0, {ConstBuffer{payload}}));
   EXPECT_THAT(response,
-              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("Finish()")));
+              StatusIs(StatusCode::kDeadlineExceeded, HasSubstr("Close()")));
 }
 
 }  // namespace


### PR DESCRIPTION
This changes the implementation of `WriteObject()` to use the blocking
API and a watchdog timer to implement stall timeouts. If the timer
expires before the `Write()` operation completes a background thread
cancels the RPC.  If the operation completes, we cancel the timer.

Fixes #9558

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9576)
<!-- Reviewable:end -->
