### PR TITLE
impl(generator): only apply service default options in one place

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_client.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_client.cc
@@ -17,7 +17,6 @@
 // source: generator/integration_tests/test.proto
 
 #include "generator/integration_tests/golden/golden_kitchen_sink_client.h"
-#include "generator/integration_tests/golden/internal/golden_kitchen_sink_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -25,7 +24,7 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options opts) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(opts), golden_internal::GoldenKitchenSinkDefaultOptions(connection_->options()))) {}
+GoldenKitchenSinkClient::GoldenKitchenSinkClient(std::shared_ptr<GoldenKitchenSinkConnection> connection, Options opts) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(opts), connection_->options())) {}
 GoldenKitchenSinkClient::~GoldenKitchenSinkClient() = default;
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>

--- a/generator/integration_tests/golden/golden_thing_admin_client.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_client.cc
@@ -17,7 +17,6 @@
 // source: generator/integration_tests/test.proto
 
 #include "generator/integration_tests/golden/golden_thing_admin_client.h"
-#include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
 #include <memory>
 #include "generator/integration_tests/golden/golden_thing_admin_options.h"
 #include <thread>
@@ -27,7 +26,7 @@ namespace cloud {
 namespace golden {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options opts) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(opts), golden_internal::GoldenThingAdminDefaultOptions(connection_->options()))) {}
+GoldenThingAdminClient::GoldenThingAdminClient(std::shared_ptr<GoldenThingAdminConnection> connection, Options opts) : connection_(std::move(connection)), options_(internal::MergeOptions(std::move(opts), connection_->options())) {}
 GoldenThingAdminClient::~GoldenThingAdminClient() = default;
 
 StreamRange<google::test::admin::database::v1::Database>

--- a/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
+++ b/generator/integration_tests/golden/internal/golden_kitchen_sink_connection_impl.cc
@@ -38,9 +38,9 @@ GoldenKitchenSinkConnectionImpl::GoldenKitchenSinkConnectionImpl(
     std::shared_ptr<golden_internal::GoldenKitchenSinkStub> stub,
     Options options)
   : background_(std::move(background)), stub_(std::move(stub)),
-    options_(internal::MergeOptions(std::move(options),
-      golden_internal::GoldenKitchenSinkDefaultOptions(
-        GoldenKitchenSinkConnection::options()))) {}
+    options_(internal::MergeOptions(
+        std::move(options),
+        GoldenKitchenSinkConnection::options())) {}
 
 StatusOr<google::test::admin::database::v1::GenerateAccessTokenResponse>
 GoldenKitchenSinkConnectionImpl::GenerateAccessToken(google::test::admin::database::v1::GenerateAccessTokenRequest const& request) {

--- a/generator/integration_tests/golden/internal/golden_thing_admin_connection_impl.cc
+++ b/generator/integration_tests/golden/internal/golden_thing_admin_connection_impl.cc
@@ -37,9 +37,9 @@ GoldenThingAdminConnectionImpl::GoldenThingAdminConnectionImpl(
     std::shared_ptr<golden_internal::GoldenThingAdminStub> stub,
     Options options)
   : background_(std::move(background)), stub_(std::move(stub)),
-    options_(internal::MergeOptions(std::move(options),
-      golden_internal::GoldenThingAdminDefaultOptions(
-        GoldenThingAdminConnection::options()))) {}
+    options_(internal::MergeOptions(
+        std::move(options),
+        GoldenThingAdminConnection::options())) {}
 
 StreamRange<google::test::admin::database::v1::Database>
 GoldenThingAdminConnectionImpl::ListDatabases(google::test::admin::database::v1::ListDatabasesRequest request) {

--- a/generator/integration_tests/golden/tests/golden_thing_admin_client_test.cc
+++ b/generator/integration_tests/golden/tests/golden_thing_admin_client_test.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/testing_util/is_proto_equal.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include "generator/integration_tests/golden/golden_thing_admin_options.h"
+#include "generator/integration_tests/golden/internal/golden_thing_admin_option_defaults.h"
 #include "generator/integration_tests/golden/mocks/mock_golden_thing_admin_connection.h"
 #include <google/iam/v1/policy.pb.h>
 #include <google/protobuf/util/field_mask_util.h>
@@ -42,7 +43,13 @@ using ::testing::Not;
 
 TEST(GoldenThingAdminClientTest, CopyMoveEquality) {
   auto conn1 = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
+  EXPECT_CALL(*conn1, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   auto conn2 = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
+  EXPECT_CALL(*conn2, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
 
   GoldenThingAdminClient c1(conn1);
   GoldenThingAdminClient c2(conn2);
@@ -240,6 +247,9 @@ TEST(GoldenThingAdminClientTest, UpdateDatabase) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, UpdateDatabaseDdl)
       .Times(2)
       .WillRepeatedly([expected_database](
@@ -272,6 +282,9 @@ TEST(GoldenThingAdminClientTest, DropDatabase) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, DropDatabase)
       .Times(2)
       .WillRepeatedly(
@@ -294,6 +307,9 @@ TEST(GoldenThingAdminClientTest, GetDatabaseDdl) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetDatabaseDdl)
       .Times(2)
       .WillRepeatedly([expected_database](::google::test::admin::database::v1::
@@ -320,6 +336,9 @@ TEST(GoldenThingAdminClientTest, SetIamPolicy) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, SetIamPolicy)
       .Times(2)
       .WillRepeatedly(
@@ -345,11 +364,12 @@ TEST(GoldenThingAdminClientTest, SetIamPolicyUpdater) {
   std::string etag_old = "\007\005\313\113\361\351\232\005";
   std::string etag_new = "\007\005\313\113\366\143\244\343";
   EXPECT_CALL(*mock, options).WillRepeatedly([] {
-    return Options{}
-        .set<GrpcTracingOptionsOption>(
-            TracingOptions().SetOptions("truncate_string_field_longer_than=64"))
-        .set<EndpointOption>("override-me")
-        .set<UserAgentProductsOption>({"override-me"});
+    return golden_internal::GoldenThingAdminDefaultOptions(
+        Options{}
+            .set<GrpcTracingOptionsOption>(TracingOptions().SetOptions(
+                "truncate_string_field_longer_than=64"))
+            .set<EndpointOption>("override-me")
+            .set<UserAgentProductsOption>({"override-me"}));
   });
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([expected_database,
@@ -407,6 +427,9 @@ TEST(GoldenThingAdminClientTest, SetIamPolicyUpdaterGetFailure) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce(
           [expected_database](::google::iam::v1::GetIamPolicyRequest const& r) {
@@ -429,6 +452,9 @@ TEST(GoldenThingAdminClientTest, SetIamPolicyUpdaterCancelled) {
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
   std::string etag_old = "\007\005\313\113\374\306\126\007";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([expected_database,
                  etag_old](::google::iam::v1::GetIamPolicyRequest const& r) {
@@ -452,6 +478,9 @@ TEST(GoldenThingAdminClientTest, SetIamPolicyUpdaterSetFailure) {
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
   std::string etag_old = "\007\005\313\113\377\272\224\367";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([expected_database,
                  etag_old](::google::iam::v1::GetIamPolicyRequest const& r) {
@@ -485,6 +514,9 @@ TEST(GoldenThingAdminClientTest, SetIamPolicyUpdaterRerun) {
   std::string etag_old = "\007\005\313\114\002\240\006\225";
   std::string etag_new = "\007\005\313\114\005\046\113\243";
   std::string etag_rerun = "\007\005\313\114\007\252\023\045";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetIamPolicy)
       .WillOnce([expected_database,
                  etag_old](::google::iam::v1::GetIamPolicyRequest const& r) {
@@ -537,6 +569,9 @@ TEST(GoldenThingAdminClientTest, GetIamPolicy) {
       "/projects/test-project/instances/test-instance/databases/test-db";
   std::string const expected_role = "roles/spanner.databaseReader";
   std::string const expected_member = "user:foobar@example.com";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetIamPolicy)
       .Times(2)
       .WillRepeatedly([expected_database, expected_role, expected_member](
@@ -570,6 +605,9 @@ TEST(GoldenThingAdminClientTest, TestIamPermissions) {
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
   std::string expected_permission = "spanner.databases.read";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, TestIamPermissions)
       .Times(2)
       .WillRepeatedly(
@@ -608,6 +646,9 @@ TEST(GoldenThingAdminClientTest, CreateBackup) {
       "/projects/test-project/instances/test-instance/backups/test-backup";
   std::chrono::system_clock::time_point expire_time =
       std::chrono::system_clock::now() + std::chrono::hours(7);
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, CreateBackup)
       .Times(2)
       .WillRepeatedly(
@@ -652,6 +693,9 @@ TEST(GoldenThingAdminClientTest, GetBackup) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_backup_name =
       "/projects/test-project/instances/test-instance/backups/test-backup";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, GetBackup)
       .Times(2)
       .WillRepeatedly(
@@ -687,6 +731,9 @@ TEST(GoldenThingAdminClientTest, UpdateBackupExpireTime) {
       std::chrono::system_clock::now() + std::chrono::hours(7);
   auto proto_expire_time =
       google::cloud::internal::ToProtoTimestamp(expire_time);
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, UpdateBackup)
       .Times(2)
       .WillRepeatedly(
@@ -733,6 +780,9 @@ TEST(GoldenThingAdminClientTest, DeleteBackup) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_backup_name =
       "/projects/test-project/instances/test-instance/backups/test-backup";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, DeleteBackup)
       .Times(2)
       .WillRepeatedly(
@@ -755,6 +805,9 @@ TEST(GoldenThingAdminClientTest, ListBackups) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_instance =
       "/projects/test-project/instances/test-instance";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, ListBackups)
       .Times(2)
       .WillRepeatedly([expected_instance](::google::test::admin::database::v1::
@@ -794,6 +847,9 @@ TEST(GoldenThingAdminClientTest, RestoreDatabase) {
       "/projects/test-project/instances/test-instance/databases/test-db";
   std::string expected_backup_name =
       "/projects/test-project/instances/test-instance/backups/test-backup";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, RestoreDatabase)
       .Times(2)
       .WillRepeatedly([expected_backup_name, expected_database,
@@ -834,6 +890,9 @@ TEST(GoldenThingAdminClientTest, ListDatabaseOperations) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_instance =
       "/projects/test-project/instances/test-instance";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, ListDatabaseOperations)
       .Times(2)
       .WillRepeatedly(
@@ -872,6 +931,9 @@ TEST(GoldenThingAdminClientTest, ListBackupOperations) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_instance =
       "/projects/test-project/instances/test-instance";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, ListBackupOperations)
       .Times(2)
       .WillRepeatedly([expected_instance](
@@ -958,6 +1020,9 @@ TEST(GoldenThingAdminClientTest, AsyncDropDatabase) {
   auto mock = std::make_shared<golden_mocks::MockGoldenThingAdminConnection>();
   std::string expected_database =
       "/projects/test-project/instances/test-instance/databases/test-db";
+  EXPECT_CALL(*mock, options).WillRepeatedly([] {
+    return golden_internal::GoldenThingAdminDefaultOptions(Options{});
+  });
   EXPECT_CALL(*mock, AsyncDropDatabase)
       .Times(2)
       .WillRepeatedly(

--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -342,8 +342,7 @@ Status ClientGenerator::GenerateCc() {
 
   // includes
   CcPrint("\n");
-  CcLocalIncludes(
-      {vars("client_header_path"), vars("option_defaults_header_path")});
+  CcLocalIncludes({vars("client_header_path")});
   CcSystemIncludes({"memory"});
   if (get_iam_policy_extension_ && set_iam_policy_extension_) {
     CcLocalIncludes({vars("options_header_path")});
@@ -358,7 +357,7 @@ Status ClientGenerator::GenerateCc() {
     "$client_class_name$::$client_class_name$(std::shared_ptr<$connection_class_name$> connection, Options opts)"
     " : connection_(std::move(connection)),"
     " options_(internal::MergeOptions(std::move(opts),"
-    " $product_internal_namespace$::$service_name$DefaultOptions(connection_->options()))) {}\n");
+    " connection_->options())) {}\n");
   // clang-format on
 
   CcPrint(  // clang-format off

--- a/generator/internal/connection_impl_generator.cc
+++ b/generator/internal/connection_impl_generator.cc
@@ -114,8 +114,7 @@ class $connection_class_name$Impl
   // `CurrentOptions()` may not have the service default options because we
   // could be running in a test that calls the ConnectionImpl layer directly,
   // and it does not create an `internal::OptionsSpan` like the Client layer.
-  // So, we have to fallback to `options_`, which we know has the service
-  // default options because we added them.
+  // So, we have to fallback to `options_`.
   HeaderPrint(R"""(
  private:
   std::unique_ptr<$product_namespace$::$retry_policy_name$> retry_policy() {
@@ -209,9 +208,9 @@ $connection_class_name$Impl::$connection_class_name$Impl(
     std::shared_ptr<$product_internal_namespace$::$stub_class_name$> stub,
     Options options)
   : background_(std::move(background)), stub_(std::move(stub)),
-    options_(internal::MergeOptions(std::move(options),
-      $product_internal_namespace$::$service_name$DefaultOptions(
-        $connection_class_name$::options()))) {}
+    options_(internal::MergeOptions(
+        std::move(options),
+        $connection_class_name$::options())) {}
 )""");
 
   for (auto const& method : methods()) {

--- a/google/cloud/accessapproval/access_approval_client.cc
+++ b/google/cloud/accessapproval/access_approval_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/accessapproval/v1/accessapproval.proto
 
 #include "google/cloud/accessapproval/access_approval_client.h"
-#include "google/cloud/accessapproval/internal/access_approval_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AccessApprovalClient::AccessApprovalClient(
     std::shared_ptr<AccessApprovalConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          accessapproval_internal::AccessApprovalDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AccessApprovalClient::~AccessApprovalClient() = default;
 
 StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>

--- a/google/cloud/accessapproval/internal/access_approval_connection_impl.cc
+++ b/google/cloud/accessapproval/internal/access_approval_connection_impl.cc
@@ -36,10 +36,8 @@ AccessApprovalConnectionImpl::AccessApprovalConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          accessapproval_internal::AccessApprovalDefaultOptions(
-              AccessApprovalConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      AccessApprovalConnection::options())) {}
 
 StreamRange<google::cloud::accessapproval::v1::ApprovalRequest>
 AccessApprovalConnectionImpl::ListApprovalRequests(

--- a/google/cloud/accesscontextmanager/access_context_manager_client.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_client.cc
@@ -17,7 +17,6 @@
 // source: google/identity/accesscontextmanager/v1/access_context_manager.proto
 
 #include "google/cloud/accesscontextmanager/access_context_manager_client.h"
-#include "google/cloud/accesscontextmanager/internal/access_context_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AccessContextManagerClient::AccessContextManagerClient(
     std::shared_ptr<AccessContextManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          accesscontextmanager_internal::AccessContextManagerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AccessContextManagerClient::~AccessContextManagerClient() = default;
 
 StreamRange<google::identity::accesscontextmanager::v1::AccessPolicy>

--- a/google/cloud/accesscontextmanager/internal/access_context_manager_connection_impl.cc
+++ b/google/cloud/accesscontextmanager/internal/access_context_manager_connection_impl.cc
@@ -39,9 +39,7 @@ AccessContextManagerConnectionImpl::AccessContextManagerConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          accesscontextmanager_internal::AccessContextManagerDefaultOptions(
-              AccessContextManagerConnection::options()))) {}
+          std::move(options), AccessContextManagerConnection::options())) {}
 
 StreamRange<google::identity::accesscontextmanager::v1::AccessPolicy>
 AccessContextManagerConnectionImpl::ListAccessPolicies(

--- a/google/cloud/apigateway/api_gateway_client.cc
+++ b/google/cloud/apigateway/api_gateway_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/apigateway/v1/apigateway_service.proto
 
 #include "google/cloud/apigateway/api_gateway_client.h"
-#include "google/cloud/apigateway/internal/api_gateway_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ApiGatewayServiceClient::ApiGatewayServiceClient(
     std::shared_ptr<ApiGatewayServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), apigateway_internal::ApiGatewayServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ApiGatewayServiceClient::~ApiGatewayServiceClient() = default;
 
 StreamRange<google::cloud::apigateway::v1::Gateway>

--- a/google/cloud/apigateway/internal/api_gateway_connection_impl.cc
+++ b/google/cloud/apigateway/internal/api_gateway_connection_impl.cc
@@ -38,9 +38,7 @@ ApiGatewayServiceConnectionImpl::ApiGatewayServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          apigateway_internal::ApiGatewayServiceDefaultOptions(
-              ApiGatewayServiceConnection::options()))) {}
+          std::move(options), ApiGatewayServiceConnection::options())) {}
 
 StreamRange<google::cloud::apigateway::v1::Gateway>
 ApiGatewayServiceConnectionImpl::ListGateways(

--- a/google/cloud/apigeeconnect/connection_client.cc
+++ b/google/cloud/apigeeconnect/connection_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/apigeeconnect/v1/connection.proto
 
 #include "google/cloud/apigeeconnect/connection_client.h"
-#include "google/cloud/apigeeconnect/internal/connection_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConnectionServiceClient::ConnectionServiceClient(
     std::shared_ptr<ConnectionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          apigeeconnect_internal::ConnectionServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ConnectionServiceClient::~ConnectionServiceClient() = default;
 
 StreamRange<google::cloud::apigeeconnect::v1::Connection>

--- a/google/cloud/apigeeconnect/internal/connection_connection_impl.cc
+++ b/google/cloud/apigeeconnect/internal/connection_connection_impl.cc
@@ -37,9 +37,7 @@ ConnectionServiceConnectionImpl::ConnectionServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          apigeeconnect_internal::ConnectionServiceDefaultOptions(
-              ConnectionServiceConnection::options()))) {}
+          std::move(options), ConnectionServiceConnection::options())) {}
 
 StreamRange<google::cloud::apigeeconnect::v1::Connection>
 ConnectionServiceConnectionImpl::ListConnections(

--- a/google/cloud/appengine/applications_client.cc
+++ b/google/cloud/appengine/applications_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/applications_client.h"
-#include "google/cloud/appengine/internal/applications_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ApplicationsClient::ApplicationsClient(
     std::shared_ptr<ApplicationsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), appengine_internal::ApplicationsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ApplicationsClient::~ApplicationsClient() = default;
 
 StatusOr<google::appengine::v1::Application> ApplicationsClient::GetApplication(

--- a/google/cloud/appengine/authorized_certificates_client.cc
+++ b/google/cloud/appengine/authorized_certificates_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/authorized_certificates_client.h"
-#include "google/cloud/appengine/internal/authorized_certificates_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AuthorizedCertificatesClient::AuthorizedCertificatesClient(
     std::shared_ptr<AuthorizedCertificatesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          appengine_internal::AuthorizedCertificatesDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AuthorizedCertificatesClient::~AuthorizedCertificatesClient() = default;
 
 StreamRange<google::appengine::v1::AuthorizedCertificate>

--- a/google/cloud/appengine/authorized_domains_client.cc
+++ b/google/cloud/appengine/authorized_domains_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/authorized_domains_client.h"
-#include "google/cloud/appengine/internal/authorized_domains_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AuthorizedDomainsClient::AuthorizedDomainsClient(
     std::shared_ptr<AuthorizedDomainsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), appengine_internal::AuthorizedDomainsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AuthorizedDomainsClient::~AuthorizedDomainsClient() = default;
 
 StreamRange<google::appengine::v1::AuthorizedDomain>

--- a/google/cloud/appengine/domain_mappings_client.cc
+++ b/google/cloud/appengine/domain_mappings_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/domain_mappings_client.h"
-#include "google/cloud/appengine/internal/domain_mappings_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DomainMappingsClient::DomainMappingsClient(
     std::shared_ptr<DomainMappingsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), appengine_internal::DomainMappingsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DomainMappingsClient::~DomainMappingsClient() = default;
 
 StreamRange<google::appengine::v1::DomainMapping>

--- a/google/cloud/appengine/firewall_client.cc
+++ b/google/cloud/appengine/firewall_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/firewall_client.h"
-#include "google/cloud/appengine/internal/firewall_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 FirewallClient::FirewallClient(std::shared_ptr<FirewallConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          appengine_internal::FirewallDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 FirewallClient::~FirewallClient() = default;
 
 StreamRange<google::appengine::v1::FirewallRule>

--- a/google/cloud/appengine/instances_client.cc
+++ b/google/cloud/appengine/instances_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/instances_client.h"
-#include "google/cloud/appengine/internal/instances_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 InstancesClient::InstancesClient(
     std::shared_ptr<InstancesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), appengine_internal::InstancesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 InstancesClient::~InstancesClient() = default;
 
 StreamRange<google::appengine::v1::Instance> InstancesClient::ListInstances(

--- a/google/cloud/appengine/internal/applications_connection_impl.cc
+++ b/google/cloud/appengine/internal/applications_connection_impl.cc
@@ -35,9 +35,8 @@ ApplicationsConnectionImpl::ApplicationsConnectionImpl(
     std::shared_ptr<appengine_internal::ApplicationsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), appengine_internal::ApplicationsDefaultOptions(
-                                  ApplicationsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ApplicationsConnection::options())) {}
 
 StatusOr<google::appengine::v1::Application>
 ApplicationsConnectionImpl::GetApplication(

--- a/google/cloud/appengine/internal/authorized_certificates_connection_impl.cc
+++ b/google/cloud/appengine/internal/authorized_certificates_connection_impl.cc
@@ -37,9 +37,7 @@ AuthorizedCertificatesConnectionImpl::AuthorizedCertificatesConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          appengine_internal::AuthorizedCertificatesDefaultOptions(
-              AuthorizedCertificatesConnection::options()))) {}
+          std::move(options), AuthorizedCertificatesConnection::options())) {}
 
 StreamRange<google::appengine::v1::AuthorizedCertificate>
 AuthorizedCertificatesConnectionImpl::ListAuthorizedCertificates(

--- a/google/cloud/appengine/internal/authorized_domains_connection_impl.cc
+++ b/google/cloud/appengine/internal/authorized_domains_connection_impl.cc
@@ -37,9 +37,7 @@ AuthorizedDomainsConnectionImpl::AuthorizedDomainsConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          appengine_internal::AuthorizedDomainsDefaultOptions(
-              AuthorizedDomainsConnection::options()))) {}
+          std::move(options), AuthorizedDomainsConnection::options())) {}
 
 StreamRange<google::appengine::v1::AuthorizedDomain>
 AuthorizedDomainsConnectionImpl::ListAuthorizedDomains(

--- a/google/cloud/appengine/internal/domain_mappings_connection_impl.cc
+++ b/google/cloud/appengine/internal/domain_mappings_connection_impl.cc
@@ -37,9 +37,8 @@ DomainMappingsConnectionImpl::DomainMappingsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), appengine_internal::DomainMappingsDefaultOptions(
-                                  DomainMappingsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DomainMappingsConnection::options())) {}
 
 StreamRange<google::appengine::v1::DomainMapping>
 DomainMappingsConnectionImpl::ListDomainMappings(

--- a/google/cloud/appengine/internal/firewall_connection_impl.cc
+++ b/google/cloud/appengine/internal/firewall_connection_impl.cc
@@ -35,9 +35,8 @@ FirewallConnectionImpl::FirewallConnectionImpl(
     std::shared_ptr<appengine_internal::FirewallStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), appengine_internal::FirewallDefaultOptions(
-                                  FirewallConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      FirewallConnection::options())) {}
 
 StreamRange<google::appengine::v1::FirewallRule>
 FirewallConnectionImpl::ListIngressRules(

--- a/google/cloud/appengine/internal/instances_connection_impl.cc
+++ b/google/cloud/appengine/internal/instances_connection_impl.cc
@@ -36,9 +36,8 @@ InstancesConnectionImpl::InstancesConnectionImpl(
     std::shared_ptr<appengine_internal::InstancesStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), appengine_internal::InstancesDefaultOptions(
-                                  InstancesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      InstancesConnection::options())) {}
 
 StreamRange<google::appengine::v1::Instance>
 InstancesConnectionImpl::ListInstances(

--- a/google/cloud/appengine/internal/services_connection_impl.cc
+++ b/google/cloud/appengine/internal/services_connection_impl.cc
@@ -36,9 +36,8 @@ ServicesConnectionImpl::ServicesConnectionImpl(
     std::shared_ptr<appengine_internal::ServicesStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), appengine_internal::ServicesDefaultOptions(
-                                  ServicesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ServicesConnection::options())) {}
 
 StreamRange<google::appengine::v1::Service>
 ServicesConnectionImpl::ListServices(

--- a/google/cloud/appengine/internal/versions_connection_impl.cc
+++ b/google/cloud/appengine/internal/versions_connection_impl.cc
@@ -36,9 +36,8 @@ VersionsConnectionImpl::VersionsConnectionImpl(
     std::shared_ptr<appengine_internal::VersionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), appengine_internal::VersionsDefaultOptions(
-                                  VersionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      VersionsConnection::options())) {}
 
 StreamRange<google::appengine::v1::Version>
 VersionsConnectionImpl::ListVersions(

--- a/google/cloud/appengine/services_client.cc
+++ b/google/cloud/appengine/services_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/services_client.h"
-#include "google/cloud/appengine/internal/services_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ServicesClient::ServicesClient(std::shared_ptr<ServicesConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          appengine_internal::ServicesDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ServicesClient::~ServicesClient() = default;
 
 StreamRange<google::appengine::v1::Service> ServicesClient::ListServices(

--- a/google/cloud/appengine/versions_client.cc
+++ b/google/cloud/appengine/versions_client.cc
@@ -17,7 +17,6 @@
 // source: google/appengine/v1/appengine.proto
 
 #include "google/cloud/appengine/versions_client.h"
-#include "google/cloud/appengine/internal/versions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VersionsClient::VersionsClient(std::shared_ptr<VersionsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          appengine_internal::VersionsDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VersionsClient::~VersionsClient() = default;
 
 StreamRange<google::appengine::v1::Version> VersionsClient::ListVersions(

--- a/google/cloud/artifactregistry/artifact_registry_client.cc
+++ b/google/cloud/artifactregistry/artifact_registry_client.cc
@@ -17,7 +17,6 @@
 // source: google/devtools/artifactregistry/v1/service.proto
 
 #include "google/cloud/artifactregistry/artifact_registry_client.h"
-#include "google/cloud/artifactregistry/internal/artifact_registry_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ArtifactRegistryClient::ArtifactRegistryClient(
     std::shared_ptr<ArtifactRegistryConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          artifactregistry_internal::ArtifactRegistryDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ArtifactRegistryClient::~ArtifactRegistryClient() = default;
 
 StreamRange<google::devtools::artifactregistry::v1::DockerImage>

--- a/google/cloud/artifactregistry/internal/artifact_registry_connection_impl.cc
+++ b/google/cloud/artifactregistry/internal/artifact_registry_connection_impl.cc
@@ -37,10 +37,8 @@ ArtifactRegistryConnectionImpl::ArtifactRegistryConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          artifactregistry_internal::ArtifactRegistryDefaultOptions(
-              ArtifactRegistryConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ArtifactRegistryConnection::options())) {}
 
 StreamRange<google::devtools::artifactregistry::v1::DockerImage>
 ArtifactRegistryConnectionImpl::ListDockerImages(

--- a/google/cloud/asset/asset_client.cc
+++ b/google/cloud/asset/asset_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/asset/v1/asset_service.proto
 
 #include "google/cloud/asset/asset_client.h"
-#include "google/cloud/asset/internal/asset_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AssetServiceClient::AssetServiceClient(
     std::shared_ptr<AssetServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          asset_internal::AssetServiceDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AssetServiceClient::~AssetServiceClient() = default;
 
 future<StatusOr<google::cloud::asset::v1::ExportAssetsResponse>>

--- a/google/cloud/asset/internal/asset_connection_impl.cc
+++ b/google/cloud/asset/internal/asset_connection_impl.cc
@@ -36,9 +36,8 @@ AssetServiceConnectionImpl::AssetServiceConnectionImpl(
     std::shared_ptr<asset_internal::AssetServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), asset_internal::AssetServiceDefaultOptions(
-                                  AssetServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      AssetServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::asset::v1::ExportAssetsResponse>>
 AssetServiceConnectionImpl::ExportAssets(

--- a/google/cloud/assuredworkloads/assured_workloads_client.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/assuredworkloads/v1/assuredworkloads.proto
 
 #include "google/cloud/assuredworkloads/assured_workloads_client.h"
-#include "google/cloud/assuredworkloads/internal/assured_workloads_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AssuredWorkloadsServiceClient::AssuredWorkloadsServiceClient(
     std::shared_ptr<AssuredWorkloadsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          assuredworkloads_internal::AssuredWorkloadsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AssuredWorkloadsServiceClient::~AssuredWorkloadsServiceClient() = default;
 
 future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>

--- a/google/cloud/assuredworkloads/internal/assured_workloads_connection_impl.cc
+++ b/google/cloud/assuredworkloads/internal/assured_workloads_connection_impl.cc
@@ -39,9 +39,7 @@ AssuredWorkloadsServiceConnectionImpl::AssuredWorkloadsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          assuredworkloads_internal::AssuredWorkloadsServiceDefaultOptions(
-              AssuredWorkloadsServiceConnection::options()))) {}
+          std::move(options), AssuredWorkloadsServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::assuredworkloads::v1::Workload>>
 AssuredWorkloadsServiceConnectionImpl::CreateWorkload(

--- a/google/cloud/automl/auto_ml_client.cc
+++ b/google/cloud/automl/auto_ml_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/automl/v1/service.proto
 
 #include "google/cloud/automl/auto_ml_client.h"
-#include "google/cloud/automl/internal/auto_ml_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AutoMlClient::AutoMlClient(std::shared_ptr<AutoMlConnection> connection,
                            Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          automl_internal::AutoMlDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AutoMlClient::~AutoMlClient() = default;
 
 future<StatusOr<google::cloud::automl::v1::Dataset>>

--- a/google/cloud/automl/internal/auto_ml_connection_impl.cc
+++ b/google/cloud/automl/internal/auto_ml_connection_impl.cc
@@ -36,10 +36,8 @@ AutoMlConnectionImpl::AutoMlConnectionImpl(
     std::shared_ptr<automl_internal::AutoMlStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          automl_internal::AutoMlDefaultOptions(AutoMlConnection::options()))) {
-}
+      options_(internal::MergeOptions(std::move(options),
+                                      AutoMlConnection::options())) {}
 
 future<StatusOr<google::cloud::automl::v1::Dataset>>
 AutoMlConnectionImpl::CreateDataset(

--- a/google/cloud/automl/internal/prediction_connection_impl.cc
+++ b/google/cloud/automl/internal/prediction_connection_impl.cc
@@ -37,8 +37,7 @@ PredictionServiceConnectionImpl::PredictionServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), automl_internal::PredictionServiceDefaultOptions(
-                                  PredictionServiceConnection::options()))) {}
+          std::move(options), PredictionServiceConnection::options())) {}
 
 StatusOr<google::cloud::automl::v1::PredictResponse>
 PredictionServiceConnectionImpl::Predict(

--- a/google/cloud/automl/prediction_client.cc
+++ b/google/cloud/automl/prediction_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/automl/v1/prediction_service.proto
 
 #include "google/cloud/automl/prediction_client.h"
-#include "google/cloud/automl/internal/prediction_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 PredictionServiceClient::PredictionServiceClient(
     std::shared_ptr<PredictionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), automl_internal::PredictionServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 PredictionServiceClient::~PredictionServiceClient() = default;
 
 StatusOr<google::cloud::automl::v1::PredictResponse>

--- a/google/cloud/baremetalsolution/bare_metal_solution_client.cc
+++ b/google/cloud/baremetalsolution/bare_metal_solution_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/baremetalsolution/v2/baremetalsolution.proto
 
 #include "google/cloud/baremetalsolution/bare_metal_solution_client.h"
-#include "google/cloud/baremetalsolution/internal/bare_metal_solution_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BareMetalSolutionClient::BareMetalSolutionClient(
     std::shared_ptr<BareMetalSolutionConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          baremetalsolution_internal::BareMetalSolutionDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BareMetalSolutionClient::~BareMetalSolutionClient() = default;
 
 StreamRange<google::cloud::baremetalsolution::v2::Instance>

--- a/google/cloud/baremetalsolution/internal/bare_metal_solution_connection_impl.cc
+++ b/google/cloud/baremetalsolution/internal/bare_metal_solution_connection_impl.cc
@@ -38,9 +38,7 @@ BareMetalSolutionConnectionImpl::BareMetalSolutionConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          baremetalsolution_internal::BareMetalSolutionDefaultOptions(
-              BareMetalSolutionConnection::options()))) {}
+          std::move(options), BareMetalSolutionConnection::options())) {}
 
 StreamRange<google::cloud::baremetalsolution::v2::Instance>
 BareMetalSolutionConnectionImpl::ListInstances(

--- a/google/cloud/batch/batch_client.cc
+++ b/google/cloud/batch/batch_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/batch/v1/batch.proto
 
 #include "google/cloud/batch/batch_client.h"
-#include "google/cloud/batch/internal/batch_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BatchServiceClient::BatchServiceClient(
     std::shared_ptr<BatchServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          batch_internal::BatchServiceDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BatchServiceClient::~BatchServiceClient() = default;
 
 StatusOr<google::cloud::batch::v1::Job> BatchServiceClient::CreateJob(

--- a/google/cloud/batch/internal/batch_connection_impl.cc
+++ b/google/cloud/batch/internal/batch_connection_impl.cc
@@ -36,9 +36,8 @@ BatchServiceConnectionImpl::BatchServiceConnectionImpl(
     std::shared_ptr<batch_internal::BatchServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), batch_internal::BatchServiceDefaultOptions(
-                                  BatchServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      BatchServiceConnection::options())) {}
 
 StatusOr<google::cloud::batch::v1::Job> BatchServiceConnectionImpl::CreateJob(
     google::cloud::batch::v1::CreateJobRequest const& request) {

--- a/google/cloud/beyondcorp/app_connections_client.cc
+++ b/google/cloud/beyondcorp/app_connections_client.cc
@@ -18,7 +18,6 @@
 // google/cloud/beyondcorp/appconnections/v1/app_connections_service.proto
 
 #include "google/cloud/beyondcorp/app_connections_client.h"
-#include "google/cloud/beyondcorp/internal/app_connections_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AppConnectionsServiceClient::AppConnectionsServiceClient(
     std::shared_ptr<AppConnectionsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          beyondcorp_internal::AppConnectionsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AppConnectionsServiceClient::~AppConnectionsServiceClient() = default;
 
 StreamRange<google::cloud::beyondcorp::appconnections::v1::AppConnection>

--- a/google/cloud/beyondcorp/app_connectors_client.cc
+++ b/google/cloud/beyondcorp/app_connectors_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/beyondcorp/appconnectors/v1/app_connectors_service.proto
 
 #include "google/cloud/beyondcorp/app_connectors_client.h"
-#include "google/cloud/beyondcorp/internal/app_connectors_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AppConnectorsServiceClient::AppConnectorsServiceClient(
     std::shared_ptr<AppConnectorsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          beyondcorp_internal::AppConnectorsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AppConnectorsServiceClient::~AppConnectorsServiceClient() = default;
 
 StreamRange<google::cloud::beyondcorp::appconnectors::v1::AppConnector>

--- a/google/cloud/beyondcorp/app_gateways_client.cc
+++ b/google/cloud/beyondcorp/app_gateways_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/beyondcorp/appgateways/v1/app_gateways_service.proto
 
 #include "google/cloud/beyondcorp/app_gateways_client.h"
-#include "google/cloud/beyondcorp/internal/app_gateways_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AppGatewaysServiceClient::AppGatewaysServiceClient(
     std::shared_ptr<AppGatewaysServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          beyondcorp_internal::AppGatewaysServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AppGatewaysServiceClient::~AppGatewaysServiceClient() = default;
 
 StreamRange<google::cloud::beyondcorp::appgateways::v1::AppGateway>

--- a/google/cloud/beyondcorp/client_connector_services_client.cc
+++ b/google/cloud/beyondcorp/client_connector_services_client.cc
@@ -18,7 +18,6 @@
 // google/cloud/beyondcorp/clientconnectorservices/v1/client_connector_services_service.proto
 
 #include "google/cloud/beyondcorp/client_connector_services_client.h"
-#include "google/cloud/beyondcorp/internal/client_connector_services_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -30,10 +29,8 @@ ClientConnectorServicesServiceClient::ClientConnectorServicesServiceClient(
     std::shared_ptr<ClientConnectorServicesServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          beyondcorp_internal::ClientConnectorServicesServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ClientConnectorServicesServiceClient::~ClientConnectorServicesServiceClient() =
     default;
 

--- a/google/cloud/beyondcorp/client_gateways_client.cc
+++ b/google/cloud/beyondcorp/client_gateways_client.cc
@@ -18,7 +18,6 @@
 // google/cloud/beyondcorp/clientgateways/v1/client_gateways_service.proto
 
 #include "google/cloud/beyondcorp/client_gateways_client.h"
-#include "google/cloud/beyondcorp/internal/client_gateways_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ClientGatewaysServiceClient::ClientGatewaysServiceClient(
     std::shared_ptr<ClientGatewaysServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          beyondcorp_internal::ClientGatewaysServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ClientGatewaysServiceClient::~ClientGatewaysServiceClient() = default;
 
 StreamRange<google::cloud::beyondcorp::clientgateways::v1::ClientGateway>

--- a/google/cloud/beyondcorp/internal/app_connections_connection_impl.cc
+++ b/google/cloud/beyondcorp/internal/app_connections_connection_impl.cc
@@ -39,9 +39,7 @@ AppConnectionsServiceConnectionImpl::AppConnectionsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          beyondcorp_internal::AppConnectionsServiceDefaultOptions(
-              AppConnectionsServiceConnection::options()))) {}
+          std::move(options), AppConnectionsServiceConnection::options())) {}
 
 StreamRange<google::cloud::beyondcorp::appconnections::v1::AppConnection>
 AppConnectionsServiceConnectionImpl::ListAppConnections(

--- a/google/cloud/beyondcorp/internal/app_connectors_connection_impl.cc
+++ b/google/cloud/beyondcorp/internal/app_connectors_connection_impl.cc
@@ -38,9 +38,7 @@ AppConnectorsServiceConnectionImpl::AppConnectorsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          beyondcorp_internal::AppConnectorsServiceDefaultOptions(
-              AppConnectorsServiceConnection::options()))) {}
+          std::move(options), AppConnectorsServiceConnection::options())) {}
 
 StreamRange<google::cloud::beyondcorp::appconnectors::v1::AppConnector>
 AppConnectorsServiceConnectionImpl::ListAppConnectors(

--- a/google/cloud/beyondcorp/internal/app_gateways_connection_impl.cc
+++ b/google/cloud/beyondcorp/internal/app_gateways_connection_impl.cc
@@ -38,9 +38,7 @@ AppGatewaysServiceConnectionImpl::AppGatewaysServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          beyondcorp_internal::AppGatewaysServiceDefaultOptions(
-              AppGatewaysServiceConnection::options()))) {}
+          std::move(options), AppGatewaysServiceConnection::options())) {}
 
 StreamRange<google::cloud::beyondcorp::appgateways::v1::AppGateway>
 AppGatewaysServiceConnectionImpl::ListAppGateways(

--- a/google/cloud/beyondcorp/internal/client_connector_services_connection_impl.cc
+++ b/google/cloud/beyondcorp/internal/client_connector_services_connection_impl.cc
@@ -42,8 +42,7 @@ ClientConnectorServicesServiceConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          beyondcorp_internal::ClientConnectorServicesServiceDefaultOptions(
-              ClientConnectorServicesServiceConnection::options()))) {}
+          ClientConnectorServicesServiceConnection::options())) {}
 
 StreamRange<google::cloud::beyondcorp::clientconnectorservices::v1::
                 ClientConnectorService>

--- a/google/cloud/beyondcorp/internal/client_gateways_connection_impl.cc
+++ b/google/cloud/beyondcorp/internal/client_gateways_connection_impl.cc
@@ -39,9 +39,7 @@ ClientGatewaysServiceConnectionImpl::ClientGatewaysServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          beyondcorp_internal::ClientGatewaysServiceDefaultOptions(
-              ClientGatewaysServiceConnection::options()))) {}
+          std::move(options), ClientGatewaysServiceConnection::options())) {}
 
 StreamRange<google::cloud::beyondcorp::clientgateways::v1::ClientGateway>
 ClientGatewaysServiceConnectionImpl::ListClientGateways(

--- a/google/cloud/bigquery/bigquery_read_client.cc
+++ b/google/cloud/bigquery/bigquery_read_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/bigquery/storage/v1/storage.proto
 
 #include "google/cloud/bigquery/bigquery_read_client.h"
-#include "google/cloud/bigquery/internal/bigquery_read_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BigQueryReadClient::BigQueryReadClient(
     std::shared_ptr<BigQueryReadConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), bigquery_internal::BigQueryReadDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BigQueryReadClient::~BigQueryReadClient() = default;
 
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>

--- a/google/cloud/bigquery/bigquery_write_client.cc
+++ b/google/cloud/bigquery/bigquery_write_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/bigquery/storage/v1/storage.proto
 
 #include "google/cloud/bigquery/bigquery_write_client.h"
-#include "google/cloud/bigquery/internal/bigquery_write_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BigQueryWriteClient::BigQueryWriteClient(
     std::shared_ptr<BigQueryWriteConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), bigquery_internal::BigQueryWriteDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BigQueryWriteClient::~BigQueryWriteClient() = default;
 
 StatusOr<google::cloud::bigquery::storage::v1::WriteStream>

--- a/google/cloud/bigquery/connection_client.cc
+++ b/google/cloud/bigquery/connection_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/bigquery/connection/v1/connection.proto
 
 #include "google/cloud/bigquery/connection_client.h"
-#include "google/cloud/bigquery/internal/connection_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConnectionServiceClient::ConnectionServiceClient(
     std::shared_ptr<ConnectionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), bigquery_internal::ConnectionServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ConnectionServiceClient::~ConnectionServiceClient() = default;
 
 StatusOr<google::cloud::bigquery::connection::v1::Connection>

--- a/google/cloud/bigquery/data_transfer_client.cc
+++ b/google/cloud/bigquery/data_transfer_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/bigquery/datatransfer/v1/datatransfer.proto
 
 #include "google/cloud/bigquery/data_transfer_client.h"
-#include "google/cloud/bigquery/internal/data_transfer_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DataTransferServiceClient::DataTransferServiceClient(
     std::shared_ptr<DataTransferServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), bigquery_internal::DataTransferServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DataTransferServiceClient::~DataTransferServiceClient() = default;
 
 StatusOr<google::cloud::bigquery::datatransfer::v1::DataSource>

--- a/google/cloud/bigquery/internal/bigquery_read_connection_impl.cc
+++ b/google/cloud/bigquery/internal/bigquery_read_connection_impl.cc
@@ -36,9 +36,8 @@ BigQueryReadConnectionImpl::BigQueryReadConnectionImpl(
     std::shared_ptr<bigquery_internal::BigQueryReadStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), bigquery_internal::BigQueryReadDefaultOptions(
-                                  BigQueryReadConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      BigQueryReadConnection::options())) {}
 
 StatusOr<google::cloud::bigquery::storage::v1::ReadSession>
 BigQueryReadConnectionImpl::CreateReadSession(

--- a/google/cloud/bigquery/internal/bigquery_write_connection_impl.cc
+++ b/google/cloud/bigquery/internal/bigquery_write_connection_impl.cc
@@ -34,9 +34,8 @@ BigQueryWriteConnectionImpl::BigQueryWriteConnectionImpl(
     std::shared_ptr<bigquery_internal::BigQueryWriteStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), bigquery_internal::BigQueryWriteDefaultOptions(
-                                  BigQueryWriteConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      BigQueryWriteConnection::options())) {}
 
 StatusOr<google::cloud::bigquery::storage::v1::WriteStream>
 BigQueryWriteConnectionImpl::CreateWriteStream(

--- a/google/cloud/bigquery/internal/connection_connection_impl.cc
+++ b/google/cloud/bigquery/internal/connection_connection_impl.cc
@@ -37,9 +37,7 @@ ConnectionServiceConnectionImpl::ConnectionServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          bigquery_internal::ConnectionServiceDefaultOptions(
-              ConnectionServiceConnection::options()))) {}
+          std::move(options), ConnectionServiceConnection::options())) {}
 
 StatusOr<google::cloud::bigquery::connection::v1::Connection>
 ConnectionServiceConnectionImpl::CreateConnection(

--- a/google/cloud/bigquery/internal/data_transfer_connection_impl.cc
+++ b/google/cloud/bigquery/internal/data_transfer_connection_impl.cc
@@ -37,9 +37,7 @@ DataTransferServiceConnectionImpl::DataTransferServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          bigquery_internal::DataTransferServiceDefaultOptions(
-              DataTransferServiceConnection::options()))) {}
+          std::move(options), DataTransferServiceConnection::options())) {}
 
 StatusOr<google::cloud::bigquery::datatransfer::v1::DataSource>
 DataTransferServiceConnectionImpl::GetDataSource(

--- a/google/cloud/bigquery/internal/model_connection_impl.cc
+++ b/google/cloud/bigquery/internal/model_connection_impl.cc
@@ -34,9 +34,8 @@ ModelServiceConnectionImpl::ModelServiceConnectionImpl(
     std::shared_ptr<bigquery_internal::ModelServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), bigquery_internal::ModelServiceDefaultOptions(
-                                  ModelServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ModelServiceConnection::options())) {}
 
 StatusOr<google::cloud::bigquery::v2::Model>
 ModelServiceConnectionImpl::GetModel(

--- a/google/cloud/bigquery/internal/reservation_connection_impl.cc
+++ b/google/cloud/bigquery/internal/reservation_connection_impl.cc
@@ -37,9 +37,7 @@ ReservationServiceConnectionImpl::ReservationServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          bigquery_internal::ReservationServiceDefaultOptions(
-              ReservationServiceConnection::options()))) {}
+          std::move(options), ReservationServiceConnection::options())) {}
 
 StatusOr<google::cloud::bigquery::reservation::v1::Reservation>
 ReservationServiceConnectionImpl::CreateReservation(

--- a/google/cloud/bigquery/model_client.cc
+++ b/google/cloud/bigquery/model_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/bigquery/v2/model.proto
 
 #include "google/cloud/bigquery/model_client.h"
-#include "google/cloud/bigquery/internal/model_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ModelServiceClient::ModelServiceClient(
     std::shared_ptr<ModelServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), bigquery_internal::ModelServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ModelServiceClient::~ModelServiceClient() = default;
 
 StatusOr<google::cloud::bigquery::v2::Model> ModelServiceClient::GetModel(

--- a/google/cloud/bigquery/reservation_client.cc
+++ b/google/cloud/bigquery/reservation_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/bigquery/reservation/v1/reservation.proto
 
 #include "google/cloud/bigquery/reservation_client.h"
-#include "google/cloud/bigquery/internal/reservation_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ReservationServiceClient::ReservationServiceClient(
     std::shared_ptr<ReservationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), bigquery_internal::ReservationServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ReservationServiceClient::~ReservationServiceClient() = default;
 
 StatusOr<google::cloud::bigquery::reservation::v1::Reservation>

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_client.h"
 #include "google/cloud/bigtable/admin/bigtable_instance_admin_options.h"
-#include "google/cloud/bigtable/admin/internal/bigtable_instance_admin_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,10 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BigtableInstanceAdminClient::BigtableInstanceAdminClient(
     std::shared_ptr<BigtableInstanceAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          bigtable_admin_internal::BigtableInstanceAdminDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BigtableInstanceAdminClient::~BigtableInstanceAdminClient() = default;
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>

--- a/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/bigtable/admin/bigtable_table_admin_client.h"
 #include "google/cloud/bigtable/admin/bigtable_table_admin_options.h"
-#include "google/cloud/bigtable/admin/internal/bigtable_table_admin_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,10 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BigtableTableAdminClient::BigtableTableAdminClient(
     std::shared_ptr<BigtableTableAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          bigtable_admin_internal::BigtableTableAdminDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BigtableTableAdminClient::~BigtableTableAdminClient() = default;
 
 StatusOr<google::bigtable::admin::v2::Table>

--- a/google/cloud/bigtable/admin/internal/bigtable_instance_admin_connection_impl.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_instance_admin_connection_impl.cc
@@ -38,9 +38,7 @@ BigtableInstanceAdminConnectionImpl::BigtableInstanceAdminConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          bigtable_admin_internal::BigtableInstanceAdminDefaultOptions(
-              BigtableInstanceAdminConnection::options()))) {}
+          std::move(options), BigtableInstanceAdminConnection::options())) {}
 
 future<StatusOr<google::bigtable::admin::v2::Instance>>
 BigtableInstanceAdminConnectionImpl::CreateInstance(

--- a/google/cloud/bigtable/admin/internal/bigtable_table_admin_connection_impl.cc
+++ b/google/cloud/bigtable/admin/internal/bigtable_table_admin_connection_impl.cc
@@ -39,9 +39,7 @@ BigtableTableAdminConnectionImpl::BigtableTableAdminConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          bigtable_admin_internal::BigtableTableAdminDefaultOptions(
-              BigtableTableAdminConnection::options()))) {}
+          std::move(options), BigtableTableAdminConnection::options())) {}
 
 StatusOr<google::bigtable::admin::v2::Table>
 BigtableTableAdminConnectionImpl::CreateTable(

--- a/google/cloud/billing/budget_client.cc
+++ b/google/cloud/billing/budget_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/billing/budgets/v1/budget_service.proto
 
 #include "google/cloud/billing/budget_client.h"
-#include "google/cloud/billing/internal/budget_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BudgetServiceClient::BudgetServiceClient(
     std::shared_ptr<BudgetServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), billing_internal::BudgetServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BudgetServiceClient::~BudgetServiceClient() = default;
 
 StatusOr<google::cloud::billing::budgets::v1::Budget>

--- a/google/cloud/billing/cloud_billing_client.cc
+++ b/google/cloud/billing/cloud_billing_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/billing/cloud_billing_client.h"
 #include "google/cloud/billing/cloud_billing_options.h"
-#include "google/cloud/billing/internal/cloud_billing_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudBillingClient::CloudBillingClient(
     std::shared_ptr<CloudBillingConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), billing_internal::CloudBillingDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudBillingClient::~CloudBillingClient() = default;
 
 StatusOr<google::cloud::billing::v1::BillingAccount>

--- a/google/cloud/billing/cloud_catalog_client.cc
+++ b/google/cloud/billing/cloud_catalog_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/billing/v1/cloud_catalog.proto
 
 #include "google/cloud/billing/cloud_catalog_client.h"
-#include "google/cloud/billing/internal/cloud_catalog_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudCatalogClient::CloudCatalogClient(
     std::shared_ptr<CloudCatalogConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), billing_internal::CloudCatalogDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudCatalogClient::~CloudCatalogClient() = default;
 
 StreamRange<google::cloud::billing::v1::Service>

--- a/google/cloud/billing/internal/budget_connection_impl.cc
+++ b/google/cloud/billing/internal/budget_connection_impl.cc
@@ -35,9 +35,8 @@ BudgetServiceConnectionImpl::BudgetServiceConnectionImpl(
     std::shared_ptr<billing_internal::BudgetServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), billing_internal::BudgetServiceDefaultOptions(
-                                  BudgetServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      BudgetServiceConnection::options())) {}
 
 StatusOr<google::cloud::billing::budgets::v1::Budget>
 BudgetServiceConnectionImpl::CreateBudget(

--- a/google/cloud/billing/internal/cloud_billing_connection_impl.cc
+++ b/google/cloud/billing/internal/cloud_billing_connection_impl.cc
@@ -35,9 +35,8 @@ CloudBillingConnectionImpl::CloudBillingConnectionImpl(
     std::shared_ptr<billing_internal::CloudBillingStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), billing_internal::CloudBillingDefaultOptions(
-                                  CloudBillingConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CloudBillingConnection::options())) {}
 
 StatusOr<google::cloud::billing::v1::BillingAccount>
 CloudBillingConnectionImpl::GetBillingAccount(

--- a/google/cloud/billing/internal/cloud_catalog_connection_impl.cc
+++ b/google/cloud/billing/internal/cloud_catalog_connection_impl.cc
@@ -35,9 +35,8 @@ CloudCatalogConnectionImpl::CloudCatalogConnectionImpl(
     std::shared_ptr<billing_internal::CloudCatalogStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), billing_internal::CloudCatalogDefaultOptions(
-                                  CloudCatalogConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CloudCatalogConnection::options())) {}
 
 StreamRange<google::cloud::billing::v1::Service>
 CloudCatalogConnectionImpl::ListServices(

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_client.cc
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/binaryauthorization/v1/service.proto
 
 #include "google/cloud/binaryauthorization/binauthz_management_service_v1_client.h"
-#include "google/cloud/binaryauthorization/internal/binauthz_management_service_v1_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ BinauthzManagementServiceV1Client::BinauthzManagementServiceV1Client(
     std::shared_ptr<BinauthzManagementServiceV1Connection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), binaryauthorization_internal::
-                               BinauthzManagementServiceV1DefaultOptions(
-                                   connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BinauthzManagementServiceV1Client::~BinauthzManagementServiceV1Client() =
     default;
 

--- a/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_connection_impl.cc
+++ b/google/cloud/binaryauthorization/internal/binauthz_management_service_v1_connection_impl.cc
@@ -41,9 +41,7 @@ BinauthzManagementServiceV1ConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          binaryauthorization_internal::
-              BinauthzManagementServiceV1DefaultOptions(
-                  BinauthzManagementServiceV1Connection::options()))) {}
+          BinauthzManagementServiceV1Connection::options())) {}
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
 BinauthzManagementServiceV1ConnectionImpl::GetPolicy(

--- a/google/cloud/binaryauthorization/internal/system_policy_v1_connection_impl.cc
+++ b/google/cloud/binaryauthorization/internal/system_policy_v1_connection_impl.cc
@@ -35,10 +35,8 @@ SystemPolicyV1ConnectionImpl::SystemPolicyV1ConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          binaryauthorization_internal::SystemPolicyV1DefaultOptions(
-              SystemPolicyV1Connection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      SystemPolicyV1Connection::options())) {}
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>
 SystemPolicyV1ConnectionImpl::GetSystemPolicy(

--- a/google/cloud/binaryauthorization/internal/validation_helper_v1_connection_impl.cc
+++ b/google/cloud/binaryauthorization/internal/validation_helper_v1_connection_impl.cc
@@ -36,9 +36,7 @@ ValidationHelperV1ConnectionImpl::ValidationHelperV1ConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          binaryauthorization_internal::ValidationHelperV1DefaultOptions(
-              ValidationHelperV1Connection::options()))) {}
+          std::move(options), ValidationHelperV1Connection::options())) {}
 
 StatusOr<google::cloud::binaryauthorization::v1::
              ValidateAttestationOccurrenceResponse>

--- a/google/cloud/binaryauthorization/system_policy_v1_client.cc
+++ b/google/cloud/binaryauthorization/system_policy_v1_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/binaryauthorization/v1/service.proto
 
 #include "google/cloud/binaryauthorization/system_policy_v1_client.h"
-#include "google/cloud/binaryauthorization/internal/system_policy_v1_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SystemPolicyV1Client::SystemPolicyV1Client(
     std::shared_ptr<SystemPolicyV1Connection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          binaryauthorization_internal::SystemPolicyV1DefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SystemPolicyV1Client::~SystemPolicyV1Client() = default;
 
 StatusOr<google::cloud::binaryauthorization::v1::Policy>

--- a/google/cloud/binaryauthorization/validation_helper_v1_client.cc
+++ b/google/cloud/binaryauthorization/validation_helper_v1_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/binaryauthorization/v1/service.proto
 
 #include "google/cloud/binaryauthorization/validation_helper_v1_client.h"
-#include "google/cloud/binaryauthorization/internal/validation_helper_v1_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ValidationHelperV1Client::ValidationHelperV1Client(
     std::shared_ptr<ValidationHelperV1Connection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          binaryauthorization_internal::ValidationHelperV1DefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ValidationHelperV1Client::~ValidationHelperV1Client() = default;
 
 StatusOr<google::cloud::binaryauthorization::v1::

--- a/google/cloud/channel/cloud_channel_client.cc
+++ b/google/cloud/channel/cloud_channel_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/channel/v1/service.proto
 
 #include "google/cloud/channel/cloud_channel_client.h"
-#include "google/cloud/channel/internal/cloud_channel_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudChannelServiceClient::CloudChannelServiceClient(
     std::shared_ptr<CloudChannelServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), channel_internal::CloudChannelServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudChannelServiceClient::~CloudChannelServiceClient() = default;
 
 StreamRange<google::cloud::channel::v1::Customer>

--- a/google/cloud/channel/internal/cloud_channel_connection_impl.cc
+++ b/google/cloud/channel/internal/cloud_channel_connection_impl.cc
@@ -38,9 +38,7 @@ CloudChannelServiceConnectionImpl::CloudChannelServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          channel_internal::CloudChannelServiceDefaultOptions(
-              CloudChannelServiceConnection::options()))) {}
+          std::move(options), CloudChannelServiceConnection::options())) {}
 
 StreamRange<google::cloud::channel::v1::Customer>
 CloudChannelServiceConnectionImpl::ListCustomers(

--- a/google/cloud/cloudbuild/cloud_build_client.cc
+++ b/google/cloud/cloudbuild/cloud_build_client.cc
@@ -17,7 +17,6 @@
 // source: google/devtools/cloudbuild/v1/cloudbuild.proto
 
 #include "google/cloud/cloudbuild/cloud_build_client.h"
-#include "google/cloud/cloudbuild/internal/cloud_build_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudBuildClient::CloudBuildClient(
     std::shared_ptr<CloudBuildConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), cloudbuild_internal::CloudBuildDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudBuildClient::~CloudBuildClient() = default;
 
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>

--- a/google/cloud/cloudbuild/internal/cloud_build_connection_impl.cc
+++ b/google/cloud/cloudbuild/internal/cloud_build_connection_impl.cc
@@ -36,9 +36,8 @@ CloudBuildConnectionImpl::CloudBuildConnectionImpl(
     std::shared_ptr<cloudbuild_internal::CloudBuildStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), cloudbuild_internal::CloudBuildDefaultOptions(
-                                  CloudBuildConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CloudBuildConnection::options())) {}
 
 future<StatusOr<google::devtools::cloudbuild::v1::Build>>
 CloudBuildConnectionImpl::CreateBuild(

--- a/google/cloud/composer/environments_client.cc
+++ b/google/cloud/composer/environments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/orchestration/airflow/service/v1/environments.proto
 
 #include "google/cloud/composer/environments_client.h"
-#include "google/cloud/composer/internal/environments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EnvironmentsClient::EnvironmentsClient(
     std::shared_ptr<EnvironmentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), composer_internal::EnvironmentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EnvironmentsClient::~EnvironmentsClient() = default;
 
 future<

--- a/google/cloud/composer/image_versions_client.cc
+++ b/google/cloud/composer/image_versions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/orchestration/airflow/service/v1/image_versions.proto
 
 #include "google/cloud/composer/image_versions_client.h"
-#include "google/cloud/composer/internal/image_versions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ImageVersionsClient::ImageVersionsClient(
     std::shared_ptr<ImageVersionsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), composer_internal::ImageVersionsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ImageVersionsClient::~ImageVersionsClient() = default;
 
 StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>

--- a/google/cloud/composer/internal/environments_connection_impl.cc
+++ b/google/cloud/composer/internal/environments_connection_impl.cc
@@ -36,9 +36,8 @@ EnvironmentsConnectionImpl::EnvironmentsConnectionImpl(
     std::shared_ptr<composer_internal::EnvironmentsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), composer_internal::EnvironmentsDefaultOptions(
-                                  EnvironmentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      EnvironmentsConnection::options())) {}
 
 future<
     StatusOr<google::cloud::orchestration::airflow::service::v1::Environment>>

--- a/google/cloud/composer/internal/image_versions_connection_impl.cc
+++ b/google/cloud/composer/internal/image_versions_connection_impl.cc
@@ -35,9 +35,8 @@ ImageVersionsConnectionImpl::ImageVersionsConnectionImpl(
     std::shared_ptr<composer_internal::ImageVersionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), composer_internal::ImageVersionsDefaultOptions(
-                                  ImageVersionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ImageVersionsConnection::options())) {}
 
 StreamRange<google::cloud::orchestration::airflow::service::v1::ImageVersion>
 ImageVersionsConnectionImpl::ListImageVersions(

--- a/google/cloud/contactcenterinsights/contact_center_insights_client.cc
+++ b/google/cloud/contactcenterinsights/contact_center_insights_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/contactcenterinsights/v1/contact_center_insights.proto
 
 #include "google/cloud/contactcenterinsights/contact_center_insights_client.h"
-#include "google/cloud/contactcenterinsights/internal/contact_center_insights_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ContactCenterInsightsClient::ContactCenterInsightsClient(
     std::shared_ptr<ContactCenterInsightsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          contactcenterinsights_internal::ContactCenterInsightsDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ContactCenterInsightsClient::~ContactCenterInsightsClient() = default;
 
 StatusOr<google::cloud::contactcenterinsights::v1::Conversation>

--- a/google/cloud/contactcenterinsights/internal/contact_center_insights_connection_impl.cc
+++ b/google/cloud/contactcenterinsights/internal/contact_center_insights_connection_impl.cc
@@ -39,9 +39,7 @@ ContactCenterInsightsConnectionImpl::ContactCenterInsightsConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          contactcenterinsights_internal::ContactCenterInsightsDefaultOptions(
-              ContactCenterInsightsConnection::options()))) {}
+          std::move(options), ContactCenterInsightsConnection::options())) {}
 
 StatusOr<google::cloud::contactcenterinsights::v1::Conversation>
 ContactCenterInsightsConnectionImpl::CreateConversation(

--- a/google/cloud/container/cluster_manager_client.cc
+++ b/google/cloud/container/cluster_manager_client.cc
@@ -17,7 +17,6 @@
 // source: google/container/v1/cluster_service.proto
 
 #include "google/cloud/container/cluster_manager_client.h"
-#include "google/cloud/container/internal/cluster_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ClusterManagerClient::ClusterManagerClient(
     std::shared_ptr<ClusterManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), container_internal::ClusterManagerDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ClusterManagerClient::~ClusterManagerClient() = default;
 
 StatusOr<google::container::v1::ListClustersResponse>

--- a/google/cloud/container/internal/cluster_manager_connection_impl.cc
+++ b/google/cloud/container/internal/cluster_manager_connection_impl.cc
@@ -36,9 +36,8 @@ ClusterManagerConnectionImpl::ClusterManagerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), container_internal::ClusterManagerDefaultOptions(
-                                  ClusterManagerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ClusterManagerConnection::options())) {}
 
 StatusOr<google::container::v1::ListClustersResponse>
 ClusterManagerConnectionImpl::ListClusters(

--- a/google/cloud/containeranalysis/container_analysis_client.cc
+++ b/google/cloud/containeranalysis/container_analysis_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/containeranalysis/container_analysis_client.h"
 #include "google/cloud/containeranalysis/container_analysis_options.h"
-#include "google/cloud/containeranalysis/internal/container_analysis_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,10 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ContainerAnalysisClient::ContainerAnalysisClient(
     std::shared_ptr<ContainerAnalysisConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          containeranalysis_internal::ContainerAnalysisDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ContainerAnalysisClient::~ContainerAnalysisClient() = default;
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(

--- a/google/cloud/containeranalysis/grafeas_client.cc
+++ b/google/cloud/containeranalysis/grafeas_client.cc
@@ -17,7 +17,6 @@
 // source: grafeas/v1/grafeas.proto
 
 #include "google/cloud/containeranalysis/grafeas_client.h"
-#include "google/cloud/containeranalysis/internal/grafeas_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 GrafeasClient::GrafeasClient(std::shared_ptr<GrafeasConnection> connection,
                              Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), containeranalysis_internal::GrafeasDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 GrafeasClient::~GrafeasClient() = default;
 
 StatusOr<grafeas::v1::Occurrence> GrafeasClient::GetOccurrence(

--- a/google/cloud/containeranalysis/internal/container_analysis_connection_impl.cc
+++ b/google/cloud/containeranalysis/internal/container_analysis_connection_impl.cc
@@ -36,9 +36,7 @@ ContainerAnalysisConnectionImpl::ContainerAnalysisConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          containeranalysis_internal::ContainerAnalysisDefaultOptions(
-              ContainerAnalysisConnection::options()))) {}
+          std::move(options), ContainerAnalysisConnection::options())) {}
 
 StatusOr<google::iam::v1::Policy> ContainerAnalysisConnectionImpl::SetIamPolicy(
     google::iam::v1::SetIamPolicyRequest const& request) {

--- a/google/cloud/containeranalysis/internal/grafeas_connection_impl.cc
+++ b/google/cloud/containeranalysis/internal/grafeas_connection_impl.cc
@@ -36,9 +36,8 @@ GrafeasConnectionImpl::GrafeasConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), containeranalysis_internal::GrafeasDefaultOptions(
-                                  GrafeasConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      GrafeasConnection::options())) {}
 
 StatusOr<grafeas::v1::Occurrence> GrafeasConnectionImpl::GetOccurrence(
     grafeas::v1::GetOccurrenceRequest const& request) {

--- a/google/cloud/datacatalog/data_catalog_client.cc
+++ b/google/cloud/datacatalog/data_catalog_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/datacatalog/data_catalog_client.h"
 #include "google/cloud/datacatalog/data_catalog_options.h"
-#include "google/cloud/datacatalog/internal/data_catalog_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DataCatalogClient::DataCatalogClient(
     std::shared_ptr<DataCatalogConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), datacatalog_internal::DataCatalogDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DataCatalogClient::~DataCatalogClient() = default;
 
 StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>

--- a/google/cloud/datacatalog/internal/data_catalog_connection_impl.cc
+++ b/google/cloud/datacatalog/internal/data_catalog_connection_impl.cc
@@ -36,9 +36,8 @@ DataCatalogConnectionImpl::DataCatalogConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), datacatalog_internal::DataCatalogDefaultOptions(
-                                  DataCatalogConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DataCatalogConnection::options())) {}
 
 StreamRange<google::cloud::datacatalog::v1::SearchCatalogResult>
 DataCatalogConnectionImpl::SearchCatalog(

--- a/google/cloud/datacatalog/internal/policy_tag_manager_connection_impl.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_connection_impl.cc
@@ -36,10 +36,8 @@ PolicyTagManagerConnectionImpl::PolicyTagManagerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          datacatalog_internal::PolicyTagManagerDefaultOptions(
-              PolicyTagManagerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      PolicyTagManagerConnection::options())) {}
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerConnectionImpl::CreateTaxonomy(

--- a/google/cloud/datacatalog/internal/policy_tag_manager_serialization_connection_impl.cc
+++ b/google/cloud/datacatalog/internal/policy_tag_manager_serialization_connection_impl.cc
@@ -39,8 +39,7 @@ PolicyTagManagerSerializationConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          datacatalog_internal::PolicyTagManagerSerializationDefaultOptions(
-              PolicyTagManagerSerializationConnection::options()))) {}
+          PolicyTagManagerSerializationConnection::options())) {}
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>
 PolicyTagManagerSerializationConnectionImpl::ReplaceTaxonomy(

--- a/google/cloud/datacatalog/policy_tag_manager_client.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/datacatalog/v1/policytagmanager.proto
 
 #include "google/cloud/datacatalog/policy_tag_manager_client.h"
-#include "google/cloud/datacatalog/internal/policy_tag_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 PolicyTagManagerClient::PolicyTagManagerClient(
     std::shared_ptr<PolicyTagManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), datacatalog_internal::PolicyTagManagerDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 PolicyTagManagerClient::~PolicyTagManagerClient() = default;
 
 StatusOr<google::cloud::datacatalog::v1::Taxonomy>

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_client.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/datacatalog/v1/policytagmanagerserialization.proto
 
 #include "google/cloud/datacatalog/policy_tag_manager_serialization_client.h"
-#include "google/cloud/datacatalog/internal/policy_tag_manager_serialization_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ PolicyTagManagerSerializationClient::PolicyTagManagerSerializationClient(
     std::shared_ptr<PolicyTagManagerSerializationConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          datacatalog_internal::PolicyTagManagerSerializationDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 PolicyTagManagerSerializationClient::~PolicyTagManagerSerializationClient() =
     default;
 

--- a/google/cloud/datamigration/data_migration_client.cc
+++ b/google/cloud/datamigration/data_migration_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/clouddms/v1/clouddms.proto
 
 #include "google/cloud/datamigration/data_migration_client.h"
-#include "google/cloud/datamigration/internal/data_migration_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DataMigrationServiceClient::DataMigrationServiceClient(
     std::shared_ptr<DataMigrationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          datamigration_internal::DataMigrationServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DataMigrationServiceClient::~DataMigrationServiceClient() = default;
 
 StreamRange<google::cloud::clouddms::v1::MigrationJob>

--- a/google/cloud/datamigration/internal/data_migration_connection_impl.cc
+++ b/google/cloud/datamigration/internal/data_migration_connection_impl.cc
@@ -38,9 +38,7 @@ DataMigrationServiceConnectionImpl::DataMigrationServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          datamigration_internal::DataMigrationServiceDefaultOptions(
-              DataMigrationServiceConnection::options()))) {}
+          std::move(options), DataMigrationServiceConnection::options())) {}
 
 StreamRange<google::cloud::clouddms::v1::MigrationJob>
 DataMigrationServiceConnectionImpl::ListMigrationJobs(

--- a/google/cloud/dataplex/content_client.cc
+++ b/google/cloud/dataplex/content_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataplex/v1/content.proto
 
 #include "google/cloud/dataplex/content_client.h"
-#include "google/cloud/dataplex/internal/content_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ContentServiceClient::ContentServiceClient(
     std::shared_ptr<ContentServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dataplex_internal::ContentServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ContentServiceClient::~ContentServiceClient() = default;
 
 StatusOr<google::cloud::dataplex::v1::Content>

--- a/google/cloud/dataplex/dataplex_client.cc
+++ b/google/cloud/dataplex/dataplex_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataplex/v1/service.proto
 
 #include "google/cloud/dataplex/dataplex_client.h"
-#include "google/cloud/dataplex/internal/dataplex_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DataplexServiceClient::DataplexServiceClient(
     std::shared_ptr<DataplexServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dataplex_internal::DataplexServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DataplexServiceClient::~DataplexServiceClient() = default;
 
 future<StatusOr<google::cloud::dataplex::v1::Lake>>

--- a/google/cloud/dataplex/internal/content_connection_impl.cc
+++ b/google/cloud/dataplex/internal/content_connection_impl.cc
@@ -36,9 +36,8 @@ ContentServiceConnectionImpl::ContentServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dataplex_internal::ContentServiceDefaultOptions(
-                                  ContentServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ContentServiceConnection::options())) {}
 
 StatusOr<google::cloud::dataplex::v1::Content>
 ContentServiceConnectionImpl::CreateContent(

--- a/google/cloud/dataplex/internal/dataplex_connection_impl.cc
+++ b/google/cloud/dataplex/internal/dataplex_connection_impl.cc
@@ -37,9 +37,8 @@ DataplexServiceConnectionImpl::DataplexServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dataplex_internal::DataplexServiceDefaultOptions(
-                                  DataplexServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DataplexServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::dataplex::v1::Lake>>
 DataplexServiceConnectionImpl::CreateLake(

--- a/google/cloud/dataplex/internal/metadata_connection_impl.cc
+++ b/google/cloud/dataplex/internal/metadata_connection_impl.cc
@@ -36,9 +36,8 @@ MetadataServiceConnectionImpl::MetadataServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dataplex_internal::MetadataServiceDefaultOptions(
-                                  MetadataServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      MetadataServiceConnection::options())) {}
 
 StatusOr<google::cloud::dataplex::v1::Entity>
 MetadataServiceConnectionImpl::CreateEntity(

--- a/google/cloud/dataplex/metadata_client.cc
+++ b/google/cloud/dataplex/metadata_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataplex/v1/metadata.proto
 
 #include "google/cloud/dataplex/metadata_client.h"
-#include "google/cloud/dataplex/internal/metadata_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 MetadataServiceClient::MetadataServiceClient(
     std::shared_ptr<MetadataServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dataplex_internal::MetadataServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 MetadataServiceClient::~MetadataServiceClient() = default;
 
 StatusOr<google::cloud::dataplex::v1::Entity>

--- a/google/cloud/dataproc/autoscaling_policy_client.cc
+++ b/google/cloud/dataproc/autoscaling_policy_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataproc/v1/autoscaling_policies.proto
 
 #include "google/cloud/dataproc/autoscaling_policy_client.h"
-#include "google/cloud/dataproc/internal/autoscaling_policy_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ AutoscalingPolicyServiceClient::AutoscalingPolicyServiceClient(
     std::shared_ptr<AutoscalingPolicyServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dataproc_internal::AutoscalingPolicyServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AutoscalingPolicyServiceClient::~AutoscalingPolicyServiceClient() = default;
 
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>

--- a/google/cloud/dataproc/batch_controller_client.cc
+++ b/google/cloud/dataproc/batch_controller_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataproc/v1/batches.proto
 
 #include "google/cloud/dataproc/batch_controller_client.h"
-#include "google/cloud/dataproc/internal/batch_controller_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 BatchControllerClient::BatchControllerClient(
     std::shared_ptr<BatchControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dataproc_internal::BatchControllerDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 BatchControllerClient::~BatchControllerClient() = default;
 
 future<StatusOr<google::cloud::dataproc::v1::Batch>>

--- a/google/cloud/dataproc/cluster_controller_client.cc
+++ b/google/cloud/dataproc/cluster_controller_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataproc/v1/clusters.proto
 
 #include "google/cloud/dataproc/cluster_controller_client.h"
-#include "google/cloud/dataproc/internal/cluster_controller_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ClusterControllerClient::ClusterControllerClient(
     std::shared_ptr<ClusterControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dataproc_internal::ClusterControllerDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ClusterControllerClient::~ClusterControllerClient() = default;
 
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>

--- a/google/cloud/dataproc/internal/autoscaling_policy_connection_impl.cc
+++ b/google/cloud/dataproc/internal/autoscaling_policy_connection_impl.cc
@@ -37,9 +37,7 @@ AutoscalingPolicyServiceConnectionImpl::AutoscalingPolicyServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dataproc_internal::AutoscalingPolicyServiceDefaultOptions(
-              AutoscalingPolicyServiceConnection::options()))) {}
+          std::move(options), AutoscalingPolicyServiceConnection::options())) {}
 
 StatusOr<google::cloud::dataproc::v1::AutoscalingPolicy>
 AutoscalingPolicyServiceConnectionImpl::CreateAutoscalingPolicy(

--- a/google/cloud/dataproc/internal/batch_controller_connection_impl.cc
+++ b/google/cloud/dataproc/internal/batch_controller_connection_impl.cc
@@ -37,9 +37,8 @@ BatchControllerConnectionImpl::BatchControllerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dataproc_internal::BatchControllerDefaultOptions(
-                                  BatchControllerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      BatchControllerConnection::options())) {}
 
 future<StatusOr<google::cloud::dataproc::v1::Batch>>
 BatchControllerConnectionImpl::CreateBatch(

--- a/google/cloud/dataproc/internal/cluster_controller_connection_impl.cc
+++ b/google/cloud/dataproc/internal/cluster_controller_connection_impl.cc
@@ -38,9 +38,7 @@ ClusterControllerConnectionImpl::ClusterControllerConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dataproc_internal::ClusterControllerDefaultOptions(
-              ClusterControllerConnection::options()))) {}
+          std::move(options), ClusterControllerConnection::options())) {}
 
 future<StatusOr<google::cloud::dataproc::v1::Cluster>>
 ClusterControllerConnectionImpl::CreateCluster(

--- a/google/cloud/dataproc/internal/job_controller_connection_impl.cc
+++ b/google/cloud/dataproc/internal/job_controller_connection_impl.cc
@@ -36,9 +36,8 @@ JobControllerConnectionImpl::JobControllerConnectionImpl(
     std::shared_ptr<dataproc_internal::JobControllerStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dataproc_internal::JobControllerDefaultOptions(
-                                  JobControllerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      JobControllerConnection::options())) {}
 
 StatusOr<google::cloud::dataproc::v1::Job>
 JobControllerConnectionImpl::SubmitJob(

--- a/google/cloud/dataproc/internal/workflow_template_connection_impl.cc
+++ b/google/cloud/dataproc/internal/workflow_template_connection_impl.cc
@@ -38,9 +38,7 @@ WorkflowTemplateServiceConnectionImpl::WorkflowTemplateServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dataproc_internal::WorkflowTemplateServiceDefaultOptions(
-              WorkflowTemplateServiceConnection::options()))) {}
+          std::move(options), WorkflowTemplateServiceConnection::options())) {}
 
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>
 WorkflowTemplateServiceConnectionImpl::CreateWorkflowTemplate(

--- a/google/cloud/dataproc/job_controller_client.cc
+++ b/google/cloud/dataproc/job_controller_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataproc/v1/jobs.proto
 
 #include "google/cloud/dataproc/job_controller_client.h"
-#include "google/cloud/dataproc/internal/job_controller_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 JobControllerClient::JobControllerClient(
     std::shared_ptr<JobControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dataproc_internal::JobControllerDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 JobControllerClient::~JobControllerClient() = default;
 
 StatusOr<google::cloud::dataproc::v1::Job> JobControllerClient::SubmitJob(

--- a/google/cloud/dataproc/workflow_template_client.cc
+++ b/google/cloud/dataproc/workflow_template_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dataproc/v1/workflow_templates.proto
 
 #include "google/cloud/dataproc/workflow_template_client.h"
-#include "google/cloud/dataproc/internal/workflow_template_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 WorkflowTemplateServiceClient::WorkflowTemplateServiceClient(
     std::shared_ptr<WorkflowTemplateServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dataproc_internal::WorkflowTemplateServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 WorkflowTemplateServiceClient::~WorkflowTemplateServiceClient() = default;
 
 StatusOr<google::cloud::dataproc::v1::WorkflowTemplate>

--- a/google/cloud/debugger/controller2_client.cc
+++ b/google/cloud/debugger/controller2_client.cc
@@ -17,7 +17,6 @@
 // source: google/devtools/clouddebugger/v2/controller.proto
 
 #include "google/cloud/debugger/controller2_client.h"
-#include "google/cloud/debugger/internal/controller2_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 Controller2Client::Controller2Client(
     std::shared_ptr<Controller2Connection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), debugger_internal::Controller2DefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 Controller2Client::~Controller2Client() = default;
 
 StatusOr<google::devtools::clouddebugger::v2::RegisterDebuggeeResponse>

--- a/google/cloud/debugger/debugger2_client.cc
+++ b/google/cloud/debugger/debugger2_client.cc
@@ -17,7 +17,6 @@
 // source: google/devtools/clouddebugger/v2/debugger.proto
 
 #include "google/cloud/debugger/debugger2_client.h"
-#include "google/cloud/debugger/internal/debugger2_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 Debugger2Client::Debugger2Client(
     std::shared_ptr<Debugger2Connection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          debugger_internal::Debugger2DefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 Debugger2Client::~Debugger2Client() = default;
 
 StatusOr<google::devtools::clouddebugger::v2::SetBreakpointResponse>

--- a/google/cloud/debugger/internal/controller2_connection_impl.cc
+++ b/google/cloud/debugger/internal/controller2_connection_impl.cc
@@ -34,9 +34,8 @@ Controller2ConnectionImpl::Controller2ConnectionImpl(
     std::shared_ptr<debugger_internal::Controller2Stub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), debugger_internal::Controller2DefaultOptions(
-                                  Controller2Connection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      Controller2Connection::options())) {}
 
 StatusOr<google::devtools::clouddebugger::v2::RegisterDebuggeeResponse>
 Controller2ConnectionImpl::RegisterDebuggee(

--- a/google/cloud/debugger/internal/debugger2_connection_impl.cc
+++ b/google/cloud/debugger/internal/debugger2_connection_impl.cc
@@ -34,9 +34,8 @@ Debugger2ConnectionImpl::Debugger2ConnectionImpl(
     std::shared_ptr<debugger_internal::Debugger2Stub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), debugger_internal::Debugger2DefaultOptions(
-                                  Debugger2Connection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      Debugger2Connection::options())) {}
 
 StatusOr<google::devtools::clouddebugger::v2::SetBreakpointResponse>
 Debugger2ConnectionImpl::SetBreakpoint(

--- a/google/cloud/dialogflow_cx/agents_client.cc
+++ b/google/cloud/dialogflow_cx/agents_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/agent.proto
 
 #include "google/cloud/dialogflow_cx/agents_client.h"
-#include "google/cloud/dialogflow_cx/internal/agents_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AgentsClient::AgentsClient(std::shared_ptr<AgentsConnection> connection,
                            Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::AgentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AgentsClient::~AgentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Agent> AgentsClient::ListAgents(

--- a/google/cloud/dialogflow_cx/changelogs_client.cc
+++ b/google/cloud/dialogflow_cx/changelogs_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/changelog.proto
 
 #include "google/cloud/dialogflow_cx/changelogs_client.h"
-#include "google/cloud/dialogflow_cx/internal/changelogs_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ChangelogsClient::ChangelogsClient(
     std::shared_ptr<ChangelogsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::ChangelogsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ChangelogsClient::~ChangelogsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Changelog>

--- a/google/cloud/dialogflow_cx/deployments_client.cc
+++ b/google/cloud/dialogflow_cx/deployments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/deployment.proto
 
 #include "google/cloud/dialogflow_cx/deployments_client.h"
-#include "google/cloud/dialogflow_cx/internal/deployments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DeploymentsClient::DeploymentsClient(
     std::shared_ptr<DeploymentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::DeploymentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DeploymentsClient::~DeploymentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Deployment>

--- a/google/cloud/dialogflow_cx/entity_types_client.cc
+++ b/google/cloud/dialogflow_cx/entity_types_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/entity_type.proto
 
 #include "google/cloud/dialogflow_cx/entity_types_client.h"
-#include "google/cloud/dialogflow_cx/internal/entity_types_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EntityTypesClient::EntityTypesClient(
     std::shared_ptr<EntityTypesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::EntityTypesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EntityTypesClient::~EntityTypesClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::EntityType>

--- a/google/cloud/dialogflow_cx/environments_client.cc
+++ b/google/cloud/dialogflow_cx/environments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/environment.proto
 
 #include "google/cloud/dialogflow_cx/environments_client.h"
-#include "google/cloud/dialogflow_cx/internal/environments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EnvironmentsClient::EnvironmentsClient(
     std::shared_ptr<EnvironmentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::EnvironmentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EnvironmentsClient::~EnvironmentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Environment>

--- a/google/cloud/dialogflow_cx/experiments_client.cc
+++ b/google/cloud/dialogflow_cx/experiments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/experiment.proto
 
 #include "google/cloud/dialogflow_cx/experiments_client.h"
-#include "google/cloud/dialogflow_cx/internal/experiments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ExperimentsClient::ExperimentsClient(
     std::shared_ptr<ExperimentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::ExperimentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ExperimentsClient::~ExperimentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Experiment>

--- a/google/cloud/dialogflow_cx/flows_client.cc
+++ b/google/cloud/dialogflow_cx/flows_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/flow.proto
 
 #include "google/cloud/dialogflow_cx/flows_client.h"
-#include "google/cloud/dialogflow_cx/internal/flows_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 FlowsClient::FlowsClient(std::shared_ptr<FlowsConnection> connection,
                          Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::FlowsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 FlowsClient::~FlowsClient() = default;
 
 StatusOr<google::cloud::dialogflow::cx::v3::Flow> FlowsClient::CreateFlow(

--- a/google/cloud/dialogflow_cx/intents_client.cc
+++ b/google/cloud/dialogflow_cx/intents_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/intent.proto
 
 #include "google/cloud/dialogflow_cx/intents_client.h"
-#include "google/cloud/dialogflow_cx/internal/intents_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 IntentsClient::IntentsClient(std::shared_ptr<IntentsConnection> connection,
                              Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::IntentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IntentsClient::~IntentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Intent>

--- a/google/cloud/dialogflow_cx/internal/agents_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/agents_connection_impl.cc
@@ -36,9 +36,8 @@ AgentsConnectionImpl::AgentsConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::AgentsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::AgentsDefaultOptions(
-                                  AgentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      AgentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Agent>
 AgentsConnectionImpl::ListAgents(

--- a/google/cloud/dialogflow_cx/internal/changelogs_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/changelogs_connection_impl.cc
@@ -36,9 +36,8 @@ ChangelogsConnectionImpl::ChangelogsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::ChangelogsDefaultOptions(
-                                  ChangelogsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ChangelogsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Changelog>
 ChangelogsConnectionImpl::ListChangelogs(

--- a/google/cloud/dialogflow_cx/internal/deployments_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/deployments_connection_impl.cc
@@ -36,9 +36,8 @@ DeploymentsConnectionImpl::DeploymentsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::DeploymentsDefaultOptions(
-                                  DeploymentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DeploymentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Deployment>
 DeploymentsConnectionImpl::ListDeployments(

--- a/google/cloud/dialogflow_cx/internal/entity_types_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/entity_types_connection_impl.cc
@@ -36,9 +36,8 @@ EntityTypesConnectionImpl::EntityTypesConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::EntityTypesDefaultOptions(
-                                  EntityTypesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      EntityTypesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::EntityType>
 EntityTypesConnectionImpl::ListEntityTypes(

--- a/google/cloud/dialogflow_cx/internal/environments_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_connection_impl.cc
@@ -37,10 +37,8 @@ EnvironmentsConnectionImpl::EnvironmentsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_cx_internal::EnvironmentsDefaultOptions(
-              EnvironmentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      EnvironmentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Environment>
 EnvironmentsConnectionImpl::ListEnvironments(

--- a/google/cloud/dialogflow_cx/internal/experiments_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/experiments_connection_impl.cc
@@ -36,9 +36,8 @@ ExperimentsConnectionImpl::ExperimentsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::ExperimentsDefaultOptions(
-                                  ExperimentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ExperimentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Experiment>
 ExperimentsConnectionImpl::ListExperiments(

--- a/google/cloud/dialogflow_cx/internal/flows_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/flows_connection_impl.cc
@@ -36,9 +36,8 @@ FlowsConnectionImpl::FlowsConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::FlowsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::FlowsDefaultOptions(
-                                  FlowsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      FlowsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::cx::v3::Flow>
 FlowsConnectionImpl::CreateFlow(

--- a/google/cloud/dialogflow_cx/internal/intents_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/intents_connection_impl.cc
@@ -35,9 +35,8 @@ IntentsConnectionImpl::IntentsConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::IntentsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::IntentsDefaultOptions(
-                                  IntentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      IntentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Intent>
 IntentsConnectionImpl::ListIntents(

--- a/google/cloud/dialogflow_cx/internal/pages_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/pages_connection_impl.cc
@@ -35,9 +35,8 @@ PagesConnectionImpl::PagesConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::PagesStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::PagesDefaultOptions(
-                                  PagesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      PagesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Page>
 PagesConnectionImpl::ListPages(

--- a/google/cloud/dialogflow_cx/internal/security_settings_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/security_settings_connection_impl.cc
@@ -37,9 +37,7 @@ SecuritySettingsServiceConnectionImpl::SecuritySettingsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_cx_internal::SecuritySettingsServiceDefaultOptions(
-              SecuritySettingsServiceConnection::options()))) {}
+          std::move(options), SecuritySettingsServiceConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>
 SecuritySettingsServiceConnectionImpl::CreateSecuritySettings(

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_connection_impl.cc
@@ -37,9 +37,7 @@ SessionEntityTypesConnectionImpl::SessionEntityTypesConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_cx_internal::SessionEntityTypesDefaultOptions(
-              SessionEntityTypesConnection::options()))) {}
+          std::move(options), SessionEntityTypesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::SessionEntityType>
 SessionEntityTypesConnectionImpl::ListSessionEntityTypes(

--- a/google/cloud/dialogflow_cx/internal/sessions_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/sessions_connection_impl.cc
@@ -34,9 +34,8 @@ SessionsConnectionImpl::SessionsConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::SessionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::SessionsDefaultOptions(
-                                  SessionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      SessionsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::cx::v3::DetectIntentResponse>
 SessionsConnectionImpl::DetectIntent(

--- a/google/cloud/dialogflow_cx/internal/test_cases_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/test_cases_connection_impl.cc
@@ -37,9 +37,8 @@ TestCasesConnectionImpl::TestCasesConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::TestCasesDefaultOptions(
-                                  TestCasesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      TestCasesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::TestCase>
 TestCasesConnectionImpl::ListTestCases(

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_connection_impl.cc
@@ -37,9 +37,7 @@ TransitionRouteGroupsConnectionImpl::TransitionRouteGroupsConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_cx_internal::TransitionRouteGroupsDefaultOptions(
-              TransitionRouteGroupsConnection::options()))) {}
+          std::move(options), TransitionRouteGroupsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>
 TransitionRouteGroupsConnectionImpl::ListTransitionRouteGroups(

--- a/google/cloud/dialogflow_cx/internal/versions_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_connection_impl.cc
@@ -36,9 +36,8 @@ VersionsConnectionImpl::VersionsConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::VersionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::VersionsDefaultOptions(
-                                  VersionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      VersionsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Version>
 VersionsConnectionImpl::ListVersions(

--- a/google/cloud/dialogflow_cx/internal/webhooks_connection_impl.cc
+++ b/google/cloud/dialogflow_cx/internal/webhooks_connection_impl.cc
@@ -35,9 +35,8 @@ WebhooksConnectionImpl::WebhooksConnectionImpl(
     std::shared_ptr<dialogflow_cx_internal::WebhooksStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_cx_internal::WebhooksDefaultOptions(
-                                  WebhooksConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      WebhooksConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::cx::v3::Webhook>
 WebhooksConnectionImpl::ListWebhooks(

--- a/google/cloud/dialogflow_cx/pages_client.cc
+++ b/google/cloud/dialogflow_cx/pages_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/page.proto
 
 #include "google/cloud/dialogflow_cx/pages_client.h"
-#include "google/cloud/dialogflow_cx/internal/pages_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 PagesClient::PagesClient(std::shared_ptr<PagesConnection> connection,
                          Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::PagesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 PagesClient::~PagesClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Page> PagesClient::ListPages(

--- a/google/cloud/dialogflow_cx/security_settings_client.cc
+++ b/google/cloud/dialogflow_cx/security_settings_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/security_settings.proto
 
 #include "google/cloud/dialogflow_cx/security_settings_client.h"
-#include "google/cloud/dialogflow_cx/internal/security_settings_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SecuritySettingsServiceClient::SecuritySettingsServiceClient(
     std::shared_ptr<SecuritySettingsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_cx_internal::SecuritySettingsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SecuritySettingsServiceClient::~SecuritySettingsServiceClient() = default;
 
 StatusOr<google::cloud::dialogflow::cx::v3::SecuritySettings>

--- a/google/cloud/dialogflow_cx/session_entity_types_client.cc
+++ b/google/cloud/dialogflow_cx/session_entity_types_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/session_entity_type.proto
 
 #include "google/cloud/dialogflow_cx/session_entity_types_client.h"
-#include "google/cloud/dialogflow_cx/internal/session_entity_types_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SessionEntityTypesClient::SessionEntityTypesClient(
     std::shared_ptr<SessionEntityTypesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_cx_internal::SessionEntityTypesDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SessionEntityTypesClient::~SessionEntityTypesClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::SessionEntityType>

--- a/google/cloud/dialogflow_cx/sessions_client.cc
+++ b/google/cloud/dialogflow_cx/sessions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/session.proto
 
 #include "google/cloud/dialogflow_cx/sessions_client.h"
-#include "google/cloud/dialogflow_cx/internal/sessions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SessionsClient::SessionsClient(std::shared_ptr<SessionsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::SessionsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SessionsClient::~SessionsClient() = default;
 
 StatusOr<google::cloud::dialogflow::cx::v3::DetectIntentResponse>

--- a/google/cloud/dialogflow_cx/test_cases_client.cc
+++ b/google/cloud/dialogflow_cx/test_cases_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/test_case.proto
 
 #include "google/cloud/dialogflow_cx/test_cases_client.h"
-#include "google/cloud/dialogflow_cx/internal/test_cases_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TestCasesClient::TestCasesClient(
     std::shared_ptr<TestCasesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::TestCasesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TestCasesClient::~TestCasesClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::TestCase>

--- a/google/cloud/dialogflow_cx/transition_route_groups_client.cc
+++ b/google/cloud/dialogflow_cx/transition_route_groups_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/transition_route_group.proto
 
 #include "google/cloud/dialogflow_cx/transition_route_groups_client.h"
-#include "google/cloud/dialogflow_cx/internal/transition_route_groups_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TransitionRouteGroupsClient::TransitionRouteGroupsClient(
     std::shared_ptr<TransitionRouteGroupsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_cx_internal::TransitionRouteGroupsDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TransitionRouteGroupsClient::~TransitionRouteGroupsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::TransitionRouteGroup>

--- a/google/cloud/dialogflow_cx/versions_client.cc
+++ b/google/cloud/dialogflow_cx/versions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/version.proto
 
 #include "google/cloud/dialogflow_cx/versions_client.h"
-#include "google/cloud/dialogflow_cx/internal/versions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VersionsClient::VersionsClient(std::shared_ptr<VersionsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::VersionsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VersionsClient::~VersionsClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Version>

--- a/google/cloud/dialogflow_cx/webhooks_client.cc
+++ b/google/cloud/dialogflow_cx/webhooks_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/cx/v3/webhook.proto
 
 #include "google/cloud/dialogflow_cx/webhooks_client.h"
-#include "google/cloud/dialogflow_cx/internal/webhooks_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 WebhooksClient::WebhooksClient(std::shared_ptr<WebhooksConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_cx_internal::WebhooksDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 WebhooksClient::~WebhooksClient() = default;
 
 StreamRange<google::cloud::dialogflow::cx::v3::Webhook>

--- a/google/cloud/dialogflow_es/agents_client.cc
+++ b/google/cloud/dialogflow_es/agents_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/agent.proto
 
 #include "google/cloud/dialogflow_es/agents_client.h"
-#include "google/cloud/dialogflow_es/internal/agents_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AgentsClient::AgentsClient(std::shared_ptr<AgentsConnection> connection,
                            Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::AgentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AgentsClient::~AgentsClient() = default;
 
 StatusOr<google::cloud::dialogflow::v2::Agent> AgentsClient::GetAgent(

--- a/google/cloud/dialogflow_es/answer_records_client.cc
+++ b/google/cloud/dialogflow_es/answer_records_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/answer_record.proto
 
 #include "google/cloud/dialogflow_es/answer_records_client.h"
-#include "google/cloud/dialogflow_es/internal/answer_records_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AnswerRecordsClient::AnswerRecordsClient(
     std::shared_ptr<AnswerRecordsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::AnswerRecordsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AnswerRecordsClient::~AnswerRecordsClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::AnswerRecord>

--- a/google/cloud/dialogflow_es/contexts_client.cc
+++ b/google/cloud/dialogflow_es/contexts_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/context.proto
 
 #include "google/cloud/dialogflow_es/contexts_client.h"
-#include "google/cloud/dialogflow_es/internal/contexts_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ContextsClient::ContextsClient(std::shared_ptr<ContextsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::ContextsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ContextsClient::~ContextsClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::Context>

--- a/google/cloud/dialogflow_es/conversation_datasets_client.cc
+++ b/google/cloud/dialogflow_es/conversation_datasets_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/conversation_dataset.proto
 
 #include "google/cloud/dialogflow_es/conversation_datasets_client.h"
-#include "google/cloud/dialogflow_es/internal/conversation_datasets_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConversationDatasetsClient::ConversationDatasetsClient(
     std::shared_ptr<ConversationDatasetsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_es_internal::ConversationDatasetsDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ConversationDatasetsClient::~ConversationDatasetsClient() = default;
 
 future<StatusOr<google::cloud::dialogflow::v2::ConversationDataset>>

--- a/google/cloud/dialogflow_es/conversation_models_client.cc
+++ b/google/cloud/dialogflow_es/conversation_models_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/conversation_model.proto
 
 #include "google/cloud/dialogflow_es/conversation_models_client.h"
-#include "google/cloud/dialogflow_es/internal/conversation_models_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConversationModelsClient::ConversationModelsClient(
     std::shared_ptr<ConversationModelsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_es_internal::ConversationModelsDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ConversationModelsClient::~ConversationModelsClient() = default;
 
 future<StatusOr<google::cloud::dialogflow::v2::ConversationModel>>

--- a/google/cloud/dialogflow_es/conversation_profiles_client.cc
+++ b/google/cloud/dialogflow_es/conversation_profiles_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/conversation_profile.proto
 
 #include "google/cloud/dialogflow_es/conversation_profiles_client.h"
-#include "google/cloud/dialogflow_es/internal/conversation_profiles_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConversationProfilesClient::ConversationProfilesClient(
     std::shared_ptr<ConversationProfilesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_es_internal::ConversationProfilesDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ConversationProfilesClient::~ConversationProfilesClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::ConversationProfile>

--- a/google/cloud/dialogflow_es/conversations_client.cc
+++ b/google/cloud/dialogflow_es/conversations_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/conversation.proto
 
 #include "google/cloud/dialogflow_es/conversations_client.h"
-#include "google/cloud/dialogflow_es/internal/conversations_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ConversationsClient::ConversationsClient(
     std::shared_ptr<ConversationsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::ConversationsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ConversationsClient::~ConversationsClient() = default;
 
 StatusOr<google::cloud::dialogflow::v2::Conversation>

--- a/google/cloud/dialogflow_es/documents_client.cc
+++ b/google/cloud/dialogflow_es/documents_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/document.proto
 
 #include "google/cloud/dialogflow_es/documents_client.h"
-#include "google/cloud/dialogflow_es/internal/documents_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DocumentsClient::DocumentsClient(
     std::shared_ptr<DocumentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::DocumentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DocumentsClient::~DocumentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::Document>

--- a/google/cloud/dialogflow_es/entity_types_client.cc
+++ b/google/cloud/dialogflow_es/entity_types_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/entity_type.proto
 
 #include "google/cloud/dialogflow_es/entity_types_client.h"
-#include "google/cloud/dialogflow_es/internal/entity_types_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EntityTypesClient::EntityTypesClient(
     std::shared_ptr<EntityTypesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::EntityTypesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EntityTypesClient::~EntityTypesClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::EntityType>

--- a/google/cloud/dialogflow_es/environments_client.cc
+++ b/google/cloud/dialogflow_es/environments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/environment.proto
 
 #include "google/cloud/dialogflow_es/environments_client.h"
-#include "google/cloud/dialogflow_es/internal/environments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EnvironmentsClient::EnvironmentsClient(
     std::shared_ptr<EnvironmentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::EnvironmentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EnvironmentsClient::~EnvironmentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::Environment>

--- a/google/cloud/dialogflow_es/fulfillments_client.cc
+++ b/google/cloud/dialogflow_es/fulfillments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/fulfillment.proto
 
 #include "google/cloud/dialogflow_es/fulfillments_client.h"
-#include "google/cloud/dialogflow_es/internal/fulfillments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 FulfillmentsClient::FulfillmentsClient(
     std::shared_ptr<FulfillmentsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::FulfillmentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 FulfillmentsClient::~FulfillmentsClient() = default;
 
 StatusOr<google::cloud::dialogflow::v2::Fulfillment>

--- a/google/cloud/dialogflow_es/intents_client.cc
+++ b/google/cloud/dialogflow_es/intents_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/intent.proto
 
 #include "google/cloud/dialogflow_es/intents_client.h"
-#include "google/cloud/dialogflow_es/internal/intents_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 IntentsClient::IntentsClient(std::shared_ptr<IntentsConnection> connection,
                              Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::IntentsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IntentsClient::~IntentsClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::Intent> IntentsClient::ListIntents(

--- a/google/cloud/dialogflow_es/internal/agents_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/agents_connection_impl.cc
@@ -36,9 +36,8 @@ AgentsConnectionImpl::AgentsConnectionImpl(
     std::shared_ptr<dialogflow_es_internal::AgentsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::AgentsDefaultOptions(
-                                  AgentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      AgentsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::v2::Agent> AgentsConnectionImpl::GetAgent(
     google::cloud::dialogflow::v2::GetAgentRequest const& request) {

--- a/google/cloud/dialogflow_es/internal/answer_records_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/answer_records_connection_impl.cc
@@ -36,10 +36,8 @@ AnswerRecordsConnectionImpl::AnswerRecordsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::AnswerRecordsDefaultOptions(
-              AnswerRecordsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      AnswerRecordsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::AnswerRecord>
 AnswerRecordsConnectionImpl::ListAnswerRecords(

--- a/google/cloud/dialogflow_es/internal/contexts_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/contexts_connection_impl.cc
@@ -35,9 +35,8 @@ ContextsConnectionImpl::ContextsConnectionImpl(
     std::shared_ptr<dialogflow_es_internal::ContextsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::ContextsDefaultOptions(
-                                  ContextsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ContextsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::Context>
 ContextsConnectionImpl::ListContexts(

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_connection_impl.cc
@@ -38,9 +38,7 @@ ConversationDatasetsConnectionImpl::ConversationDatasetsConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::ConversationDatasetsDefaultOptions(
-              ConversationDatasetsConnection::options()))) {}
+          std::move(options), ConversationDatasetsConnection::options())) {}
 
 future<StatusOr<google::cloud::dialogflow::v2::ConversationDataset>>
 ConversationDatasetsConnectionImpl::CreateConversationDataset(

--- a/google/cloud/dialogflow_es/internal/conversation_models_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_models_connection_impl.cc
@@ -38,9 +38,7 @@ ConversationModelsConnectionImpl::ConversationModelsConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::ConversationModelsDefaultOptions(
-              ConversationModelsConnection::options()))) {}
+          std::move(options), ConversationModelsConnection::options())) {}
 
 future<StatusOr<google::cloud::dialogflow::v2::ConversationModel>>
 ConversationModelsConnectionImpl::CreateConversationModel(

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_connection_impl.cc
@@ -38,9 +38,7 @@ ConversationProfilesConnectionImpl::ConversationProfilesConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::ConversationProfilesDefaultOptions(
-              ConversationProfilesConnection::options()))) {}
+          std::move(options), ConversationProfilesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::ConversationProfile>
 ConversationProfilesConnectionImpl::ListConversationProfiles(

--- a/google/cloud/dialogflow_es/internal/conversations_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/conversations_connection_impl.cc
@@ -36,10 +36,8 @@ ConversationsConnectionImpl::ConversationsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::ConversationsDefaultOptions(
-              ConversationsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ConversationsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::v2::Conversation>
 ConversationsConnectionImpl::CreateConversation(

--- a/google/cloud/dialogflow_es/internal/documents_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/documents_connection_impl.cc
@@ -37,9 +37,8 @@ DocumentsConnectionImpl::DocumentsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::DocumentsDefaultOptions(
-                                  DocumentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DocumentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::Document>
 DocumentsConnectionImpl::ListDocuments(

--- a/google/cloud/dialogflow_es/internal/entity_types_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/entity_types_connection_impl.cc
@@ -37,9 +37,8 @@ EntityTypesConnectionImpl::EntityTypesConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::EntityTypesDefaultOptions(
-                                  EntityTypesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      EntityTypesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::EntityType>
 EntityTypesConnectionImpl::ListEntityTypes(

--- a/google/cloud/dialogflow_es/internal/environments_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/environments_connection_impl.cc
@@ -36,10 +36,8 @@ EnvironmentsConnectionImpl::EnvironmentsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::EnvironmentsDefaultOptions(
-              EnvironmentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      EnvironmentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::Environment>
 EnvironmentsConnectionImpl::ListEnvironments(

--- a/google/cloud/dialogflow_es/internal/fulfillments_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/fulfillments_connection_impl.cc
@@ -35,10 +35,8 @@ FulfillmentsConnectionImpl::FulfillmentsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::FulfillmentsDefaultOptions(
-              FulfillmentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      FulfillmentsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::v2::Fulfillment>
 FulfillmentsConnectionImpl::GetFulfillment(

--- a/google/cloud/dialogflow_es/internal/intents_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/intents_connection_impl.cc
@@ -36,9 +36,8 @@ IntentsConnectionImpl::IntentsConnectionImpl(
     std::shared_ptr<dialogflow_es_internal::IntentsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::IntentsDefaultOptions(
-                                  IntentsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      IntentsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::Intent>
 IntentsConnectionImpl::ListIntents(

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_connection_impl.cc
@@ -36,10 +36,8 @@ KnowledgeBasesConnectionImpl::KnowledgeBasesConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::KnowledgeBasesDefaultOptions(
-              KnowledgeBasesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      KnowledgeBasesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::KnowledgeBase>
 KnowledgeBasesConnectionImpl::ListKnowledgeBases(

--- a/google/cloud/dialogflow_es/internal/participants_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/participants_connection_impl.cc
@@ -36,10 +36,8 @@ ParticipantsConnectionImpl::ParticipantsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::ParticipantsDefaultOptions(
-              ParticipantsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ParticipantsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::v2::Participant>
 ParticipantsConnectionImpl::CreateParticipant(

--- a/google/cloud/dialogflow_es/internal/session_entity_types_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_connection_impl.cc
@@ -37,9 +37,7 @@ SessionEntityTypesConnectionImpl::SessionEntityTypesConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          dialogflow_es_internal::SessionEntityTypesDefaultOptions(
-              SessionEntityTypesConnection::options()))) {}
+          std::move(options), SessionEntityTypesConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::SessionEntityType>
 SessionEntityTypesConnectionImpl::ListSessionEntityTypes(

--- a/google/cloud/dialogflow_es/internal/sessions_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/sessions_connection_impl.cc
@@ -34,9 +34,8 @@ SessionsConnectionImpl::SessionsConnectionImpl(
     std::shared_ptr<dialogflow_es_internal::SessionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::SessionsDefaultOptions(
-                                  SessionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      SessionsConnection::options())) {}
 
 StatusOr<google::cloud::dialogflow::v2::DetectIntentResponse>
 SessionsConnectionImpl::DetectIntent(

--- a/google/cloud/dialogflow_es/internal/versions_connection_impl.cc
+++ b/google/cloud/dialogflow_es/internal/versions_connection_impl.cc
@@ -35,9 +35,8 @@ VersionsConnectionImpl::VersionsConnectionImpl(
     std::shared_ptr<dialogflow_es_internal::VersionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), dialogflow_es_internal::VersionsDefaultOptions(
-                                  VersionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      VersionsConnection::options())) {}
 
 StreamRange<google::cloud::dialogflow::v2::Version>
 VersionsConnectionImpl::ListVersions(

--- a/google/cloud/dialogflow_es/knowledge_bases_client.cc
+++ b/google/cloud/dialogflow_es/knowledge_bases_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/knowledge_base.proto
 
 #include "google/cloud/dialogflow_es/knowledge_bases_client.h"
-#include "google/cloud/dialogflow_es/internal/knowledge_bases_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 KnowledgeBasesClient::KnowledgeBasesClient(
     std::shared_ptr<KnowledgeBasesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::KnowledgeBasesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 KnowledgeBasesClient::~KnowledgeBasesClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::KnowledgeBase>

--- a/google/cloud/dialogflow_es/participants_client.cc
+++ b/google/cloud/dialogflow_es/participants_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/participant.proto
 
 #include "google/cloud/dialogflow_es/participants_client.h"
-#include "google/cloud/dialogflow_es/internal/participants_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ParticipantsClient::ParticipantsClient(
     std::shared_ptr<ParticipantsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::ParticipantsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ParticipantsClient::~ParticipantsClient() = default;
 
 StatusOr<google::cloud::dialogflow::v2::Participant>

--- a/google/cloud/dialogflow_es/session_entity_types_client.cc
+++ b/google/cloud/dialogflow_es/session_entity_types_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/session_entity_type.proto
 
 #include "google/cloud/dialogflow_es/session_entity_types_client.h"
-#include "google/cloud/dialogflow_es/internal/session_entity_types_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SessionEntityTypesClient::SessionEntityTypesClient(
     std::shared_ptr<SessionEntityTypesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dialogflow_es_internal::SessionEntityTypesDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SessionEntityTypesClient::~SessionEntityTypesClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::SessionEntityType>

--- a/google/cloud/dialogflow_es/sessions_client.cc
+++ b/google/cloud/dialogflow_es/sessions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/session.proto
 
 #include "google/cloud/dialogflow_es/sessions_client.h"
-#include "google/cloud/dialogflow_es/internal/sessions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SessionsClient::SessionsClient(std::shared_ptr<SessionsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::SessionsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SessionsClient::~SessionsClient() = default;
 
 StatusOr<google::cloud::dialogflow::v2::DetectIntentResponse>

--- a/google/cloud/dialogflow_es/versions_client.cc
+++ b/google/cloud/dialogflow_es/versions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/dialogflow/v2/version.proto
 
 #include "google/cloud/dialogflow_es/versions_client.h"
-#include "google/cloud/dialogflow_es/internal/versions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VersionsClient::VersionsClient(std::shared_ptr<VersionsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), dialogflow_es_internal::VersionsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VersionsClient::~VersionsClient() = default;
 
 StreamRange<google::cloud::dialogflow::v2::Version>

--- a/google/cloud/dlp/dlp_client.cc
+++ b/google/cloud/dlp/dlp_client.cc
@@ -17,7 +17,6 @@
 // source: google/privacy/dlp/v2/dlp.proto
 
 #include "google/cloud/dlp/dlp_client.h"
-#include "google/cloud/dlp/internal/dlp_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DlpServiceClient::DlpServiceClient(
     std::shared_ptr<DlpServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          dlp_internal::DlpServiceDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DlpServiceClient::~DlpServiceClient() = default;
 
 StatusOr<google::privacy::dlp::v2::InspectContentResponse>

--- a/google/cloud/dlp/internal/dlp_connection_impl.cc
+++ b/google/cloud/dlp/internal/dlp_connection_impl.cc
@@ -36,8 +36,7 @@ DlpServiceConnectionImpl::DlpServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      dlp_internal::DlpServiceDefaultOptions(
-                                          DlpServiceConnection::options()))) {}
+                                      DlpServiceConnection::options())) {}
 
 StatusOr<google::privacy::dlp::v2::InspectContentResponse>
 DlpServiceConnectionImpl::InspectContent(

--- a/google/cloud/documentai/document_processor_client.cc
+++ b/google/cloud/documentai/document_processor_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/documentai/v1/document_processor_service.proto
 
 #include "google/cloud/documentai/document_processor_client.h"
-#include "google/cloud/documentai/internal/document_processor_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ DocumentProcessorServiceClient::DocumentProcessorServiceClient(
     std::shared_ptr<DocumentProcessorServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          documentai_internal::DocumentProcessorServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DocumentProcessorServiceClient::~DocumentProcessorServiceClient() = default;
 
 StatusOr<google::cloud::documentai::v1::ProcessResponse>

--- a/google/cloud/documentai/internal/document_processor_connection_impl.cc
+++ b/google/cloud/documentai/internal/document_processor_connection_impl.cc
@@ -37,9 +37,7 @@ DocumentProcessorServiceConnectionImpl::DocumentProcessorServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          documentai_internal::DocumentProcessorServiceDefaultOptions(
-              DocumentProcessorServiceConnection::options()))) {}
+          std::move(options), DocumentProcessorServiceConnection::options())) {}
 
 StatusOr<google::cloud::documentai::v1::ProcessResponse>
 DocumentProcessorServiceConnectionImpl::ProcessDocument(

--- a/google/cloud/eventarc/eventarc_client.cc
+++ b/google/cloud/eventarc/eventarc_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/eventarc/v1/eventarc.proto
 
 #include "google/cloud/eventarc/eventarc_client.h"
-#include "google/cloud/eventarc/internal/eventarc_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EventarcClient::EventarcClient(std::shared_ptr<EventarcConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          eventarc_internal::EventarcDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EventarcClient::~EventarcClient() = default;
 
 StatusOr<google::cloud::eventarc::v1::Trigger> EventarcClient::GetTrigger(

--- a/google/cloud/eventarc/internal/eventarc_connection_impl.cc
+++ b/google/cloud/eventarc/internal/eventarc_connection_impl.cc
@@ -37,8 +37,7 @@ EventarcConnectionImpl::EventarcConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      eventarc_internal::EventarcDefaultOptions(
-                                          EventarcConnection::options()))) {}
+                                      EventarcConnection::options())) {}
 
 StatusOr<google::cloud::eventarc::v1::Trigger>
 EventarcConnectionImpl::GetTrigger(

--- a/google/cloud/eventarc/internal/publisher_connection_impl.cc
+++ b/google/cloud/eventarc/internal/publisher_connection_impl.cc
@@ -34,9 +34,8 @@ PublisherConnectionImpl::PublisherConnectionImpl(
     std::shared_ptr<eventarc_internal::PublisherStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), eventarc_internal::PublisherDefaultOptions(
-                                  PublisherConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      PublisherConnection::options())) {}
 
 StatusOr<google::cloud::eventarc::publishing::v1::
              PublishChannelConnectionEventsResponse>

--- a/google/cloud/eventarc/publisher_client.cc
+++ b/google/cloud/eventarc/publisher_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/eventarc/publishing/v1/publisher.proto
 
 #include "google/cloud/eventarc/publisher_client.h"
-#include "google/cloud/eventarc/internal/publisher_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 PublisherClient::PublisherClient(
     std::shared_ptr<PublisherConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          eventarc_internal::PublisherDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 PublisherClient::~PublisherClient() = default;
 
 StatusOr<google::cloud::eventarc::publishing::v1::

--- a/google/cloud/filestore/cloud_filestore_manager_client.cc
+++ b/google/cloud/filestore/cloud_filestore_manager_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/filestore/v1/cloud_filestore_service.proto
 
 #include "google/cloud/filestore/cloud_filestore_manager_client.h"
-#include "google/cloud/filestore/internal/cloud_filestore_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudFilestoreManagerClient::CloudFilestoreManagerClient(
     std::shared_ptr<CloudFilestoreManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          filestore_internal::CloudFilestoreManagerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudFilestoreManagerClient::~CloudFilestoreManagerClient() = default;
 
 StreamRange<google::cloud::filestore::v1::Instance>

--- a/google/cloud/filestore/internal/cloud_filestore_manager_connection_impl.cc
+++ b/google/cloud/filestore/internal/cloud_filestore_manager_connection_impl.cc
@@ -38,9 +38,7 @@ CloudFilestoreManagerConnectionImpl::CloudFilestoreManagerConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          filestore_internal::CloudFilestoreManagerDefaultOptions(
-              CloudFilestoreManagerConnection::options()))) {}
+          std::move(options), CloudFilestoreManagerConnection::options())) {}
 
 StreamRange<google::cloud::filestore::v1::Instance>
 CloudFilestoreManagerConnectionImpl::ListInstances(

--- a/google/cloud/functions/cloud_functions_client.cc
+++ b/google/cloud/functions/cloud_functions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/functions/v1/functions.proto
 
 #include "google/cloud/functions/cloud_functions_client.h"
-#include "google/cloud/functions/internal/cloud_functions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudFunctionsServiceClient::CloudFunctionsServiceClient(
     std::shared_ptr<CloudFunctionsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          functions_internal::CloudFunctionsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudFunctionsServiceClient::~CloudFunctionsServiceClient() = default;
 
 StreamRange<google::cloud::functions::v1::CloudFunction>

--- a/google/cloud/functions/internal/cloud_functions_connection_impl.cc
+++ b/google/cloud/functions/internal/cloud_functions_connection_impl.cc
@@ -38,9 +38,7 @@ CloudFunctionsServiceConnectionImpl::CloudFunctionsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          functions_internal::CloudFunctionsServiceDefaultOptions(
-              CloudFunctionsServiceConnection::options()))) {}
+          std::move(options), CloudFunctionsServiceConnection::options())) {}
 
 StreamRange<google::cloud::functions::v1::CloudFunction>
 CloudFunctionsServiceConnectionImpl::ListFunctions(

--- a/google/cloud/gameservices/game_server_clusters_client.cc
+++ b/google/cloud/gameservices/game_server_clusters_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/gaming/v1/game_server_clusters_service.proto
 
 #include "google/cloud/gameservices/game_server_clusters_client.h"
-#include "google/cloud/gameservices/internal/game_server_clusters_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ GameServerClustersServiceClient::GameServerClustersServiceClient(
     std::shared_ptr<GameServerClustersServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          gameservices_internal::GameServerClustersServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 GameServerClustersServiceClient::~GameServerClustersServiceClient() = default;
 
 StreamRange<google::cloud::gaming::v1::GameServerCluster>

--- a/google/cloud/gameservices/game_server_configs_client.cc
+++ b/google/cloud/gameservices/game_server_configs_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/gaming/v1/game_server_configs_service.proto
 
 #include "google/cloud/gameservices/game_server_configs_client.h"
-#include "google/cloud/gameservices/internal/game_server_configs_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ GameServerConfigsServiceClient::GameServerConfigsServiceClient(
     std::shared_ptr<GameServerConfigsServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          gameservices_internal::GameServerConfigsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 GameServerConfigsServiceClient::~GameServerConfigsServiceClient() = default;
 
 StreamRange<google::cloud::gaming::v1::GameServerConfig>

--- a/google/cloud/gameservices/game_server_deployments_client.cc
+++ b/google/cloud/gameservices/game_server_deployments_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/gaming/v1/game_server_deployments_service.proto
 
 #include "google/cloud/gameservices/game_server_deployments_client.h"
-#include "google/cloud/gameservices/internal/game_server_deployments_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ GameServerDeploymentsServiceClient::GameServerDeploymentsServiceClient(
     std::shared_ptr<GameServerDeploymentsServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          gameservices_internal::GameServerDeploymentsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 GameServerDeploymentsServiceClient::~GameServerDeploymentsServiceClient() =
     default;
 

--- a/google/cloud/gameservices/internal/game_server_clusters_connection_impl.cc
+++ b/google/cloud/gameservices/internal/game_server_clusters_connection_impl.cc
@@ -40,9 +40,8 @@ GameServerClustersServiceConnectionImpl::
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          gameservices_internal::GameServerClustersServiceDefaultOptions(
-              GameServerClustersServiceConnection::options()))) {}
+          std::move(options), GameServerClustersServiceConnection::options())) {
+}
 
 StreamRange<google::cloud::gaming::v1::GameServerCluster>
 GameServerClustersServiceConnectionImpl::ListGameServerClusters(

--- a/google/cloud/gameservices/internal/game_server_configs_connection_impl.cc
+++ b/google/cloud/gameservices/internal/game_server_configs_connection_impl.cc
@@ -38,9 +38,7 @@ GameServerConfigsServiceConnectionImpl::GameServerConfigsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          gameservices_internal::GameServerConfigsServiceDefaultOptions(
-              GameServerConfigsServiceConnection::options()))) {}
+          std::move(options), GameServerConfigsServiceConnection::options())) {}
 
 StreamRange<google::cloud::gaming::v1::GameServerConfig>
 GameServerConfigsServiceConnectionImpl::ListGameServerConfigs(

--- a/google/cloud/gameservices/internal/game_server_deployments_connection_impl.cc
+++ b/google/cloud/gameservices/internal/game_server_deployments_connection_impl.cc
@@ -41,8 +41,7 @@ GameServerDeploymentsServiceConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          gameservices_internal::GameServerDeploymentsServiceDefaultOptions(
-              GameServerDeploymentsServiceConnection::options()))) {}
+          GameServerDeploymentsServiceConnection::options())) {}
 
 StreamRange<google::cloud::gaming::v1::GameServerDeployment>
 GameServerDeploymentsServiceConnectionImpl::ListGameServerDeployments(

--- a/google/cloud/gameservices/internal/realms_connection_impl.cc
+++ b/google/cloud/gameservices/internal/realms_connection_impl.cc
@@ -37,10 +37,8 @@ RealmsServiceConnectionImpl::RealmsServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          gameservices_internal::RealmsServiceDefaultOptions(
-              RealmsServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      RealmsServiceConnection::options())) {}
 
 StreamRange<google::cloud::gaming::v1::Realm>
 RealmsServiceConnectionImpl::ListRealms(

--- a/google/cloud/gameservices/realms_client.cc
+++ b/google/cloud/gameservices/realms_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/gaming/v1/realms_service.proto
 
 #include "google/cloud/gameservices/realms_client.h"
-#include "google/cloud/gameservices/internal/realms_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 RealmsServiceClient::RealmsServiceClient(
     std::shared_ptr<RealmsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), gameservices_internal::RealmsServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 RealmsServiceClient::~RealmsServiceClient() = default;
 
 StreamRange<google::cloud::gaming::v1::Realm> RealmsServiceClient::ListRealms(

--- a/google/cloud/gkehub/gke_hub_client.cc
+++ b/google/cloud/gkehub/gke_hub_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/gkehub/v1/service.proto
 
 #include "google/cloud/gkehub/gke_hub_client.h"
-#include "google/cloud/gkehub/internal/gke_hub_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 GkeHubClient::GkeHubClient(std::shared_ptr<GkeHubConnection> connection,
                            Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          gkehub_internal::GkeHubDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 GkeHubClient::~GkeHubClient() = default;
 
 StreamRange<google::cloud::gkehub::v1::Membership>

--- a/google/cloud/gkehub/internal/gke_hub_connection_impl.cc
+++ b/google/cloud/gkehub/internal/gke_hub_connection_impl.cc
@@ -36,10 +36,8 @@ GkeHubConnectionImpl::GkeHubConnectionImpl(
     std::shared_ptr<gkehub_internal::GkeHubStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          gkehub_internal::GkeHubDefaultOptions(GkeHubConnection::options()))) {
-}
+      options_(internal::MergeOptions(std::move(options),
+                                      GkeHubConnection::options())) {}
 
 StreamRange<google::cloud::gkehub::v1::Membership>
 GkeHubConnectionImpl::ListMemberships(

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/iam/iam_client.h"
 #include "google/cloud/iam/iam_options.h"
-#include "google/cloud/iam/internal/iam_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -29,9 +28,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IAMClient::IAMClient(std::shared_ptr<IAMConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          iam_internal::IAMDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IAMClient::~IAMClient() = default;
 
 StreamRange<google::iam::admin::v1::ServiceAccount>

--- a/google/cloud/iam/iam_credentials_client.cc
+++ b/google/cloud/iam/iam_credentials_client.cc
@@ -17,7 +17,6 @@
 // source: google/iam/credentials/v1/iamcredentials.proto
 
 #include "google/cloud/iam/iam_credentials_client.h"
-#include "google/cloud/iam/internal/iam_credentials_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 IAMCredentialsClient::IAMCredentialsClient(
     std::shared_ptr<IAMCredentialsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          iam_internal::IAMCredentialsDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IAMCredentialsClient::~IAMCredentialsClient() = default;
 
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>

--- a/google/cloud/iam/iam_policy_client.cc
+++ b/google/cloud/iam/iam_policy_client.cc
@@ -17,7 +17,6 @@
 // source: google/iam/v1/iam_policy.proto
 
 #include "google/cloud/iam/iam_policy_client.h"
-#include "google/cloud/iam/internal/iam_policy_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 IAMPolicyClient::IAMPolicyClient(
     std::shared_ptr<IAMPolicyConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          iam_internal::IAMPolicyDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IAMPolicyClient::~IAMPolicyClient() = default;
 
 StatusOr<google::iam::v1::Policy> IAMPolicyClient::SetIamPolicy(

--- a/google/cloud/iam/internal/iam_connection_impl.cc
+++ b/google/cloud/iam/internal/iam_connection_impl.cc
@@ -35,9 +35,8 @@ IAMConnectionImpl::IAMConnectionImpl(
     std::shared_ptr<iam_internal::IAMStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          iam_internal::IAMDefaultOptions(IAMConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      IAMConnection::options())) {}
 
 StreamRange<google::iam::admin::v1::ServiceAccount>
 IAMConnectionImpl::ListServiceAccounts(

--- a/google/cloud/iam/internal/iam_credentials_connection_impl.cc
+++ b/google/cloud/iam/internal/iam_credentials_connection_impl.cc
@@ -34,9 +34,8 @@ IAMCredentialsConnectionImpl::IAMCredentialsConnectionImpl(
     std::shared_ptr<iam_internal::IAMCredentialsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), iam_internal::IAMCredentialsDefaultOptions(
-                                  IAMCredentialsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      IAMCredentialsConnection::options())) {}
 
 StatusOr<google::iam::credentials::v1::GenerateAccessTokenResponse>
 IAMCredentialsConnectionImpl::GenerateAccessToken(

--- a/google/cloud/iam/internal/iam_policy_connection_impl.cc
+++ b/google/cloud/iam/internal/iam_policy_connection_impl.cc
@@ -35,8 +35,7 @@ IAMPolicyConnectionImpl::IAMPolicyConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      iam_internal::IAMPolicyDefaultOptions(
-                                          IAMPolicyConnection::options()))) {}
+                                      IAMPolicyConnection::options())) {}
 
 StatusOr<google::iam::v1::Policy> IAMPolicyConnectionImpl::SetIamPolicy(
     google::iam::v1::SetIamPolicyRequest const& request) {

--- a/google/cloud/iap/identity_aware_proxy_admin_client.cc
+++ b/google/cloud/iap/identity_aware_proxy_admin_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/iap/v1/service.proto
 
 #include "google/cloud/iap/identity_aware_proxy_admin_client.h"
-#include "google/cloud/iap/internal/identity_aware_proxy_admin_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ IdentityAwareProxyAdminServiceClient::IdentityAwareProxyAdminServiceClient(
     std::shared_ptr<IdentityAwareProxyAdminServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          iap_internal::IdentityAwareProxyAdminServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IdentityAwareProxyAdminServiceClient::~IdentityAwareProxyAdminServiceClient() =
     default;
 

--- a/google/cloud/iap/identity_aware_proxy_o_auth_client.cc
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/iap/v1/service.proto
 
 #include "google/cloud/iap/identity_aware_proxy_o_auth_client.h"
-#include "google/cloud/iap/internal/identity_aware_proxy_o_auth_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ IdentityAwareProxyOAuthServiceClient::IdentityAwareProxyOAuthServiceClient(
     std::shared_ptr<IdentityAwareProxyOAuthServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          iap_internal::IdentityAwareProxyOAuthServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IdentityAwareProxyOAuthServiceClient::~IdentityAwareProxyOAuthServiceClient() =
     default;
 

--- a/google/cloud/iap/internal/identity_aware_proxy_admin_connection_impl.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_admin_connection_impl.cc
@@ -39,8 +39,7 @@ IdentityAwareProxyAdminServiceConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          iap_internal::IdentityAwareProxyAdminServiceDefaultOptions(
-              IdentityAwareProxyAdminServiceConnection::options()))) {}
+          IdentityAwareProxyAdminServiceConnection::options())) {}
 
 StatusOr<google::iam::v1::Policy>
 IdentityAwareProxyAdminServiceConnectionImpl::SetIamPolicy(

--- a/google/cloud/iap/internal/identity_aware_proxy_o_auth_connection_impl.cc
+++ b/google/cloud/iap/internal/identity_aware_proxy_o_auth_connection_impl.cc
@@ -39,8 +39,7 @@ IdentityAwareProxyOAuthServiceConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          iap_internal::IdentityAwareProxyOAuthServiceDefaultOptions(
-              IdentityAwareProxyOAuthServiceConnection::options()))) {}
+          IdentityAwareProxyOAuthServiceConnection::options())) {}
 
 StatusOr<google::cloud::iap::v1::ListBrandsResponse>
 IdentityAwareProxyOAuthServiceConnectionImpl::ListBrands(

--- a/google/cloud/ids/ids_client.cc
+++ b/google/cloud/ids/ids_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/ids/v1/ids.proto
 
 #include "google/cloud/ids/ids_client.h"
-#include "google/cloud/ids/internal/ids_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -27,9 +26,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 IDSClient::IDSClient(std::shared_ptr<IDSConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          ids_internal::IDSDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IDSClient::~IDSClient() = default;
 
 StreamRange<google::cloud::ids::v1::Endpoint> IDSClient::ListEndpoints(

--- a/google/cloud/ids/internal/ids_connection_impl.cc
+++ b/google/cloud/ids/internal/ids_connection_impl.cc
@@ -36,9 +36,8 @@ IDSConnectionImpl::IDSConnectionImpl(
     std::shared_ptr<ids_internal::IDSStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          ids_internal::IDSDefaultOptions(IDSConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      IDSConnection::options())) {}
 
 StreamRange<google::cloud::ids::v1::Endpoint> IDSConnectionImpl::ListEndpoints(
     google::cloud::ids::v1::ListEndpointsRequest request) {

--- a/google/cloud/iot/device_manager_client.cc
+++ b/google/cloud/iot/device_manager_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/iot/device_manager_client.h"
 #include "google/cloud/iot/device_manager_options.h"
-#include "google/cloud/iot/internal/device_manager_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DeviceManagerClient::DeviceManagerClient(
     std::shared_ptr<DeviceManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          iot_internal::DeviceManagerDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DeviceManagerClient::~DeviceManagerClient() = default;
 
 StatusOr<google::cloud::iot::v1::DeviceRegistry>

--- a/google/cloud/iot/internal/device_manager_connection_impl.cc
+++ b/google/cloud/iot/internal/device_manager_connection_impl.cc
@@ -35,9 +35,8 @@ DeviceManagerConnectionImpl::DeviceManagerConnectionImpl(
     std::shared_ptr<iot_internal::DeviceManagerStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), iot_internal::DeviceManagerDefaultOptions(
-                                  DeviceManagerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DeviceManagerConnection::options())) {}
 
 StatusOr<google::cloud::iot::v1::DeviceRegistry>
 DeviceManagerConnectionImpl::CreateDeviceRegistry(

--- a/google/cloud/kms/ekm_client.cc
+++ b/google/cloud/kms/ekm_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/kms/v1/ekm_service.proto
 
 #include "google/cloud/kms/ekm_client.h"
-#include "google/cloud/kms/internal/ekm_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EkmServiceClient::EkmServiceClient(
     std::shared_ptr<EkmServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          kms_internal::EkmServiceDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EkmServiceClient::~EkmServiceClient() = default;
 
 StreamRange<google::cloud::kms::v1::EkmConnection>

--- a/google/cloud/kms/internal/ekm_connection_impl.cc
+++ b/google/cloud/kms/internal/ekm_connection_impl.cc
@@ -36,8 +36,7 @@ EkmServiceConnectionImpl::EkmServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      kms_internal::EkmServiceDefaultOptions(
-                                          EkmServiceConnection::options()))) {}
+                                      EkmServiceConnection::options())) {}
 
 StreamRange<google::cloud::kms::v1::EkmConnection>
 EkmServiceConnectionImpl::ListEkmConnections(

--- a/google/cloud/kms/internal/key_management_connection_impl.cc
+++ b/google/cloud/kms/internal/key_management_connection_impl.cc
@@ -37,9 +37,7 @@ KeyManagementServiceConnectionImpl::KeyManagementServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), kms_internal::KeyManagementServiceDefaultOptions(
-                                  KeyManagementServiceConnection::options()))) {
-}
+          std::move(options), KeyManagementServiceConnection::options())) {}
 
 StreamRange<google::cloud::kms::v1::KeyRing>
 KeyManagementServiceConnectionImpl::ListKeyRings(

--- a/google/cloud/kms/key_management_client.cc
+++ b/google/cloud/kms/key_management_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/kms/v1/service.proto
 
 #include "google/cloud/kms/key_management_client.h"
-#include "google/cloud/kms/internal/key_management_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 KeyManagementServiceClient::KeyManagementServiceClient(
     std::shared_ptr<KeyManagementServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), kms_internal::KeyManagementServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 KeyManagementServiceClient::~KeyManagementServiceClient() = default;
 
 StreamRange<google::cloud::kms::v1::KeyRing>

--- a/google/cloud/language/internal/language_connection_impl.cc
+++ b/google/cloud/language/internal/language_connection_impl.cc
@@ -35,9 +35,8 @@ LanguageServiceConnectionImpl::LanguageServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), language_internal::LanguageServiceDefaultOptions(
-                                  LanguageServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      LanguageServiceConnection::options())) {}
 
 StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>
 LanguageServiceConnectionImpl::AnalyzeSentiment(

--- a/google/cloud/language/language_client.cc
+++ b/google/cloud/language/language_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/language/v1/language_service.proto
 
 #include "google/cloud/language/language_client.h"
-#include "google/cloud/language/internal/language_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 LanguageServiceClient::LanguageServiceClient(
     std::shared_ptr<LanguageServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), language_internal::LanguageServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 LanguageServiceClient::~LanguageServiceClient() = default;
 
 StatusOr<google::cloud::language::v1::AnalyzeSentimentResponse>

--- a/google/cloud/logging/internal/logging_service_v2_connection_impl.cc
+++ b/google/cloud/logging/internal/logging_service_v2_connection_impl.cc
@@ -36,9 +36,8 @@ LoggingServiceV2ConnectionImpl::LoggingServiceV2ConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), logging_internal::LoggingServiceV2DefaultOptions(
-                                  LoggingServiceV2Connection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      LoggingServiceV2Connection::options())) {}
 
 Status LoggingServiceV2ConnectionImpl::DeleteLog(
     google::logging::v2::DeleteLogRequest const& request) {

--- a/google/cloud/logging/logging_service_v2_client.cc
+++ b/google/cloud/logging/logging_service_v2_client.cc
@@ -17,7 +17,6 @@
 // source: google/logging/v2/logging.proto
 
 #include "google/cloud/logging/logging_service_v2_client.h"
-#include "google/cloud/logging/internal/logging_service_v2_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 LoggingServiceV2Client::LoggingServiceV2Client(
     std::shared_ptr<LoggingServiceV2Connection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), logging_internal::LoggingServiceV2DefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 LoggingServiceV2Client::~LoggingServiceV2Client() = default;
 
 Status LoggingServiceV2Client::DeleteLog(std::string const& log_name,

--- a/google/cloud/managedidentities/internal/managed_identities_connection_impl.cc
+++ b/google/cloud/managedidentities/internal/managed_identities_connection_impl.cc
@@ -39,9 +39,7 @@ ManagedIdentitiesServiceConnectionImpl::ManagedIdentitiesServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          managedidentities_internal::ManagedIdentitiesServiceDefaultOptions(
-              ManagedIdentitiesServiceConnection::options()))) {}
+          std::move(options), ManagedIdentitiesServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>
 ManagedIdentitiesServiceConnectionImpl::CreateMicrosoftAdDomain(

--- a/google/cloud/managedidentities/managed_identities_client.cc
+++ b/google/cloud/managedidentities/managed_identities_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/managedidentities/v1/managed_identities_service.proto
 
 #include "google/cloud/managedidentities/managed_identities_client.h"
-#include "google/cloud/managedidentities/internal/managed_identities_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ ManagedIdentitiesServiceClient::ManagedIdentitiesServiceClient(
     std::shared_ptr<ManagedIdentitiesServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          managedidentities_internal::ManagedIdentitiesServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ManagedIdentitiesServiceClient::~ManagedIdentitiesServiceClient() = default;
 
 future<StatusOr<google::cloud::managedidentities::v1::Domain>>

--- a/google/cloud/memcache/cloud_memcache_client.cc
+++ b/google/cloud/memcache/cloud_memcache_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/memcache/v1/cloud_memcache.proto
 
 #include "google/cloud/memcache/cloud_memcache_client.h"
-#include "google/cloud/memcache/internal/cloud_memcache_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudMemcacheClient::CloudMemcacheClient(
     std::shared_ptr<CloudMemcacheConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), memcache_internal::CloudMemcacheDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudMemcacheClient::~CloudMemcacheClient() = default;
 
 StreamRange<google::cloud::memcache::v1::Instance>

--- a/google/cloud/memcache/internal/cloud_memcache_connection_impl.cc
+++ b/google/cloud/memcache/internal/cloud_memcache_connection_impl.cc
@@ -36,9 +36,8 @@ CloudMemcacheConnectionImpl::CloudMemcacheConnectionImpl(
     std::shared_ptr<memcache_internal::CloudMemcacheStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), memcache_internal::CloudMemcacheDefaultOptions(
-                                  CloudMemcacheConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CloudMemcacheConnection::options())) {}
 
 StreamRange<google::cloud::memcache::v1::Instance>
 CloudMemcacheConnectionImpl::ListInstances(

--- a/google/cloud/monitoring/alert_policy_client.cc
+++ b/google/cloud/monitoring/alert_policy_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/alert_service.proto
 
 #include "google/cloud/monitoring/alert_policy_client.h"
-#include "google/cloud/monitoring/internal/alert_policy_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AlertPolicyServiceClient::AlertPolicyServiceClient(
     std::shared_ptr<AlertPolicyServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          monitoring_internal::AlertPolicyServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AlertPolicyServiceClient::~AlertPolicyServiceClient() = default;
 
 StreamRange<google::monitoring::v3::AlertPolicy>

--- a/google/cloud/monitoring/dashboards_client.cc
+++ b/google/cloud/monitoring/dashboards_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/dashboard/v1/dashboards_service.proto
 
 #include "google/cloud/monitoring/dashboards_client.h"
-#include "google/cloud/monitoring/internal/dashboards_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DashboardsServiceClient::DashboardsServiceClient(
     std::shared_ptr<DashboardsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), monitoring_internal::DashboardsServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DashboardsServiceClient::~DashboardsServiceClient() = default;
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>

--- a/google/cloud/monitoring/group_client.cc
+++ b/google/cloud/monitoring/group_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/group_service.proto
 
 #include "google/cloud/monitoring/group_client.h"
-#include "google/cloud/monitoring/internal/group_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 GroupServiceClient::GroupServiceClient(
     std::shared_ptr<GroupServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), monitoring_internal::GroupServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 GroupServiceClient::~GroupServiceClient() = default;
 
 StreamRange<google::monitoring::v3::Group> GroupServiceClient::ListGroups(

--- a/google/cloud/monitoring/internal/alert_policy_connection_impl.cc
+++ b/google/cloud/monitoring/internal/alert_policy_connection_impl.cc
@@ -37,9 +37,7 @@ AlertPolicyServiceConnectionImpl::AlertPolicyServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          monitoring_internal::AlertPolicyServiceDefaultOptions(
-              AlertPolicyServiceConnection::options()))) {}
+          std::move(options), AlertPolicyServiceConnection::options())) {}
 
 StreamRange<google::monitoring::v3::AlertPolicy>
 AlertPolicyServiceConnectionImpl::ListAlertPolicies(

--- a/google/cloud/monitoring/internal/dashboards_connection_impl.cc
+++ b/google/cloud/monitoring/internal/dashboards_connection_impl.cc
@@ -37,9 +37,7 @@ DashboardsServiceConnectionImpl::DashboardsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          monitoring_internal::DashboardsServiceDefaultOptions(
-              DashboardsServiceConnection::options()))) {}
+          std::move(options), DashboardsServiceConnection::options())) {}
 
 StatusOr<google::monitoring::dashboard::v1::Dashboard>
 DashboardsServiceConnectionImpl::CreateDashboard(

--- a/google/cloud/monitoring/internal/group_connection_impl.cc
+++ b/google/cloud/monitoring/internal/group_connection_impl.cc
@@ -36,9 +36,8 @@ GroupServiceConnectionImpl::GroupServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::GroupServiceDefaultOptions(
-                                  GroupServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      GroupServiceConnection::options())) {}
 
 StreamRange<google::monitoring::v3::Group>
 GroupServiceConnectionImpl::ListGroups(

--- a/google/cloud/monitoring/internal/metric_connection_impl.cc
+++ b/google/cloud/monitoring/internal/metric_connection_impl.cc
@@ -37,9 +37,8 @@ MetricServiceConnectionImpl::MetricServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::MetricServiceDefaultOptions(
-                                  MetricServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      MetricServiceConnection::options())) {}
 
 StreamRange<google::api::MonitoredResourceDescriptor>
 MetricServiceConnectionImpl::ListMonitoredResourceDescriptors(

--- a/google/cloud/monitoring/internal/metrics_scopes_connection_impl.cc
+++ b/google/cloud/monitoring/internal/metrics_scopes_connection_impl.cc
@@ -36,9 +36,8 @@ MetricsScopesConnectionImpl::MetricsScopesConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::MetricsScopesDefaultOptions(
-                                  MetricsScopesConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      MetricsScopesConnection::options())) {}
 
 StatusOr<google::monitoring::metricsscope::v1::MetricsScope>
 MetricsScopesConnectionImpl::GetMetricsScope(

--- a/google/cloud/monitoring/internal/notification_channel_connection_impl.cc
+++ b/google/cloud/monitoring/internal/notification_channel_connection_impl.cc
@@ -40,8 +40,7 @@ NotificationChannelServiceConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          monitoring_internal::NotificationChannelServiceDefaultOptions(
-              NotificationChannelServiceConnection::options()))) {}
+          NotificationChannelServiceConnection::options())) {}
 
 StreamRange<google::monitoring::v3::NotificationChannelDescriptor>
 NotificationChannelServiceConnectionImpl::ListNotificationChannelDescriptors(

--- a/google/cloud/monitoring/internal/query_connection_impl.cc
+++ b/google/cloud/monitoring/internal/query_connection_impl.cc
@@ -36,9 +36,8 @@ QueryServiceConnectionImpl::QueryServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), monitoring_internal::QueryServiceDefaultOptions(
-                                  QueryServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      QueryServiceConnection::options())) {}
 
 StreamRange<google::monitoring::v3::TimeSeriesData>
 QueryServiceConnectionImpl::QueryTimeSeries(

--- a/google/cloud/monitoring/internal/service_monitoring_connection_impl.cc
+++ b/google/cloud/monitoring/internal/service_monitoring_connection_impl.cc
@@ -37,9 +37,7 @@ ServiceMonitoringServiceConnectionImpl::ServiceMonitoringServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          monitoring_internal::ServiceMonitoringServiceDefaultOptions(
-              ServiceMonitoringServiceConnection::options()))) {}
+          std::move(options), ServiceMonitoringServiceConnection::options())) {}
 
 StatusOr<google::monitoring::v3::Service>
 ServiceMonitoringServiceConnectionImpl::CreateService(

--- a/google/cloud/monitoring/internal/uptime_check_connection_impl.cc
+++ b/google/cloud/monitoring/internal/uptime_check_connection_impl.cc
@@ -37,9 +37,7 @@ UptimeCheckServiceConnectionImpl::UptimeCheckServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          monitoring_internal::UptimeCheckServiceDefaultOptions(
-              UptimeCheckServiceConnection::options()))) {}
+          std::move(options), UptimeCheckServiceConnection::options())) {}
 
 StreamRange<google::monitoring::v3::UptimeCheckConfig>
 UptimeCheckServiceConnectionImpl::ListUptimeCheckConfigs(

--- a/google/cloud/monitoring/metric_client.cc
+++ b/google/cloud/monitoring/metric_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/metric_service.proto
 
 #include "google/cloud/monitoring/metric_client.h"
-#include "google/cloud/monitoring/internal/metric_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 MetricServiceClient::MetricServiceClient(
     std::shared_ptr<MetricServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), monitoring_internal::MetricServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 MetricServiceClient::~MetricServiceClient() = default;
 
 StreamRange<google::api::MonitoredResourceDescriptor>

--- a/google/cloud/monitoring/metrics_scopes_client.cc
+++ b/google/cloud/monitoring/metrics_scopes_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/metricsscope/v1/metrics_scopes.proto
 
 #include "google/cloud/monitoring/metrics_scopes_client.h"
-#include "google/cloud/monitoring/internal/metrics_scopes_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 MetricsScopesClient::MetricsScopesClient(
     std::shared_ptr<MetricsScopesConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), monitoring_internal::MetricsScopesDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 MetricsScopesClient::~MetricsScopesClient() = default;
 
 StatusOr<google::monitoring::metricsscope::v1::MetricsScope>

--- a/google/cloud/monitoring/notification_channel_client.cc
+++ b/google/cloud/monitoring/notification_channel_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/notification_service.proto
 
 #include "google/cloud/monitoring/notification_channel_client.h"
-#include "google/cloud/monitoring/internal/notification_channel_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ NotificationChannelServiceClient::NotificationChannelServiceClient(
     std::shared_ptr<NotificationChannelServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          monitoring_internal::NotificationChannelServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 NotificationChannelServiceClient::~NotificationChannelServiceClient() = default;
 
 StreamRange<google::monitoring::v3::NotificationChannelDescriptor>

--- a/google/cloud/monitoring/query_client.cc
+++ b/google/cloud/monitoring/query_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/query_service.proto
 
 #include "google/cloud/monitoring/query_client.h"
-#include "google/cloud/monitoring/internal/query_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 QueryServiceClient::QueryServiceClient(
     std::shared_ptr<QueryServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), monitoring_internal::QueryServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 QueryServiceClient::~QueryServiceClient() = default;
 
 StreamRange<google::monitoring::v3::TimeSeriesData>

--- a/google/cloud/monitoring/service_monitoring_client.cc
+++ b/google/cloud/monitoring/service_monitoring_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/service_service.proto
 
 #include "google/cloud/monitoring/service_monitoring_client.h"
-#include "google/cloud/monitoring/internal/service_monitoring_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ ServiceMonitoringServiceClient::ServiceMonitoringServiceClient(
     std::shared_ptr<ServiceMonitoringServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          monitoring_internal::ServiceMonitoringServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ServiceMonitoringServiceClient::~ServiceMonitoringServiceClient() = default;
 
 StatusOr<google::monitoring::v3::Service>

--- a/google/cloud/monitoring/uptime_check_client.cc
+++ b/google/cloud/monitoring/uptime_check_client.cc
@@ -17,7 +17,6 @@
 // source: google/monitoring/v3/uptime_service.proto
 
 #include "google/cloud/monitoring/uptime_check_client.h"
-#include "google/cloud/monitoring/internal/uptime_check_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 UptimeCheckServiceClient::UptimeCheckServiceClient(
     std::shared_ptr<UptimeCheckServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          monitoring_internal::UptimeCheckServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 UptimeCheckServiceClient::~UptimeCheckServiceClient() = default;
 
 StreamRange<google::monitoring::v3::UptimeCheckConfig>

--- a/google/cloud/networkmanagement/internal/reachability_connection_impl.cc
+++ b/google/cloud/networkmanagement/internal/reachability_connection_impl.cc
@@ -38,9 +38,7 @@ ReachabilityServiceConnectionImpl::ReachabilityServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          networkmanagement_internal::ReachabilityServiceDefaultOptions(
-              ReachabilityServiceConnection::options()))) {}
+          std::move(options), ReachabilityServiceConnection::options())) {}
 
 StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>
 ReachabilityServiceConnectionImpl::ListConnectivityTests(

--- a/google/cloud/networkmanagement/reachability_client.cc
+++ b/google/cloud/networkmanagement/reachability_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/networkmanagement/v1/reachability.proto
 
 #include "google/cloud/networkmanagement/reachability_client.h"
-#include "google/cloud/networkmanagement/internal/reachability_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ReachabilityServiceClient::ReachabilityServiceClient(
     std::shared_ptr<ReachabilityServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          networkmanagement_internal::ReachabilityServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ReachabilityServiceClient::~ReachabilityServiceClient() = default;
 
 StreamRange<google::cloud::networkmanagement::v1::ConnectivityTest>

--- a/google/cloud/notebooks/internal/managed_notebook_connection_impl.cc
+++ b/google/cloud/notebooks/internal/managed_notebook_connection_impl.cc
@@ -38,9 +38,7 @@ ManagedNotebookServiceConnectionImpl::ManagedNotebookServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          notebooks_internal::ManagedNotebookServiceDefaultOptions(
-              ManagedNotebookServiceConnection::options()))) {}
+          std::move(options), ManagedNotebookServiceConnection::options())) {}
 
 StreamRange<google::cloud::notebooks::v1::Runtime>
 ManagedNotebookServiceConnectionImpl::ListRuntimes(

--- a/google/cloud/notebooks/internal/notebook_connection_impl.cc
+++ b/google/cloud/notebooks/internal/notebook_connection_impl.cc
@@ -37,9 +37,8 @@ NotebookServiceConnectionImpl::NotebookServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), notebooks_internal::NotebookServiceDefaultOptions(
-                                  NotebookServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      NotebookServiceConnection::options())) {}
 
 StreamRange<google::cloud::notebooks::v1::Instance>
 NotebookServiceConnectionImpl::ListInstances(

--- a/google/cloud/notebooks/managed_notebook_client.cc
+++ b/google/cloud/notebooks/managed_notebook_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/notebooks/v1/managed_service.proto
 
 #include "google/cloud/notebooks/managed_notebook_client.h"
-#include "google/cloud/notebooks/internal/managed_notebook_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ManagedNotebookServiceClient::ManagedNotebookServiceClient(
     std::shared_ptr<ManagedNotebookServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          notebooks_internal::ManagedNotebookServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ManagedNotebookServiceClient::~ManagedNotebookServiceClient() = default;
 
 StreamRange<google::cloud::notebooks::v1::Runtime>

--- a/google/cloud/notebooks/notebook_client.cc
+++ b/google/cloud/notebooks/notebook_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/notebooks/v1/service.proto
 
 #include "google/cloud/notebooks/notebook_client.h"
-#include "google/cloud/notebooks/internal/notebook_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 NotebookServiceClient::NotebookServiceClient(
     std::shared_ptr<NotebookServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), notebooks_internal::NotebookServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 NotebookServiceClient::~NotebookServiceClient() = default;
 
 StreamRange<google::cloud::notebooks::v1::Instance>

--- a/google/cloud/optimization/fleet_routing_client.cc
+++ b/google/cloud/optimization/fleet_routing_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/optimization/v1/fleet_routing.proto
 
 #include "google/cloud/optimization/fleet_routing_client.h"
-#include "google/cloud/optimization/internal/fleet_routing_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 FleetRoutingClient::FleetRoutingClient(
     std::shared_ptr<FleetRoutingConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), optimization_internal::FleetRoutingDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 FleetRoutingClient::~FleetRoutingClient() = default;
 
 StatusOr<google::cloud::optimization::v1::OptimizeToursResponse>

--- a/google/cloud/optimization/internal/fleet_routing_connection_impl.cc
+++ b/google/cloud/optimization/internal/fleet_routing_connection_impl.cc
@@ -36,9 +36,8 @@ FleetRoutingConnectionImpl::FleetRoutingConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), optimization_internal::FleetRoutingDefaultOptions(
-                                  FleetRoutingConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      FleetRoutingConnection::options())) {}
 
 StatusOr<google::cloud::optimization::v1::OptimizeToursResponse>
 FleetRoutingConnectionImpl::OptimizeTours(

--- a/google/cloud/orgpolicy/internal/org_policy_connection_impl.cc
+++ b/google/cloud/orgpolicy/internal/org_policy_connection_impl.cc
@@ -35,9 +35,8 @@ OrgPolicyConnectionImpl::OrgPolicyConnectionImpl(
     std::shared_ptr<orgpolicy_internal::OrgPolicyStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), orgpolicy_internal::OrgPolicyDefaultOptions(
-                                  OrgPolicyConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      OrgPolicyConnection::options())) {}
 
 StreamRange<google::cloud::orgpolicy::v2::Constraint>
 OrgPolicyConnectionImpl::ListConstraints(

--- a/google/cloud/orgpolicy/org_policy_client.cc
+++ b/google/cloud/orgpolicy/org_policy_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/orgpolicy/v2/orgpolicy.proto
 
 #include "google/cloud/orgpolicy/org_policy_client.h"
-#include "google/cloud/orgpolicy/internal/org_policy_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 OrgPolicyClient::OrgPolicyClient(
     std::shared_ptr<OrgPolicyConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), orgpolicy_internal::OrgPolicyDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 OrgPolicyClient::~OrgPolicyClient() = default;
 
 StreamRange<google::cloud::orgpolicy::v2::Constraint>

--- a/google/cloud/osconfig/agent_endpoint_client.cc
+++ b/google/cloud/osconfig/agent_endpoint_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/osconfig/agentendpoint/v1/agentendpoint.proto
 
 #include "google/cloud/osconfig/agent_endpoint_client.h"
-#include "google/cloud/osconfig/internal/agent_endpoint_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AgentEndpointServiceClient::AgentEndpointServiceClient(
     std::shared_ptr<AgentEndpointServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          osconfig_internal::AgentEndpointServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AgentEndpointServiceClient::~AgentEndpointServiceClient() = default;
 
 StreamRange<

--- a/google/cloud/osconfig/internal/agent_endpoint_connection_impl.cc
+++ b/google/cloud/osconfig/internal/agent_endpoint_connection_impl.cc
@@ -38,9 +38,7 @@ AgentEndpointServiceConnectionImpl::AgentEndpointServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          osconfig_internal::AgentEndpointServiceDefaultOptions(
-              AgentEndpointServiceConnection::options()))) {}
+          std::move(options), AgentEndpointServiceConnection::options())) {}
 
 StreamRange<
     google::cloud::osconfig::agentendpoint::v1::ReceiveTaskNotificationResponse>

--- a/google/cloud/osconfig/internal/os_config_connection_impl.cc
+++ b/google/cloud/osconfig/internal/os_config_connection_impl.cc
@@ -36,9 +36,8 @@ OsConfigServiceConnectionImpl::OsConfigServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), osconfig_internal::OsConfigServiceDefaultOptions(
-                                  OsConfigServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      OsConfigServiceConnection::options())) {}
 
 StatusOr<google::cloud::osconfig::v1::PatchJob>
 OsConfigServiceConnectionImpl::ExecutePatchJob(

--- a/google/cloud/osconfig/os_config_client.cc
+++ b/google/cloud/osconfig/os_config_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/osconfig/v1/osconfig_service.proto
 
 #include "google/cloud/osconfig/os_config_client.h"
-#include "google/cloud/osconfig/internal/os_config_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 OsConfigServiceClient::OsConfigServiceClient(
     std::shared_ptr<OsConfigServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), osconfig_internal::OsConfigServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 OsConfigServiceClient::~OsConfigServiceClient() = default;
 
 StatusOr<google::cloud::osconfig::v1::PatchJob>

--- a/google/cloud/oslogin/internal/os_login_connection_impl.cc
+++ b/google/cloud/oslogin/internal/os_login_connection_impl.cc
@@ -34,9 +34,8 @@ OsLoginServiceConnectionImpl::OsLoginServiceConnectionImpl(
     std::shared_ptr<oslogin_internal::OsLoginServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), oslogin_internal::OsLoginServiceDefaultOptions(
-                                  OsLoginServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      OsLoginServiceConnection::options())) {}
 
 Status OsLoginServiceConnectionImpl::DeletePosixAccount(
     google::cloud::oslogin::v1::DeletePosixAccountRequest const& request) {

--- a/google/cloud/oslogin/os_login_client.cc
+++ b/google/cloud/oslogin/os_login_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/oslogin/v1/oslogin.proto
 
 #include "google/cloud/oslogin/os_login_client.h"
-#include "google/cloud/oslogin/internal/os_login_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 OsLoginServiceClient::OsLoginServiceClient(
     std::shared_ptr<OsLoginServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), oslogin_internal::OsLoginServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 OsLoginServiceClient::~OsLoginServiceClient() = default;
 
 Status OsLoginServiceClient::DeletePosixAccount(std::string const& name,

--- a/google/cloud/policytroubleshooter/iam_checker_client.cc
+++ b/google/cloud/policytroubleshooter/iam_checker_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/policytroubleshooter/v1/checker.proto
 
 #include "google/cloud/policytroubleshooter/iam_checker_client.h"
-#include "google/cloud/policytroubleshooter/internal/iam_checker_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 IamCheckerClient::IamCheckerClient(
     std::shared_ptr<IamCheckerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          policytroubleshooter_internal::IamCheckerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 IamCheckerClient::~IamCheckerClient() = default;
 
 StatusOr<google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>

--- a/google/cloud/policytroubleshooter/internal/iam_checker_connection_impl.cc
+++ b/google/cloud/policytroubleshooter/internal/iam_checker_connection_impl.cc
@@ -35,10 +35,8 @@ IamCheckerConnectionImpl::IamCheckerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          policytroubleshooter_internal::IamCheckerDefaultOptions(
-              IamCheckerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      IamCheckerConnection::options())) {}
 
 StatusOr<google::cloud::policytroubleshooter::v1::TroubleshootIamPolicyResponse>
 IamCheckerConnectionImpl::TroubleshootIamPolicy(

--- a/google/cloud/privateca/certificate_authority_client.cc
+++ b/google/cloud/privateca/certificate_authority_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/security/privateca/v1/service.proto
 
 #include "google/cloud/privateca/certificate_authority_client.h"
-#include "google/cloud/privateca/internal/certificate_authority_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ CertificateAuthorityServiceClient::CertificateAuthorityServiceClient(
     std::shared_ptr<CertificateAuthorityServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          privateca_internal::CertificateAuthorityServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CertificateAuthorityServiceClient::~CertificateAuthorityServiceClient() =
     default;
 

--- a/google/cloud/privateca/internal/certificate_authority_connection_impl.cc
+++ b/google/cloud/privateca/internal/certificate_authority_connection_impl.cc
@@ -41,8 +41,7 @@ CertificateAuthorityServiceConnectionImpl::
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
           std::move(options),
-          privateca_internal::CertificateAuthorityServiceDefaultOptions(
-              CertificateAuthorityServiceConnection::options()))) {}
+          CertificateAuthorityServiceConnection::options())) {}
 
 StatusOr<google::cloud::security::privateca::v1::Certificate>
 CertificateAuthorityServiceConnectionImpl::CreateCertificate(

--- a/google/cloud/profiler/internal/profiler_connection_impl.cc
+++ b/google/cloud/profiler/internal/profiler_connection_impl.cc
@@ -35,9 +35,8 @@ ProfilerServiceConnectionImpl::ProfilerServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), profiler_internal::ProfilerServiceDefaultOptions(
-                                  ProfilerServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ProfilerServiceConnection::options())) {}
 
 StatusOr<google::devtools::cloudprofiler::v2::Profile>
 ProfilerServiceConnectionImpl::CreateProfile(

--- a/google/cloud/profiler/profiler_client.cc
+++ b/google/cloud/profiler/profiler_client.cc
@@ -17,7 +17,6 @@
 // source: google/devtools/cloudprofiler/v2/profiler.proto
 
 #include "google/cloud/profiler/profiler_client.h"
-#include "google/cloud/profiler/internal/profiler_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ProfilerServiceClient::ProfilerServiceClient(
     std::shared_ptr<ProfilerServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), profiler_internal::ProfilerServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ProfilerServiceClient::~ProfilerServiceClient() = default;
 
 StatusOr<google::devtools::cloudprofiler::v2::Profile>

--- a/google/cloud/pubsublite/admin_client.cc
+++ b/google/cloud/pubsublite/admin_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/pubsublite/v1/admin.proto
 
 #include "google/cloud/pubsublite/admin_client.h"
-#include "google/cloud/pubsublite/internal/admin_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 AdminServiceClient::AdminServiceClient(
     std::shared_ptr<AdminServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), pubsublite_internal::AdminServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 AdminServiceClient::~AdminServiceClient() = default;
 
 StatusOr<google::cloud::pubsublite::v1::Topic> AdminServiceClient::CreateTopic(

--- a/google/cloud/pubsublite/internal/admin_connection_impl.cc
+++ b/google/cloud/pubsublite/internal/admin_connection_impl.cc
@@ -38,9 +38,8 @@ AdminServiceConnectionImpl::AdminServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), pubsublite_internal::AdminServiceDefaultOptions(
-                                  AdminServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      AdminServiceConnection::options())) {}
 
 StatusOr<google::cloud::pubsublite::v1::Topic>
 AdminServiceConnectionImpl::CreateTopic(

--- a/google/cloud/pubsublite/internal/topic_stats_connection_impl.cc
+++ b/google/cloud/pubsublite/internal/topic_stats_connection_impl.cc
@@ -36,9 +36,7 @@ TopicStatsServiceConnectionImpl::TopicStatsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          pubsublite_internal::TopicStatsServiceDefaultOptions(
-              TopicStatsServiceConnection::options()))) {}
+          std::move(options), TopicStatsServiceConnection::options())) {}
 
 StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>
 TopicStatsServiceConnectionImpl::ComputeMessageStats(

--- a/google/cloud/pubsublite/topic_stats_client.cc
+++ b/google/cloud/pubsublite/topic_stats_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/pubsublite/v1/topic_stats.proto
 
 #include "google/cloud/pubsublite/topic_stats_client.h"
-#include "google/cloud/pubsublite/internal/topic_stats_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TopicStatsServiceClient::TopicStatsServiceClient(
     std::shared_ptr<TopicStatsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), pubsublite_internal::TopicStatsServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TopicStatsServiceClient::~TopicStatsServiceClient() = default;
 
 StatusOr<google::cloud::pubsublite::v1::ComputeMessageStatsResponse>

--- a/google/cloud/recommender/internal/recommender_connection_impl.cc
+++ b/google/cloud/recommender/internal/recommender_connection_impl.cc
@@ -36,9 +36,8 @@ RecommenderConnectionImpl::RecommenderConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), recommender_internal::RecommenderDefaultOptions(
-                                  RecommenderConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      RecommenderConnection::options())) {}
 
 StreamRange<google::cloud::recommender::v1::Insight>
 RecommenderConnectionImpl::ListInsights(

--- a/google/cloud/recommender/recommender_client.cc
+++ b/google/cloud/recommender/recommender_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/recommender/v1/recommender_service.proto
 
 #include "google/cloud/recommender/recommender_client.h"
-#include "google/cloud/recommender/internal/recommender_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 RecommenderClient::RecommenderClient(
     std::shared_ptr<RecommenderConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), recommender_internal::RecommenderDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 RecommenderClient::~RecommenderClient() = default;
 
 StreamRange<google::cloud::recommender::v1::Insight>

--- a/google/cloud/redis/cloud_redis_client.cc
+++ b/google/cloud/redis/cloud_redis_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/redis/v1/cloud_redis.proto
 
 #include "google/cloud/redis/cloud_redis_client.h"
-#include "google/cloud/redis/internal/cloud_redis_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudRedisClient::CloudRedisClient(
     std::shared_ptr<CloudRedisConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          redis_internal::CloudRedisDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudRedisClient::~CloudRedisClient() = default;
 
 StreamRange<google::cloud::redis::v1::Instance> CloudRedisClient::ListInstances(

--- a/google/cloud/redis/internal/cloud_redis_connection_impl.cc
+++ b/google/cloud/redis/internal/cloud_redis_connection_impl.cc
@@ -37,8 +37,7 @@ CloudRedisConnectionImpl::CloudRedisConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      redis_internal::CloudRedisDefaultOptions(
-                                          CloudRedisConnection::options()))) {}
+                                      CloudRedisConnection::options())) {}
 
 StreamRange<google::cloud::redis::v1::Instance>
 CloudRedisConnectionImpl::ListInstances(

--- a/google/cloud/resourcemanager/folders_client.cc
+++ b/google/cloud/resourcemanager/folders_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/resourcemanager/folders_client.h"
 #include "google/cloud/resourcemanager/folders_options.h"
-#include "google/cloud/resourcemanager/internal/folders_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 FoldersClient::FoldersClient(std::shared_ptr<FoldersConnection> connection,
                              Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), resourcemanager_internal::FoldersDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 FoldersClient::~FoldersClient() = default;
 
 StatusOr<google::cloud::resourcemanager::v3::Folder> FoldersClient::GetFolder(

--- a/google/cloud/resourcemanager/internal/folders_connection_impl.cc
+++ b/google/cloud/resourcemanager/internal/folders_connection_impl.cc
@@ -37,9 +37,8 @@ FoldersConnectionImpl::FoldersConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), resourcemanager_internal::FoldersDefaultOptions(
-                                  FoldersConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      FoldersConnection::options())) {}
 
 StatusOr<google::cloud::resourcemanager::v3::Folder>
 FoldersConnectionImpl::GetFolder(

--- a/google/cloud/resourcemanager/internal/organizations_connection_impl.cc
+++ b/google/cloud/resourcemanager/internal/organizations_connection_impl.cc
@@ -36,10 +36,8 @@ OrganizationsConnectionImpl::OrganizationsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          resourcemanager_internal::OrganizationsDefaultOptions(
-              OrganizationsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      OrganizationsConnection::options())) {}
 
 StatusOr<google::cloud::resourcemanager::v3::Organization>
 OrganizationsConnectionImpl::GetOrganization(

--- a/google/cloud/resourcemanager/internal/projects_connection_impl.cc
+++ b/google/cloud/resourcemanager/internal/projects_connection_impl.cc
@@ -37,9 +37,8 @@ ProjectsConnectionImpl::ProjectsConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), resourcemanager_internal::ProjectsDefaultOptions(
-                                  ProjectsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ProjectsConnection::options())) {}
 
 StatusOr<google::cloud::resourcemanager::v3::Project>
 ProjectsConnectionImpl::GetProject(

--- a/google/cloud/resourcemanager/organizations_client.cc
+++ b/google/cloud/resourcemanager/organizations_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/resourcemanager/v3/organizations.proto
 
 #include "google/cloud/resourcemanager/organizations_client.h"
-#include "google/cloud/resourcemanager/internal/organizations_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 OrganizationsClient::OrganizationsClient(
     std::shared_ptr<OrganizationsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          resourcemanager_internal::OrganizationsDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 OrganizationsClient::~OrganizationsClient() = default;
 
 StatusOr<google::cloud::resourcemanager::v3::Organization>

--- a/google/cloud/resourcemanager/projects_client.cc
+++ b/google/cloud/resourcemanager/projects_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/resourcemanager/v3/projects.proto
 
 #include "google/cloud/resourcemanager/projects_client.h"
-#include "google/cloud/resourcemanager/internal/projects_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ProjectsClient::ProjectsClient(std::shared_ptr<ProjectsConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), resourcemanager_internal::ProjectsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ProjectsClient::~ProjectsClient() = default;
 
 StatusOr<google::cloud::resourcemanager::v3::Project>

--- a/google/cloud/resourcesettings/internal/resource_settings_connection_impl.cc
+++ b/google/cloud/resourcesettings/internal/resource_settings_connection_impl.cc
@@ -38,9 +38,7 @@ ResourceSettingsServiceConnectionImpl::ResourceSettingsServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          resourcesettings_internal::ResourceSettingsServiceDefaultOptions(
-              ResourceSettingsServiceConnection::options()))) {}
+          std::move(options), ResourceSettingsServiceConnection::options())) {}
 
 StreamRange<google::cloud::resourcesettings::v1::Setting>
 ResourceSettingsServiceConnectionImpl::ListSettings(

--- a/google/cloud/resourcesettings/resource_settings_client.cc
+++ b/google/cloud/resourcesettings/resource_settings_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/resourcesettings/v1/resource_settings.proto
 
 #include "google/cloud/resourcesettings/resource_settings_client.h"
-#include "google/cloud/resourcesettings/internal/resource_settings_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ResourceSettingsServiceClient::ResourceSettingsServiceClient(
     std::shared_ptr<ResourceSettingsServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          resourcesettings_internal::ResourceSettingsServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ResourceSettingsServiceClient::~ResourceSettingsServiceClient() = default;
 
 StreamRange<google::cloud::resourcesettings::v1::Setting>

--- a/google/cloud/retail/catalog_client.cc
+++ b/google/cloud/retail/catalog_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/retail/v2/catalog_service.proto
 
 #include "google/cloud/retail/catalog_client.h"
-#include "google/cloud/retail/internal/catalog_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CatalogServiceClient::CatalogServiceClient(
     std::shared_ptr<CatalogServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), retail_internal::CatalogServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CatalogServiceClient::~CatalogServiceClient() = default;
 
 StreamRange<google::cloud::retail::v2::Catalog>

--- a/google/cloud/retail/completion_client.cc
+++ b/google/cloud/retail/completion_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/retail/v2/completion_service.proto
 
 #include "google/cloud/retail/completion_client.h"
-#include "google/cloud/retail/internal/completion_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CompletionServiceClient::CompletionServiceClient(
     std::shared_ptr<CompletionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), retail_internal::CompletionServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CompletionServiceClient::~CompletionServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::CompleteQueryResponse>

--- a/google/cloud/retail/internal/catalog_connection_impl.cc
+++ b/google/cloud/retail/internal/catalog_connection_impl.cc
@@ -35,9 +35,8 @@ CatalogServiceConnectionImpl::CatalogServiceConnectionImpl(
     std::shared_ptr<retail_internal::CatalogServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), retail_internal::CatalogServiceDefaultOptions(
-                                  CatalogServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CatalogServiceConnection::options())) {}
 
 StreamRange<google::cloud::retail::v2::Catalog>
 CatalogServiceConnectionImpl::ListCatalogs(

--- a/google/cloud/retail/internal/completion_connection_impl.cc
+++ b/google/cloud/retail/internal/completion_connection_impl.cc
@@ -37,8 +37,7 @@ CompletionServiceConnectionImpl::CompletionServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::CompletionServiceDefaultOptions(
-                                  CompletionServiceConnection::options()))) {}
+          std::move(options), CompletionServiceConnection::options())) {}
 
 StatusOr<google::cloud::retail::v2::CompleteQueryResponse>
 CompletionServiceConnectionImpl::CompleteQuery(

--- a/google/cloud/retail/internal/prediction_connection_impl.cc
+++ b/google/cloud/retail/internal/prediction_connection_impl.cc
@@ -36,8 +36,7 @@ PredictionServiceConnectionImpl::PredictionServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), retail_internal::PredictionServiceDefaultOptions(
-                                  PredictionServiceConnection::options()))) {}
+          std::move(options), PredictionServiceConnection::options())) {}
 
 StatusOr<google::cloud::retail::v2::PredictResponse>
 PredictionServiceConnectionImpl::Predict(

--- a/google/cloud/retail/internal/product_connection_impl.cc
+++ b/google/cloud/retail/internal/product_connection_impl.cc
@@ -36,9 +36,8 @@ ProductServiceConnectionImpl::ProductServiceConnectionImpl(
     std::shared_ptr<retail_internal::ProductServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), retail_internal::ProductServiceDefaultOptions(
-                                  ProductServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ProductServiceConnection::options())) {}
 
 StatusOr<google::cloud::retail::v2::Product>
 ProductServiceConnectionImpl::CreateProduct(

--- a/google/cloud/retail/internal/search_connection_impl.cc
+++ b/google/cloud/retail/internal/search_connection_impl.cc
@@ -35,9 +35,8 @@ SearchServiceConnectionImpl::SearchServiceConnectionImpl(
     std::shared_ptr<retail_internal::SearchServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), retail_internal::SearchServiceDefaultOptions(
-                                  SearchServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      SearchServiceConnection::options())) {}
 
 StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult>
 SearchServiceConnectionImpl::Search(

--- a/google/cloud/retail/internal/user_event_connection_impl.cc
+++ b/google/cloud/retail/internal/user_event_connection_impl.cc
@@ -36,9 +36,8 @@ UserEventServiceConnectionImpl::UserEventServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), retail_internal::UserEventServiceDefaultOptions(
-                                  UserEventServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      UserEventServiceConnection::options())) {}
 
 StatusOr<google::cloud::retail::v2::UserEvent>
 UserEventServiceConnectionImpl::WriteUserEvent(

--- a/google/cloud/retail/prediction_client.cc
+++ b/google/cloud/retail/prediction_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/retail/v2/prediction_service.proto
 
 #include "google/cloud/retail/prediction_client.h"
-#include "google/cloud/retail/internal/prediction_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 PredictionServiceClient::PredictionServiceClient(
     std::shared_ptr<PredictionServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), retail_internal::PredictionServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 PredictionServiceClient::~PredictionServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::PredictResponse>

--- a/google/cloud/retail/product_client.cc
+++ b/google/cloud/retail/product_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/retail/v2/product_service.proto
 
 #include "google/cloud/retail/product_client.h"
-#include "google/cloud/retail/internal/product_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ProductServiceClient::ProductServiceClient(
     std::shared_ptr<ProductServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), retail_internal::ProductServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ProductServiceClient::~ProductServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::Product>

--- a/google/cloud/retail/search_client.cc
+++ b/google/cloud/retail/search_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/retail/v2/search_service.proto
 
 #include "google/cloud/retail/search_client.h"
-#include "google/cloud/retail/internal/search_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SearchServiceClient::SearchServiceClient(
     std::shared_ptr<SearchServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), retail_internal::SearchServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SearchServiceClient::~SearchServiceClient() = default;
 
 StreamRange<google::cloud::retail::v2::SearchResponse::SearchResult>

--- a/google/cloud/retail/user_event_client.cc
+++ b/google/cloud/retail/user_event_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/retail/v2/user_event_service.proto
 
 #include "google/cloud/retail/user_event_client.h"
-#include "google/cloud/retail/internal/user_event_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 UserEventServiceClient::UserEventServiceClient(
     std::shared_ptr<UserEventServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), retail_internal::UserEventServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 UserEventServiceClient::~UserEventServiceClient() = default;
 
 StatusOr<google::cloud::retail::v2::UserEvent>

--- a/google/cloud/run/internal/revisions_connection_impl.cc
+++ b/google/cloud/run/internal/revisions_connection_impl.cc
@@ -37,8 +37,7 @@ RevisionsConnectionImpl::RevisionsConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      run_internal::RevisionsDefaultOptions(
-                                          RevisionsConnection::options()))) {}
+                                      RevisionsConnection::options())) {}
 
 StatusOr<google::cloud::run::v2::Revision> RevisionsConnectionImpl::GetRevision(
     google::cloud::run::v2::GetRevisionRequest const& request) {

--- a/google/cloud/run/internal/services_connection_impl.cc
+++ b/google/cloud/run/internal/services_connection_impl.cc
@@ -37,8 +37,7 @@ ServicesConnectionImpl::ServicesConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      run_internal::ServicesDefaultOptions(
-                                          ServicesConnection::options()))) {}
+                                      ServicesConnection::options())) {}
 
 future<StatusOr<google::cloud::run::v2::Service>>
 ServicesConnectionImpl::CreateService(

--- a/google/cloud/run/revisions_client.cc
+++ b/google/cloud/run/revisions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/run/v2/revision.proto
 
 #include "google/cloud/run/revisions_client.h"
-#include "google/cloud/run/internal/revisions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 RevisionsClient::RevisionsClient(
     std::shared_ptr<RevisionsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          run_internal::RevisionsDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 RevisionsClient::~RevisionsClient() = default;
 
 StatusOr<google::cloud::run::v2::Revision> RevisionsClient::GetRevision(

--- a/google/cloud/run/services_client.cc
+++ b/google/cloud/run/services_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/run/v2/service.proto
 
 #include "google/cloud/run/services_client.h"
-#include "google/cloud/run/internal/services_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ServicesClient::ServicesClient(std::shared_ptr<ServicesConnection> connection,
                                Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          run_internal::ServicesDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ServicesClient::~ServicesClient() = default;
 
 future<StatusOr<google::cloud::run::v2::Service>> ServicesClient::CreateService(

--- a/google/cloud/scheduler/cloud_scheduler_client.cc
+++ b/google/cloud/scheduler/cloud_scheduler_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/scheduler/v1/cloudscheduler.proto
 
 #include "google/cloud/scheduler/cloud_scheduler_client.h"
-#include "google/cloud/scheduler/internal/cloud_scheduler_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudSchedulerClient::CloudSchedulerClient(
     std::shared_ptr<CloudSchedulerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), scheduler_internal::CloudSchedulerDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudSchedulerClient::~CloudSchedulerClient() = default;
 
 StreamRange<google::cloud::scheduler::v1::Job> CloudSchedulerClient::ListJobs(

--- a/google/cloud/scheduler/internal/cloud_scheduler_connection_impl.cc
+++ b/google/cloud/scheduler/internal/cloud_scheduler_connection_impl.cc
@@ -36,9 +36,8 @@ CloudSchedulerConnectionImpl::CloudSchedulerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), scheduler_internal::CloudSchedulerDefaultOptions(
-                                  CloudSchedulerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CloudSchedulerConnection::options())) {}
 
 StreamRange<google::cloud::scheduler::v1::Job>
 CloudSchedulerConnectionImpl::ListJobs(

--- a/google/cloud/secretmanager/internal/secret_manager_connection_impl.cc
+++ b/google/cloud/secretmanager/internal/secret_manager_connection_impl.cc
@@ -37,9 +37,7 @@ SecretManagerServiceConnectionImpl::SecretManagerServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          secretmanager_internal::SecretManagerServiceDefaultOptions(
-              SecretManagerServiceConnection::options()))) {}
+          std::move(options), SecretManagerServiceConnection::options())) {}
 
 StreamRange<google::cloud::secretmanager::v1::Secret>
 SecretManagerServiceConnectionImpl::ListSecrets(

--- a/google/cloud/secretmanager/secret_manager_client.cc
+++ b/google/cloud/secretmanager/secret_manager_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/secretmanager/v1/service.proto
 
 #include "google/cloud/secretmanager/secret_manager_client.h"
-#include "google/cloud/secretmanager/internal/secret_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SecretManagerServiceClient::SecretManagerServiceClient(
     std::shared_ptr<SecretManagerServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          secretmanager_internal::SecretManagerServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SecretManagerServiceClient::~SecretManagerServiceClient() = default;
 
 StreamRange<google::cloud::secretmanager::v1::Secret>

--- a/google/cloud/securitycenter/internal/security_center_connection_impl.cc
+++ b/google/cloud/securitycenter/internal/security_center_connection_impl.cc
@@ -37,10 +37,8 @@ SecurityCenterConnectionImpl::SecurityCenterConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          securitycenter_internal::SecurityCenterDefaultOptions(
-              SecurityCenterConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      SecurityCenterConnection::options())) {}
 
 future<StatusOr<google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>
 SecurityCenterConnectionImpl::BulkMuteFindings(

--- a/google/cloud/securitycenter/security_center_client.cc
+++ b/google/cloud/securitycenter/security_center_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/securitycenter/v1/securitycenter_service.proto
 
 #include "google/cloud/securitycenter/security_center_client.h"
-#include "google/cloud/securitycenter/internal/security_center_option_defaults.h"
 #include "google/cloud/securitycenter/security_center_options.h"
 #include <memory>
 #include <thread>
@@ -30,10 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SecurityCenterClient::SecurityCenterClient(
     std::shared_ptr<SecurityCenterConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          securitycenter_internal::SecurityCenterDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SecurityCenterClient::~SecurityCenterClient() = default;
 
 future<StatusOr<google::cloud::securitycenter::v1::BulkMuteFindingsResponse>>

--- a/google/cloud/servicecontrol/internal/quota_controller_connection_impl.cc
+++ b/google/cloud/servicecontrol/internal/quota_controller_connection_impl.cc
@@ -35,10 +35,8 @@ QuotaControllerConnectionImpl::QuotaControllerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          servicecontrol_internal::QuotaControllerDefaultOptions(
-              QuotaControllerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      QuotaControllerConnection::options())) {}
 
 StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>
 QuotaControllerConnectionImpl::AllocateQuota(

--- a/google/cloud/servicecontrol/internal/service_controller_connection_impl.cc
+++ b/google/cloud/servicecontrol/internal/service_controller_connection_impl.cc
@@ -36,9 +36,7 @@ ServiceControllerConnectionImpl::ServiceControllerConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          servicecontrol_internal::ServiceControllerDefaultOptions(
-              ServiceControllerConnection::options()))) {}
+          std::move(options), ServiceControllerConnection::options())) {}
 
 StatusOr<google::api::servicecontrol::v1::CheckResponse>
 ServiceControllerConnectionImpl::Check(

--- a/google/cloud/servicecontrol/quota_controller_client.cc
+++ b/google/cloud/servicecontrol/quota_controller_client.cc
@@ -17,7 +17,6 @@
 // source: google/api/servicecontrol/v1/quota_controller.proto
 
 #include "google/cloud/servicecontrol/quota_controller_client.h"
-#include "google/cloud/servicecontrol/internal/quota_controller_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 QuotaControllerClient::QuotaControllerClient(
     std::shared_ptr<QuotaControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          servicecontrol_internal::QuotaControllerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 QuotaControllerClient::~QuotaControllerClient() = default;
 
 StatusOr<google::api::servicecontrol::v1::AllocateQuotaResponse>

--- a/google/cloud/servicecontrol/service_controller_client.cc
+++ b/google/cloud/servicecontrol/service_controller_client.cc
@@ -17,7 +17,6 @@
 // source: google/api/servicecontrol/v1/service_controller.proto
 
 #include "google/cloud/servicecontrol/service_controller_client.h"
-#include "google/cloud/servicecontrol/internal/service_controller_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ServiceControllerClient::ServiceControllerClient(
     std::shared_ptr<ServiceControllerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          servicecontrol_internal::ServiceControllerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ServiceControllerClient::~ServiceControllerClient() = default;
 
 StatusOr<google::api::servicecontrol::v1::CheckResponse>

--- a/google/cloud/servicedirectory/internal/lookup_connection_impl.cc
+++ b/google/cloud/servicedirectory/internal/lookup_connection_impl.cc
@@ -35,10 +35,8 @@ LookupServiceConnectionImpl::LookupServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          servicedirectory_internal::LookupServiceDefaultOptions(
-              LookupServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      LookupServiceConnection::options())) {}
 
 StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>
 LookupServiceConnectionImpl::ResolveService(

--- a/google/cloud/servicedirectory/internal/registration_connection_impl.cc
+++ b/google/cloud/servicedirectory/internal/registration_connection_impl.cc
@@ -37,9 +37,7 @@ RegistrationServiceConnectionImpl::RegistrationServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          servicedirectory_internal::RegistrationServiceDefaultOptions(
-              RegistrationServiceConnection::options()))) {}
+          std::move(options), RegistrationServiceConnection::options())) {}
 
 StatusOr<google::cloud::servicedirectory::v1::Namespace>
 RegistrationServiceConnectionImpl::CreateNamespace(

--- a/google/cloud/servicedirectory/lookup_client.cc
+++ b/google/cloud/servicedirectory/lookup_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/servicedirectory/v1/lookup_service.proto
 
 #include "google/cloud/servicedirectory/lookup_client.h"
-#include "google/cloud/servicedirectory/internal/lookup_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 LookupServiceClient::LookupServiceClient(
     std::shared_ptr<LookupServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          servicedirectory_internal::LookupServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 LookupServiceClient::~LookupServiceClient() = default;
 
 StatusOr<google::cloud::servicedirectory::v1::ResolveServiceResponse>

--- a/google/cloud/servicedirectory/registration_client.cc
+++ b/google/cloud/servicedirectory/registration_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/servicedirectory/v1/registration_service.proto
 
 #include "google/cloud/servicedirectory/registration_client.h"
-#include "google/cloud/servicedirectory/internal/registration_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 RegistrationServiceClient::RegistrationServiceClient(
     std::shared_ptr<RegistrationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          servicedirectory_internal::RegistrationServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 RegistrationServiceClient::~RegistrationServiceClient() = default;
 
 StatusOr<google::cloud::servicedirectory::v1::Namespace>

--- a/google/cloud/servicemanagement/internal/service_manager_connection_impl.cc
+++ b/google/cloud/servicemanagement/internal/service_manager_connection_impl.cc
@@ -37,10 +37,8 @@ ServiceManagerConnectionImpl::ServiceManagerConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          servicemanagement_internal::ServiceManagerDefaultOptions(
-              ServiceManagerConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ServiceManagerConnection::options())) {}
 
 StreamRange<google::api::servicemanagement::v1::ManagedService>
 ServiceManagerConnectionImpl::ListServices(

--- a/google/cloud/servicemanagement/service_manager_client.cc
+++ b/google/cloud/servicemanagement/service_manager_client.cc
@@ -17,7 +17,6 @@
 // source: google/api/servicemanagement/v1/servicemanager.proto
 
 #include "google/cloud/servicemanagement/service_manager_client.h"
-#include "google/cloud/servicemanagement/internal/service_manager_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ServiceManagerClient::ServiceManagerClient(
     std::shared_ptr<ServiceManagerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          servicemanagement_internal::ServiceManagerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ServiceManagerClient::~ServiceManagerClient() = default;
 
 StreamRange<google::api::servicemanagement::v1::ManagedService>

--- a/google/cloud/serviceusage/internal/service_usage_connection_impl.cc
+++ b/google/cloud/serviceusage/internal/service_usage_connection_impl.cc
@@ -37,9 +37,8 @@ ServiceUsageConnectionImpl::ServiceUsageConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), serviceusage_internal::ServiceUsageDefaultOptions(
-                                  ServiceUsageConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ServiceUsageConnection::options())) {}
 
 future<StatusOr<google::api::serviceusage::v1::EnableServiceResponse>>
 ServiceUsageConnectionImpl::EnableService(

--- a/google/cloud/serviceusage/service_usage_client.cc
+++ b/google/cloud/serviceusage/service_usage_client.cc
@@ -17,7 +17,6 @@
 // source: google/api/serviceusage/v1/serviceusage.proto
 
 #include "google/cloud/serviceusage/service_usage_client.h"
-#include "google/cloud/serviceusage/internal/service_usage_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ServiceUsageClient::ServiceUsageClient(
     std::shared_ptr<ServiceUsageConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), serviceusage_internal::ServiceUsageDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ServiceUsageClient::~ServiceUsageClient() = default;
 
 future<StatusOr<google::api::serviceusage::v1::EnableServiceResponse>>

--- a/google/cloud/shell/cloud_shell_client.cc
+++ b/google/cloud/shell/cloud_shell_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/shell/v1/cloudshell.proto
 
 #include "google/cloud/shell/cloud_shell_client.h"
-#include "google/cloud/shell/internal/cloud_shell_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudShellServiceClient::CloudShellServiceClient(
     std::shared_ptr<CloudShellServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), shell_internal::CloudShellServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudShellServiceClient::~CloudShellServiceClient() = default;
 
 StatusOr<google::cloud::shell::v1::Environment>

--- a/google/cloud/shell/internal/cloud_shell_connection_impl.cc
+++ b/google/cloud/shell/internal/cloud_shell_connection_impl.cc
@@ -37,8 +37,7 @@ CloudShellServiceConnectionImpl::CloudShellServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), shell_internal::CloudShellServiceDefaultOptions(
-                                  CloudShellServiceConnection::options()))) {}
+          std::move(options), CloudShellServiceConnection::options())) {}
 
 StatusOr<google::cloud::shell::v1::Environment>
 CloudShellServiceConnectionImpl::GetEnvironment(

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/spanner/admin/database_admin_client.h"
 #include "google/cloud/spanner/admin/database_admin_options.h"
-#include "google/cloud/spanner/admin/internal/database_admin_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 DatabaseAdminClient::DatabaseAdminClient(
     std::shared_ptr<DatabaseAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), spanner_admin_internal::DatabaseAdminDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 DatabaseAdminClient::~DatabaseAdminClient() = default;
 
 StreamRange<google::spanner::admin::database::v1::Database>

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/spanner/admin/instance_admin_client.h"
 #include "google/cloud/spanner/admin/instance_admin_options.h"
-#include "google/cloud/spanner/admin/internal/instance_admin_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 InstanceAdminClient::InstanceAdminClient(
     std::shared_ptr<InstanceAdminConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), spanner_admin_internal::InstanceAdminDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 InstanceAdminClient::~InstanceAdminClient() = default;
 
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>

--- a/google/cloud/spanner/admin/internal/database_admin_connection_impl.cc
+++ b/google/cloud/spanner/admin/internal/database_admin_connection_impl.cc
@@ -37,10 +37,8 @@ DatabaseAdminConnectionImpl::DatabaseAdminConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          spanner_admin_internal::DatabaseAdminDefaultOptions(
-              DatabaseAdminConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DatabaseAdminConnection::options())) {}
 
 StreamRange<google::spanner::admin::database::v1::Database>
 DatabaseAdminConnectionImpl::ListDatabases(

--- a/google/cloud/spanner/admin/internal/instance_admin_connection_impl.cc
+++ b/google/cloud/spanner/admin/internal/instance_admin_connection_impl.cc
@@ -37,10 +37,8 @@ InstanceAdminConnectionImpl::InstanceAdminConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          spanner_admin_internal::InstanceAdminDefaultOptions(
-              InstanceAdminConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      InstanceAdminConnection::options())) {}
 
 StreamRange<google::spanner::admin::instance::v1::InstanceConfig>
 InstanceAdminConnectionImpl::ListInstanceConfigs(

--- a/google/cloud/speech/internal/speech_connection_impl.cc
+++ b/google/cloud/speech/internal/speech_connection_impl.cc
@@ -35,10 +35,8 @@ SpeechConnectionImpl::SpeechConnectionImpl(
     std::shared_ptr<speech_internal::SpeechStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          speech_internal::SpeechDefaultOptions(SpeechConnection::options()))) {
-}
+      options_(internal::MergeOptions(std::move(options),
+                                      SpeechConnection::options())) {}
 
 StatusOr<google::cloud::speech::v1::RecognizeResponse>
 SpeechConnectionImpl::Recognize(

--- a/google/cloud/speech/speech_client.cc
+++ b/google/cloud/speech/speech_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/speech/v1/cloud_speech.proto
 
 #include "google/cloud/speech/speech_client.h"
-#include "google/cloud/speech/internal/speech_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 SpeechClient::SpeechClient(std::shared_ptr<SpeechConnection> connection,
                            Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          speech_internal::SpeechDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 SpeechClient::~SpeechClient() = default;
 
 StatusOr<google::cloud::speech::v1::RecognizeResponse> SpeechClient::Recognize(

--- a/google/cloud/storagetransfer/internal/storage_transfer_connection_impl.cc
+++ b/google/cloud/storagetransfer/internal/storage_transfer_connection_impl.cc
@@ -38,9 +38,7 @@ StorageTransferServiceConnectionImpl::StorageTransferServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          storagetransfer_internal::StorageTransferServiceDefaultOptions(
-              StorageTransferServiceConnection::options()))) {}
+          std::move(options), StorageTransferServiceConnection::options())) {}
 
 StatusOr<google::storagetransfer::v1::GoogleServiceAccount>
 StorageTransferServiceConnectionImpl::GetGoogleServiceAccount(

--- a/google/cloud/storagetransfer/storage_transfer_client.cc
+++ b/google/cloud/storagetransfer/storage_transfer_client.cc
@@ -17,7 +17,6 @@
 // source: google/storagetransfer/v1/transfer.proto
 
 #include "google/cloud/storagetransfer/storage_transfer_client.h"
-#include "google/cloud/storagetransfer/internal/storage_transfer_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 StorageTransferServiceClient::StorageTransferServiceClient(
     std::shared_ptr<StorageTransferServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          storagetransfer_internal::StorageTransferServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 StorageTransferServiceClient::~StorageTransferServiceClient() = default;
 
 StatusOr<google::storagetransfer::v1::GoogleServiceAccount>

--- a/google/cloud/talent/company_client.cc
+++ b/google/cloud/talent/company_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/talent/v4/company_service.proto
 
 #include "google/cloud/talent/company_client.h"
-#include "google/cloud/talent/internal/company_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CompanyServiceClient::CompanyServiceClient(
     std::shared_ptr<CompanyServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), talent_internal::CompanyServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CompanyServiceClient::~CompanyServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::Company>

--- a/google/cloud/talent/completion_client.cc
+++ b/google/cloud/talent/completion_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/talent/v4/completion_service.proto
 
 #include "google/cloud/talent/completion_client.h"
-#include "google/cloud/talent/internal/completion_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CompletionClient::CompletionClient(
     std::shared_ptr<CompletionConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          talent_internal::CompletionDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CompletionClient::~CompletionClient() = default;
 
 StatusOr<google::cloud::talent::v4::CompleteQueryResponse>

--- a/google/cloud/talent/event_client.cc
+++ b/google/cloud/talent/event_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/talent/v4/event_service.proto
 
 #include "google/cloud/talent/event_client.h"
-#include "google/cloud/talent/internal/event_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 EventServiceClient::EventServiceClient(
     std::shared_ptr<EventServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), talent_internal::EventServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 EventServiceClient::~EventServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::ClientEvent>

--- a/google/cloud/talent/internal/company_connection_impl.cc
+++ b/google/cloud/talent/internal/company_connection_impl.cc
@@ -35,9 +35,8 @@ CompanyServiceConnectionImpl::CompanyServiceConnectionImpl(
     std::shared_ptr<talent_internal::CompanyServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), talent_internal::CompanyServiceDefaultOptions(
-                                  CompanyServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      CompanyServiceConnection::options())) {}
 
 StatusOr<google::cloud::talent::v4::Company>
 CompanyServiceConnectionImpl::CreateCompany(

--- a/google/cloud/talent/internal/completion_connection_impl.cc
+++ b/google/cloud/talent/internal/completion_connection_impl.cc
@@ -35,8 +35,7 @@ CompletionConnectionImpl::CompletionConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      talent_internal::CompletionDefaultOptions(
-                                          CompletionConnection::options()))) {}
+                                      CompletionConnection::options())) {}
 
 StatusOr<google::cloud::talent::v4::CompleteQueryResponse>
 CompletionConnectionImpl::CompleteQuery(

--- a/google/cloud/talent/internal/event_connection_impl.cc
+++ b/google/cloud/talent/internal/event_connection_impl.cc
@@ -34,9 +34,8 @@ EventServiceConnectionImpl::EventServiceConnectionImpl(
     std::shared_ptr<talent_internal::EventServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), talent_internal::EventServiceDefaultOptions(
-                                  EventServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      EventServiceConnection::options())) {}
 
 StatusOr<google::cloud::talent::v4::ClientEvent>
 EventServiceConnectionImpl::CreateClientEvent(

--- a/google/cloud/talent/internal/job_connection_impl.cc
+++ b/google/cloud/talent/internal/job_connection_impl.cc
@@ -37,8 +37,7 @@ JobServiceConnectionImpl::JobServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      talent_internal::JobServiceDefaultOptions(
-                                          JobServiceConnection::options()))) {}
+                                      JobServiceConnection::options())) {}
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceConnectionImpl::CreateJob(
     google::cloud::talent::v4::CreateJobRequest const& request) {

--- a/google/cloud/talent/internal/tenant_connection_impl.cc
+++ b/google/cloud/talent/internal/tenant_connection_impl.cc
@@ -35,9 +35,8 @@ TenantServiceConnectionImpl::TenantServiceConnectionImpl(
     std::shared_ptr<talent_internal::TenantServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), talent_internal::TenantServiceDefaultOptions(
-                                  TenantServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      TenantServiceConnection::options())) {}
 
 StatusOr<google::cloud::talent::v4::Tenant>
 TenantServiceConnectionImpl::CreateTenant(

--- a/google/cloud/talent/job_client.cc
+++ b/google/cloud/talent/job_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/talent/v4/job_service.proto
 
 #include "google/cloud/talent/job_client.h"
-#include "google/cloud/talent/internal/job_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 JobServiceClient::JobServiceClient(
     std::shared_ptr<JobServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          talent_internal::JobServiceDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 JobServiceClient::~JobServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::Job> JobServiceClient::CreateJob(

--- a/google/cloud/talent/tenant_client.cc
+++ b/google/cloud/talent/tenant_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/talent/v4/tenant_service.proto
 
 #include "google/cloud/talent/tenant_client.h"
-#include "google/cloud/talent/internal/tenant_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TenantServiceClient::TenantServiceClient(
     std::shared_ptr<TenantServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), talent_internal::TenantServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TenantServiceClient::~TenantServiceClient() = default;
 
 StatusOr<google::cloud::talent::v4::Tenant> TenantServiceClient::CreateTenant(

--- a/google/cloud/tasks/cloud_tasks_client.cc
+++ b/google/cloud/tasks/cloud_tasks_client.cc
@@ -18,7 +18,6 @@
 
 #include "google/cloud/tasks/cloud_tasks_client.h"
 #include "google/cloud/tasks/cloud_tasks_options.h"
-#include "google/cloud/tasks/internal/cloud_tasks_option_defaults.h"
 #include <memory>
 #include <thread>
 
@@ -30,9 +29,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 CloudTasksClient::CloudTasksClient(
     std::shared_ptr<CloudTasksConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          tasks_internal::CloudTasksDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 CloudTasksClient::~CloudTasksClient() = default;
 
 StreamRange<google::cloud::tasks::v2::Queue> CloudTasksClient::ListQueues(

--- a/google/cloud/tasks/internal/cloud_tasks_connection_impl.cc
+++ b/google/cloud/tasks/internal/cloud_tasks_connection_impl.cc
@@ -36,8 +36,7 @@ CloudTasksConnectionImpl::CloudTasksConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(std::move(options),
-                                      tasks_internal::CloudTasksDefaultOptions(
-                                          CloudTasksConnection::options()))) {}
+                                      CloudTasksConnection::options())) {}
 
 StreamRange<google::cloud::tasks::v2::Queue>
 CloudTasksConnectionImpl::ListQueues(

--- a/google/cloud/texttospeech/internal/text_to_speech_connection_impl.cc
+++ b/google/cloud/texttospeech/internal/text_to_speech_connection_impl.cc
@@ -35,9 +35,8 @@ TextToSpeechConnectionImpl::TextToSpeechConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), texttospeech_internal::TextToSpeechDefaultOptions(
-                                  TextToSpeechConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      TextToSpeechConnection::options())) {}
 
 StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>
 TextToSpeechConnectionImpl::ListVoices(

--- a/google/cloud/texttospeech/text_to_speech_client.cc
+++ b/google/cloud/texttospeech/text_to_speech_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/texttospeech/v1/cloud_tts.proto
 
 #include "google/cloud/texttospeech/text_to_speech_client.h"
-#include "google/cloud/texttospeech/internal/text_to_speech_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TextToSpeechClient::TextToSpeechClient(
     std::shared_ptr<TextToSpeechConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), texttospeech_internal::TextToSpeechDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TextToSpeechClient::~TextToSpeechClient() = default;
 
 StatusOr<google::cloud::texttospeech::v1::ListVoicesResponse>

--- a/google/cloud/tpu/internal/tpu_connection_impl.cc
+++ b/google/cloud/tpu/internal/tpu_connection_impl.cc
@@ -36,9 +36,8 @@ TpuConnectionImpl::TpuConnectionImpl(
     std::shared_ptr<tpu_internal::TpuStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          tpu_internal::TpuDefaultOptions(TpuConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      TpuConnection::options())) {}
 
 StreamRange<google::cloud::tpu::v1::Node> TpuConnectionImpl::ListNodes(
     google::cloud::tpu::v1::ListNodesRequest request) {

--- a/google/cloud/tpu/tpu_client.cc
+++ b/google/cloud/tpu/tpu_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/tpu/v1/cloud_tpu.proto
 
 #include "google/cloud/tpu/tpu_client.h"
-#include "google/cloud/tpu/internal/tpu_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -27,9 +26,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 TpuClient::TpuClient(std::shared_ptr<TpuConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          tpu_internal::TpuDefaultOptions(connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TpuClient::~TpuClient() = default;
 
 StreamRange<google::cloud::tpu::v1::Node> TpuClient::ListNodes(

--- a/google/cloud/trace/internal/trace_connection_impl.cc
+++ b/google/cloud/trace/internal/trace_connection_impl.cc
@@ -34,9 +34,8 @@ TraceServiceConnectionImpl::TraceServiceConnectionImpl(
     std::shared_ptr<trace_internal::TraceServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), trace_internal::TraceServiceDefaultOptions(
-                                  TraceServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      TraceServiceConnection::options())) {}
 
 Status TraceServiceConnectionImpl::BatchWriteSpans(
     google::devtools::cloudtrace::v2::BatchWriteSpansRequest const& request) {

--- a/google/cloud/trace/trace_client.cc
+++ b/google/cloud/trace/trace_client.cc
@@ -17,7 +17,6 @@
 // source: google/devtools/cloudtrace/v2/tracing.proto
 
 #include "google/cloud/trace/trace_client.h"
-#include "google/cloud/trace/internal/trace_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TraceServiceClient::TraceServiceClient(
     std::shared_ptr<TraceServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          trace_internal::TraceServiceDefaultOptions(connection_->options()))) {
-}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TraceServiceClient::~TraceServiceClient() = default;
 
 Status TraceServiceClient::BatchWriteSpans(

--- a/google/cloud/translate/internal/translation_connection_impl.cc
+++ b/google/cloud/translate/internal/translation_connection_impl.cc
@@ -38,9 +38,7 @@ TranslationServiceConnectionImpl::TranslationServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          translate_internal::TranslationServiceDefaultOptions(
-              TranslationServiceConnection::options()))) {}
+          std::move(options), TranslationServiceConnection::options())) {}
 
 StatusOr<google::cloud::translation::v3::TranslateTextResponse>
 TranslationServiceConnectionImpl::TranslateText(

--- a/google/cloud/translate/translation_client.cc
+++ b/google/cloud/translate/translation_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/translate/v3/translation_service.proto
 
 #include "google/cloud/translate/translation_client.h"
-#include "google/cloud/translate/internal/translation_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TranslationServiceClient::TranslationServiceClient(
     std::shared_ptr<TranslationServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), translate_internal::TranslationServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TranslationServiceClient::~TranslationServiceClient() = default;
 
 StatusOr<google::cloud::translation::v3::TranslateTextResponse>

--- a/google/cloud/video/internal/livestream_connection_impl.cc
+++ b/google/cloud/video/internal/livestream_connection_impl.cc
@@ -38,8 +38,7 @@ LivestreamServiceConnectionImpl::LivestreamServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), video_internal::LivestreamServiceDefaultOptions(
-                                  LivestreamServiceConnection::options()))) {}
+          std::move(options), LivestreamServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::video::livestream::v1::Channel>>
 LivestreamServiceConnectionImpl::CreateChannel(

--- a/google/cloud/video/internal/transcoder_connection_impl.cc
+++ b/google/cloud/video/internal/transcoder_connection_impl.cc
@@ -37,8 +37,7 @@ TranscoderServiceConnectionImpl::TranscoderServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options), video_internal::TranscoderServiceDefaultOptions(
-                                  TranscoderServiceConnection::options()))) {}
+          std::move(options), TranscoderServiceConnection::options())) {}
 
 StatusOr<google::cloud::video::transcoder::v1::Job>
 TranscoderServiceConnectionImpl::CreateJob(

--- a/google/cloud/video/internal/video_stitcher_connection_impl.cc
+++ b/google/cloud/video/internal/video_stitcher_connection_impl.cc
@@ -37,9 +37,7 @@ VideoStitcherServiceConnectionImpl::VideoStitcherServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          video_internal::VideoStitcherServiceDefaultOptions(
-              VideoStitcherServiceConnection::options()))) {}
+          std::move(options), VideoStitcherServiceConnection::options())) {}
 
 StatusOr<google::cloud::video::stitcher::v1::CdnKey>
 VideoStitcherServiceConnectionImpl::CreateCdnKey(

--- a/google/cloud/video/livestream_client.cc
+++ b/google/cloud/video/livestream_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/video/livestream/v1/service.proto
 
 #include "google/cloud/video/livestream_client.h"
-#include "google/cloud/video/internal/livestream_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 LivestreamServiceClient::LivestreamServiceClient(
     std::shared_ptr<LivestreamServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), video_internal::LivestreamServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 LivestreamServiceClient::~LivestreamServiceClient() = default;
 
 future<StatusOr<google::cloud::video::livestream::v1::Channel>>

--- a/google/cloud/video/transcoder_client.cc
+++ b/google/cloud/video/transcoder_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/video/transcoder/v1/services.proto
 
 #include "google/cloud/video/transcoder_client.h"
-#include "google/cloud/video/internal/transcoder_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 TranscoderServiceClient::TranscoderServiceClient(
     std::shared_ptr<TranscoderServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), video_internal::TranscoderServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 TranscoderServiceClient::~TranscoderServiceClient() = default;
 
 StatusOr<google::cloud::video::transcoder::v1::Job>

--- a/google/cloud/video/video_stitcher_client.cc
+++ b/google/cloud/video/video_stitcher_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/video/stitcher/v1/video_stitcher_service.proto
 
 #include "google/cloud/video/video_stitcher_client.h"
-#include "google/cloud/video/internal/video_stitcher_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VideoStitcherServiceClient::VideoStitcherServiceClient(
     std::shared_ptr<VideoStitcherServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), video_internal::VideoStitcherServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VideoStitcherServiceClient::~VideoStitcherServiceClient() = default;
 
 StatusOr<google::cloud::video::stitcher::v1::CdnKey>

--- a/google/cloud/videointelligence/internal/video_intelligence_connection_impl.cc
+++ b/google/cloud/videointelligence/internal/video_intelligence_connection_impl.cc
@@ -38,9 +38,7 @@ VideoIntelligenceServiceConnectionImpl::VideoIntelligenceServiceConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          videointelligence_internal::VideoIntelligenceServiceDefaultOptions(
-              VideoIntelligenceServiceConnection::options()))) {}
+          std::move(options), VideoIntelligenceServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::videointelligence::v1::AnnotateVideoResponse>>
 VideoIntelligenceServiceConnectionImpl::AnnotateVideo(

--- a/google/cloud/videointelligence/video_intelligence_client.cc
+++ b/google/cloud/videointelligence/video_intelligence_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/videointelligence/v1/video_intelligence.proto
 
 #include "google/cloud/videointelligence/video_intelligence_client.h"
-#include "google/cloud/videointelligence/internal/video_intelligence_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -29,10 +28,8 @@ VideoIntelligenceServiceClient::VideoIntelligenceServiceClient(
     std::shared_ptr<VideoIntelligenceServiceConnection> connection,
     Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          videointelligence_internal::VideoIntelligenceServiceDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VideoIntelligenceServiceClient::~VideoIntelligenceServiceClient() = default;
 
 future<StatusOr<google::cloud::videointelligence::v1::AnnotateVideoResponse>>

--- a/google/cloud/vision/image_annotator_client.cc
+++ b/google/cloud/vision/image_annotator_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/vision/v1/image_annotator.proto
 
 #include "google/cloud/vision/image_annotator_client.h"
-#include "google/cloud/vision/internal/image_annotator_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ImageAnnotatorClient::ImageAnnotatorClient(
     std::shared_ptr<ImageAnnotatorConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), vision_internal::ImageAnnotatorDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ImageAnnotatorClient::~ImageAnnotatorClient() = default;
 
 StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>

--- a/google/cloud/vision/internal/image_annotator_connection_impl.cc
+++ b/google/cloud/vision/internal/image_annotator_connection_impl.cc
@@ -35,9 +35,8 @@ ImageAnnotatorConnectionImpl::ImageAnnotatorConnectionImpl(
     std::shared_ptr<vision_internal::ImageAnnotatorStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), vision_internal::ImageAnnotatorDefaultOptions(
-                                  ImageAnnotatorConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ImageAnnotatorConnection::options())) {}
 
 StatusOr<google::cloud::vision::v1::BatchAnnotateImagesResponse>
 ImageAnnotatorConnectionImpl::BatchAnnotateImages(

--- a/google/cloud/vision/internal/product_search_connection_impl.cc
+++ b/google/cloud/vision/internal/product_search_connection_impl.cc
@@ -36,9 +36,8 @@ ProductSearchConnectionImpl::ProductSearchConnectionImpl(
     std::shared_ptr<vision_internal::ProductSearchStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), vision_internal::ProductSearchDefaultOptions(
-                                  ProductSearchConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ProductSearchConnection::options())) {}
 
 StatusOr<google::cloud::vision::v1::ProductSet>
 ProductSearchConnectionImpl::CreateProductSet(

--- a/google/cloud/vision/product_search_client.cc
+++ b/google/cloud/vision/product_search_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/vision/v1/product_search_service.proto
 
 #include "google/cloud/vision/product_search_client.h"
-#include "google/cloud/vision/internal/product_search_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ProductSearchClient::ProductSearchClient(
     std::shared_ptr<ProductSearchConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), vision_internal::ProductSearchDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ProductSearchClient::~ProductSearchClient() = default;
 
 StatusOr<google::cloud::vision::v1::ProductSet>

--- a/google/cloud/vmmigration/internal/vm_migration_connection_impl.cc
+++ b/google/cloud/vmmigration/internal/vm_migration_connection_impl.cc
@@ -37,9 +37,8 @@ VmMigrationConnectionImpl::VmMigrationConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), vmmigration_internal::VmMigrationDefaultOptions(
-                                  VmMigrationConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      VmMigrationConnection::options())) {}
 
 StreamRange<google::cloud::vmmigration::v1::Source>
 VmMigrationConnectionImpl::ListSources(

--- a/google/cloud/vmmigration/vm_migration_client.cc
+++ b/google/cloud/vmmigration/vm_migration_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/vmmigration/v1/vmmigration.proto
 
 #include "google/cloud/vmmigration/vm_migration_client.h"
-#include "google/cloud/vmmigration/internal/vm_migration_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VmMigrationClient::VmMigrationClient(
     std::shared_ptr<VmMigrationConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), vmmigration_internal::VmMigrationDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VmMigrationClient::~VmMigrationClient() = default;
 
 StreamRange<google::cloud::vmmigration::v1::Source>

--- a/google/cloud/vpcaccess/internal/vpc_access_connection_impl.cc
+++ b/google/cloud/vpcaccess/internal/vpc_access_connection_impl.cc
@@ -37,10 +37,8 @@ VpcAccessServiceConnectionImpl::VpcAccessServiceConnectionImpl(
     Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          vpcaccess_internal::VpcAccessServiceDefaultOptions(
-              VpcAccessServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      VpcAccessServiceConnection::options())) {}
 
 future<StatusOr<google::cloud::vpcaccess::v1::Connector>>
 VpcAccessServiceConnectionImpl::CreateConnector(

--- a/google/cloud/vpcaccess/vpc_access_client.cc
+++ b/google/cloud/vpcaccess/vpc_access_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/vpcaccess/v1/vpc_access.proto
 
 #include "google/cloud/vpcaccess/vpc_access_client.h"
-#include "google/cloud/vpcaccess/internal/vpc_access_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 VpcAccessServiceClient::VpcAccessServiceClient(
     std::shared_ptr<VpcAccessServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), vpcaccess_internal::VpcAccessServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 VpcAccessServiceClient::~VpcAccessServiceClient() = default;
 
 future<StatusOr<google::cloud::vpcaccess::v1::Connector>>

--- a/google/cloud/webrisk/internal/web_risk_connection_impl.cc
+++ b/google/cloud/webrisk/internal/web_risk_connection_impl.cc
@@ -34,9 +34,8 @@ WebRiskServiceConnectionImpl::WebRiskServiceConnectionImpl(
     std::shared_ptr<webrisk_internal::WebRiskServiceStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), webrisk_internal::WebRiskServiceDefaultOptions(
-                                  WebRiskServiceConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      WebRiskServiceConnection::options())) {}
 
 StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>
 WebRiskServiceConnectionImpl::ComputeThreatListDiff(

--- a/google/cloud/webrisk/web_risk_client.cc
+++ b/google/cloud/webrisk/web_risk_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/webrisk/v1/webrisk.proto
 
 #include "google/cloud/webrisk/web_risk_client.h"
-#include "google/cloud/webrisk/internal/web_risk_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 WebRiskServiceClient::WebRiskServiceClient(
     std::shared_ptr<WebRiskServiceConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), webrisk_internal::WebRiskServiceDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 WebRiskServiceClient::~WebRiskServiceClient() = default;
 
 StatusOr<google::cloud::webrisk::v1::ComputeThreatListDiffResponse>

--- a/google/cloud/websecurityscanner/internal/web_security_scanner_connection_impl.cc
+++ b/google/cloud/websecurityscanner/internal/web_security_scanner_connection_impl.cc
@@ -37,9 +37,7 @@ WebSecurityScannerConnectionImpl::WebSecurityScannerConnectionImpl(
     : background_(std::move(background)),
       stub_(std::move(stub)),
       options_(internal::MergeOptions(
-          std::move(options),
-          websecurityscanner_internal::WebSecurityScannerDefaultOptions(
-              WebSecurityScannerConnection::options()))) {}
+          std::move(options), WebSecurityScannerConnection::options())) {}
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>
 WebSecurityScannerConnectionImpl::CreateScanConfig(

--- a/google/cloud/websecurityscanner/web_security_scanner_client.cc
+++ b/google/cloud/websecurityscanner/web_security_scanner_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/websecurityscanner/v1/web_security_scanner.proto
 
 #include "google/cloud/websecurityscanner/web_security_scanner_client.h"
-#include "google/cloud/websecurityscanner/internal/web_security_scanner_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,10 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 WebSecurityScannerClient::WebSecurityScannerClient(
     std::shared_ptr<WebSecurityScannerConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts),
-          websecurityscanner_internal::WebSecurityScannerDefaultOptions(
-              connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 WebSecurityScannerClient::~WebSecurityScannerClient() = default;
 
 StatusOr<google::cloud::websecurityscanner::v1::ScanConfig>

--- a/google/cloud/workflows/executions_client.cc
+++ b/google/cloud/workflows/executions_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/workflows/executions/v1/executions.proto
 
 #include "google/cloud/workflows/executions_client.h"
-#include "google/cloud/workflows/internal/executions_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 ExecutionsClient::ExecutionsClient(
     std::shared_ptr<ExecutionsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), workflows_internal::ExecutionsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 ExecutionsClient::~ExecutionsClient() = default;
 
 StreamRange<google::cloud::workflows::executions::v1::Execution>

--- a/google/cloud/workflows/internal/executions_connection_impl.cc
+++ b/google/cloud/workflows/internal/executions_connection_impl.cc
@@ -35,9 +35,8 @@ ExecutionsConnectionImpl::ExecutionsConnectionImpl(
     std::shared_ptr<workflows_internal::ExecutionsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), workflows_internal::ExecutionsDefaultOptions(
-                                  ExecutionsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      ExecutionsConnection::options())) {}
 
 StreamRange<google::cloud::workflows::executions::v1::Execution>
 ExecutionsConnectionImpl::ListExecutions(

--- a/google/cloud/workflows/internal/workflows_connection_impl.cc
+++ b/google/cloud/workflows/internal/workflows_connection_impl.cc
@@ -36,9 +36,8 @@ WorkflowsConnectionImpl::WorkflowsConnectionImpl(
     std::shared_ptr<workflows_internal::WorkflowsStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options), workflows_internal::WorkflowsDefaultOptions(
-                                  WorkflowsConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      WorkflowsConnection::options())) {}
 
 StreamRange<google::cloud::workflows::v1::Workflow>
 WorkflowsConnectionImpl::ListWorkflows(

--- a/google/cloud/workflows/workflows_client.cc
+++ b/google/cloud/workflows/workflows_client.cc
@@ -17,7 +17,6 @@
 // source: google/cloud/workflows/v1/workflows.proto
 
 #include "google/cloud/workflows/workflows_client.h"
-#include "google/cloud/workflows/internal/workflows_option_defaults.h"
 #include <memory>
 
 namespace google {
@@ -28,9 +27,8 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 WorkflowsClient::WorkflowsClient(
     std::shared_ptr<WorkflowsConnection> connection, Options opts)
     : connection_(std::move(connection)),
-      options_(internal::MergeOptions(
-          std::move(opts), workflows_internal::WorkflowsDefaultOptions(
-                               connection_->options()))) {}
+      options_(
+          internal::MergeOptions(std::move(opts), connection_->options())) {}
 WorkflowsClient::~WorkflowsClient() = default;
 
 StreamRange<google::cloud::workflows::v1::Workflow>


### PR DESCRIPTION
Only call `$service_name$DefaultOptions()` from the `Make*Connection()`
factory, rather that also from the "ConnectionImpl" and "Client" ctors.
This makes it very clear where the defaults are coming from, and avoids
redundant work.  (It also opens a path for the default options to depend
on information only available during `Make*Connection()`.)

This does mean that tests that skip `Make*Connection()` will need to
ensure that the mock connection's `options()` expectation supplies the
default options, but this is a feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9577)
<!-- Reviewable:end -->
