### PR TITLE
test(storage): use shorter random object names

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -149,6 +149,15 @@ std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
   return storage::testing::MakeRandomBucketName(gen, RandomBucketPrefix());
 }
 
+std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
+  auto constexpr kObjectNameLength = 32;
+  return google::cloud::internal::Sample(gen, kObjectNameLength,
+                                         "abcdefghijklmnopqrstuvwxyz"
+                                         "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+                                         "0123456789") +
+         ".txt";
+}
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -33,7 +33,6 @@ namespace storage_benchmarks {
 
 using ::google::cloud::storage::testing::MakeRandomData;
 using ::google::cloud::storage::testing::MakeRandomFileName;
-using ::google::cloud::storage::testing::MakeRandomObjectName;
 using ::google::cloud::testing_util::kGB;
 using ::google::cloud::testing_util::kGiB;
 using ::google::cloud::testing_util::kKB;
@@ -105,6 +104,7 @@ std::string ToString(ExperimentTransport v);
 std::string RandomBucketPrefix();
 
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);
+std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen);
 
 template <typename Rep, typename Period>
 std::string FormatBandwidthGbPerSecond(


### PR DESCRIPTION
The computers do not care, but it was hard to inspect the output with
the very long names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9579)
<!-- Reviewable:end -->
