### PR TITLE
impl(rest): tune HandleFactory cleanup

### DIFF
--- a/google/cloud/internal/curl_handle_factory.cc
+++ b/google/cloud/internal/curl_handle_factory.cc
@@ -117,14 +117,14 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr h, HandleDisposition d) {
     std::unique_lock<std::mutex> lk(last_client_ip_address_mu_);
     last_client_ip_address_ = ip;
   }
+  // Use a temporary data structure to release any excess handles *after* the
+  // lock is released.
+  std::vector<CurlPtr> released;
   std::unique_lock<std::mutex> lk(handles_mu_);
   if (d == HandleDisposition::kDiscard) {
     --active_handles_;
     return;
   }
-  // Use a temporary data structure to release any excess handles *after* the
-  // lock is released.
-  std::vector<CurlPtr> released;
   // If needed, release several handles to make room, amortizing the cost when
   // many threads are releasing handles at the same time.
   if (handles_.size() >= maximum_size_) {
@@ -167,14 +167,14 @@ CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
 void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti m,
                                                  HandleDisposition d) {
   if (!m) return;
+  // Use a temporary data structure to release any excess handles *after* the
+  // lock is released.
+  std::vector<CurlMulti> released;
   std::unique_lock<std::mutex> lk(multi_handles_mu_);
   if (d == HandleDisposition::kDiscard) {
     --active_multi_handles_;
     return;
   }
-  // Use a temporary data structure to release any excess handles *after* the
-  // lock is released.
-  std::vector<CurlMulti> released;
   // If needed, release several handles to make room, amortizing the cost when
   // many threads are releasing handles at the same time.
   if (multi_handles_.size() >= maximum_size_) {

--- a/google/cloud/internal/curl_handle_factory.cc
+++ b/google/cloud/internal/curl_handle_factory.cc
@@ -84,7 +84,11 @@ void DefaultCurlHandleFactory::SetCurlOptions(CURL* handle) {
 
 PooledCurlHandleFactory::PooledCurlHandleFactory(std::size_t maximum_size,
                                                  Options const& o)
-    : maximum_size_(maximum_size), cainfo_(CAInfo(o)), capath_(CAPath(o)) {}
+    : maximum_size_(maximum_size),
+      cainfo_(CAInfo(o)),
+      capath_(CAPath(o)),
+      active_handles_(0),
+      active_multi_handles_(0) {}
 
 PooledCurlHandleFactory::~PooledCurlHandleFactory() = default;
 
@@ -103,6 +107,7 @@ CurlPtr PooledCurlHandleFactory::CreateHandle() {
   lk.unlock();
   auto curl = MakeCurlPtr();
   SetCurlOptions(curl.get());
+  ++active_handles_;
   return curl;
 }
 
@@ -116,7 +121,10 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr h, HandleDisposition d) {
     std::unique_lock<std::mutex> lk(last_client_ip_address_mu_);
     last_client_ip_address_ = ip;
   }
-  if (d == HandleDisposition::kDiscard) return;
+  if (d == HandleDisposition::kDiscard) {
+    --active_handles_;
+    return;
+  }
   // Use a temporary data structure to release any excess handles *after* the
   // lock is released.
   std::vector<CurlPtr> released;
@@ -124,14 +132,27 @@ void PooledCurlHandleFactory::CleanupHandle(CurlPtr h, HandleDisposition d) {
   // If needed, release several handles to make room, amortizing the cost when
   // many threads are releasing handles at the same time.
   if (handles_.size() >= maximum_size_) {
-    auto const keep_count = maximum_size_ / 2;
-    auto const release_count = handles_.size() - keep_count;
+    // Sometimes the application may be using a lot more handles than
+    // `maximum_size_`. For example, if many threads demand a handle for
+    // downloads, then each thread will have a handle.
+    // When these handles are returned we want to minimize the locking overhead
+    // (and contention) by removing them in larger blocks. At the same time, we
+    // do not want to empty the pool because other threads may need some handles
+    // from the pool.  Finally, when the number of active handles is close to
+    // the maximum size of the pool, we just want to remove enough handles to
+    // make room.
+    //
+    // Note that active_handles_ >= handles_.size() is a class invariant, and we
+    // just checked that handles_.size() >= maximum_size_ > maximum_size / 2
+    auto const release_count = std::min(handles_.size() - maximum_size_ / 2,
+                                        active_handles_ - maximum_size_);
     released.reserve(release_count);
     auto const end = std::next(handles_.begin(), release_count);
     std::move(handles_.begin(), end, std::back_inserter(released));
     handles_.erase(handles_.begin(), end);
   }
   handles_.push_back(std::move(h));
+  active_handles_ -= released.size();
 }
 
 CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
@@ -143,6 +164,7 @@ CurlMulti PooledCurlHandleFactory::CreateMultiHandle() {
     return m;
   }
   lk.unlock();
+  ++active_multi_handles_;
   return CurlMulti(curl_multi_init(), &curl_multi_cleanup);
 }
 
@@ -156,14 +178,16 @@ void PooledCurlHandleFactory::CleanupMultiHandle(CurlMulti m,
   // If needed, release several handles to make room, amortizing the cost when
   // many threads are releasing handles at the same time.
   if (multi_handles_.size() >= maximum_size_) {
-    auto const keep_count = maximum_size_ / 2;
-    auto const release_count = multi_handles_.size() - keep_count;
+    // Same idea as is CleanupHandle()
+    auto const release_count = std::min(handles_.size() - maximum_size_ / 2,
+                                        active_multi_handles_ - maximum_size_);
     released.reserve(release_count);
     auto const end = std::next(multi_handles_.begin(), release_count);
     std::move(multi_handles_.begin(), end, std::back_inserter(released));
     multi_handles_.erase(multi_handles_.begin(), end);
   }
   multi_handles_.push_back(std::move(m));
+  active_multi_handles_ -= released.size();
 }
 
 void PooledCurlHandleFactory::SetCurlOptions(CURL* handle) {

--- a/google/cloud/internal/curl_handle_factory.h
+++ b/google/cloud/internal/curl_handle_factory.h
@@ -19,7 +19,6 @@
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
-#include <atomic>
 #include <deque>
 #include <mutex>
 #include <string>

--- a/google/cloud/internal/curl_handle_factory.h
+++ b/google/cloud/internal/curl_handle_factory.h
@@ -19,6 +19,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include "absl/types/optional.h"
+#include <atomic>
 #include <deque>
 #include <mutex>
 #include <string>
@@ -154,6 +155,8 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
   std::deque<CurlMulti> multi_handles_;
   mutable std::mutex last_client_ip_address_mu_;
   std::string last_client_ip_address_;
+  std::atomic<std::size_t> active_handles_;
+  std::atomic<std::size_t> active_multi_handles_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/curl_handle_factory.h
+++ b/google/cloud/internal/curl_handle_factory.h
@@ -151,12 +151,14 @@ class PooledCurlHandleFactory : public CurlHandleFactory {
 
   mutable std::mutex handles_mu_;
   std::deque<CurlPtr> handles_;
+  std::size_t active_handles_ = 0;
+
   mutable std::mutex multi_handles_mu_;
   std::deque<CurlMulti> multi_handles_;
+  std::size_t active_multi_handles_ = 0;
+
   mutable std::mutex last_client_ip_address_mu_;
   std::string last_client_ip_address_;
-  std::atomic<std::size_t> active_handles_;
-  std::atomic<std::size_t> active_multi_handles_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/curl_handle_factory_benchmark.cc
+++ b/google/cloud/internal/curl_handle_factory_benchmark.cc
@@ -47,19 +47,19 @@ bool CreateAndCleanup(CurlHandleFactory& factory) {
 //  L1 Instruction 32 KiB (x48)
 //  L2 Unified 1024 KiB (x48)
 //  L3 Unified 39424 KiB (x2)
-// Load Average: 7.87, 6.41, 5.61
+// Load Average: 12.07, 5.96, 3.01
 //----------------------------------------------------------------------------------
 // Benchmark                                        Time             CPU Iterations
 //----------------------------------------------------------------------------------
-// PoolFixture/Burst/real_time/threads:1          626 ns          626 ns 1115290
-// PoolFixture/Burst/real_time/threads:2          838 ns         1631 ns 887016
-// PoolFixture/Burst/real_time/threads:4          976 ns         3640 ns 570456
-// PoolFixture/Burst/real_time/threads:8         1172 ns         8115 ns 646784
-// PoolFixture/Burst/real_time/threads:16        1398 ns        19700 ns 594416
-// PoolFixture/Burst/real_time/threads:32        1850 ns        54669 ns 592704
-// PoolFixture/Burst/real_time/threads:64        1877 ns       114773 ns 400960
-// PoolFixture/Burst/real_time/threads:128       2100 ns       198027 ns 335360
-// PoolFixture/Burst/real_time/threads:256       2170 ns       210219 ns 256000
+// PoolFixture/Burst/real_time/threads:1          604 ns          604 ns     1152471
+// PoolFixture/Burst/real_time/threads:2          617 ns         1232 ns     1120720
+// PoolFixture/Burst/real_time/threads:4         1134 ns         4134 ns      699136
+// PoolFixture/Burst/real_time/threads:8         1055 ns         7409 ns      741768
+// PoolFixture/Burst/real_time/threads:16        1084 ns        15405 ns      708912
+// PoolFixture/Burst/real_time/threads:32        1224 ns        36308 ns      633728
+// PoolFixture/Burst/real_time/threads:64        1763 ns       107314 ns      454784
+// PoolFixture/Burst/real_time/threads:128       1838 ns       170508 ns      408704
+// PoolFixture/Burst/real_time/threads:256       1917 ns       179444 ns      319232
 // clang-format on
 BENCHMARK_DEFINE_F(PoolFixture, Burst)(benchmark::State& state) {
   for (auto _ : state) {
@@ -78,22 +78,22 @@ BENCHMARK_REGISTER_F(PoolFixture, Burst)->ThreadRange(1, 1 << 8)->UseRealTime();
 //  L1 Instruction 32 KiB (x48)
 //  L2 Unified 1024 KiB (x48)
 //  L3 Unified 39424 KiB (x2)
-// Load Average: 2.91, 2.31, 3.68
+// Load Average: 8.49, 4.69, 2.41
 //------------------------------------------------------------------
 // Benchmark                        Time             CPU   Iterations
 //------------------------------------------------------------------
-// PoolFixture/Linear/1           602 ns          602 ns      1181239
-// PoolFixture/Linear/2          1269 ns         1269 ns       551564
-// PoolFixture/Linear/4          2535 ns         2535 ns       275365
-// PoolFixture/Linear/8          5071 ns         5069 ns       137769
-// PoolFixture/Linear/16        10146 ns        10143 ns        69062
-// PoolFixture/Linear/32        20283 ns        20280 ns        34552
-// PoolFixture/Linear/64        40571 ns        40566 ns        17277
-// PoolFixture/Linear/128       81125 ns        81114 ns         8640
-// PoolFixture/Linear/256      162330 ns       162304 ns         4316
-// PoolFixture/Linear/512      324911 ns       324844 ns         2159
-// PoolFixture/Linear/1024     650354 ns       650268 ns         1080
-// PoolFixture/Linear_BigO     634.95 N        634.85 N
+// PoolFixture/Linear/1           565 ns          565 ns      1238384
+// PoolFixture/Linear/2          1141 ns         1141 ns       619762
+// PoolFixture/Linear/4          2431 ns         2431 ns       287628
+// PoolFixture/Linear/8          4858 ns         4857 ns       143748
+// PoolFixture/Linear/16         9714 ns         9713 ns        71886
+// PoolFixture/Linear/32        19402 ns        19400 ns        35986
+// PoolFixture/Linear/64        38784 ns        38782 ns        18028
+// PoolFixture/Linear/128       77622 ns        77611 ns         9025
+// PoolFixture/Linear/256      155368 ns       155337 ns         4510
+// PoolFixture/Linear/512      310703 ns       310682 ns         2256
+// PoolFixture/Linear/1024     621968 ns       621804 ns         1125
+// PoolFixture/Linear_BigO     607.25 N        607.11 N
 // PoolFixture/Linear_RMS           0 %             0 %
 // clang-format on
 BENCHMARK_DEFINE_F(PoolFixture, Linear)(benchmark::State& state) {

--- a/google/cloud/internal/curl_handle_factory_benchmark.cc
+++ b/google/cloud/internal/curl_handle_factory_benchmark.cc
@@ -47,19 +47,19 @@ bool CreateAndCleanup(CurlHandleFactory& factory) {
 //  L1 Instruction 32 KiB (x48)
 //  L2 Unified 1024 KiB (x48)
 //  L3 Unified 39424 KiB (x2)
-// Load Average: 12.07, 5.96, 3.01
-//----------------------------------------------------------------------------------
-// Benchmark                                        Time             CPU Iterations
-//----------------------------------------------------------------------------------
-// PoolFixture/Burst/real_time/threads:1          604 ns          604 ns     1152471
-// PoolFixture/Burst/real_time/threads:2          617 ns         1232 ns     1120720
-// PoolFixture/Burst/real_time/threads:4         1134 ns         4134 ns      699136
-// PoolFixture/Burst/real_time/threads:8         1055 ns         7409 ns      741768
-// PoolFixture/Burst/real_time/threads:16        1084 ns        15405 ns      708912
-// PoolFixture/Burst/real_time/threads:32        1224 ns        36308 ns      633728
-// PoolFixture/Burst/real_time/threads:64        1763 ns       107314 ns      454784
-// PoolFixture/Burst/real_time/threads:128       1838 ns       170508 ns      408704
-// PoolFixture/Burst/real_time/threads:256       1917 ns       179444 ns      319232
+// Load Average: 4.17, 4.07, 9.64
+// ----------------------------------------------------------------------------------
+// Benchmark                                        Time             CPU   Iterations
+// ----------------------------------------------------------------------------------
+// PoolFixture/Burst/real_time/threads:1          608 ns          608 ns      1226533
+// PoolFixture/Burst/real_time/threads:2          776 ns         1550 ns       828674
+// PoolFixture/Burst/real_time/threads:4         1164 ns         4234 ns       629056
+// PoolFixture/Burst/real_time/threads:8         1291 ns         8838 ns       728752
+// PoolFixture/Burst/real_time/threads:16        1095 ns        15615 ns       682480
+// PoolFixture/Burst/real_time/threads:32        1258 ns        37116 ns       656256
+// PoolFixture/Burst/real_time/threads:64        1821 ns       111173 ns       451008
+// PoolFixture/Burst/real_time/threads:128       1946 ns       182346 ns       376192
+// PoolFixture/Burst/real_time/threads:256       2005 ns       192227 ns       356608
 // clang-format on
 BENCHMARK_DEFINE_F(PoolFixture, Burst)(benchmark::State& state) {
   for (auto _ : state) {
@@ -78,22 +78,22 @@ BENCHMARK_REGISTER_F(PoolFixture, Burst)->ThreadRange(1, 1 << 8)->UseRealTime();
 //  L1 Instruction 32 KiB (x48)
 //  L2 Unified 1024 KiB (x48)
 //  L3 Unified 39424 KiB (x2)
-// Load Average: 8.49, 4.69, 2.41
-//------------------------------------------------------------------
+// Load Average: 5.36, 4.37, 9.62
+// ------------------------------------------------------------------
 // Benchmark                        Time             CPU   Iterations
-//------------------------------------------------------------------
-// PoolFixture/Linear/1           565 ns          565 ns      1238384
-// PoolFixture/Linear/2          1141 ns         1141 ns       619762
-// PoolFixture/Linear/4          2431 ns         2431 ns       287628
-// PoolFixture/Linear/8          4858 ns         4857 ns       143748
-// PoolFixture/Linear/16         9714 ns         9713 ns        71886
-// PoolFixture/Linear/32        19402 ns        19400 ns        35986
-// PoolFixture/Linear/64        38784 ns        38782 ns        18028
-// PoolFixture/Linear/128       77622 ns        77611 ns         9025
-// PoolFixture/Linear/256      155368 ns       155337 ns         4510
-// PoolFixture/Linear/512      310703 ns       310682 ns         2256
-// PoolFixture/Linear/1024     621968 ns       621804 ns         1125
-// PoolFixture/Linear_BigO     607.25 N        607.11 N
+// ------------------------------------------------------------------
+// PoolFixture/Linear/1           615 ns          615 ns      1135031
+// PoolFixture/Linear/2          1231 ns         1231 ns       567135
+// PoolFixture/Linear/4          2469 ns         2469 ns       284093
+// PoolFixture/Linear/8          4931 ns         4930 ns       141870
+// PoolFixture/Linear/16         9838 ns         9836 ns        70890
+// PoolFixture/Linear/32        19701 ns        19696 ns        35525
+// PoolFixture/Linear/64        39313 ns        39308 ns        17789
+// PoolFixture/Linear/128       78875 ns        78848 ns         8852
+// PoolFixture/Linear/256      157491 ns       157468 ns         4436
+// PoolFixture/Linear/512      314841 ns       314757 ns         2224
+// PoolFixture/Linear/1024     632701 ns       632620 ns         1114
+// PoolFixture/Linear_BigO     617.16 N        617.06 N
 // PoolFixture/Linear_RMS           0 %             0 %
 // clang-format on
 BENCHMARK_DEFINE_F(PoolFixture, Linear)(benchmark::State& state) {

--- a/google/cloud/internal/curl_handle_factory_benchmark.cc
+++ b/google/cloud/internal/curl_handle_factory_benchmark.cc
@@ -47,19 +47,19 @@ bool CreateAndCleanup(CurlHandleFactory& factory) {
 //  L1 Instruction 32 KiB (x48)
 //  L2 Unified 1024 KiB (x48)
 //  L3 Unified 39424 KiB (x2)
-// Load Average: 15.12, 5.10, 1.98
+// Load Average: 7.87, 6.41, 5.61
 //----------------------------------------------------------------------------------
 // Benchmark                                        Time             CPU Iterations
 //----------------------------------------------------------------------------------
-// PoolFixture/Burst/real_time/threads:1          611 ns          611 ns 1138757
-// PoolFixture/Burst/real_time/threads:2          753 ns         1503 ns 931064
-// PoolFixture/Burst/real_time/threads:4          912 ns         3460 ns 775028
-// PoolFixture/Burst/real_time/threads:8          977 ns         6946 ns 719024
-// PoolFixture/Burst/real_time/threads:16        1038 ns        14855 ns 645392
-// PoolFixture/Burst/real_time/threads:32        1280 ns        38140 ns 570144
-// PoolFixture/Burst/real_time/threads:64        1665 ns       101765 ns 510976
-// PoolFixture/Burst/real_time/threads:128       1846 ns       172375 ns 388736
-// PoolFixture/Burst/real_time/threads:256       1859 ns       180947 ns 377600
+// PoolFixture/Burst/real_time/threads:1          626 ns          626 ns 1115290
+// PoolFixture/Burst/real_time/threads:2          838 ns         1631 ns 887016
+// PoolFixture/Burst/real_time/threads:4          976 ns         3640 ns 570456
+// PoolFixture/Burst/real_time/threads:8         1172 ns         8115 ns 646784
+// PoolFixture/Burst/real_time/threads:16        1398 ns        19700 ns 594416
+// PoolFixture/Burst/real_time/threads:32        1850 ns        54669 ns 592704
+// PoolFixture/Burst/real_time/threads:64        1877 ns       114773 ns 400960
+// PoolFixture/Burst/real_time/threads:128       2100 ns       198027 ns 335360
+// PoolFixture/Burst/real_time/threads:256       2170 ns       210219 ns 256000
 // clang-format on
 BENCHMARK_DEFINE_F(PoolFixture, Burst)(benchmark::State& state) {
   for (auto _ : state) {
@@ -78,22 +78,22 @@ BENCHMARK_REGISTER_F(PoolFixture, Burst)->ThreadRange(1, 1 << 8)->UseRealTime();
 //  L1 Instruction 32 KiB (x48)
 //  L2 Unified 1024 KiB (x48)
 //  L3 Unified 39424 KiB (x2)
-// Load Average: 10.79, 7.87, 3.39
+// Load Average: 2.91, 2.31, 3.68
 //------------------------------------------------------------------
 // Benchmark                        Time             CPU   Iterations
 //------------------------------------------------------------------
-// PoolFixture/Linear/1           628 ns          628 ns      1098609
-// PoolFixture/Linear/2          1255 ns         1255 ns       553833
-// PoolFixture/Linear/4          2491 ns         2490 ns       278630
-// PoolFixture/Linear/8          4967 ns         4967 ns       140583
-// PoolFixture/Linear/16         9935 ns         9935 ns        70534
-// PoolFixture/Linear/32        19896 ns        19892 ns        35236
-// PoolFixture/Linear/64        39706 ns        39700 ns        17636
-// PoolFixture/Linear/128       79433 ns        79428 ns         8816
-// PoolFixture/Linear/256      159164 ns       159102 ns         4392
-// PoolFixture/Linear/512      318709 ns       318687 ns         2202
-// PoolFixture/Linear/1024     638671 ns       638514 ns         1098
-// PoolFixture/Linear_BigO     623.33 N        623.20 N
+// PoolFixture/Linear/1           602 ns          602 ns      1181239
+// PoolFixture/Linear/2          1269 ns         1269 ns       551564
+// PoolFixture/Linear/4          2535 ns         2535 ns       275365
+// PoolFixture/Linear/8          5071 ns         5069 ns       137769
+// PoolFixture/Linear/16        10146 ns        10143 ns        69062
+// PoolFixture/Linear/32        20283 ns        20280 ns        34552
+// PoolFixture/Linear/64        40571 ns        40566 ns        17277
+// PoolFixture/Linear/128       81125 ns        81114 ns         8640
+// PoolFixture/Linear/256      162330 ns       162304 ns         4316
+// PoolFixture/Linear/512      324911 ns       324844 ns         2159
+// PoolFixture/Linear/1024     650354 ns       650268 ns         1080
+// PoolFixture/Linear_BigO     634.95 N        634.85 N
 // PoolFixture/Linear_RMS           0 %             0 %
 // clang-format on
 BENCHMARK_DEFINE_F(PoolFixture, Linear)(benchmark::State& state) {


### PR DESCRIPTION
Before this change, the pool would always remove half the handles to
make room for additional handles returning to the pool. We want to
remove fewer handles when there are few excess handles, and remove
more handles (but not all handles) when there are more excess handles.

Fixes #9469 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9582)
<!-- Reviewable:end -->
