### PR TITLE
impl(generator): do not OCC loop when there is no backoff policy

### DIFF
--- a/generator/internal/client_generator.cc
+++ b/generator/internal/client_generator.cc
@@ -481,7 +481,10 @@ $client_class_name$::Async$method_name$(ExperimentalTag tag, Options opts) {
             {" set_request;\n"
              "  set_request.set_resource(resource);\n"
              "  auto backoff_policy = internal::CurrentOptions()"
-             ".get<$service_name$BackoffPolicyOption>()->clone();\n"
+             ".get<$service_name$BackoffPolicyOption>();\n"
+             "  if (backoff_policy != nullptr) {\n"
+             "    backoff_policy = backoff_policy->clone();\n"
+             "  }\n"
              "  for (;;) {\n"
              "    auto recent = connection_->"},
             {get_method_name + "(get_request);\n"},
@@ -496,8 +499,9 @@ $client_class_name$::Async$method_name$(ExperimentalTag tag, Options opts) {
              "    *set_request.mutable_policy() = *std::move(policy);\n"
              "    auto result = connection_->"},
             {set_method_name + "(set_request);\n"},
-            {"    if (result || result.status().code() != StatusCode::kAborted)"
-             " {\n"
+            {"    if (result ||\n"
+             "        result.status().code() != StatusCode::kAborted ||\n"
+             "        backoff_policy == nullptr) {\n"
              "      return result;\n"
              "    }\n"
              "    std::this_thread::sleep_for("

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_client.cc
@@ -349,8 +349,10 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
   auto backoff_policy = internal::CurrentOptions()
-                            .get<BigtableInstanceAdminBackoffPolicyOption>()
-                            ->clone();
+                            .get<BigtableInstanceAdminBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -362,7 +364,8 @@ StatusOr<google::iam::v1::Policy> BigtableInstanceAdminClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/billing/cloud_billing_client.cc
+++ b/google/cloud/billing/cloud_billing_client.cc
@@ -190,9 +190,11 @@ StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
-  auto backoff_policy = internal::CurrentOptions()
-                            .get<CloudBillingBackoffPolicyOption>()
-                            ->clone();
+  auto backoff_policy =
+      internal::CurrentOptions().get<CloudBillingBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -204,7 +206,8 @@ StatusOr<google::iam::v1::Policy> CloudBillingClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/containeranalysis/container_analysis_client.cc
+++ b/google/cloud/containeranalysis/container_analysis_client.cc
@@ -55,9 +55,11 @@ StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
-  auto backoff_policy = internal::CurrentOptions()
-                            .get<ContainerAnalysisBackoffPolicyOption>()
-                            ->clone();
+  auto backoff_policy =
+      internal::CurrentOptions().get<ContainerAnalysisBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -69,7 +71,8 @@ StatusOr<google::iam::v1::Policy> ContainerAnalysisClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/datacatalog/data_catalog_client.cc
+++ b/google/cloud/datacatalog/data_catalog_client.cc
@@ -590,7 +590,10 @@ StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
   auto backoff_policy =
-      internal::CurrentOptions().get<DataCatalogBackoffPolicyOption>()->clone();
+      internal::CurrentOptions().get<DataCatalogBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -602,7 +605,8 @@ StatusOr<google::iam::v1::Policy> DataCatalogClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/iam/iam_client.cc
+++ b/google/cloud/iam/iam_client.cc
@@ -248,7 +248,10 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
   auto backoff_policy =
-      internal::CurrentOptions().get<IAMBackoffPolicyOption>()->clone();
+      internal::CurrentOptions().get<IAMBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -260,7 +263,8 @@ StatusOr<google::iam::v1::Policy> IAMClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/iot/device_manager_client.cc
+++ b/google/cloud/iot/device_manager_client.cc
@@ -266,9 +266,11 @@ StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
-  auto backoff_policy = internal::CurrentOptions()
-                            .get<DeviceManagerBackoffPolicyOption>()
-                            ->clone();
+  auto backoff_policy =
+      internal::CurrentOptions().get<DeviceManagerBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -280,7 +282,8 @@ StatusOr<google::iam::v1::Policy> DeviceManagerClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/resourcemanager/folders_client.cc
+++ b/google/cloud/resourcemanager/folders_client.cc
@@ -201,7 +201,10 @@ StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
   auto backoff_policy =
-      internal::CurrentOptions().get<FoldersBackoffPolicyOption>()->clone();
+      internal::CurrentOptions().get<FoldersBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -213,7 +216,8 @@ StatusOr<google::iam::v1::Policy> FoldersClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/securitycenter/security_center_client.cc
+++ b/google/cloud/securitycenter/security_center_client.cc
@@ -459,9 +459,11 @@ StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
-  auto backoff_policy = internal::CurrentOptions()
-                            .get<SecurityCenterBackoffPolicyOption>()
-                            ->clone();
+  auto backoff_policy =
+      internal::CurrentOptions().get<SecurityCenterBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -473,7 +475,8 @@ StatusOr<google::iam::v1::Policy> SecurityCenterClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/spanner/admin/database_admin_client.cc
+++ b/google/cloud/spanner/admin/database_admin_client.cc
@@ -158,9 +158,11 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
-  auto backoff_policy = internal::CurrentOptions()
-                            .get<DatabaseAdminBackoffPolicyOption>()
-                            ->clone();
+  auto backoff_policy =
+      internal::CurrentOptions().get<DatabaseAdminBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -172,7 +174,8 @@ StatusOr<google::iam::v1::Policy> DatabaseAdminClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/spanner/admin/instance_admin_client.cc
+++ b/google/cloud/spanner/admin/instance_admin_client.cc
@@ -175,9 +175,11 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
   get_request.set_resource(resource);
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
-  auto backoff_policy = internal::CurrentOptions()
-                            .get<InstanceAdminBackoffPolicyOption>()
-                            ->clone();
+  auto backoff_policy =
+      internal::CurrentOptions().get<InstanceAdminBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -189,7 +191,8 @@ StatusOr<google::iam::v1::Policy> InstanceAdminClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());

--- a/google/cloud/tasks/cloud_tasks_client.cc
+++ b/google/cloud/tasks/cloud_tasks_client.cc
@@ -183,7 +183,10 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
   google::iam::v1::SetIamPolicyRequest set_request;
   set_request.set_resource(resource);
   auto backoff_policy =
-      internal::CurrentOptions().get<CloudTasksBackoffPolicyOption>()->clone();
+      internal::CurrentOptions().get<CloudTasksBackoffPolicyOption>();
+  if (backoff_policy != nullptr) {
+    backoff_policy = backoff_policy->clone();
+  }
   for (;;) {
     auto recent = connection_->GetIamPolicy(get_request);
     if (!recent) {
@@ -195,7 +198,8 @@ StatusOr<google::iam::v1::Policy> CloudTasksClient::SetIamPolicy(
     }
     *set_request.mutable_policy() = *std::move(policy);
     auto result = connection_->SetIamPolicy(set_request);
-    if (result || result.status().code() != StatusCode::kAborted) {
+    if (result || result.status().code() != StatusCode::kAborted ||
+        backoff_policy == nullptr) {
       return result;
     }
     std::this_thread::sleep_for(backoff_policy->OnCompletion());


### PR DESCRIPTION
In the OCC-loop overload of SetIamPolicy(), do not loop on kAborted
when there is no BackoffPolicyOption.  This will not affect production
code as there is a default BackoffPolicyOption in that case.  However,
a mock connection in a test may not have one, but we undoubtedly never
want to loop in that circumstance anyway unless the test has expressly
set a policy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9585)
<!-- Reviewable:end -->
