### PR TITLE
impl(spanner): only apply default options in one place

### DIFF
--- a/google/cloud/spanner/client.h
+++ b/google/cloud/spanner/client.h
@@ -132,9 +132,7 @@ class Client {
    */
   explicit Client(std::shared_ptr<Connection> conn, Options opts = {})
       : conn_(std::move(conn)),
-        opts_(internal::MergeOptions(
-            std::move(opts),
-            spanner_internal::DefaultOptions(conn_->options()))) {}
+        opts_(internal::MergeOptions(std::move(opts), conn_->options())) {}
 
   /// @name Backwards compatibility for `ClientOptions`.
   ///@{

--- a/google/cloud/spanner/internal/connection_impl.cc
+++ b/google/cloud/spanner/internal/connection_impl.cc
@@ -105,9 +105,7 @@ ConnectionImpl::ConnectionImpl(
     std::vector<std::shared_ptr<SpannerStub>> stubs, Options opts)
     : db_(std::move(db)),
       background_threads_(std::move(background_threads)),
-      opts_(internal::MergeOptions(
-          std::move(opts),
-          spanner_internal::DefaultOptions(Connection::options()))),
+      opts_(internal::MergeOptions(std::move(opts), Connection::options())),
       session_pool_(MakeSessionPool(db_, std::move(stubs),
                                     background_threads_->cq(), opts_)) {}
 


### PR DESCRIPTION
Follow the lead of the generator, and only apply the Spanner default
options in one place: `spanner::MakeConnection()`.

None of the `Client` tests are sensitive to the options returned by
the mock connection, and the `ConnectionImpl` tests already add the
`spanner_internal::DefaultOptions()` themselves.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9588)
<!-- Reviewable:end -->
