### PR TITLE
test(storage): add options to select upload function

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -54,6 +54,7 @@ struct ThroughputOptions {
       ExperimentTransport::kXml,   ExperimentTransport::kJsonV2,
       ExperimentTransport::kXmlV2,
   };
+  std::vector<std::string> upload_functions = {"InsertObject", "WriteObject"};
   std::vector<bool> enabled_crc32c = {false, true};
   std::vector<bool> enabled_md5 = {false, true};
   std::string rest_endpoint = "https://storage.googleapis.com";


### PR DESCRIPTION
Sometimes we just want to benchmark `WriteObject()` or `InsertObject()`,
but the benchmark was always testing with both.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9589)
<!-- Reviewable:end -->
