### PR TITLE
test(storage): cleanup benchmark output

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -51,6 +51,11 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
      << ',' << r.elapsed_time.count()          //
      << ',' << r.cpu_time.count()              //
      << ',' << CleanupCsv(r.peer)              //
+     << ',' << CleanupCsv(r.bucket_name)       //
+     << ',' << CleanupCsv(r.object_name)       //
+     << ',' << CleanupCsv(r.generation)        //
+     << ',' << CleanupCsv(r.upload_id)         //
+     << ',' << CleanupCsv(r.retry_count)       //
      << ',' << CleanupCsv(r.notes)             //
      << ',' << r.status.code()                 //
      << ',' << CleanupCsv(r.status.message())  //
@@ -60,7 +65,8 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
 void PrintThroughputResultHeader(std::ostream& os) {
   os << "Library,Transport,Op,Start,ObjectSize,TransferOffset,TransferSize"
      << ",AppBufferSize,Crc32cEnabled,MD5Enabled"
-     << ",ElapsedTimeUs,CpuTimeUs,Peer,Notes,StatusCode,Status\n";
+     << ",ElapsedTimeUs,CpuTimeUs,Peer,BucketName,ObjectName,Generation"
+     << ",UploadId,RetryCount,Notes,StatusCode,Status\n";
 }
 
 char const* ToString(OpType op) {

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -90,6 +90,16 @@ struct ThroughputResult {
   google::cloud::Status status;
   /// The peer used during the transfer
   std::string peer;
+  /// The bucket name
+  std::string bucket_name;
+  /// The object name
+  std::string object_name;
+  /// The object generation
+  std::string generation;
+  /// The upload id
+  std::string upload_id;
+  /// Retry Count
+  std::string retry_count;
   /// Additional notes
   std::string notes;
 };

--- a/google/cloud/storage/benchmarks/throughput_result_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_result_test.cc
@@ -71,15 +71,27 @@ TEST(ThroughputResult, HeaderMatches) {
   EXPECT_TRUE(header_stream);
   auto const header = std::move(header_stream).str();
 
-  auto const line = ToString(ThroughputResult{
-      ExperimentLibrary::kCppClient, ExperimentTransport::kGrpc, kOpInsert,
-      std::chrono::system_clock::now(),
-      /*object_size=*/8 * kMiB, /*transfer_offset=*/4 * kMiB,
-      /*transfer_size=*/3 * kMiB,
-      /*app_buffer_size=*/2 * kMiB,
-      /*crc_enabled=*/true, /*md5_enabled=*/false,
-      std::chrono::microseconds(234000), std::chrono::microseconds(345000),
-      Status{StatusCode::kOutOfRange, "OOR-status-message"}, "peer", "notes"});
+  auto const line = ToString(
+      ThroughputResult{ExperimentLibrary::kCppClient,
+                       ExperimentTransport::kGrpc,
+                       kOpInsert,
+                       std::chrono::system_clock::now(),
+                       /*object_size=*/8 * kMiB,
+                       /*transfer_offset=*/4 * kMiB,
+                       /*transfer_size=*/3 * kMiB,
+                       /*app_buffer_size=*/2 * kMiB,
+                       /*crc_enabled=*/true,
+                       /*md5_enabled=*/false,
+                       std::chrono::microseconds(234000),
+                       std::chrono::microseconds(345000),
+                       Status{StatusCode::kOutOfRange, "OOR-status-message"},
+                       "peer",
+                       "bucket-name",
+                       "object-name",
+                       "generation",
+                       "upload-id",
+                       "retry-count",
+                       "notes"});
   ASSERT_STATUS_OK(line);
   ASSERT_FALSE(header.empty());
   ASSERT_FALSE(line->empty());
@@ -107,6 +119,11 @@ TEST(ThroughputResult, HeaderMatches) {
   EXPECT_THAT(*line, HasSubstr(StatusCodeToString(StatusCode::kOutOfRange)));
   EXPECT_THAT(*line, HasSubstr("OOR-status-message"));
   EXPECT_THAT(*line, HasSubstr("peer"));
+  EXPECT_THAT(*line, HasSubstr(",bucket-name,"));
+  EXPECT_THAT(*line, HasSubstr(",object-name,"));
+  EXPECT_THAT(*line, HasSubstr(",generation,"));
+  EXPECT_THAT(*line, HasSubstr(",upload-id,"));
+  EXPECT_THAT(*line, HasSubstr(",retry-count,"));
   EXPECT_THAT(*line, HasSubstr(",notes,"));
 }
 


### PR DESCRIPTION
Use specific fields for the bucket name, object name, object generation,
and (when applicable) the upload id. For REST uploads, cleanup the
upload id: we used to print the full URL. Create a field to include the
number of retries, but that is not filled yet.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9592)
<!-- Reviewable:end -->
