### PR TITLE
feat(storage): experimental options to tune stall timeouts

### DIFF
--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -127,7 +127,9 @@ class CurlImpl {
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds transfer_stall_timeout_;
+  std::uint32_t transfer_stall_minimum_rate_ = 1;
   std::chrono::seconds download_stall_timeout_;
+  std::uint32_t download_stall_minimum_rate_ = 1;
   std::string http_version_;
   std::int32_t http_code_;
   std::set<std::int32_t> ignored_http_error_codes_;

--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -57,6 +57,16 @@ struct TransferStallTimeoutOption {
 };
 
 /**
+ * The minimum accepted bytes/second transfer rate.
+ *
+ * If the average rate is below this value for the `TransferStallTimeoutOption`
+ * then the transfer is aborted.
+ */
+struct TransferStallMinimumRateOption {
+  using Type = std::uint32_t;
+};
+
+/**
  * Sets the download stall timeout.
  *
  * If a download *stalls*, i.e., no bytes are received for a significant period,
@@ -75,6 +85,16 @@ struct DownloadStallTimeoutOption {
 };
 
 /**
+ * The minimum accepted bytes/second download rate.
+ *
+ * If the average rate is below this value for the `DownloadStallTimeoutOption`
+ * then the download is aborted.
+ */
+struct DownloadStallMinimumRateOption {
+  using Type = std::uint32_t;
+};
+
+/**
  * Some services appropriate Http error codes for their own use. If any such
  * error codes need to be treated as non-failures, this option can indicate
  * which codes.
@@ -84,10 +104,10 @@ struct IgnoredHttpErrorCodes {
 };
 
 /// The complete list of options accepted by `CurlRestClient`
-using RestOptionList =
-    ::google::cloud::OptionList<UserIpOption, TransferStallTimeoutOption,
-                                DownloadStallTimeoutOption,
-                                IgnoredHttpErrorCodes>;
+using RestOptionList = ::google::cloud::OptionList<
+    UserIpOption, TransferStallTimeoutOption, TransferStallMinimumRateOption,
+    DownloadStallTimeoutOption, DownloadStallMinimumRateOption,
+    IgnoredHttpErrorCodes>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -18,6 +18,7 @@
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -63,7 +64,7 @@ struct TransferStallTimeoutOption {
  * then the transfer is aborted.
  */
 struct TransferStallMinimumRateOption {
-  using Type = std::uint32_t;
+  using Type = std::int32_t;
 };
 
 /**
@@ -91,7 +92,7 @@ struct DownloadStallTimeoutOption {
  * then the download is aborted.
  */
 struct DownloadStallMinimumRateOption {
-  using Type = std::uint32_t;
+  using Type = std::int32_t;
 };
 
 /**

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -187,6 +187,8 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
           .set<MaximumCurlSocketSendSizeOption>(0)
           .set<TransferStallTimeoutOption>(std::chrono::seconds(
               GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_STALL_TIMEOUT))
+          .set<storage_experimental::TransferStallMinimumRateOption>(1)
+          .set<storage_experimental::DownloadStallMinimumRateOption>(1)
           .set<RetryPolicyOption>(
               LimitedTimeRetryPolicy(
                   STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD)
@@ -238,8 +240,12 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
       Options{}
           .set<rest::DownloadStallTimeoutOption>(
               o.get<DownloadStallTimeoutOption>())
+          .set<rest::DownloadStallMinimumRateOption>(
+              o.get<storage_experimental::DownloadStallMinimumRateOption>())
           .set<rest::TransferStallTimeoutOption>(
               o.get<TransferStallTimeoutOption>())
+          .set<rest::TransferStallMinimumRateOption>(
+              o.get<storage_experimental::TransferStallMinimumRateOption>())
           .set<rest::MaximumCurlSocketRecvSizeOption>(
               o.get<MaximumCurlSocketRecvSizeOption>())
           .set<rest::MaximumCurlSocketSendSizeOption>(

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -325,6 +325,8 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_EQ("test-project-id", opts.get<ProjectIdOption>());
   EXPECT_LT(0, opts.get<ConnectionPoolSizeOption>());
   EXPECT_LT(0, opts.get<DownloadBufferSizeOption>());
+  EXPECT_LT(0,
+            opts.get<storage_experimental::DownloadStallMinimumRateOption>());
   EXPECT_LT(0, opts.get<UploadBufferSizeOption>());
   EXPECT_LT(0, opts.get<MaximumSimpleUploadSizeOption>());
   EXPECT_TRUE(opts.has<EnableCurlSslLockingOption>());
@@ -332,6 +334,8 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_EQ(0, opts.get<MaximumCurlSocketSendSizeOption>());
   EXPECT_EQ(0, opts.get<MaximumCurlSocketRecvSizeOption>());
   EXPECT_LT(0, opts.get<TransferStallTimeoutOption>().count());
+  EXPECT_LT(0,
+            opts.get<storage_experimental::TransferStallMinimumRateOption>());
   EXPECT_THAT(opts.get<CARootsFilePathOption>(), IsEmpty());
 }
 
@@ -360,13 +364,19 @@ TEST_F(ClientOptionsTest, DefaultOptions) {
   EXPECT_EQ(0, o.get<MaximumCurlSocketRecvSizeOption>());
   EXPECT_EQ(0, o.get<MaximumCurlSocketSendSizeOption>());
   EXPECT_LT(std::chrono::seconds(0), o.get<TransferStallTimeoutOption>());
+  EXPECT_LT(0, o.get<storage_experimental::TransferStallMinimumRateOption>());
   EXPECT_LT(std::chrono::seconds(0), o.get<DownloadStallTimeoutOption>());
+  EXPECT_LT(0, o.get<storage_experimental::DownloadStallMinimumRateOption>());
 
   namespace rest = ::google::cloud::rest_internal;
   EXPECT_EQ(o.get<rest::DownloadStallTimeoutOption>(),
             o.get<DownloadStallTimeoutOption>());
+  EXPECT_EQ(o.get<rest::DownloadStallMinimumRateOption>(),
+            o.get<storage_experimental::DownloadStallMinimumRateOption>());
   EXPECT_EQ(o.get<rest::TransferStallTimeoutOption>(),
             o.get<TransferStallTimeoutOption>());
+  EXPECT_EQ(o.get<rest::TransferStallMinimumRateOption>(),
+            o.get<storage_experimental::TransferStallMinimumRateOption>());
   EXPECT_EQ(o.get<rest::MaximumCurlSocketRecvSizeOption>(),
             o.get<MaximumCurlSocketRecvSizeOption>());
   EXPECT_EQ(o.get<rest::MaximumCurlSocketSendSizeOption>(),

--- a/google/cloud/storage/internal/curl_download_request.cc
+++ b/google/cloud/storage/internal/curl_download_request.cc
@@ -261,11 +261,13 @@ Status CurlDownloadRequest::SetOptions() {
   if (download_stall_timeout_.count() != 0) {
     // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
     auto const timeout = static_cast<long>(download_stall_timeout_.count());
+    // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
+    auto const limit = static_cast<long>(download_stall_minimum_rate_);
     status = handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
     if (!status.ok()) return OnTransferError(std::move(status));
-    // Timeout if the download receives less than 1 byte/second (i.e.
-    // effectively no bytes) for `transfer_stall_timeout_` seconds.
-    status = handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
+    // Timeout if the download receives less than `limit` bytes in `timeout`
+    // seconds for `transfer_stall_timeout_` seconds.
+    status = handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, limit);
     if (!status.ok()) return OnTransferError(std::move(status));
     status = handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
     if (!status.ok()) return OnTransferError(std::move(status));

--- a/google/cloud/storage/internal/curl_download_request.h
+++ b/google/cloud/storage/internal/curl_download_request.h
@@ -135,6 +135,7 @@ class CurlDownloadRequest : public ObjectReadSource {
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds download_stall_timeout_;
+  std::uint32_t download_stall_minimum_rate_ = 0;
   CurlHandle handle_;
   rest_internal::CurlMulti multi_;
   std::shared_ptr<rest_internal::CurlHandleFactory> factory_;

--- a/google/cloud/storage/internal/curl_request.cc
+++ b/google/cloud/storage/internal/curl_request.cc
@@ -120,10 +120,12 @@ StatusOr<HttpResponse> CurlRequest::MakeRequestImpl() {
   if (transfer_stall_timeout_.count() != 0) {
     // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
     auto const timeout = static_cast<long>(transfer_stall_timeout_.count());
+    // NOLINTNEXTLINE(google-runtime-int) - libcurl *requires* `long`
+    auto const limit = static_cast<long>(transfer_stall_minimum_rate_);
     handle_.SetOption(CURLOPT_CONNECTTIMEOUT, timeout);
     // Timeout if the request sends or receives less than 1 byte/second (i.e.
     // effectively no bytes) for `transfer_stall_timeout_` seconds.
-    handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, 1L);
+    handle_.SetOption(CURLOPT_LOW_SPEED_LIMIT, limit);
     handle_.SetOption(CURLOPT_LOW_SPEED_TIME, timeout);
   }
   auto status = handle_.EasyPerform();

--- a/google/cloud/storage/internal/curl_request.h
+++ b/google/cloud/storage/internal/curl_request.h
@@ -78,6 +78,7 @@ class CurlRequest {
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds transfer_stall_timeout_;
+  std::uint32_t transfer_stall_minimum_rate_;
   CurlHandle handle_;
   std::shared_ptr<rest_internal::CurlHandleFactory> factory_;
 };

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -59,6 +59,7 @@ CurlRequest CurlRequestBuilder::BuildRequest() && {
   request.logging_enabled_ = logging_enabled_;
   request.socket_options_ = socket_options_;
   request.transfer_stall_timeout_ = transfer_stall_timeout_;
+  request.transfer_stall_minimum_rate_ = transfer_stall_minimum_rate_;
   return request;
 }
 
@@ -75,6 +76,7 @@ CurlRequestBuilder::BuildDownloadRequest() && {
   request->logging_enabled_ = logging_enabled_;
   request->socket_options_ = socket_options_;
   request->download_stall_timeout_ = download_stall_timeout_;
+  request->download_stall_minimum_rate_ = download_stall_minimum_rate_;
   auto status = request->SetOptions();
   if (!status.ok()) return status;
   return request;
@@ -95,7 +97,11 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   http_version_ =
       std::move(options.get<storage_experimental::HttpVersionOption>());
   transfer_stall_timeout_ = options.get<TransferStallTimeoutOption>();
+  transfer_stall_minimum_rate_ =
+      options.get<storage_experimental::TransferStallMinimumRateOption>();
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
+  download_stall_minimum_rate_ =
+      options.get<storage_experimental::DownloadStallMinimumRateOption>();
   return *this;
 }
 

--- a/google/cloud/storage/internal/curl_request_builder.h
+++ b/google/cloud/storage/internal/curl_request_builder.h
@@ -197,7 +197,9 @@ class CurlRequestBuilder {
   bool logging_enabled_ = false;
   CurlHandle::SocketOptions socket_options_;
   std::chrono::seconds transfer_stall_timeout_;
+  std::uint32_t transfer_stall_minimum_rate_ = 0;
   std::chrono::seconds download_stall_timeout_;
+  std::uint32_t download_stall_minimum_rate_ = 0;
   std::string http_version_;
 };
 

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -23,6 +23,7 @@
 #include "google/cloud/credentials.h"
 #include "google/cloud/options.h"
 #include <chrono>
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -56,7 +57,7 @@ struct HttpVersionOption {
  * then the transfer is aborted.
  */
 struct TransferStallMinimumRateOption {
-  using Type = std::uint32_t;
+  using Type = std::int32_t;
 };
 
 /**
@@ -66,7 +67,7 @@ struct TransferStallMinimumRateOption {
  * then the download is aborted.
  */
 struct DownloadStallMinimumRateOption {
-  using Type = std::uint32_t;
+  using Type = std::int32_t;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -48,6 +48,27 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 struct HttpVersionOption {
   using Type = std::string;
 };
+
+/**
+ * The minimum accepted bytes/second transfer rate.
+ *
+ * If the average rate is below this value for the `TransferStallTimeoutOption`
+ * then the transfer is aborted.
+ */
+struct TransferStallMinimumRateOption {
+  using Type = std::uint32_t;
+};
+
+/**
+ * The minimum accepted bytes/second download rate.
+ *
+ * If the average rate is below this value for the `DownloadStallTimeoutOption`
+ * then the download is aborted.
+ */
+struct DownloadStallMinimumRateOption {
+  using Type = std::uint32_t;
+};
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental
 


### PR DESCRIPTION
Some applications need more progress than just "at least 1 byte per
second for K seconds".  These new options allow them to require "at
least N bytes per second for K seconds".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9593)
<!-- Reviewable:end -->
