### PR TITLE
cleanup(storage): correctly declare `GroupOptions()` overloads

### DIFF
--- a/google/cloud/storage/internal/group_options.h
+++ b/google/cloud/storage/internal/group_options.h
@@ -41,31 +41,42 @@ inline google::cloud::Options GroupOptions() {
 }
 
 template <typename... Tail>
-static Options GroupOptions(Options& bundle, Tail&&... t) {
+Options GroupOptions(Options& bundle, Tail&&... t);
+template <typename... Tail>
+Options GroupOptions(Options&& bundle, Tail&&... t);
+template <typename... Tail>
+Options GroupOptions(Options const& bundle, Tail&&... t);
+template <typename... Tail>
+Options GroupOptions(Options const&& bundle, Tail&&... t);
+template <typename Head, typename... Tail>
+Options GroupOptions(Head&&, Tail&&... t);
+
+template <typename... Tail>
+Options GroupOptions(Options& bundle, Tail&&... t) {
   return google::cloud::internal::MergeOptions(
       GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
 }
 
 template <typename... Tail>
-static Options GroupOptions(Options&& bundle, Tail&&... t) {
+Options GroupOptions(Options&& bundle, Tail&&... t) {
   return google::cloud::internal::MergeOptions(
       GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
 }
 
 template <typename... Tail>
-static Options GroupOptions(Options const& bundle, Tail&&... t) {
+Options GroupOptions(Options const& bundle, Tail&&... t) {
   return google::cloud::internal::MergeOptions(
       GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
 }
 
 template <typename... Tail>
-static Options GroupOptions(Options const&& bundle, Tail&&... t) {
+Options GroupOptions(Options const&& bundle, Tail&&... t) {
   return google::cloud::internal::MergeOptions(
       GroupOptions(std::forward<Tail>(t)...), std::move(bundle));
 }
 
 template <typename Head, typename... Tail>
-static Options GroupOptions(Head&&, Tail&&... t) {
+Options GroupOptions(Head&&, Tail&&... t) {
   return GroupOptions(std::forward<Tail>(t)...);
 }
 ///@}

--- a/google/cloud/storage/internal/group_options_test.cc
+++ b/google/cloud/storage/internal/group_options_test.cc
@@ -60,6 +60,14 @@ TEST(MakeOptionSpanTest, OverridesMixedWithRequestOptions) {
   EXPECT_EQ("test-endpoint", group.get<EndpointOption>());
 }
 
+TEST(MakeOptionSpanTest, Declaration) {
+  auto const g1 = GroupOptions(SimulateRawClientOptions(), 5);
+  EXPECT_EQ("u-p-default", g1.get<UserProjectOption>());
+
+  auto const g2 = GroupOptions(5, SimulateRawClientOptions());
+  EXPECT_EQ("u-p-default", g2.get<UserProjectOption>());
+}
+
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Do not use `static`, these are global functions. And declare all
overloads before they are used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9596)
<!-- Reviewable:end -->
