### PR TITLE
test(storage): benchmark options to tune stall timeouts

### DIFF
--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -301,6 +301,14 @@ gcs_bm::ClientProvider BaseProvider(ThroughputOptions const& options) {
       opts.set<google::cloud::storage::internal::TargetApiVersionOption>(
           *options.target_api_version_path);
     }
+    if (options.transfer_stall_minimum_rate.has_value()) {
+      opts.set<gcs_ex::TransferStallMinimumRateOption>(
+          *options.transfer_stall_minimum_rate);
+    }
+    if (options.download_stall_minimum_rate.has_value()) {
+      opts.set<gcs_ex::DownloadStallMinimumRateOption>(
+          *options.download_stall_minimum_rate);
+    }
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
     using ::google::cloud::storage_experimental::DefaultGrpcClient;
     if (options.grpc_background_threads.has_value()) {

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -332,13 +332,21 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
          options.direct_path_endpoint = val;
        }},
       {"--transfer-stall-timeout",
-       "configure the storage::TransferStallTimeoutOption: the maximum time"
-       " allowed for data to 'stall' (make no progress) on all operations,"
-       " except for downloads (see --download-stall-timeout)."
+       "configure `storage::TransferStallTimeoutOption`: the maximum time"
+       " allowed for data to 'stall' (make insufficient progress) on all"
+       " operations, except for downloads (see --download-stall-timeout)."
        " This option is intended for troubleshooting, most of the time the"
        " value is not expected to change the library performance.",
        [&options](std::string const& val) {
          options.transfer_stall_timeout = ParseDuration(val);
+       }},
+      {"--transfer-stall-minimum-rate",
+       "configure `storage::TransferStallMinimumRateOption`: the transfer"
+       " is aborted if the average transfer rate is below this limit for"
+       " the period set via `storage::TransferStallTimeoutOption`.",
+       [&options](std::string const& val) {
+         options.transfer_stall_minimum_rate =
+             static_cast<std::uint32_t>(ParseBufferSize(val));
        }},
       {"--download-stall-timeout",
        "configure the storage::DownloadStallTimeoutOption: the maximum time"
@@ -347,6 +355,14 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        " value is not expected to change the library performance.",
        [&options](std::string const& val) {
          options.download_stall_timeout = ParseDuration(val);
+       }},
+      {"--download-stall-minimum-rate",
+       "configure `storage::DownloadStallMinimumRateOption`: the download"
+       " is aborted if the average transfer rate is below this limit for"
+       " the period set via `storage::DownloadStallTimeoutOption`.",
+       [&options](std::string const& val) {
+         options.download_stall_minimum_rate =
+             static_cast<std::uint32_t>(ParseBufferSize(val));
        }},
       {"--minimum-sample-delay",
        "configure the minimum time between samples."

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -61,7 +61,9 @@ struct ThroughputOptions {
   std::string grpc_endpoint = "storage.googleapis.com";
   std::string direct_path_endpoint = "google-c2p:///storage.googleapis.com";
   std::chrono::seconds transfer_stall_timeout{};
+  absl::optional<std::uint32_t> transfer_stall_minimum_rate;
   std::chrono::seconds download_stall_timeout{};
+  absl::optional<std::uint32_t> download_stall_minimum_rate;
   std::chrono::milliseconds minimum_sample_delay{};
   std::int64_t minimum_read_offset = 0;
   std::int64_t maximum_read_offset = 0;

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -56,7 +56,9 @@ TEST(ThroughputOptions, Basic) {
       "--grpc-endpoint=test-only-grpc",
       "--direct-path-endpoint=test-only-direct-path",
       "--transfer-stall-timeout=86400s",
+      "--transfer-stall-minimum-rate=7KiB",
       "--download-stall-timeout=86401s",
+      "--download-stall-minimum-rate=9KiB",
       "--minimum-sample-delay=250ms",
       "--minimum-read-offset=32KiB",
       "--maximum-read-offset=48KiB",
@@ -99,7 +101,9 @@ TEST(ThroughputOptions, Basic) {
   EXPECT_EQ("test-only-grpc", options->grpc_endpoint);
   EXPECT_EQ("test-only-direct-path", options->direct_path_endpoint);
   EXPECT_EQ(std::chrono::seconds(86400), options->transfer_stall_timeout);
+  EXPECT_EQ(7 * kKiB, options->transfer_stall_minimum_rate);
   EXPECT_EQ(std::chrono::seconds(86401), options->download_stall_timeout);
+  EXPECT_EQ(9 * kKiB, options->download_stall_minimum_rate);
   EXPECT_EQ(std::chrono::milliseconds(250), options->minimum_sample_delay);
   EXPECT_EQ("vN", options->target_api_version_path.value_or(""));
   EXPECT_EQ(16, options->grpc_background_threads.value_or(0));


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9598)
<!-- Reviewable:end -->
