### PR TITLE
cleanup: remove magic test strings for `ServiceAccountCredentials`

### DIFF
--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -495,7 +495,7 @@ TEST(ServiceAccountCredentialsTest, RefreshingUpdatesTimestamps) {
         EXPECT_EQ(info->token_uri, payload.value("aud", ""));
       };
 
-  // Set  up the mock request / response for the first Refresh().
+  // Set up the mock request / response for the first Refresh().
   auto const clock_value_1 = 10000;
   auto const clock_value_2 = 20000;
 


### PR DESCRIPTION
I want to make changes to `ServiceAccountCredentials`, and having
hard-coded magic strings makes it harder than it should be. Took the
opportunity to remove unused code from the test, and that make the
test fixture unjustified.

Part of the work #7674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9601)
<!-- Reviewable:end -->
