### PR TITLE
test(rest): use storage service in integration test

### DIFF
--- a/google/cloud/internal/unified_rest_credentials_integration_test.cc
+++ b/google/cloud/internal/unified_rest_credentials_integration_test.cc
@@ -151,6 +151,25 @@ TEST(UnifiedRestCredentialsIntegrationTest, ServiceAccountCredentials) {
           MakeServiceAccountCredentials(contents))));
 }
 
+TEST(UnifiedRestCredentialsIntegrationTest, StorageGoogleDefaultCredentials) {
+  ASSERT_NO_FATAL_FAILURE(MakeStorageRpcCall(
+      Options{}.set<UnifiedCredentialsOption>(MakeGoogleDefaultCredentials())));
+}
+
+TEST(UnifiedRestCredentialsIntegrationTest, StorageServiceAccount) {
+  auto project = internal::GetEnv("GOOGLE_CLOUD_PROJECT");
+  ASSERT_TRUE(project.has_value());
+  auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_REST_TEST_KEY_FILE_JSON");
+  ASSERT_TRUE(env.has_value());
+  std::string key_file = std::move(*env);
+  std::ifstream is(key_file);
+  auto contents = std::string{std::istreambuf_iterator<char>{is}, {}};
+
+  ASSERT_NO_FATAL_FAILURE(
+      MakeStorageRpcCall(Options{}.set<UnifiedCredentialsOption>(
+          MakeServiceAccountCredentials(contents))));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal


### PR DESCRIPTION
The storage service has some particular requirements w.r.t. self-signed
JWTs for service account credentials.  We need to support self-signed
JWTs for a number of reasons. Adding a test before I change the service
account credentials implementation will avoid regressions.

Part of the work for #7674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9610)
<!-- Reviewable:end -->
