### PR TITLE
cleanup(rest): remove constant parameters

### DIFF
--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -90,10 +90,8 @@ std::string MakeJWTAssertion(std::string const& header,
 /// JWT assertion. The assertion combined with the grant type is used to create
 /// the refresh payload.
 std::vector<std::pair<std::string, std::string>>
-CreateServiceAccountRefreshPayload(
-    ServiceAccountCredentialsInfo const& info,
-    std::pair<std::string, std::string> grant_type,
-    std::chrono::system_clock::time_point now);
+CreateServiceAccountRefreshPayload(ServiceAccountCredentialsInfo const& info,
+                                   std::chrono::system_clock::time_point now);
 
 /**
  * Wrapper class for Google OAuth 2.0 service account credentials.

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -56,8 +56,6 @@ constexpr char kScopeForTest1[] =
 constexpr std::time_t kFixedJwtTimestamp = 1530060324;
 constexpr char kGrantParamUnescaped[] =
     "urn:ietf:params:oauth:grant-type:jwt-bearer";
-constexpr char kGrantParamEscaped[] =
-    "urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer";
 constexpr char kSubjectForGrant[] = "user@foo.bar";
 
 auto constexpr kProjectId = "test-only-project-id";
@@ -709,14 +707,13 @@ TEST(ServiceAccountCredentialsTest, CreateServiceAccountRefreshPayload) {
   auto components = AssertionComponentsFromInfo(*info, FakeClock::now());
   auto assertion =
       MakeJWTAssertion(components.first, components.second, info->private_key);
-  auto actual_payload = CreateServiceAccountRefreshPayload(
-      *info, std::make_pair("grant_type", kGrantParamEscaped),
-      FakeClock::now());
+  auto actual_payload =
+      CreateServiceAccountRefreshPayload(*info, FakeClock::now());
 
   EXPECT_THAT(actual_payload, Contains(std::pair<std::string, std::string>(
                                   "assertion", assertion)));
   EXPECT_THAT(actual_payload, Contains(std::pair<std::string, std::string>(
-                                  "grant_type", kGrantParamEscaped)));
+                                  "grant_type", kGrantParamUnescaped)));
 }
 
 /// @test Parsing a refresh response with missing fields results in failure.


### PR DESCRIPTION
Also cleaned up some complicated implementation using `MergeOptions()`.

Part of the work for #7674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9613)
<!-- Reviewable:end -->
