### PR TITLE
impl(rest): helper functions to create self-signed JWTs

### DIFF
--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -94,6 +94,34 @@ CreateServiceAccountRefreshPayload(ServiceAccountCredentialsInfo const& info,
                                    std::chrono::system_clock::time_point now);
 
 /**
+ * Make a self-signed JWT from the service account.
+ *
+ * Self-signed JWTs bypass the intermediate step of exchanging client assertions
+ * for OAuth tokens. The advantages of self-signed JTWs include:
+ *
+ * - They are more efficient, they require more or less the same amount of
+ *   local work, and save a round-trip to the token endpoint, typically
+ *   https://oauth2.googleapis.com/token.
+ * - While this service is extremely reliable, removing external dependencies in
+ *   critical path almost always improves reliability.
+ * - They work better in VPC-SC environments and other environments with limited
+ *   Internet access.
+ *
+ * @warning At this time only scope-based self-signed JWTs are supported.
+ *
+ * [aip/4111]: https://google.aip.dev/auth/4111
+ *
+ * @param info the parsed service account information, see
+ * `ParseServiceAccountCredentials()`
+ * @param tp the current time
+ * @return a bearer token for authentication.  Include this value in the
+ *   `Authorization` header with the "Bearer" type.
+ */
+StatusOr<std::string> MakeSelfSignedJWT(
+    ServiceAccountCredentialsInfo const& info,
+    std::chrono::system_clock::time_point tp);
+
+/**
  * Wrapper class for Google OAuth 2.0 service account credentials.
  *
  * Takes a ServiceAccountCredentialsInfo and obtains access tokens from the

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -96,20 +96,20 @@ CreateServiceAccountRefreshPayload(ServiceAccountCredentialsInfo const& info,
 /**
  * Make a self-signed JWT from the service account.
  *
- * Self-signed JWTs bypass the intermediate step of exchanging client assertions
- * for OAuth tokens. The advantages of self-signed JTWs include:
+ * [Self-signed JWTs] bypass the intermediate step of exchanging client
+ * assertions for OAuth tokens. The advantages of self-signed JTWs include:
  *
- * - They are more efficient, they require more or less the same amount of
+ * - They are more efficient, as they require more or less the same amount of
  *   local work, and save a round-trip to the token endpoint, typically
  *   https://oauth2.googleapis.com/token.
  * - While this service is extremely reliable, removing external dependencies in
- *   critical path almost always improves reliability.
+ *   the critical path almost always improves reliability.
  * - They work better in VPC-SC environments and other environments with limited
  *   Internet access.
  *
  * @warning At this time only scope-based self-signed JWTs are supported.
  *
- * [aip/4111]: https://google.aip.dev/auth/4111
+ * [Self-signed JWTs]: https://google.aip.dev/auth/4111
  *
  * @param info the parsed service account information, see
  * `ParseServiceAccountCredentials()`

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -199,8 +199,6 @@ TEST(ServiceAccountCredentialsTest, MakeSelfSignedJWT) {
 
   ASSERT_EQ(expected_header, header) << "header=" << header;
   ASSERT_EQ(expected_payload, payload) << "payload=" << payload;
-  ASSERT_EQ(expected_header, header) << "header=" << header;
-  ASSERT_EQ(expected_payload, payload) << "payload=" << payload;
 
   auto signature = internal::SignUsingSha256(
       components[0] + '.' + components[1], info->private_key);

--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -45,6 +45,7 @@ using ::testing::_;
 using ::testing::A;
 using ::testing::ByMove;
 using ::testing::Contains;
+using ::testing::ElementsAreArray;
 using ::testing::HasSubstr;
 using ::testing::Not;
 using ::testing::Return;
@@ -160,6 +161,98 @@ void CheckInfoYieldsExpectedAssertion(std::unique_ptr<MockRestClient> mock,
   EXPECT_EQ(std::make_pair(std::string{"Authorization"},
                            std::string{"Type access-token-value"}),
             credentials.AuthorizationHeader().value());
+}
+
+TEST(ServiceAccountCredentialsTest, MakeSelfSignedJWT) {
+  auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
+  ASSERT_STATUS_OK(info);
+  auto const now = std::chrono::system_clock::now();
+  auto actual = MakeSelfSignedJWT(*info, now);
+  ASSERT_STATUS_OK(actual);
+
+  std::vector<std::string> components = absl::StrSplit(*actual, '.');
+  std::vector<std::string> decoded(components.size());
+  std::transform(components.begin(), components.end(), decoded.begin(),
+                 [](std::string const& e) {
+                   auto v = UrlsafeBase64Decode(e).value();
+                   return std::string{v.begin(), v.end()};
+                 });
+  ASSERT_THAT(3, decoded.size());
+  auto const header = nlohmann::json::parse(decoded[0], nullptr);
+  ASSERT_FALSE(header.is_null()) << "header=" << decoded[0];
+  auto const payload = nlohmann::json::parse(decoded[1], nullptr);
+  ASSERT_FALSE(payload.is_null()) << "payload=" << decoded[1];
+
+  auto const expected_header = nlohmann::json{
+      {"alg", "RS256"}, {"typ", "JWT"}, {"kid", info->private_key_id}};
+
+  auto const iat =
+      std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
+  auto const exp = iat + std::chrono::hours(1);
+  auto const expected_payload = nlohmann::json{
+      {"iss", info->client_email},
+      {"sub", info->client_email},
+      {"iat", iat.count()},
+      {"exp", exp.count()},
+      {"scope", "https://www.googleapis.com/auth/cloud-platform"},
+  };
+
+  ASSERT_EQ(expected_header, header) << "header=" << header;
+  ASSERT_EQ(expected_payload, payload) << "payload=" << payload;
+  ASSERT_EQ(expected_header, header) << "header=" << header;
+  ASSERT_EQ(expected_payload, payload) << "payload=" << payload;
+
+  auto signature = internal::SignUsingSha256(
+      components[0] + '.' + components[1], info->private_key);
+  ASSERT_STATUS_OK(signature);
+  EXPECT_THAT(*signature,
+              ElementsAreArray(decoded[2].begin(), decoded[2].end()));
+}
+
+TEST(ServiceAccountCredentialsTest, MakeSelfSignedJWTWithScopes) {
+  auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
+  ASSERT_STATUS_OK(info);
+  info->scopes = std::set<std::string>{"test-only-s1", "test-only-s2"};
+
+  auto const now = std::chrono::system_clock::now();
+  auto actual = MakeSelfSignedJWT(*info, now);
+  ASSERT_STATUS_OK(actual);
+
+  std::vector<std::string> components = absl::StrSplit(*actual, '.');
+  std::vector<std::string> decoded(components.size());
+  std::transform(components.begin(), components.end(), decoded.begin(),
+                 [](std::string const& e) {
+                   auto v = UrlsafeBase64Decode(e).value();
+                   return std::string{v.begin(), v.end()};
+                 });
+  ASSERT_THAT(3, decoded.size());
+  auto const header = nlohmann::json::parse(decoded[0], nullptr);
+  ASSERT_FALSE(header.is_null()) << "header=" << decoded[0];
+  auto const payload = nlohmann::json::parse(decoded[1], nullptr);
+  ASSERT_FALSE(payload.is_null()) << "payload=" << decoded[1];
+
+  auto const expected_header = nlohmann::json{
+      {"alg", "RS256"}, {"typ", "JWT"}, {"kid", info->private_key_id}};
+
+  auto const iat =
+      std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch());
+  auto const exp = iat + std::chrono::hours(1);
+  auto const expected_payload = nlohmann::json{
+      {"iss", info->client_email},
+      {"sub", info->client_email},
+      {"iat", iat.count()},
+      {"exp", exp.count()},
+      {"scope", "test-only-s1 test-only-s2"},
+  };
+
+  ASSERT_EQ(expected_header, header) << "header=" << header;
+  ASSERT_EQ(expected_payload, payload) << "payload=" << payload;
+
+  auto signature = internal::SignUsingSha256(
+      components[0] + '.' + components[1], info->private_key);
+  ASSERT_STATUS_OK(signature);
+  EXPECT_THAT(*signature,
+              ElementsAreArray(decoded[2].begin(), decoded[2].end()));
 }
 
 /// @test Verify that we can create service account credentials from a keyfile.

--- a/google/cloud/internal/unified_rest_credentials_integration_test.cc
+++ b/google/cloud/internal/unified_rest_credentials_integration_test.cc
@@ -16,6 +16,7 @@
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/oauth2_google_credentials.h"
 #include "google/cloud/internal/oauth2_minimal_iam_credentials_rest.h"
+#include "google/cloud/internal/oauth2_service_account_credentials.h"
 #include "google/cloud/internal/rest_client.h"
 #include "google/cloud/log.h"
 #include "google/cloud/testing_util/scoped_environment.h"
@@ -168,6 +169,46 @@ TEST(UnifiedRestCredentialsIntegrationTest, StorageServiceAccount) {
   ASSERT_NO_FATAL_FAILURE(
       MakeStorageRpcCall(Options{}.set<UnifiedCredentialsOption>(
           MakeServiceAccountCredentials(contents))));
+}
+
+// TODO(#7674) - the service account credentials should create self-signed JWTs
+TEST(UnifiedRestCredentialsIntegrationTest, BigQuerySelfSignedJWT) {
+  // Manually create a self-signed JWT and then use it as an access token
+  auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_REST_TEST_KEY_FILE_JSON");
+  ASSERT_TRUE(env.has_value());
+  std::ifstream is(*env);
+  auto contents = std::string{std::istreambuf_iterator<char>{is}, {}};
+  auto info = oauth2_internal::ParseServiceAccountCredentials(contents, *env);
+  ASSERT_STATUS_OK(info);
+
+  auto const now = std::chrono::system_clock::now();
+  auto const expiration =
+      now + oauth2_internal::GoogleOAuthAccessTokenLifetime();
+  auto jwt = oauth2_internal::MakeSelfSignedJWT(*info, now);
+
+  ASSERT_NO_FATAL_FAILURE(
+      MakeBigQueryRpcCall(Options{}.set<UnifiedCredentialsOption>(
+          MakeAccessTokenCredentials(*jwt, expiration))));
+}
+
+// TODO(#7674) - the service account credentials should create self-signed JWTs
+TEST(UnifiedRestCredentialsIntegrationTest, StorageSelfSignedJWT) {
+  // Manually create a self-signed JWT and then use it as an access token
+  auto env = internal::GetEnv("GOOGLE_CLOUD_CPP_REST_TEST_KEY_FILE_JSON");
+  ASSERT_TRUE(env.has_value());
+  std::ifstream is(*env);
+  auto contents = std::string{std::istreambuf_iterator<char>{is}, {}};
+  auto info = oauth2_internal::ParseServiceAccountCredentials(contents, *env);
+  ASSERT_STATUS_OK(info);
+
+  auto const now = std::chrono::system_clock::now();
+  auto const expiration =
+      now + oauth2_internal::GoogleOAuthAccessTokenLifetime();
+  auto jwt = oauth2_internal::MakeSelfSignedJWT(*info, now);
+
+  ASSERT_NO_FATAL_FAILURE(
+      MakeStorageRpcCall(Options{}.set<UnifiedCredentialsOption>(
+          MakeAccessTokenCredentials(*jwt, expiration))));
 }
 
 }  // namespace


### PR DESCRIPTION
Service Accounts can create self-signed JWTs. These JWTs serve as access
tokens, to GCP, but do not require an RPC to create them. They are,
therefore, more efficient to create, more reliable, and work with the
token endpoint (https://oauth2.googleapis.com/token) is blocked by a
firewall or hidden by something like VPC-SC.

Part of the work for #7674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9616)
<!-- Reviewable:end -->
