### PR TITLE
impl: check if options are empty

### DIFF
--- a/google/cloud/options.cc
+++ b/google/cloud/options.cc
@@ -35,6 +35,8 @@ void CheckExpectedOptionsImpl(std::set<std::type_index> const& expected,
   }
 }
 
+bool IsEmpty(Options const& options) { return options.m_.empty(); }
+
 Options MergeOptions(Options preferred, Options alternatives) {
   if (preferred.m_.empty()) return alternatives;
   preferred.m_.insert(std::make_move_iterator(alternatives.m_.begin()),

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -33,6 +33,7 @@ namespace internal {
 Options MergeOptions(Options, Options);
 void CheckExpectedOptionsImpl(std::set<std::type_index> const&, Options const&,
                               char const*);
+// TODO(#8800) - Remove when bigtable::Table no longer uses bigtable::DataClient
 bool IsEmpty(Options const&);
 template <typename T>
 inline T const& DefaultValue() {

--- a/google/cloud/options.h
+++ b/google/cloud/options.h
@@ -33,6 +33,7 @@ namespace internal {
 Options MergeOptions(Options, Options);
 void CheckExpectedOptionsImpl(std::set<std::type_index> const&, Options const&,
                               char const*);
+bool IsEmpty(Options const&);
 template <typename T>
 inline T const& DefaultValue() {
   static auto const* const kDefaultValue = new T{};
@@ -209,6 +210,7 @@ class Options {
   friend Options internal::MergeOptions(Options, Options);
   friend void internal::CheckExpectedOptionsImpl(
       std::set<std::type_index> const&, Options const&, char const*);
+  friend bool internal::IsEmpty(Options const&);
 
   // The type-erased data holder of all the option values.
   class DataHolder {

--- a/google/cloud/options_test.cc
+++ b/google/cloud/options_test.cc
@@ -251,6 +251,16 @@ TEST(CheckUnexpectedOptions, OptionsListOneUnexpected) {
               Contains(ContainsRegex("caller: Unexpected option.+FooOption")));
 }
 
+TEST(IsEmpty, Yes) {
+  Options opts;
+  EXPECT_TRUE(internal::IsEmpty(opts));
+}
+
+TEST(IsEmpty, No) {
+  auto opts = Options{}.set<IntOption>(0);
+  EXPECT_FALSE(internal::IsEmpty(opts));
+}
+
 TEST(MergeOptions, Basics) {
   auto a = Options{}.set<StringOption>("from a").set<IntOption>(42);
   auto b = Options{}.set<StringOption>("from b").set<BoolOption>(true);


### PR DESCRIPTION
Part of the work for #7688 

Add an internal helper to see if Options are empty or not.

There are two code paths in the `bigtable::Table` client. One that uses `client_` and one that uses `connection_`. Per operation options only apply to the path that uses the `connection_`. I do not want to check if `opts.has<T>` for each `T` option. So, we just check to see if the options are empty.

The code in bigtable will look vaguely like this:

```cc
Status Table::Foo(Options opts) {
  if (!connection_ && !google::cloud::internal::IsEmpty(opts)) {
    return Status(StatusCode::kFailedPrecondition,
                   "Per-operation options only apply to `Table`s constructed "
                   "with a `DataConnection`.");
  }
  // etc...
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9617)
<!-- Reviewable:end -->
