### PR TITLE
refactor: move `GroupOptions` into common

### DIFF
--- a/google/cloud/google_cloud_cpp_common.bzl
+++ b/google/cloud/google_cloud_cpp_common.bzl
@@ -52,6 +52,7 @@ google_cloud_cpp_common_hdrs = [
     "internal/future_then_impl.h",
     "internal/future_then_meta.h",
     "internal/getenv.h",
+    "internal/group_options.h",
     "internal/invoke_result.h",
     "internal/ios_flags_saver.h",
     "internal/log_impl.h",

--- a/google/cloud/google_cloud_cpp_common.cmake
+++ b/google/cloud/google_cloud_cpp_common.cmake
@@ -76,6 +76,7 @@ add_library(
     internal/future_then_meta.h
     internal/getenv.cc
     internal/getenv.h
+    internal/group_options.h
     internal/invoke_result.h
     internal/ios_flags_saver.h
     internal/log_impl.cc
@@ -233,6 +234,7 @@ if (BUILD_TESTING)
         internal/filesystem_test.cc
         internal/format_time_point_test.cc
         internal/future_impl_test.cc
+        internal/group_options_test.cc
         internal/invoke_result_test.cc
         internal/log_impl_test.cc
         internal/pagination_range_test.cc

--- a/google/cloud/google_cloud_cpp_common_unit_tests.bzl
+++ b/google/cloud/google_cloud_cpp_common_unit_tests.bzl
@@ -34,6 +34,7 @@ google_cloud_cpp_common_unit_tests = [
     "internal/filesystem_test.cc",
     "internal/format_time_point_test.cc",
     "internal/future_impl_test.cc",
+    "internal/group_options_test.cc",
     "internal/invoke_result_test.cc",
     "internal/log_impl_test.cc",
     "internal/pagination_range_test.cc",

--- a/google/cloud/internal/group_options.h
+++ b/google/cloud/internal/group_options.h
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GROUP_OPTIONS_H
-#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GROUP_OPTIONS_H
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GROUP_OPTIONS_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GROUP_OPTIONS_H
 
-#include "google/cloud/storage/version.h"
 #include "google/cloud/options.h"
+#include "google/cloud/version.h"
 #include <utility>
 
 namespace google {
 namespace cloud {
-namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
@@ -83,8 +82,7 @@ Options GroupOptions(Head&&, Tail&&... t) {
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
 }  // namespace cloud
 }  // namespace google
 
-#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GROUP_OPTIONS_H
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_GROUP_OPTIONS_H

--- a/google/cloud/internal/group_options_test.cc
+++ b/google/cloud/internal/group_options_test.cc
@@ -12,33 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "google/cloud/storage/internal/group_options.h"
-#include "google/cloud/storage/well_known_parameters.h"
+#include "google/cloud/internal/group_options.h"
 #include "google/cloud/common_options.h"
 #include <gmock/gmock.h>
 
 namespace google {
 namespace cloud {
-namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-google::cloud::Options SimulateRawClientOptions() {
+Options TestOptions() {
   return Options{}
       .set<UserProjectOption>("u-p-default")
       .set<AuthorityOption>("a-default");
 }
 
-TEST(MakeOptionSpanTest, JustDefaults) {
-  auto const group = GroupOptions(SimulateRawClientOptions());
+TEST(MakeOptionSpanTest, JustOptions) {
+  auto const group = GroupOptions(TestOptions());
   EXPECT_EQ("u-p-default", group.get<UserProjectOption>());
   EXPECT_EQ("a-default", group.get<AuthorityOption>());
 }
 
 TEST(MakeOptionSpanTest, Overrides) {
   auto const group =
-      GroupOptions(SimulateRawClientOptions(),
+      GroupOptions(TestOptions(),
                    Options{}
                        .set<EndpointOption>("test-endpoint")
                        .set<AuthorityOption>("a-override-1"),
@@ -49,28 +47,31 @@ TEST(MakeOptionSpanTest, Overrides) {
 }
 
 TEST(MakeOptionSpanTest, OverridesMixedWithRequestOptions) {
+  int x = 5;
+  int const& y = x;
+  int const z = 10;
+  struct Thing {};
+
   auto const group = GroupOptions(
-      SimulateRawClientOptions(), IfGenerationMatch(0),
-      Options{}.set<EndpointOption>("test-endpoint"), IfGenerationNotMatch(0),
-      Options{}.set<AuthorityOption>("a-override-1"), IfMetagenerationMatch(0),
-      Options{}.set<AuthorityOption>("a-override-2"),
-      IfMetagenerationNotMatch(0), Generation(7), IfGenerationMatch(0));
+      "string", TestOptions(), Thing{},
+      Options{}.set<EndpointOption>("test-endpoint"), 5,
+      Options{}.set<AuthorityOption>("a-override-1"), x,
+      Options{}.set<AuthorityOption>("a-override-2"), y, std::move(z));
   EXPECT_EQ("u-p-default", group.get<UserProjectOption>());
   EXPECT_EQ("a-override-2", group.get<AuthorityOption>());
   EXPECT_EQ("test-endpoint", group.get<EndpointOption>());
 }
 
 TEST(MakeOptionSpanTest, Declaration) {
-  auto const g1 = GroupOptions(SimulateRawClientOptions(), 5);
+  auto const g1 = GroupOptions(TestOptions(), 5);
   EXPECT_EQ("u-p-default", g1.get<UserProjectOption>());
 
-  auto const g2 = GroupOptions(5, SimulateRawClientOptions());
+  auto const g2 = GroupOptions(5, TestOptions());
   EXPECT_EQ("u-p-default", g2.get<UserProjectOption>());
 }
 
 }  // namespace
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/async_client.h
+++ b/google/cloud/storage/async_client.h
@@ -16,10 +16,10 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_ASYNC_CLIENT_H
 
 #include "google/cloud/storage/internal/async_connection.h"
-#include "google/cloud/storage/internal/group_options.h"
 #include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/background_threads.h"
+#include "google/cloud/internal/group_options.h"
 #include "google/cloud/status_or.h"
 
 namespace google {
@@ -199,7 +199,7 @@ class AsyncClient {
 
   template <typename... RequestOptions>
   google::cloud::Options SpanOptions(RequestOptions&&... o) const {
-    return google::cloud::storage::internal::GroupOptions(
+    return google::cloud::internal::GroupOptions(
         connection_->options(), std::forward<RequestOptions>(o)...);
   }
 

--- a/google/cloud/storage/client.h
+++ b/google/cloud/storage/client.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_CLIENT_H
 
 #include "google/cloud/storage/hmac_key_metadata.h"
-#include "google/cloud/storage/internal/group_options.h"
 #include "google/cloud/storage/internal/logging_client.h"
 #include "google/cloud/storage/internal/parameter_pack_validation.h"
 #include "google/cloud/storage/internal/policy_document_request.h"
@@ -35,6 +34,7 @@
 #include "google/cloud/storage/retry_policy.h"
 #include "google/cloud/storage/upload_options.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/group_options.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
@@ -3293,8 +3293,8 @@ class Client {
 
   template <typename... RequestOptions>
   google::cloud::Options SpanOptions(RequestOptions&&... o) const {
-    return internal::GroupOptions(raw_client_->options(),
-                                  std::forward<RequestOptions>(o)...);
+    return google::cloud::internal::GroupOptions(
+        raw_client_->options(), std::forward<RequestOptions>(o)...);
   }
 
   // The version of UploadFile() where UseResumableUploadSession is one of the

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -55,7 +55,6 @@ google_cloud_cpp_storage_hdrs = [
     "internal/generate_message_boundary.h",
     "internal/generic_object_request.h",
     "internal/generic_request.h",
-    "internal/group_options.h",
     "internal/hash_function.h",
     "internal/hash_function_impl.h",
     "internal/hash_validator.h",

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -87,7 +87,6 @@ add_library(
     internal/generate_message_boundary.h
     internal/generic_object_request.h
     internal/generic_request.h
-    internal/group_options.h
     internal/hash_function.cc
     internal/hash_function.h
     internal/hash_function_impl.cc
@@ -451,7 +450,6 @@ if (BUILD_TESTING)
         internal/default_object_acl_requests_test.cc
         internal/generate_message_boundary_test.cc
         internal/generic_request_test.cc
-        internal/group_options_test.cc
         internal/hash_function_impl_test.cc
         internal/hash_validator_test.cc
         internal/hash_values_test.cc

--- a/google/cloud/storage/storage_client_unit_tests.bzl
+++ b/google/cloud/storage/storage_client_unit_tests.bzl
@@ -53,7 +53,6 @@ storage_client_unit_tests = [
     "internal/default_object_acl_requests_test.cc",
     "internal/generate_message_boundary_test.cc",
     "internal/generic_request_test.cc",
-    "internal/group_options_test.cc",
     "internal/hash_function_impl_test.cc",
     "internal/hash_validator_test.cc",
     "internal/hash_values_test.cc",


### PR DESCRIPTION
Part of the work for #7688 

The following client functions exist in bigtable:
`Table::(Async)ReadModifyWriteRow(..., Args&&... rules);`

I will need to accept `Options` passed into the parameter pack. `storage::internal::GroupOptions` is the solution to this problem. So move it out of storage and into common.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9618)
<!-- Reviewable:end -->
