### PR TITLE
test(storage): improvements in upload benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
@@ -388,8 +388,6 @@ google::cloud::StatusOr<AggregateUploadThroughputOptions> SelfTest(
           "--thread-count=1",
           "--iteration-count=1",
           "--api=JSON",
-          "--grpc-channel-count=1",
-          "--grpc-plugin-config=dp",
       },
       kDescription);
 }

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/aggregate_upload_throughput_options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <iterator>
 #include <sstream>
@@ -20,8 +21,60 @@
 namespace google {
 namespace cloud {
 namespace storage_benchmarks {
+namespace {
 
+namespace gcs = ::google::cloud::storage;
+namespace gcs_ex = ::google::cloud::storage_experimental;
 using ::google::cloud::testing_util::OptionDescriptor;
+
+StatusOr<AggregateUploadThroughputOptions> ValidateOptions(
+    std::string const& usage, AggregateUploadThroughputOptions options) {
+  auto make_status = [](std::ostringstream& os) {
+    auto const code = google::cloud::StatusCode::kInvalidArgument;
+    return google::cloud::Status{code, std::move(os).str()};
+  };
+
+  if (options.bucket_name.empty()) {
+    std::ostringstream os;
+    os << "Missing --bucket option\n" << usage << "\n";
+    return make_status(os);
+  }
+  if (options.object_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of objects (" << options.object_count
+       << "), check your --object-count option\n";
+    return make_status(os);
+  }
+  if (options.minimum_object_size > options.maximum_object_size) {
+    std::ostringstream os;
+    os << "Invalid object size range [" << options.minimum_object_size << ","
+       << options.maximum_object_size << "], check your --minimum-object-size"
+       << " and --maximum-object-size options";
+    return make_status(os);
+  }
+  if (options.thread_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of threads (" << options.thread_count
+       << "), check your --thread-count option\n";
+    return make_status(os);
+  }
+  if (options.iteration_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of iterations (" << options.iteration_count
+       << "), check your --iteration-count option\n";
+    return make_status(os);
+  }
+  if (options.client_options.get<GrpcNumChannelsOption>() < 0) {
+    std::ostringstream os;
+    os << "Invalid number of gRPC channels ("
+       << options.client_options.get<GrpcNumChannelsOption>()
+       << "), check your --grpc-channel-count option\n";
+    return make_status(os);
+  }
+  return options;
+}
+
+}  // namespace
 
 google::cloud::StatusOr<AggregateUploadThroughputOptions>
 ParseAggregateUploadThroughputOptions(std::vector<std::string> const& argv,
@@ -66,25 +119,52 @@ ParseAggregateUploadThroughputOptions(std::vector<std::string> const& argv,
          options.iteration_count = std::stoi(val);
        }},
       {"--api", "select the API (JSON, XML, or GRPC) for the benchmark",
-       [&options](std::string const& val) {
-         options.api = ParseApiName(val).value();
-       }},
-      {"--grpc-channel-count", "controls the number of gRPC channels",
-       [&options](std::string const& val) {
-         options.grpc_channel_count = std::stoi(val);
-       }},
-      {"--grpc-plugin-config",
-       "low-level experimental settings for the GCS+gRPC plugin",
-       [&options](std::string const& val) {
-         options.grpc_plugin_config = val;
-       }},
-      {"--rest-http-version", "change the preferred HTTP version",
-       [&options](std::string const& val) { options.rest_http_version = val; }},
+       [&options](std::string const& val) { options.api = val; }},
       {"--client-per-thread",
        "use a different storage::Client object in each thread",
        [&options](std::string const& val) {
          options.client_per_thread =
              testing_util::ParseBoolean(val).value_or("true");
+       }},
+      {"--grpc-channel-count", "controls the number of gRPC channels",
+       [&options](std::string const& val) {
+         options.client_options.set<GrpcNumChannelsOption>(std::stoi(val));
+       }},
+      {"--rest-http-version", "change the preferred HTTP version",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs_ex::HttpVersionOption>(val);
+       }},
+      {"--rest-endpoint", "change the REST endpoint",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs::RestEndpointOption>(val);
+       }},
+      {"--grpc-endpoint", "change the gRPC endpoint",
+       [&options](std::string const& val) {
+         options.client_options.set<EndpointOption>(val);
+       }},
+      {"--transfer-stall-timeout",
+       "configure `storage::TransferStallTimeoutOption`: the maximum time"
+       " allowed for data to 'stall' (make insufficient progress) on all"
+       " operations, except for downloads (see --download-stall-timeout)."
+       " This option is intended for troubleshooting, most of the time the"
+       " value is not expected to change the library performance.",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs::TransferStallTimeoutOption>(
+             ParseDuration(val));
+       }},
+      {"--transfer-stall-minimum-rate",
+       "configure `storage::TransferStallMinimumRateOption`: the transfer"
+       " is aborted if the average transfer rate is below this limit for"
+       " the period set via `storage::TransferStallTimeoutOption`.",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs_ex::TransferStallMinimumRateOption>(
+             static_cast<std::uint32_t>(ParseBufferSize(val)));
+       }},
+      {"--grpc-background-threads",
+       "change the default number of gRPC background threads",
+       [&options](std::string const& val) {
+         options.client_options.set<GrpcBackgroundThreadPoolSizeOption>(
+             std::stoi(val));
        }},
   };
   auto usage = BuildUsage(desc, argv[0]);
@@ -102,57 +182,16 @@ ParseAggregateUploadThroughputOptions(std::vector<std::string> const& argv,
     return options;
   }
 
-  auto make_status = [](std::ostringstream& os) {
-    auto const code = google::cloud::StatusCode::kInvalidArgument;
-    return google::cloud::Status{code, std::move(os).str()};
-  };
-
   if (unparsed.size() != 1) {
     std::ostringstream os;
     os << "Unknown arguments or options: "
        << absl::StrJoin(std::next(unparsed.begin()), unparsed.end(), ", ")
        << "\n"
        << usage << "\n";
-    return make_status(os);
-  }
-  if (options.bucket_name.empty()) {
-    std::ostringstream os;
-    os << "Missing --bucket option\n" << usage << "\n";
-    return make_status(os);
-  }
-  if (options.object_count <= 0) {
-    std::ostringstream os;
-    os << "Invalid number of objects (" << options.object_count
-       << "), check your --object-count option\n";
-    return make_status(os);
-  }
-  if (options.minimum_object_size > options.maximum_object_size) {
-    std::ostringstream os;
-    os << "Invalid object size range [" << options.minimum_object_size << ","
-       << options.maximum_object_size << "], check your --minimum-object-size"
-       << " and --maximum-object-size options";
-    return make_status(os);
-  }
-  if (options.thread_count <= 0) {
-    std::ostringstream os;
-    os << "Invalid number of threads (" << options.thread_count
-       << "), check your --thread-count option\n";
-    return make_status(os);
-  }
-  if (options.iteration_count <= 0) {
-    std::ostringstream os;
-    os << "Invalid number of iterations (" << options.iteration_count
-       << "), check your --iteration-count option\n";
-    return make_status(os);
-  }
-  if (options.grpc_channel_count < 0) {
-    std::ostringstream os;
-    os << "Invalid number of gRPC channels (" << options.grpc_channel_count
-       << "), check your --grpc-channel-count option\n";
-    return make_status(os);
+    return Status{StatusCode::kInvalidArgument, std::move(os).str()};
   }
 
-  return options;
+  return ValidateOptions(usage, std::move(options));
 }
 
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.h
@@ -34,11 +34,9 @@ struct AggregateUploadThroughputOptions {
   std::int64_t resumable_upload_chunk_size = 64 * kMiB;
   int thread_count = 1;
   int iteration_count = 1;
-  ApiName api = ApiName::kApiGrpc;
-  int grpc_channel_count = 0;
-  std::string grpc_plugin_config;
-  std::string rest_http_version;
+  std::string api = "JSON";
   bool client_per_thread = false;
+  Options client_options;
   bool exit_after_parse = false;
 };
 


### PR DESCRIPTION
I want to use the `aggregate_upload_throughput` benchmark to compare
gRPC vs. DirectPath vs. REST with different timeout parameters and
other options. It seemed simpler to add a `google::cloud::Options` to
the benchmark configuration, that will require fewer changes in the
future, and simplifies (I think) the client initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9622)
<!-- Reviewable:end -->
