### PR TITLE
feat(bigtable): per-operation Options (pt. 1)

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -25,21 +25,23 @@
 
 namespace google {
 namespace cloud {
-namespace bigtable {
+namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace {
 
-std::vector<FailedMutation> MakeUnimplementedFailedMutations(std::size_t n) {
-  std::vector<FailedMutation> mutations;
+std::vector<bigtable::FailedMutation> MakeFailedMutations(Status const& status,
+                                                          std::size_t n) {
+  std::vector<bigtable::FailedMutation> mutations;
   mutations.reserve(n);
   for (int i = 0; i != static_cast<int>(n); ++i) {
-    mutations.emplace_back(FailedMutation(
-        Status(StatusCode::kUnimplemented, "not implemented"), i));
+    mutations.emplace_back(bigtable::FailedMutation(status, i));
   }
   return mutations;
 }
 
-}  // namespace
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
+namespace bigtable {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 DataConnection::~DataConnection() = default;
 
@@ -58,13 +60,15 @@ future<Status> DataConnection::AsyncApply(
 std::vector<FailedMutation> DataConnection::BulkApply(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string const&, BulkMutation mut) {
-  return MakeUnimplementedFailedMutations(mut.size());
+  return bigtable_internal::MakeFailedMutations(
+      Status(StatusCode::kUnimplemented, "not-implemented"), mut.size());
 }
 
 future<std::vector<FailedMutation>> DataConnection::AsyncBulkApply(
     // NOLINTNEXTLINE(performance-unnecessary-value-param)
     std::string const&, BulkMutation mut) {
-  return make_ready_future(MakeUnimplementedFailedMutations(mut.size()));
+  return make_ready_future(bigtable_internal::MakeFailedMutations(
+      Status(StatusCode::kUnimplemented, "not-implemented"), mut.size()));
 }
 
 RowReader DataConnection::ReadRows(

--- a/google/cloud/bigtable/data_connection.h
+++ b/google/cloud/bigtable/data_connection.h
@@ -32,6 +32,13 @@
 
 namespace google {
 namespace cloud {
+namespace bigtable_internal {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+std::vector<bigtable::FailedMutation> MakeFailedMutations(Status const& status,
+                                                          std::size_t n);
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace bigtable_internal
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 

--- a/google/cloud/bigtable/legacy_table_test.cc
+++ b/google/cloud/bigtable/legacy_table_test.cc
@@ -26,15 +26,22 @@ namespace {
 
 namespace btproto = ::google::bigtable::v2;
 using ::google::cloud::testing_util::FakeCompletionQueueImpl;
+using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
+using ::testing::MockFunction;
+
+Options NonEmptyOptions() {
+  struct TestOption {
+    using Type = bool;
+  };
+  return Options{}.set<TestOption>(true);
+}
 
 /// Define types and functions used in the tests.
-namespace {
 class TableTest : public ::google::cloud::bigtable::testing::TableTestFixture {
  public:
   TableTest() : TableTestFixture(CompletionQueue{}) {}
 };
-}  // anonymous namespace
 
 TEST_F(TableTest, ClientProjectId) {
   EXPECT_EQ(kProjectId, client_->project_id());
@@ -258,6 +265,127 @@ TEST_F(ValidContextMdAsyncTest, AsyncReadModifyWriteRow) {
   FinishTest(table_->AsyncReadModifyWriteRow(
       "row_key", ReadModifyWriteRule::IncrementAmount("fam", "counter", 1),
       ReadModifyWriteRule::AppendValue("fam", "list", ";element")));
+}
+
+TEST_F(TableTest, ApplyWithOptions) {
+  Table table(client_, kTableId);
+  auto status = table.Apply(SingleRowMutation("row"), NonEmptyOptions());
+  EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, AsyncApplyWithOptions) {
+  Table table(client_, kTableId);
+  auto status = table.AsyncApply(SingleRowMutation("row"), NonEmptyOptions());
+  EXPECT_THAT(status.get(), StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, BulkApplyWithOptions) {
+  Table table(client_, kTableId);
+  auto bulk = BulkMutation(SingleRowMutation("r1"), SingleRowMutation("r2"));
+  auto failed = table.BulkApply(bulk, NonEmptyOptions());
+  ASSERT_EQ(2, failed.size());
+  EXPECT_EQ(0, failed[0].original_index());
+  EXPECT_THAT(failed[0].status(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_EQ(1, failed[1].original_index());
+  EXPECT_THAT(failed[1].status(), StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, AsyncBulkApplyWithOptions) {
+  Table table(client_, kTableId);
+  auto bulk = BulkMutation(SingleRowMutation("r1"), SingleRowMutation("r2"));
+  auto failed = table.AsyncBulkApply(bulk, NonEmptyOptions()).get();
+  ASSERT_EQ(2, failed.size());
+  EXPECT_EQ(0, failed[0].original_index());
+  EXPECT_THAT(failed[0].status(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_EQ(1, failed[1].original_index());
+  EXPECT_THAT(failed[1].status(), StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, ReadRowsWithOptions) {
+  Table table(client_, kTableId);
+  auto reader =
+      table.ReadRows(RowSet(), Filter::PassAllFilter(), NonEmptyOptions());
+  auto it = reader.begin();
+  EXPECT_NE(it, reader.end());
+  EXPECT_THAT(*it, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_EQ(++it, reader.end());
+}
+
+TEST_F(TableTest, ReadRowsWithLimitWithOptions) {
+  Table table(client_, kTableId);
+  auto reader =
+      table.ReadRows(RowSet(), 1, Filter::PassAllFilter(), NonEmptyOptions());
+  auto it = reader.begin();
+  EXPECT_NE(it, reader.end());
+  EXPECT_THAT(*it, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_EQ(++it, reader.end());
+}
+
+TEST_F(TableTest, ReadRowWithOptions) {
+  Table table(client_, kTableId);
+  auto row = table.ReadRow("row", Filter::PassAllFilter(), NonEmptyOptions());
+  EXPECT_THAT(row, StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, AsyncReadRowWithOptions) {
+  Table table(client_, kTableId);
+  auto row =
+      table.AsyncReadRow("row", Filter::PassAllFilter(), NonEmptyOptions());
+  EXPECT_THAT(row.get(), StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, CheckAndMutateRowWithOptions) {
+  Table table(client_, kTableId);
+  auto branch = table.CheckAndMutateRow("row", Filter::PassAllFilter(), {}, {},
+                                        NonEmptyOptions());
+  EXPECT_THAT(branch, StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, AsyncCheckAndMutateRowWithOptions) {
+  Table table(client_, kTableId);
+  auto branch = table.AsyncCheckAndMutateRow("row", Filter::PassAllFilter(), {},
+                                             {}, NonEmptyOptions());
+  EXPECT_THAT(branch.get(), StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, SampleRowsWithOptions) {
+  Table table(client_, kTableId);
+  auto rows = table.SampleRows(NonEmptyOptions());
+  EXPECT_THAT(rows, StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, AsyncSampleRowsWithOptions) {
+  Table table(client_, kTableId);
+  auto rows = table.AsyncSampleRows(NonEmptyOptions());
+  EXPECT_THAT(rows.get(), StatusIs(StatusCode::kFailedPrecondition));
+}
+
+TEST_F(TableTest, AsyncReadRowsWithOptions) {
+  MockFunction<future<bool>(bigtable::Row const&)> on_row;
+  EXPECT_CALL(on_row, Call).Times(0);
+
+  MockFunction<void(Status)> on_finish;
+  EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
+    EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+  });
+
+  Table table(client_, kTableId);
+  table.AsyncReadRows(on_row.AsStdFunction(), on_finish.AsStdFunction(),
+                      RowSet(), Filter::PassAllFilter(), NonEmptyOptions());
+}
+
+TEST_F(TableTest, AsyncReadRowsWithLimitWithOptions) {
+  MockFunction<future<bool>(bigtable::Row const&)> on_row;
+  EXPECT_CALL(on_row, Call).Times(0);
+
+  MockFunction<void(Status)> on_finish;
+  EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
+    EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+  });
+
+  Table table(client_, kTableId);
+  table.AsyncReadRows(on_row.AsStdFunction(), on_finish.AsStdFunction(),
+                      RowSet(), 1, Filter::PassAllFilter(), NonEmptyOptions());
 }
 
 }  // namespace

--- a/google/cloud/bigtable/legacy_table_test.cc
+++ b/google/cloud/bigtable/legacy_table_test.cc
@@ -270,13 +270,13 @@ TEST_F(ValidContextMdAsyncTest, AsyncReadModifyWriteRow) {
 TEST_F(TableTest, ApplyWithOptions) {
   Table table(client_, kTableId);
   auto status = table.Apply(SingleRowMutation("row"), NonEmptyOptions());
-  EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, AsyncApplyWithOptions) {
   Table table(client_, kTableId);
   auto status = table.AsyncApply(SingleRowMutation("row"), NonEmptyOptions());
-  EXPECT_THAT(status.get(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(status.get(), StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, BulkApplyWithOptions) {
@@ -285,9 +285,9 @@ TEST_F(TableTest, BulkApplyWithOptions) {
   auto failed = table.BulkApply(bulk, NonEmptyOptions());
   ASSERT_EQ(2, failed.size());
   EXPECT_EQ(0, failed[0].original_index());
-  EXPECT_THAT(failed[0].status(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(failed[0].status(), StatusIs(StatusCode::kInvalidArgument));
   EXPECT_EQ(1, failed[1].original_index());
-  EXPECT_THAT(failed[1].status(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(failed[1].status(), StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, AsyncBulkApplyWithOptions) {
@@ -296,9 +296,9 @@ TEST_F(TableTest, AsyncBulkApplyWithOptions) {
   auto failed = table.AsyncBulkApply(bulk, NonEmptyOptions()).get();
   ASSERT_EQ(2, failed.size());
   EXPECT_EQ(0, failed[0].original_index());
-  EXPECT_THAT(failed[0].status(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(failed[0].status(), StatusIs(StatusCode::kInvalidArgument));
   EXPECT_EQ(1, failed[1].original_index());
-  EXPECT_THAT(failed[1].status(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(failed[1].status(), StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, ReadRowsWithOptions) {
@@ -307,7 +307,7 @@ TEST_F(TableTest, ReadRowsWithOptions) {
       table.ReadRows(RowSet(), Filter::PassAllFilter(), NonEmptyOptions());
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
-  EXPECT_THAT(*it, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(*it, StatusIs(StatusCode::kInvalidArgument));
   EXPECT_EQ(++it, reader.end());
 }
 
@@ -317,47 +317,47 @@ TEST_F(TableTest, ReadRowsWithLimitWithOptions) {
       table.ReadRows(RowSet(), 1, Filter::PassAllFilter(), NonEmptyOptions());
   auto it = reader.begin();
   EXPECT_NE(it, reader.end());
-  EXPECT_THAT(*it, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(*it, StatusIs(StatusCode::kInvalidArgument));
   EXPECT_EQ(++it, reader.end());
 }
 
 TEST_F(TableTest, ReadRowWithOptions) {
   Table table(client_, kTableId);
   auto row = table.ReadRow("row", Filter::PassAllFilter(), NonEmptyOptions());
-  EXPECT_THAT(row, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(row, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, AsyncReadRowWithOptions) {
   Table table(client_, kTableId);
   auto row =
       table.AsyncReadRow("row", Filter::PassAllFilter(), NonEmptyOptions());
-  EXPECT_THAT(row.get(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(row.get(), StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, CheckAndMutateRowWithOptions) {
   Table table(client_, kTableId);
   auto branch = table.CheckAndMutateRow("row", Filter::PassAllFilter(), {}, {},
                                         NonEmptyOptions());
-  EXPECT_THAT(branch, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(branch, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, AsyncCheckAndMutateRowWithOptions) {
   Table table(client_, kTableId);
   auto branch = table.AsyncCheckAndMutateRow("row", Filter::PassAllFilter(), {},
                                              {}, NonEmptyOptions());
-  EXPECT_THAT(branch.get(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(branch.get(), StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, SampleRowsWithOptions) {
   Table table(client_, kTableId);
   auto rows = table.SampleRows(NonEmptyOptions());
-  EXPECT_THAT(rows, StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(rows, StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, AsyncSampleRowsWithOptions) {
   Table table(client_, kTableId);
   auto rows = table.AsyncSampleRows(NonEmptyOptions());
-  EXPECT_THAT(rows.get(), StatusIs(StatusCode::kFailedPrecondition));
+  EXPECT_THAT(rows.get(), StatusIs(StatusCode::kInvalidArgument));
 }
 
 TEST_F(TableTest, AsyncReadRowsWithOptions) {
@@ -366,7 +366,7 @@ TEST_F(TableTest, AsyncReadRowsWithOptions) {
 
   MockFunction<void(Status)> on_finish;
   EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
-    EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+    EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
   });
 
   Table table(client_, kTableId);
@@ -380,7 +380,7 @@ TEST_F(TableTest, AsyncReadRowsWithLimitWithOptions) {
 
   MockFunction<void(Status)> on_finish;
   EXPECT_CALL(on_finish, Call).WillOnce([](Status const& status) {
-    EXPECT_THAT(status, StatusIs(StatusCode::kFailedPrecondition));
+    EXPECT_THAT(status, StatusIs(StatusCode::kInvalidArgument));
   });
 
   Table table(client_, kTableId);

--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -54,7 +54,7 @@ Status Table::Apply(SingleRowMutation mut, Options opts) {
     return connection_->Apply(table_name_, std::move(mut));
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
-    return Status(StatusCode::kFailedPrecondition,
+    return Status(StatusCode::kInvalidArgument,
                   "Per-operation options only apply to `Table`s constructed "
                   "with a `DataConnection`.");
   }
@@ -107,7 +107,7 @@ future<Status> Table::AsyncApply(SingleRowMutation mut, Options opts) {
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
     return make_ready_future(
-        Status(StatusCode::kFailedPrecondition,
+        Status(StatusCode::kInvalidArgument,
                "Per-operation options only apply to `Table`s constructed "
                "with a `DataConnection`."));
   }
@@ -157,7 +157,7 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut, Options opts) {
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
     return bigtable_internal::MakeFailedMutations(
-        Status(StatusCode::kFailedPrecondition,
+        Status(StatusCode::kInvalidArgument,
                "Per-operation options only apply to `Table`s constructed "
                "with a `DataConnection`."),
         mut.size());
@@ -199,7 +199,7 @@ future<std::vector<FailedMutation>> Table::AsyncBulkApply(BulkMutation mut,
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
     return make_ready_future(bigtable_internal::MakeFailedMutations(
-        Status(StatusCode::kFailedPrecondition,
+        Status(StatusCode::kInvalidArgument,
                "Per-operation options only apply to `Table`s constructed "
                "with a `DataConnection`."),
         mut.size()));
@@ -228,7 +228,7 @@ RowReader Table::ReadRows(RowSet row_set, std::int64_t rows_limit,
   if (!google::cloud::internal::IsEmpty(opts)) {
     return MakeRowReader(
         std::make_shared<bigtable_internal::StatusOnlyRowReader>(
-            Status(StatusCode::kFailedPrecondition,
+            Status(StatusCode::kInvalidArgument,
                    "Per-operation options only apply to `Table`s constructed "
                    "with a `DataConnection`.")));
   }
@@ -249,7 +249,7 @@ StatusOr<std::pair<bool, Row>> Table::ReadRow(std::string row_key,
                                 std::move(filter));
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
-    return Status(StatusCode::kFailedPrecondition,
+    return Status(StatusCode::kInvalidArgument,
                   "Per-operation options only apply to `Table`s constructed "
                   "with a `DataConnection`.");
   }
@@ -285,7 +285,7 @@ StatusOr<MutationBranch> Table::CheckAndMutateRow(
         std::move(true_mutations), std::move(false_mutations));
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
-    return Status(StatusCode::kFailedPrecondition,
+    return Status(StatusCode::kInvalidArgument,
                   "Per-operation options only apply to `Table`s constructed "
                   "with a `DataConnection`.");
   }
@@ -328,7 +328,7 @@ future<StatusOr<MutationBranch>> Table::AsyncCheckAndMutateRow(
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
     return make_ready_future<StatusOr<MutationBranch>>(
-        Status(StatusCode::kFailedPrecondition,
+        Status(StatusCode::kInvalidArgument,
                "Per-operation options only apply to `Table`s constructed "
                "with a `DataConnection`."));
   }
@@ -385,7 +385,7 @@ StatusOr<std::vector<bigtable::RowKeySample>> Table::SampleRows(Options opts) {
     return connection_->SampleRows(table_name_);
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
-    return Status(StatusCode::kFailedPrecondition,
+    return Status(StatusCode::kInvalidArgument,
                   "Per-operation options only apply to `Table`s constructed "
                   "with a `DataConnection`.");
   }
@@ -438,7 +438,7 @@ future<StatusOr<std::vector<bigtable::RowKeySample>>> Table::AsyncSampleRows(
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
     return make_ready_future<StatusOr<std::vector<RowKeySample>>>(
-        Status(StatusCode::kFailedPrecondition,
+        Status(StatusCode::kInvalidArgument,
                "Per-operation options only apply to `Table`s constructed "
                "with a `DataConnection`."));
   }
@@ -514,7 +514,7 @@ future<StatusOr<std::pair<bool, Row>>> Table::AsyncReadRow(std::string row_key,
   }
   if (!google::cloud::internal::IsEmpty(opts)) {
     return make_ready_future<StatusOr<std::pair<bool, Row>>>(
-        Status(StatusCode::kFailedPrecondition,
+        Status(StatusCode::kInvalidArgument,
                "Per-operation options only apply to `Table`s constructed "
                "with a `DataConnection`."));
   }

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -36,6 +36,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "google/cloud/future.h"
 #include "google/cloud/grpc_error_delegate.h"
+#include "google/cloud/internal/group_options.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status.h"
 #include "google/cloud/status_or.h"
@@ -415,6 +416,8 @@ class Table {
    *     then discards) the data in the mutation.  In general, a
    *     `SingleRowMutation` can be used to modify and/or delete multiple cells,
    *     across different columns and column families.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @return status of the operation.
    *
@@ -430,7 +433,7 @@ class Table {
    * @par Example
    * @snippet data_snippets.cc apply
    */
-  Status Apply(SingleRowMutation mut);
+  Status Apply(SingleRowMutation mut, Options opts = {});
 
   /**
    * Makes asynchronous attempts to apply the mutation to a row.
@@ -440,9 +443,11 @@ class Table {
    *     is not subject to any SLA or deprecation policy.
    *
    * @param mut the mutation. Note that this function takes ownership
-   * (and then discards) the data in the mutation.  In general, a
+   *     (and then discards) the data in the mutation.  In general, a
    *     `SingleRowMutation` can be used to modify and/or delete
-   * multiple cells, across different columns and column families.
+   *     multiple cells, across different columns and column families.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @par Idempotency
    * This operation is idempotent if the provided mutations are idempotent. Note
@@ -452,7 +457,7 @@ class Table {
    * @par Example
    * @snippet data_async_snippets.cc async-apply
    */
-  future<Status> AsyncApply(SingleRowMutation mut);
+  future<Status> AsyncApply(SingleRowMutation mut, Options opts = {});
 
   /**
    * Attempts to apply mutations to multiple rows.
@@ -480,6 +485,8 @@ class Table {
    *     across different columns and column families.
    *
    * @param mut the mutations
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    * @returns a list of failed mutations
    *
    * @par Idempotency
@@ -495,7 +502,7 @@ class Table {
    * @par Example
    * @snippet data_snippets.cc bulk apply
    */
-  std::vector<FailedMutation> BulkApply(BulkMutation mut);
+  std::vector<FailedMutation> BulkApply(BulkMutation mut, Options opts = {});
 
   /**
    * Makes asynchronous attempts to apply mutations to multiple rows.
@@ -523,6 +530,8 @@ class Table {
    *     across different columns and column families.
    *
    * @param mut the mutations
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    * @returns a future to be filled with a list of failed mutations, when the
    *     operation is complete.
    *
@@ -539,13 +548,16 @@ class Table {
    * @par Example
    * @snippet data_async_snippets.cc bulk async-bulk-apply
    */
-  future<std::vector<FailedMutation>> AsyncBulkApply(BulkMutation mut);
+  future<std::vector<FailedMutation>> AsyncBulkApply(BulkMutation mut,
+                                                     Options opts = {});
 
   /**
    * Reads a set of rows from the table.
    *
    * @param row_set the rows to read from.
    * @param filter is applied on the server-side to data in the rows.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @par Idempotency
    * This is a read-only operation and therefore it is always idempotent.
@@ -560,7 +572,7 @@ class Table {
    * @par Example
    * @snippet read_snippets.cc read rows
    */
-  RowReader ReadRows(RowSet row_set, Filter filter);
+  RowReader ReadRows(RowSet row_set, Filter filter, Options opts = {});
 
   /**
    * Reads a limited set of rows from the table.
@@ -570,6 +582,8 @@ class Table {
    *     number or zero. Use `ReadRows(RowSet, Filter)` to read all matching
    *     rows.
    * @param filter is applied on the server-side to data in the rows.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @par Idempotency
    * This is a read-only operation and therefore it is always idempotent.
@@ -584,7 +598,8 @@ class Table {
    * @par Example
    * @snippet read_snippets.cc read rows with limit
    */
-  RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter);
+  RowReader ReadRows(RowSet row_set, std::int64_t rows_limit, Filter filter,
+                     Options opts = {});
 
   /**
    * Read and return a single row from the table.
@@ -592,6 +607,8 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    * @returns a tuple, the first element is a boolean, with value `false` if the
    *     row does not exist.  If the first element is `true` the second element
    *     has the contents of the Row.  Note that the contents may be empty
@@ -608,7 +625,8 @@ class Table {
    * @par Example
    * @snippet read_snippets.cc read row
    */
-  StatusOr<std::pair<bool, Row>> ReadRow(std::string row_key, Filter filter);
+  StatusOr<std::pair<bool, Row>> ReadRow(std::string row_key, Filter filter,
+                                         Options opts = {});
 
   /**
    * Atomic test-and-set for a row using filter expressions.
@@ -622,6 +640,8 @@ class Table {
    * @param filter the filter expression.
    * @param true_mutations the mutations for the "filter passed" case.
    * @param false_mutations the mutations for the "filter did not pass" case.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    * @returns true if the filter passed.
    *
    * @par Idempotency
@@ -640,7 +660,7 @@ class Table {
    */
   StatusOr<MutationBranch> CheckAndMutateRow(
       std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
-      std::vector<Mutation> false_mutations);
+      std::vector<Mutation> false_mutations, Options opts = {});
 
   /**
    * Make an asynchronous request to conditionally mutate a row.
@@ -657,6 +677,8 @@ class Table {
    *     true
    * @param false_mutations the mutations which will be performed if @p filter
    *     is false
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @par Idempotency
    * This operation is always treated as non-idempotent.
@@ -671,7 +693,7 @@ class Table {
    */
   future<StatusOr<MutationBranch>> AsyncCheckAndMutateRow(
       std::string row_key, Filter filter, std::vector<Mutation> true_mutations,
-      std::vector<Mutation> false_mutations);
+      std::vector<Mutation> false_mutations, Options opts = {});
 
   /**
    * Sample of the row keys in the table, including approximate data sizes.
@@ -691,7 +713,7 @@ class Table {
    * @par Examples
    * @snippet data_snippets.cc sample row keys
    */
-  StatusOr<std::vector<bigtable::RowKeySample>> SampleRows();
+  StatusOr<std::vector<bigtable::RowKeySample>> SampleRows(Options opts = {});
 
   /**
    * Asynchronously obtains a sample of the row keys in the table, including
@@ -714,7 +736,8 @@ class Table {
    * @par Examples
    * @snippet data_async_snippets.cc async sample row keys
    */
-  future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows();
+  future<StatusOr<std::vector<bigtable::RowKeySample>>> AsyncSampleRows(
+      Options opts = {});
 
   /**
    * Atomically read and modify the row in the server, returning the
@@ -829,6 +852,8 @@ class Table {
    *     results are undefined
    * @param row_set the rows to read from.
    * @param filter is applied on the server-side to data in the rows.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @tparam RowFunctor the type of the @p on_row callback.
    * @tparam FinishFunctor the type of the @p on_finish callback.
@@ -843,9 +868,9 @@ class Table {
    */
   template <typename RowFunctor, typename FinishFunctor>
   void AsyncReadRows(RowFunctor on_row, FinishFunctor on_finish, RowSet row_set,
-                     Filter filter) {
+                     Filter filter, Options opts = {}) {
     AsyncReadRows(std::move(on_row), std::move(on_finish), std::move(row_set),
-                  RowReader::NO_ROWS_LIMIT, std::move(filter));
+                  RowReader::NO_ROWS_LIMIT, std::move(filter), std::move(opts));
   }
 
   /**
@@ -869,6 +894,8 @@ class Table {
    *     number or zero. Use `AsyncReadRows(RowSet, Filter)` to
    *     read all matching rows.
    * @param filter is applied on the server-side to data in the rows.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    *
    * @tparam RowFunctor the type of the @p on_row callback.
    * @tparam FinishFunctor the type of the @p on_finish callback.
@@ -886,7 +913,8 @@ class Table {
   template <typename RowFunctor, typename FinishFunctor>
   void AsyncReadRows(RowFunctor on_row, FinishFunctor on_finish,
                      // NOLINTNEXTLINE(performance-unnecessary-value-param)
-                     RowSet row_set, std::int64_t rows_limit, Filter filter) {
+                     RowSet row_set, std::int64_t rows_limit, Filter filter,
+                     Options opts = {}) {
     static_assert(
         google::cloud::internal::is_invocable<RowFunctor, bigtable::Row>::value,
         "RowFunctor must be invocable with Row.");
@@ -912,10 +940,18 @@ class Table {
     };
 
     if (connection_) {
-      google::cloud::internal::OptionsSpan span(options_);
+      google::cloud::internal::OptionsSpan span(
+          google::cloud::internal::MergeOptions(std::move(opts), options_));
       connection_->AsyncReadRows(table_name_, std::move(on_row_fn),
                                  std::move(on_finish_fn), std::move(row_set),
                                  rows_limit, std::move(filter));
+      return;
+    }
+    if (!google::cloud::internal::IsEmpty(opts)) {
+      on_finish_fn(
+          Status(StatusCode::kFailedPrecondition,
+                 "Per-operation options only apply to `Table`s constructed "
+                 "with a `DataConnection`."));
       return;
     }
 
@@ -937,6 +973,8 @@ class Table {
    * @param row_key the row to read.
    * @param filter a filter expression, can be used to select a subset of the
    *     column families and columns in the row.
+   * @param opts (Optional) Override the class-level options, such as retry,
+   *     backoff, and idempotency policies.
    * @returns a future satisfied when the operation completes, fails
    *     permanently or keeps failing transiently, but the retry policy has been
    *     exhausted. The future will return a tuple. The first element is a
@@ -957,7 +995,8 @@ class Table {
    * @snippet data_async_snippets.cc async read row
    */
   future<StatusOr<std::pair<bool, Row>>> AsyncReadRow(std::string row_key,
-                                                      Filter filter);
+                                                      Filter filter,
+                                                      Options opts = {});
 
  private:
   /**

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -949,7 +949,7 @@ class Table {
     }
     if (!google::cloud::internal::IsEmpty(opts)) {
       on_finish_fn(
-          Status(StatusCode::kFailedPrecondition,
+          Status(StatusCode::kInvalidArgument,
                  "Per-operation options only apply to `Table`s constructed "
                  "with a `DataConnection`."));
       return;


### PR DESCRIPTION
Most of the work for #7688 

This PR handles all calls except for `Table::(Async)ReadModifyWriteRow(...)`, which are a little bit more involved.

If `Options` are supplied to a `Table` implemented by `DataClient`, we will immediately return a `kInvalidArgument` error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9623)
<!-- Reviewable:end -->
