### PR TITLE
feat(generator): support services with location-dependent endpoints

### DIFF
--- a/ci/cloudbuild/builds/generate-libraries.sh
+++ b/ci/cloudbuild/builds/generate-libraries.sh
@@ -64,6 +64,9 @@ for dox in google/cloud/*/doc/main.dox; do
     variable=$(grep -om1 "${variable_re}" "${option_defaults_cc}")
     endpoint_re='"[^"]*?\.googleapis\.com"'
     endpoint=$(grep -Pom1 "${endpoint_re}" "${option_defaults_cc}")
+    if grep -q 'location,' "${option_defaults_cc}"; then
+      endpoint="\"<location>-${endpoint:1:-1}\""
+    fi
     make_connection_re='Make.*?Connection()'
     make_connection=$(grep -Pom1 "${make_connection_re}" "${connection_h}")
     env_vars+=("- \`${variable}=...\` overrides the")

--- a/generator/generator_config.proto
+++ b/generator/generator_config.proto
@@ -76,6 +76,22 @@ message ServiceConfiguration {
   // decorators, for example, Storage requires a round-robin decorator to get
   // good performance.
   bool omit_stub_factory = 14;
+
+  // Control the overloads generated for `Make*Connection()`.
+  enum EndpointLocationStyle {
+    // Default. `Make*Connection(Options options = {})`.
+    LOCATION_INDEPENDENT = 0;
+
+    // `Make*Connection(std::string const& location, Options options = {})`.
+    LOCATION_DEPENDENT = 1;
+
+    // Both of the above, for services that were initially released as
+    // "LOCATION_INDEPENDENT" (probably with a useless default endpoint),
+    // but were subsequently acknowledged to be "LOCATION_DEPENDENT".
+    // Do not use for new services.
+    LOCATION_DEPENDENT_COMPAT = 2;
+  }
+  EndpointLocationStyle endpoint_location_style = 15;
 }
 
 message GeneratorConfiguration {

--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -449,6 +449,7 @@ service {
   initial_copyright_year: "2022"
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -456,6 +457,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -463,6 +465,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -472,6 +475,7 @@ service {
   initial_copyright_year: "2022"
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -479,6 +483,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -486,6 +491,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -493,6 +499,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -501,6 +508,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -508,6 +516,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -516,6 +525,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -523,6 +533,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -530,6 +541,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -537,6 +549,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -544,6 +557,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -551,6 +565,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -558,6 +573,7 @@ service {
   product_path: "google/cloud/dialogflow_cx"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 # Dialogflow ES
@@ -566,6 +582,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -574,6 +591,7 @@ service {
   initial_copyright_year: "2022"
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -581,6 +599,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -589,6 +608,7 @@ service {
   initial_copyright_year: "2022"
   service_endpoint_env_var: "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -596,6 +616,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -603,6 +624,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -610,6 +632,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -617,6 +640,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -624,6 +648,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -631,6 +656,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -639,6 +665,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -647,6 +674,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -654,6 +682,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -661,6 +690,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -668,6 +698,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -676,6 +707,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -683,6 +715,7 @@ service {
   product_path: "google/cloud/dialogflow_es"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 
@@ -692,6 +725,7 @@ service {
   product_path: "google/cloud/documentai"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 # Eventarc

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -101,10 +101,9 @@ class GoldenKitchenSinkConnection {
  * A factory function to construct an object of type `GoldenKitchenSinkConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of GoldenKitchenSinkClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of GoldenKitchenSinkClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GoldenKitchenSinkConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -112,9 +111,8 @@ class GoldenKitchenSinkConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::golden::GoldenKitchenSinkPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GoldenKitchenSinkConnection` created by
  * this function.

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -130,10 +130,9 @@ class GoldenThingAdminConnection {
  * A factory function to construct an object of type `GoldenThingAdminConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of GoldenThingAdminClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of GoldenThingAdminClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GoldenThingAdminConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -141,9 +140,8 @@ class GoldenThingAdminConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::golden::GoldenThingAdminPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GoldenThingAdminConnection` created by
  * this function.

--- a/generator/internal/codegen_utils.cc
+++ b/generator/internal/codegen_utils.cc
@@ -123,6 +123,19 @@ void ProcessArgEmulatorEndpointEnvVar(
   }
 }
 
+void ProcessArgEndpointLocationStyle(
+    std::vector<std::pair<std::string, std::string>>& command_line_args) {
+  auto endpoint_location_style =
+      std::find_if(command_line_args.begin(), command_line_args.end(),
+                   [](std::pair<std::string, std::string> const& p) {
+                     return p.first == "endpoint_location_style";
+                   });
+  if (endpoint_location_style == command_line_args.end()) {
+    command_line_args.emplace_back("endpoint_location_style",
+                                   "LOCATION_INDEPENDENT");
+  }
+}
+
 void ProcessArgGenerateAsyncRpc(
     std::vector<std::pair<std::string, std::string>>& command_line_args) {
   ProcessRepeated("gen_async_rpc", "gen_async_rpcs", command_line_args);
@@ -230,6 +243,7 @@ ProcessCommandLineArgs(std::string const& parameters) {
   ProcessArgOmitRpc(command_line_args);
   ProcessArgServiceEndpointEnvVar(command_line_args);
   ProcessArgEmulatorEndpointEnvVar(command_line_args);
+  ProcessArgEndpointLocationStyle(command_line_args);
   ProcessArgGenerateAsyncRpc(command_line_args);
   ProcessArgRetryGrpcStatusCode(command_line_args);
   ProcessArgAdditionalProtoFiles(command_line_args);

--- a/generator/internal/codegen_utils_test.cc
+++ b/generator/internal/codegen_utils_test.cc
@@ -312,6 +312,15 @@ TEST(ProcessCommandLineArgs, ProcessOmitStubFactory) {
   EXPECT_THAT(*result, Contains(Pair("omit_stub_factory", "true")));
 }
 
+TEST(ProcessCommandLineArgs, ProcessEndpointLocationStyle) {
+  auto result = ProcessCommandLineArgs(
+      "product_path=google/cloud/spanner/"
+      ",endpoint_location_style=LOCATION_DEPENDENT_COMPAT");
+  ASSERT_THAT(result, IsOk());
+  EXPECT_THAT(*result, Contains(Pair("endpoint_location_style",
+                                     "LOCATION_DEPENDENT_COMPAT")));
+}
+
 }  // namespace
 }  // namespace generator_internal
 }  // namespace cloud

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -260,9 +260,9 @@ std::shared_ptr<$connection_class_name$> Make$connection_class_name$(
     case ServiceConfiguration::LOCATION_DEPENDENT_COMPAT:
       HeaderPrint(R"""(
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/generator/internal/service_code_generator.cc
+++ b/generator/internal/service_code_generator.cc
@@ -87,6 +87,14 @@ ServiceCodeGenerator::ServiceCodeGenerator(
   SetMethods();
 }
 
+ServiceCodeGenerator::ServiceConfiguration::EndpointLocationStyle
+ServiceCodeGenerator::EndpointLocationStyle() const {
+  auto endpoint_location_style = ServiceConfiguration::LOCATION_INDEPENDENT;
+  ServiceConfiguration::EndpointLocationStyle_Parse(
+      vars("endpoint_location_style"), &endpoint_location_style);
+  return endpoint_location_style;
+}
+
 bool ServiceCodeGenerator::HasLongrunningMethod() const {
   return std::any_of(methods_.begin(), methods_.end(),
                      [](google::protobuf::MethodDescriptor const& m) {

--- a/generator/internal/service_code_generator.h
+++ b/generator/internal/service_code_generator.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GENERATOR_INTERNAL_SERVICE_CODE_GENERATOR_H
 
 #include "google/cloud/status.h"
+#include "generator/generator_config.pb.h"
 #include "generator/internal/codegen_utils.h"
 #include "generator/internal/descriptor_utils.h"
 #include "generator/internal/generator_interface.h"
@@ -54,6 +55,8 @@ class ServiceCodeGenerator : public GeneratorInterface {
  protected:
   using MethodDescriptorList = std::vector<
       std::reference_wrapper<google::protobuf::MethodDescriptor const>>;
+  using ServiceConfiguration =
+      google::cloud::cpp::generator::ServiceConfiguration;
 
   virtual Status GenerateHeader() = 0;
   virtual Status GenerateCc() = 0;
@@ -91,6 +94,11 @@ class ServiceCodeGenerator : public GeneratorInterface {
                        char const* file, int line);
   void CcPrintMethod(google::protobuf::MethodDescriptor const& method,
                      char const* file, int line, std::string const& text);
+
+  /**
+   * How the endpoint for the service might depend upon its location.
+   */
+  ServiceConfiguration::EndpointLocationStyle EndpointLocationStyle() const;
 
   /**
    * Determines if the service contains at least one method that returns a

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -43,6 +43,7 @@ ABSL_FLAG(std::string, scaffold, "",
 ABSL_FLAG(bool, update_ci, true, "Update the CI support files.");
 
 namespace {
+
 google::cloud::StatusOr<google::cloud::cpp::generator::GeneratorConfiguration>
 GetConfig(std::string const& filepath) {
   std::ifstream input(filepath);
@@ -234,6 +235,10 @@ int main(int argc, char** argv) {
                       service.service_endpoint_env_var());
     args.emplace_back("--cpp_codegen_opt=emulator_endpoint_env_var=" +
                       service.emulator_endpoint_env_var());
+    args.emplace_back(
+        "--cpp_codegen_opt=endpoint_location_style=" +
+        google::cloud::cpp::generator::ServiceConfiguration::
+            EndpointLocationStyle_Name(service.endpoint_location_style()));
     for (auto const& gen_async_rpc : service.gen_async_rpcs()) {
       args.emplace_back("--cpp_codegen_opt=gen_async_rpc=" + gen_async_rpc);
     }

--- a/google/cloud/accessapproval/access_approval_connection.h
+++ b/google/cloud/accessapproval/access_approval_connection.h
@@ -113,10 +113,9 @@ class AccessApprovalConnection {
  * A factory function to construct an object of type `AccessApprovalConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AccessApprovalClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AccessApprovalClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AccessApprovalConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -124,9 +123,8 @@ class AccessApprovalConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::accessapproval::AccessApprovalPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AccessApprovalConnection` created by
  * this function.

--- a/google/cloud/accesscontextmanager/access_context_manager_connection.h
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection.h
@@ -193,9 +193,9 @@ class AccessContextManagerConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AccessContextManagerClient, and that class used instead.
+ * AccessContextManagerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AccessContextManagerConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -203,9 +203,8 @@ class AccessContextManagerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::accesscontextmanager::AccessContextManagerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AccessContextManagerConnection`
  * created by this function.

--- a/google/cloud/apigateway/api_gateway_connection.h
+++ b/google/cloud/apigateway/api_gateway_connection.h
@@ -125,9 +125,9 @@ class ApiGatewayServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ApiGatewayServiceClient, and that class used instead.
+ * ApiGatewayServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ApiGatewayServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -135,9 +135,8 @@ class ApiGatewayServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::apigateway::ApiGatewayServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ApiGatewayServiceConnection` created
  * by this function.

--- a/google/cloud/apigeeconnect/connection_connection.h
+++ b/google/cloud/apigeeconnect/connection_connection.h
@@ -75,9 +75,9 @@ class ConnectionServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ConnectionServiceClient, and that class used instead.
+ * ConnectionServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ConnectionServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -85,9 +85,8 @@ class ConnectionServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::apigeeconnect::ConnectionServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ConnectionServiceConnection` created
  * by this function.

--- a/google/cloud/appengine/applications_connection.h
+++ b/google/cloud/appengine/applications_connection.h
@@ -86,10 +86,9 @@ class ApplicationsConnection {
  * A factory function to construct an object of type `ApplicationsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ApplicationsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ApplicationsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ApplicationsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -97,9 +96,8 @@ class ApplicationsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::ApplicationsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ApplicationsConnection` created by
  * this function.

--- a/google/cloud/appengine/authorized_certificates_connection.h
+++ b/google/cloud/appengine/authorized_certificates_connection.h
@@ -91,9 +91,9 @@ class AuthorizedCertificatesConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AuthorizedCertificatesClient, and that class used instead.
+ * AuthorizedCertificatesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AuthorizedCertificatesConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -101,9 +101,8 @@ class AuthorizedCertificatesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::AuthorizedCertificatesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AuthorizedCertificatesConnection`
  * created by this function.

--- a/google/cloud/appengine/authorized_domains_connection.h
+++ b/google/cloud/appengine/authorized_domains_connection.h
@@ -75,9 +75,9 @@ class AuthorizedDomainsConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AuthorizedDomainsClient, and that class used instead.
+ * AuthorizedDomainsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AuthorizedDomainsConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -85,9 +85,8 @@ class AuthorizedDomainsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::AuthorizedDomainsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AuthorizedDomainsConnection` created
  * by this function.

--- a/google/cloud/appengine/domain_mappings_connection.h
+++ b/google/cloud/appengine/domain_mappings_connection.h
@@ -90,10 +90,9 @@ class DomainMappingsConnection {
  * A factory function to construct an object of type `DomainMappingsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DomainMappingsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DomainMappingsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DomainMappingsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -101,9 +100,8 @@ class DomainMappingsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::DomainMappingsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DomainMappingsConnection` created by
  * this function.

--- a/google/cloud/appengine/firewall_connection.h
+++ b/google/cloud/appengine/firewall_connection.h
@@ -87,10 +87,9 @@ class FirewallConnection {
  * A factory function to construct an object of type `FirewallConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of FirewallClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of FirewallClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `FirewallConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -98,9 +97,8 @@ class FirewallConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::FirewallPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `FirewallConnection` created by
  * this function.

--- a/google/cloud/appengine/instances_connection.h
+++ b/google/cloud/appengine/instances_connection.h
@@ -83,10 +83,9 @@ class InstancesConnection {
  * A factory function to construct an object of type `InstancesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of InstancesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of InstancesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `InstancesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,9 +93,8 @@ class InstancesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::InstancesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `InstancesConnection` created by
  * this function.

--- a/google/cloud/appengine/services_connection.h
+++ b/google/cloud/appengine/services_connection.h
@@ -83,10 +83,9 @@ class ServicesConnection {
  * A factory function to construct an object of type `ServicesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ServicesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ServicesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ServicesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,9 +93,8 @@ class ServicesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::ServicesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ServicesConnection` created by
  * this function.

--- a/google/cloud/appengine/versions_connection.h
+++ b/google/cloud/appengine/versions_connection.h
@@ -86,10 +86,9 @@ class VersionsConnection {
  * A factory function to construct an object of type `VersionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of VersionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of VersionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VersionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -97,9 +96,8 @@ class VersionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::appengine::VersionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `VersionsConnection` created by
  * this function.

--- a/google/cloud/artifactregistry/artifact_registry_connection.h
+++ b/google/cloud/artifactregistry/artifact_registry_connection.h
@@ -184,10 +184,9 @@ class ArtifactRegistryConnection {
  * `ArtifactRegistryConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ArtifactRegistryClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ArtifactRegistryClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ArtifactRegistryConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -195,9 +194,8 @@ class ArtifactRegistryConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::artifactregistry::ArtifactRegistryPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ArtifactRegistryConnection` created
  * by this function.

--- a/google/cloud/asset/asset_connection.h
+++ b/google/cloud/asset/asset_connection.h
@@ -139,10 +139,9 @@ class AssetServiceConnection {
  * A factory function to construct an object of type `AssetServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AssetServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AssetServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AssetServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -150,9 +149,8 @@ class AssetServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::asset::AssetServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AssetServiceConnection` created by
  * this function.

--- a/google/cloud/assuredworkloads/assured_workloads_connection.h
+++ b/google/cloud/assuredworkloads/assured_workloads_connection.h
@@ -97,9 +97,9 @@ class AssuredWorkloadsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AssuredWorkloadsServiceClient, and that class used instead.
+ * AssuredWorkloadsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AssuredWorkloadsServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -107,9 +107,8 @@ class AssuredWorkloadsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::assuredworkloads::AssuredWorkloadsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AssuredWorkloadsServiceConnection`
  * created by this function.

--- a/google/cloud/automl/auto_ml_connection.h
+++ b/google/cloud/automl/auto_ml_connection.h
@@ -127,10 +127,9 @@ class AutoMlConnection {
  * A factory function to construct an object of type `AutoMlConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AutoMlClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AutoMlClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AutoMlConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -138,9 +137,8 @@ class AutoMlConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::automl::AutoMlPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AutoMlConnection` created by
  * this function.

--- a/google/cloud/automl/prediction_connection.h
+++ b/google/cloud/automl/prediction_connection.h
@@ -79,9 +79,9 @@ class PredictionServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * PredictionServiceClient, and that class used instead.
+ * PredictionServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `PredictionServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -89,9 +89,8 @@ class PredictionServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::automl::PredictionServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `PredictionServiceConnection` created
  * by this function.

--- a/google/cloud/baremetalsolution/bare_metal_solution_connection.h
+++ b/google/cloud/baremetalsolution/bare_metal_solution_connection.h
@@ -157,9 +157,9 @@ class BareMetalSolutionConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * BareMetalSolutionClient, and that class used instead.
+ * BareMetalSolutionClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BareMetalSolutionConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -167,9 +167,8 @@ class BareMetalSolutionConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::baremetalsolution::BareMetalSolutionPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BareMetalSolutionConnection` created
  * by this function.

--- a/google/cloud/batch/batch_connection.h
+++ b/google/cloud/batch/batch_connection.h
@@ -90,10 +90,9 @@ class BatchServiceConnection {
  * A factory function to construct an object of type `BatchServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of BatchServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of BatchServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BatchServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -101,9 +100,8 @@ class BatchServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::batch::BatchServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BatchServiceConnection` created by
  * this function.

--- a/google/cloud/beyondcorp/app_connections_connection.h
+++ b/google/cloud/beyondcorp/app_connections_connection.h
@@ -106,9 +106,9 @@ class AppConnectionsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AppConnectionsServiceClient, and that class used instead.
+ * AppConnectionsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AppConnectionsServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -116,9 +116,8 @@ class AppConnectionsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::beyondcorp::AppConnectionsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AppConnectionsServiceConnection`
  * created by this function.

--- a/google/cloud/beyondcorp/app_connectors_connection.h
+++ b/google/cloud/beyondcorp/app_connectors_connection.h
@@ -105,9 +105,9 @@ class AppConnectorsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AppConnectorsServiceClient, and that class used instead.
+ * AppConnectorsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AppConnectorsServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -115,9 +115,8 @@ class AppConnectorsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::beyondcorp::AppConnectorsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AppConnectorsServiceConnection`
  * created by this function.

--- a/google/cloud/beyondcorp/app_gateways_connection.h
+++ b/google/cloud/beyondcorp/app_gateways_connection.h
@@ -96,9 +96,9 @@ class AppGatewaysServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AppGatewaysServiceClient, and that class used instead.
+ * AppGatewaysServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AppGatewaysServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -106,9 +106,8 @@ class AppGatewaysServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::beyondcorp::AppGatewaysServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AppGatewaysServiceConnection`
  * created by this function.

--- a/google/cloud/beyondcorp/client_connector_services_connection.h
+++ b/google/cloud/beyondcorp/client_connector_services_connection.h
@@ -108,9 +108,9 @@ class ClientConnectorServicesServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ClientConnectorServicesServiceClient, and that class used instead.
+ * ClientConnectorServicesServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ClientConnectorServicesServiceConnection`. Expected options are any
  * of the types in the following option lists:
  *
@@ -118,9 +118,8 @@ class ClientConnectorServicesServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::beyondcorp::ClientConnectorServicesServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `ClientConnectorServicesServiceConnection` created by this function.

--- a/google/cloud/beyondcorp/client_gateways_connection.h
+++ b/google/cloud/beyondcorp/client_gateways_connection.h
@@ -96,9 +96,9 @@ class ClientGatewaysServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ClientGatewaysServiceClient, and that class used instead.
+ * ClientGatewaysServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ClientGatewaysServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -106,9 +106,8 @@ class ClientGatewaysServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::beyondcorp::ClientGatewaysServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ClientGatewaysServiceConnection`
  * created by this function.

--- a/google/cloud/bigquery/bigquery_read_connection.h
+++ b/google/cloud/bigquery/bigquery_read_connection.h
@@ -92,10 +92,9 @@ class BigQueryReadConnection {
  * A factory function to construct an object of type `BigQueryReadConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of BigQueryReadClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of BigQueryReadClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BigQueryReadConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -103,9 +102,8 @@ class BigQueryReadConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigquery::BigQueryReadPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BigQueryReadConnection` created by
  * this function.

--- a/google/cloud/bigquery/bigquery_write_connection.h
+++ b/google/cloud/bigquery/bigquery_write_connection.h
@@ -100,10 +100,9 @@ class BigQueryWriteConnection {
  * A factory function to construct an object of type `BigQueryWriteConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of BigQueryWriteClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of BigQueryWriteClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BigQueryWriteConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -111,9 +110,8 @@ class BigQueryWriteConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigquery::BigQueryWritePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BigQueryWriteConnection` created by
  * this function.

--- a/google/cloud/bigquery/connection_connection.h
+++ b/google/cloud/bigquery/connection_connection.h
@@ -103,9 +103,9 @@ class ConnectionServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ConnectionServiceClient, and that class used instead.
+ * ConnectionServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ConnectionServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -113,9 +113,8 @@ class ConnectionServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigquery::ConnectionServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ConnectionServiceConnection` created
  * by this function.

--- a/google/cloud/bigquery/data_transfer_connection.h
+++ b/google/cloud/bigquery/data_transfer_connection.h
@@ -143,9 +143,9 @@ class DataTransferServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * DataTransferServiceClient, and that class used instead.
+ * DataTransferServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DataTransferServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -153,9 +153,8 @@ class DataTransferServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigquery::DataTransferServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DataTransferServiceConnection`
  * created by this function.

--- a/google/cloud/bigquery/model_connection.h
+++ b/google/cloud/bigquery/model_connection.h
@@ -80,10 +80,9 @@ class ModelServiceConnection {
  * A factory function to construct an object of type `ModelServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ModelServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ModelServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ModelServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -91,9 +90,8 @@ class ModelServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigquery::ModelServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ModelServiceConnection` created by
  * this function.

--- a/google/cloud/bigquery/reservation_connection.h
+++ b/google/cloud/bigquery/reservation_connection.h
@@ -168,9 +168,9 @@ class ReservationServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ReservationServiceClient, and that class used instead.
+ * ReservationServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ReservationServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -178,9 +178,8 @@ class ReservationServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigquery::ReservationServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ReservationServiceConnection`
  * created by this function.

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.h
@@ -143,9 +143,9 @@ class BigtableInstanceAdminConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * BigtableInstanceAdminClient, and that class used instead.
+ * BigtableInstanceAdminClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BigtableInstanceAdminConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -153,9 +153,8 @@ class BigtableInstanceAdminConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigtable_admin::BigtableInstanceAdminPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BigtableInstanceAdminConnection`
  * created by this function.

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.h
@@ -137,9 +137,9 @@ class BigtableTableAdminConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * BigtableTableAdminClient, and that class used instead.
+ * BigtableTableAdminClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BigtableTableAdminConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -147,9 +147,8 @@ class BigtableTableAdminConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::bigtable_admin::BigtableTableAdminPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BigtableTableAdminConnection`
  * created by this function.

--- a/google/cloud/billing/budget_connection.h
+++ b/google/cloud/billing/budget_connection.h
@@ -84,10 +84,9 @@ class BudgetServiceConnection {
  * A factory function to construct an object of type `BudgetServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of BudgetServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of BudgetServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BudgetServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -95,9 +94,8 @@ class BudgetServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::billing::BudgetServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BudgetServiceConnection` created by
  * this function.

--- a/google/cloud/billing/cloud_billing_connection.h
+++ b/google/cloud/billing/cloud_billing_connection.h
@@ -107,10 +107,9 @@ class CloudBillingConnection {
  * A factory function to construct an object of type `CloudBillingConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudBillingClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudBillingClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudBillingConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -118,9 +117,8 @@ class CloudBillingConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::billing::CloudBillingPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudBillingConnection` created by
  * this function.

--- a/google/cloud/billing/cloud_catalog_connection.h
+++ b/google/cloud/billing/cloud_catalog_connection.h
@@ -75,10 +75,9 @@ class CloudCatalogConnection {
  * A factory function to construct an object of type `CloudCatalogConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudCatalogClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudCatalogClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudCatalogConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -86,9 +85,8 @@ class CloudCatalogConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::billing::CloudCatalogPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudCatalogConnection` created by
  * this function.

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.h
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.h
@@ -103,9 +103,9 @@ class BinauthzManagementServiceV1Connection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * BinauthzManagementServiceV1Client, and that class used instead.
+ * BinauthzManagementServiceV1Client.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BinauthzManagementServiceV1Connection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -114,9 +114,8 @@ class BinauthzManagementServiceV1Connection {
  * -
  * `google::cloud::binaryauthorization::BinauthzManagementServiceV1PolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `BinauthzManagementServiceV1Connection` created by this function.

--- a/google/cloud/binaryauthorization/system_policy_v1_connection.h
+++ b/google/cloud/binaryauthorization/system_policy_v1_connection.h
@@ -73,10 +73,9 @@ class SystemPolicyV1Connection {
  * A factory function to construct an object of type `SystemPolicyV1Connection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of SystemPolicyV1Client,
- * and that class used instead.
+ * should be passed as an argument to the constructor of SystemPolicyV1Client.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SystemPolicyV1Connection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -84,9 +83,8 @@ class SystemPolicyV1Connection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::binaryauthorization::SystemPolicyV1PolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `SystemPolicyV1Connection` created by
  * this function.

--- a/google/cloud/binaryauthorization/validation_helper_v1_connection.h
+++ b/google/cloud/binaryauthorization/validation_helper_v1_connection.h
@@ -77,9 +77,9 @@ class ValidationHelperV1Connection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ValidationHelperV1Client, and that class used instead.
+ * ValidationHelperV1Client.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ValidationHelperV1Connection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -87,9 +87,8 @@ class ValidationHelperV1Connection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::binaryauthorization::ValidationHelperV1PolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ValidationHelperV1Connection`
  * created by this function.

--- a/google/cloud/channel/cloud_channel_connection.h
+++ b/google/cloud/channel/cloud_channel_connection.h
@@ -253,9 +253,9 @@ class CloudChannelServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * CloudChannelServiceClient, and that class used instead.
+ * CloudChannelServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudChannelServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -263,9 +263,8 @@ class CloudChannelServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::channel::CloudChannelServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudChannelServiceConnection`
  * created by this function.

--- a/google/cloud/cloudbuild/cloud_build_connection.h
+++ b/google/cloud/cloudbuild/cloud_build_connection.h
@@ -142,10 +142,9 @@ class CloudBuildConnection {
  * A factory function to construct an object of type `CloudBuildConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudBuildClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudBuildClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudBuildConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -153,9 +152,8 @@ class CloudBuildConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::cloudbuild::CloudBuildPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudBuildConnection` created by
  * this function.

--- a/google/cloud/composer/environments_connection.h
+++ b/google/cloud/composer/environments_connection.h
@@ -97,10 +97,9 @@ class EnvironmentsConnection {
  * A factory function to construct an object of type `EnvironmentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EnvironmentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EnvironmentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EnvironmentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -108,9 +107,8 @@ class EnvironmentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::composer::EnvironmentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `EnvironmentsConnection` created by
  * this function.

--- a/google/cloud/composer/image_versions_connection.h
+++ b/google/cloud/composer/image_versions_connection.h
@@ -74,10 +74,9 @@ class ImageVersionsConnection {
  * A factory function to construct an object of type `ImageVersionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ImageVersionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ImageVersionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ImageVersionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -85,9 +84,8 @@ class ImageVersionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::composer::ImageVersionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ImageVersionsConnection` created by
  * this function.

--- a/google/cloud/contactcenterinsights/contact_center_insights_connection.h
+++ b/google/cloud/contactcenterinsights/contact_center_insights_connection.h
@@ -235,9 +235,9 @@ class ContactCenterInsightsConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ContactCenterInsightsClient, and that class used instead.
+ * ContactCenterInsightsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ContactCenterInsightsConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -246,9 +246,8 @@ class ContactCenterInsightsConnection {
  * -
  * `google::cloud::contactcenterinsights::ContactCenterInsightsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ContactCenterInsightsConnection`
  * created by this function.

--- a/google/cloud/container/cluster_manager_connection.h
+++ b/google/cloud/container/cluster_manager_connection.h
@@ -169,10 +169,9 @@ class ClusterManagerConnection {
  * A factory function to construct an object of type `ClusterManagerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ClusterManagerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ClusterManagerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ClusterManagerConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -180,9 +179,8 @@ class ClusterManagerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::container::ClusterManagerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ClusterManagerConnection` created by
  * this function.

--- a/google/cloud/containeranalysis/container_analysis_connection.h
+++ b/google/cloud/containeranalysis/container_analysis_connection.h
@@ -85,9 +85,9 @@ class ContainerAnalysisConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ContainerAnalysisClient, and that class used instead.
+ * ContainerAnalysisClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ContainerAnalysisConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -95,9 +95,8 @@ class ContainerAnalysisConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::containeranalysis::ContainerAnalysisPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ContainerAnalysisConnection` created
  * by this function.

--- a/google/cloud/containeranalysis/grafeas_connection.h
+++ b/google/cloud/containeranalysis/grafeas_connection.h
@@ -110,10 +110,9 @@ class GrafeasConnection {
  * A factory function to construct an object of type `GrafeasConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of GrafeasClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of GrafeasClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GrafeasConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -121,9 +120,8 @@ class GrafeasConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::containeranalysis::GrafeasPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GrafeasConnection` created by
  * this function.

--- a/google/cloud/datacatalog/data_catalog_connection.h
+++ b/google/cloud/datacatalog/data_catalog_connection.h
@@ -181,10 +181,9 @@ class DataCatalogConnection {
  * A factory function to construct an object of type `DataCatalogConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DataCatalogClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DataCatalogClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DataCatalogConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -192,9 +191,8 @@ class DataCatalogConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::datacatalog::DataCatalogPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DataCatalogConnection` created by
  * this function.

--- a/google/cloud/datacatalog/policy_tag_manager_connection.h
+++ b/google/cloud/datacatalog/policy_tag_manager_connection.h
@@ -109,10 +109,9 @@ class PolicyTagManagerConnection {
  * `PolicyTagManagerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of PolicyTagManagerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of PolicyTagManagerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `PolicyTagManagerConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -120,9 +119,8 @@ class PolicyTagManagerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::datacatalog::PolicyTagManagerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `PolicyTagManagerConnection` created
  * by this function.

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_connection.h
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_connection.h
@@ -84,9 +84,9 @@ class PolicyTagManagerSerializationConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * PolicyTagManagerSerializationClient, and that class used instead.
+ * PolicyTagManagerSerializationClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `PolicyTagManagerSerializationConnection`. Expected options are any
  * of the types in the following option lists:
  *
@@ -94,9 +94,8 @@ class PolicyTagManagerSerializationConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::datacatalog::PolicyTagManagerSerializationPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `PolicyTagManagerSerializationConnection` created by this function.

--- a/google/cloud/datamigration/data_migration_connection.h
+++ b/google/cloud/datamigration/data_migration_connection.h
@@ -143,9 +143,9 @@ class DataMigrationServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * DataMigrationServiceClient, and that class used instead.
+ * DataMigrationServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DataMigrationServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -153,9 +153,8 @@ class DataMigrationServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::datamigration::DataMigrationServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DataMigrationServiceConnection`
  * created by this function.

--- a/google/cloud/dataplex/content_connection.h
+++ b/google/cloud/dataplex/content_connection.h
@@ -93,10 +93,9 @@ class ContentServiceConnection {
  * A factory function to construct an object of type `ContentServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ContentServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ContentServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ContentServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -104,9 +103,8 @@ class ContentServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataplex::ContentServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ContentServiceConnection` created by
  * this function.

--- a/google/cloud/dataplex/dataplex_connection.h
+++ b/google/cloud/dataplex/dataplex_connection.h
@@ -173,10 +173,9 @@ class DataplexServiceConnection {
  * `DataplexServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DataplexServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DataplexServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DataplexServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -184,9 +183,8 @@ class DataplexServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataplex::DataplexServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DataplexServiceConnection` created
  * by this function.

--- a/google/cloud/dataplex/metadata_connection.h
+++ b/google/cloud/dataplex/metadata_connection.h
@@ -97,10 +97,9 @@ class MetadataServiceConnection {
  * `MetadataServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of MetadataServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of MetadataServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `MetadataServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -108,9 +107,8 @@ class MetadataServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataplex::MetadataServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `MetadataServiceConnection` created
  * by this function.

--- a/google/cloud/dataproc/autoscaling_policy_connection.h
+++ b/google/cloud/dataproc/autoscaling_policy_connection.h
@@ -95,9 +95,9 @@ class AutoscalingPolicyServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AutoscalingPolicyServiceClient, and that class used instead.
+ * AutoscalingPolicyServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AutoscalingPolicyServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -105,9 +105,8 @@ class AutoscalingPolicyServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataproc::AutoscalingPolicyServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AutoscalingPolicyServiceConnection`
  * created by this function.

--- a/google/cloud/dataproc/batch_controller_connection.h
+++ b/google/cloud/dataproc/batch_controller_connection.h
@@ -85,10 +85,9 @@ class BatchControllerConnection {
  * `BatchControllerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of BatchControllerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of BatchControllerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `BatchControllerConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -96,9 +95,8 @@ class BatchControllerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataproc::BatchControllerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `BatchControllerConnection` created
  * by this function.

--- a/google/cloud/dataproc/cluster_controller_connection.h
+++ b/google/cloud/dataproc/cluster_controller_connection.h
@@ -101,9 +101,9 @@ class ClusterControllerConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ClusterControllerClient, and that class used instead.
+ * ClusterControllerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ClusterControllerConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -111,9 +111,8 @@ class ClusterControllerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataproc::ClusterControllerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ClusterControllerConnection` created
  * by this function.

--- a/google/cloud/dataproc/job_controller_connection.h
+++ b/google/cloud/dataproc/job_controller_connection.h
@@ -94,10 +94,9 @@ class JobControllerConnection {
  * A factory function to construct an object of type `JobControllerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of JobControllerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of JobControllerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `JobControllerConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -105,9 +104,8 @@ class JobControllerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataproc::JobControllerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `JobControllerConnection` created by
  * this function.

--- a/google/cloud/dataproc/workflow_template_connection.h
+++ b/google/cloud/dataproc/workflow_template_connection.h
@@ -107,9 +107,9 @@ class WorkflowTemplateServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * WorkflowTemplateServiceClient, and that class used instead.
+ * WorkflowTemplateServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `WorkflowTemplateServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -117,9 +117,8 @@ class WorkflowTemplateServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dataproc::WorkflowTemplateServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `WorkflowTemplateServiceConnection`
  * created by this function.

--- a/google/cloud/debugger/controller2_connection.h
+++ b/google/cloud/debugger/controller2_connection.h
@@ -85,10 +85,9 @@ class Controller2Connection {
  * A factory function to construct an object of type `Controller2Connection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of Controller2Client,
- * and that class used instead.
+ * should be passed as an argument to the constructor of Controller2Client.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `Controller2Connection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -96,9 +95,8 @@ class Controller2Connection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::debugger::Controller2PolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `Controller2Connection` created by
  * this function.

--- a/google/cloud/debugger/debugger2_connection.h
+++ b/google/cloud/debugger/debugger2_connection.h
@@ -88,10 +88,9 @@ class Debugger2Connection {
  * A factory function to construct an object of type `Debugger2Connection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of Debugger2Client,
- * and that class used instead.
+ * should be passed as an argument to the constructor of Debugger2Client.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `Debugger2Connection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -99,9 +98,8 @@ class Debugger2Connection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::debugger::Debugger2PolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `Debugger2Connection` created by
  * this function.

--- a/google/cloud/dialogflow_cx/agents_connection.cc
+++ b/google/cloud/dialogflow_cx/agents_connection.cc
@@ -90,15 +90,21 @@ AgentsConnection::GetAgentValidationResult(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<AgentsConnection> MakeAgentsConnection(Options options) {
+std::shared_ptr<AgentsConnection> MakeAgentsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  AgentsPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::AgentsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::AgentsDefaultOptions(location,
+                                                         std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultAgentsStub(background->cq(),
                                                               options);
   return std::make_shared<dialogflow_cx_internal::AgentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<AgentsConnection> MakeAgentsConnection(Options options) {
+  return MakeAgentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/agents_connection.h
+++ b/google/cloud/dialogflow_cx/agents_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -103,10 +104,9 @@ class AgentsConnection {
  * A factory function to construct an object of type `AgentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AgentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AgentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AgentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -114,12 +114,22 @@ class AgentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::AgentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `AgentsConnection` created by
  * this function.
+ */
+std::shared_ptr<AgentsConnection> MakeAgentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<AgentsConnection> MakeAgentsConnection(Options options = {});
 

--- a/google/cloud/dialogflow_cx/agents_connection.h
+++ b/google/cloud/dialogflow_cx/agents_connection.h
@@ -125,9 +125,9 @@ std::shared_ptr<AgentsConnection> MakeAgentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/changelogs_connection.cc
+++ b/google/cloud/dialogflow_cx/changelogs_connection.cc
@@ -49,16 +49,21 @@ ChangelogsConnection::GetChangelog(
 }
 
 std::shared_ptr<ChangelogsConnection> MakeChangelogsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ChangelogsPolicyOptionList>(options, __func__);
-  options =
-      dialogflow_cx_internal::ChangelogsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::ChangelogsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultChangelogsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::ChangelogsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ChangelogsConnection> MakeChangelogsConnection(
+    Options options) {
+  return MakeChangelogsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/changelogs_connection.h
+++ b/google/cloud/dialogflow_cx/changelogs_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -75,10 +76,9 @@ class ChangelogsConnection {
  * A factory function to construct an object of type `ChangelogsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ChangelogsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ChangelogsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ChangelogsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -86,12 +86,22 @@ class ChangelogsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::ChangelogsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ChangelogsConnection` created by
  * this function.
+ */
+std::shared_ptr<ChangelogsConnection> MakeChangelogsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ChangelogsConnection> MakeChangelogsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/changelogs_connection.h
+++ b/google/cloud/dialogflow_cx/changelogs_connection.h
@@ -97,9 +97,9 @@ std::shared_ptr<ChangelogsConnection> MakeChangelogsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/deployments_connection.cc
+++ b/google/cloud/dialogflow_cx/deployments_connection.cc
@@ -49,17 +49,22 @@ DeploymentsConnection::GetDeployment(
 }
 
 std::shared_ptr<DeploymentsConnection> MakeDeploymentsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  DeploymentsPolicyOptionList>(options,
                                                               __func__);
-  options =
-      dialogflow_cx_internal::DeploymentsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::DeploymentsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultDeploymentsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::DeploymentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<DeploymentsConnection> MakeDeploymentsConnection(
+    Options options) {
+  return MakeDeploymentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/deployments_connection.h
+++ b/google/cloud/dialogflow_cx/deployments_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -75,10 +76,9 @@ class DeploymentsConnection {
  * A factory function to construct an object of type `DeploymentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DeploymentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DeploymentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DeploymentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -86,12 +86,22 @@ class DeploymentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::DeploymentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `DeploymentsConnection` created by
  * this function.
+ */
+std::shared_ptr<DeploymentsConnection> MakeDeploymentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<DeploymentsConnection> MakeDeploymentsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/deployments_connection.h
+++ b/google/cloud/dialogflow_cx/deployments_connection.h
@@ -97,9 +97,9 @@ std::shared_ptr<DeploymentsConnection> MakeDeploymentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/doc/main.dox
+++ b/google/cloud/dialogflow_cx/doc/main.dox
@@ -44,67 +44,67 @@ which should give you a taste of the Dialogflow API C++ client library API.
 <!-- inject-endpoint-env-vars-start -->
 
 - `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeAgentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CHANGELOGS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeChangelogsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DEPLOYMENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeDeploymentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeEntityTypesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeEnvironmentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_EXPERIMENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeExperimentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_FLOWS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeFlowsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeIntentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_PAGES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakePagesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SECURITY_SETTINGS_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSecuritySettingsServiceConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSessionEntityTypesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSessionsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_TEST_CASES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeTestCasesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeTransitionRouteGroupsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeVersionsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_WEBHOOKS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeWebhooksConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->

--- a/google/cloud/dialogflow_cx/entity_types_connection.cc
+++ b/google/cloud/dialogflow_cx/entity_types_connection.cc
@@ -66,17 +66,22 @@ Status EntityTypesConnection::DeleteEntityType(
 }
 
 std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  EntityTypesPolicyOptionList>(options,
                                                               __func__);
-  options =
-      dialogflow_cx_internal::EntityTypesDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::EntityTypesDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultEntityTypesStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::EntityTypesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
+    Options options) {
+  return MakeEntityTypesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/entity_types_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -89,10 +90,9 @@ class EntityTypesConnection {
  * A factory function to construct an object of type `EntityTypesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EntityTypesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EntityTypesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EntityTypesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -100,12 +100,22 @@ class EntityTypesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::EntityTypesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `EntityTypesConnection` created by
  * this function.
+ */
+std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/entity_types_connection.h
@@ -111,9 +111,9 @@ std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/environments_connection.cc
+++ b/google/cloud/dialogflow_cx/environments_connection.cc
@@ -102,17 +102,22 @@ EnvironmentsConnection::DeployFlow(
 }
 
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  EnvironmentsPolicyOptionList>(options,
                                                                __func__);
-  options =
-      dialogflow_cx_internal::EnvironmentsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::EnvironmentsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultEnvironmentsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::EnvironmentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
+    Options options) {
+  return MakeEnvironmentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/environments_connection.h
+++ b/google/cloud/dialogflow_cx/environments_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -115,10 +116,9 @@ class EnvironmentsConnection {
  * A factory function to construct an object of type `EnvironmentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EnvironmentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EnvironmentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EnvironmentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -126,12 +126,22 @@ class EnvironmentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::EnvironmentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `EnvironmentsConnection` created by
  * this function.
+ */
+std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/environments_connection.h
+++ b/google/cloud/dialogflow_cx/environments_connection.h
@@ -137,9 +137,9 @@ std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/experiments_connection.cc
+++ b/google/cloud/dialogflow_cx/experiments_connection.cc
@@ -78,17 +78,22 @@ ExperimentsConnection::StopExperiment(
 }
 
 std::shared_ptr<ExperimentsConnection> MakeExperimentsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ExperimentsPolicyOptionList>(options,
                                                               __func__);
-  options =
-      dialogflow_cx_internal::ExperimentsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::ExperimentsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultExperimentsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::ExperimentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ExperimentsConnection> MakeExperimentsConnection(
+    Options options) {
+  return MakeExperimentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/experiments_connection.h
+++ b/google/cloud/dialogflow_cx/experiments_connection.h
@@ -119,9 +119,9 @@ std::shared_ptr<ExperimentsConnection> MakeExperimentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/experiments_connection.h
+++ b/google/cloud/dialogflow_cx/experiments_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -97,10 +98,9 @@ class ExperimentsConnection {
  * A factory function to construct an object of type `ExperimentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ExperimentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ExperimentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ExperimentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -108,12 +108,22 @@ class ExperimentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::ExperimentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ExperimentsConnection` created by
  * this function.
+ */
+std::shared_ptr<ExperimentsConnection> MakeExperimentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ExperimentsConnection> MakeExperimentsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/flows_connection.cc
+++ b/google/cloud/dialogflow_cx/flows_connection.cc
@@ -95,15 +95,21 @@ FlowsConnection::ExportFlow(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-std::shared_ptr<FlowsConnection> MakeFlowsConnection(Options options) {
+std::shared_ptr<FlowsConnection> MakeFlowsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  FlowsPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::FlowsDefaultOptions(std::move(options));
+  options =
+      dialogflow_cx_internal::FlowsDefaultOptions(location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub =
       dialogflow_cx_internal::CreateDefaultFlowsStub(background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::FlowsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<FlowsConnection> MakeFlowsConnection(Options options) {
+  return MakeFlowsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/flows_connection.h
+++ b/google/cloud/dialogflow_cx/flows_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -108,10 +109,9 @@ class FlowsConnection {
  * A factory function to construct an object of type `FlowsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of FlowsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of FlowsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `FlowsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -119,12 +119,22 @@ class FlowsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::FlowsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `FlowsConnection` created by
  * this function.
+ */
+std::shared_ptr<FlowsConnection> MakeFlowsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<FlowsConnection> MakeFlowsConnection(Options options = {});
 

--- a/google/cloud/dialogflow_cx/flows_connection.h
+++ b/google/cloud/dialogflow_cx/flows_connection.h
@@ -130,9 +130,9 @@ std::shared_ptr<FlowsConnection> MakeFlowsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/intents_connection.cc
+++ b/google/cloud/dialogflow_cx/intents_connection.cc
@@ -65,15 +65,21 @@ Status IntentsConnection::DeleteIntent(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<IntentsConnection> MakeIntentsConnection(Options options) {
+std::shared_ptr<IntentsConnection> MakeIntentsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  IntentsPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::IntentsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::IntentsDefaultOptions(location,
+                                                          std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultIntentsStub(background->cq(),
                                                                options);
   return std::make_shared<dialogflow_cx_internal::IntentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<IntentsConnection> MakeIntentsConnection(Options options) {
+  return MakeIntentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/intents_connection.h
+++ b/google/cloud/dialogflow_cx/intents_connection.h
@@ -105,9 +105,9 @@ std::shared_ptr<IntentsConnection> MakeIntentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/intents_connection.h
+++ b/google/cloud/dialogflow_cx/intents_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -83,10 +84,9 @@ class IntentsConnection {
  * A factory function to construct an object of type `IntentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IntentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IntentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IntentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,12 +94,22 @@ class IntentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::IntentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `IntentsConnection` created by
  * this function.
+ */
+std::shared_ptr<IntentsConnection> MakeIntentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<IntentsConnection> MakeIntentsConnection(Options options = {});
 

--- a/google/cloud/dialogflow_cx/internal/agents_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/agents_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/agents_option_defaults.h"
 #include "google/cloud/dialogflow_cx/agents_connection.h"
 #include "google/cloud/dialogflow_cx/agents_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options AgentsDefaultOptions(Options options) {
+Options AgentsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_AGENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_AGENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::AgentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/agents_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/agents_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options AgentsDefaultOptions(Options options);
+Options AgentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/changelogs_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/changelogs_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/changelogs_option_defaults.h"
 #include "google/cloud/dialogflow_cx/changelogs_connection.h"
 #include "google/cloud/dialogflow_cx/changelogs_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ChangelogsDefaultOptions(Options options) {
+Options ChangelogsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CHANGELOGS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_CHANGELOGS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_CHANGELOGS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::ChangelogsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/changelogs_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/changelogs_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ChangelogsDefaultOptions(Options options);
+Options ChangelogsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/deployments_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/deployments_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/deployments_option_defaults.h"
 #include "google/cloud/dialogflow_cx/deployments_connection.h"
 #include "google/cloud/dialogflow_cx/deployments_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options DeploymentsDefaultOptions(Options options) {
+Options DeploymentsDefaultOptions(std::string const& location,
+                                  Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_DEPLOYMENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_DEPLOYMENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_DEPLOYMENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::DeploymentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/deployments_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/deployments_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options DeploymentsDefaultOptions(Options options);
+Options DeploymentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/entity_types_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/entity_types_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/entity_types_option_defaults.h"
 #include "google/cloud/dialogflow_cx/entity_types_connection.h"
 #include "google/cloud/dialogflow_cx/entity_types_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options EntityTypesDefaultOptions(Options options) {
+Options EntityTypesDefaultOptions(std::string const& location,
+                                  Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_ENTITY_TYPES_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_ENTITY_TYPES_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::EntityTypesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/entity_types_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/entity_types_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options EntityTypesDefaultOptions(Options options);
+Options EntityTypesDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/environments_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/environments_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/environments_option_defaults.h"
 #include "google/cloud/dialogflow_cx/environments_connection.h"
 #include "google/cloud/dialogflow_cx/environments_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options EnvironmentsDefaultOptions(Options options) {
+Options EnvironmentsDefaultOptions(std::string const& location,
+                                   Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENT_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::EnvironmentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/environments_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/environments_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options EnvironmentsDefaultOptions(Options options);
+Options EnvironmentsDefaultOptions(std::string const& location,
+                                   Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/experiments_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/experiments_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/experiments_option_defaults.h"
 #include "google/cloud/dialogflow_cx/experiments_connection.h"
 #include "google/cloud/dialogflow_cx/experiments_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ExperimentsDefaultOptions(Options options) {
+Options ExperimentsDefaultOptions(std::string const& location,
+                                  Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_EXPERIMENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_EXPERIMENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_EXPERIMENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::ExperimentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/experiments_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/experiments_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ExperimentsDefaultOptions(Options options);
+Options ExperimentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/flows_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/flows_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/flows_option_defaults.h"
 #include "google/cloud/dialogflow_cx/flows_connection.h"
 #include "google/cloud/dialogflow_cx/flows_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options FlowsDefaultOptions(Options options) {
+Options FlowsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_FLOWS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_FLOWS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_FLOWS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::FlowsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/flows_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/flows_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options FlowsDefaultOptions(Options options);
+Options FlowsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/intents_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/intents_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/intents_option_defaults.h"
 #include "google/cloud/dialogflow_cx/intents_connection.h"
 #include "google/cloud/dialogflow_cx/intents_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options IntentsDefaultOptions(Options options) {
+Options IntentsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_INTENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_INTENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::IntentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/intents_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/intents_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options IntentsDefaultOptions(Options options);
+Options IntentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/pages_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/pages_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/pages_option_defaults.h"
 #include "google/cloud/dialogflow_cx/pages_connection.h"
 #include "google/cloud/dialogflow_cx/pages_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options PagesDefaultOptions(Options options) {
+Options PagesDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_PAGES_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_PAGES_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_PAGES_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::PagesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/pages_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/pages_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options PagesDefaultOptions(Options options);
+Options PagesDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/security_settings_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/security_settings_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/security_settings_option_defaults.h"
 #include "google/cloud/dialogflow_cx/security_settings_connection.h"
 #include "google/cloud/dialogflow_cx/security_settings_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options SecuritySettingsServiceDefaultOptions(Options options) {
+Options SecuritySettingsServiceDefaultOptions(std::string const& location,
+                                              Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_SECURITY_SETTINGS_SERVICE_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_SECURITY_SETTINGS_SERVICE_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::SecuritySettingsServiceRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/security_settings_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/security_settings_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options SecuritySettingsServiceDefaultOptions(Options options);
+Options SecuritySettingsServiceDefaultOptions(std::string const& location,
+                                              Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/session_entity_types_option_defaults.h"
 #include "google/cloud/dialogflow_cx/session_entity_types_connection.h"
 #include "google/cloud/dialogflow_cx/session_entity_types_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options SessionEntityTypesDefaultOptions(Options options) {
+Options SessionEntityTypesDefaultOptions(std::string const& location,
+                                         Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::SessionEntityTypesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/session_entity_types_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/session_entity_types_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options SessionEntityTypesDefaultOptions(Options options);
+Options SessionEntityTypesDefaultOptions(std::string const& location,
+                                         Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/sessions_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/sessions_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/sessions_option_defaults.h"
 #include "google/cloud/dialogflow_cx/sessions_connection.h"
 #include "google/cloud/dialogflow_cx/sessions_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options SessionsDefaultOptions(Options options) {
+Options SessionsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_SESSIONS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_SESSIONS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::SessionsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/sessions_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/sessions_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options SessionsDefaultOptions(Options options);
+Options SessionsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/test_cases_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/test_cases_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/test_cases_option_defaults.h"
 #include "google/cloud/dialogflow_cx/test_cases_connection.h"
 #include "google/cloud/dialogflow_cx/test_cases_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options TestCasesDefaultOptions(Options options) {
+Options TestCasesDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_TEST_CASES_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_TEST_CASES_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_TEST_CASES_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::TestCasesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/test_cases_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/test_cases_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options TestCasesDefaultOptions(Options options);
+Options TestCasesDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/transition_route_groups_option_defaults.h"
 #include "google/cloud/dialogflow_cx/transition_route_groups_connection.h"
 #include "google/cloud/dialogflow_cx/transition_route_groups_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options TransitionRouteGroupsDefaultOptions(Options options) {
+Options TransitionRouteGroupsDefaultOptions(std::string const& location,
+                                            Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_TRANSITION_ROUTE_GROUPS_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::TransitionRouteGroupsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/transition_route_groups_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/transition_route_groups_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options TransitionRouteGroupsDefaultOptions(Options options);
+Options TransitionRouteGroupsDefaultOptions(std::string const& location,
+                                            Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/versions_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/versions_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/versions_option_defaults.h"
 #include "google/cloud/dialogflow_cx/versions_connection.h"
 #include "google/cloud/dialogflow_cx/versions_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options VersionsDefaultOptions(Options options) {
+Options VersionsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::VersionsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/versions_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/versions_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options VersionsDefaultOptions(Options options);
+Options VersionsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/internal/webhooks_option_defaults.cc
+++ b/google/cloud/dialogflow_cx/internal/webhooks_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_cx/internal/webhooks_option_defaults.h"
 #include "google/cloud/dialogflow_cx/webhooks_connection.h"
 #include "google/cloud/dialogflow_cx/webhooks_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options WebhooksDefaultOptions(Options options) {
+Options WebhooksDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_WEBHOOKS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_WEBHOOKS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_WEBHOOKS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_cx::WebhooksRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_cx/internal/webhooks_option_defaults.h
+++ b/google/cloud/dialogflow_cx/internal/webhooks_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_cx_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options WebhooksDefaultOptions(Options options);
+Options WebhooksDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_cx_internal

--- a/google/cloud/dialogflow_cx/pages_connection.cc
+++ b/google/cloud/dialogflow_cx/pages_connection.cc
@@ -61,15 +61,21 @@ Status PagesConnection::DeletePage(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<PagesConnection> MakePagesConnection(Options options) {
+std::shared_ptr<PagesConnection> MakePagesConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  PagesPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::PagesDefaultOptions(std::move(options));
+  options =
+      dialogflow_cx_internal::PagesDefaultOptions(location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub =
       dialogflow_cx_internal::CreateDefaultPagesStub(background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::PagesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<PagesConnection> MakePagesConnection(Options options) {
+  return MakePagesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/pages_connection.h
+++ b/google/cloud/dialogflow_cx/pages_connection.h
@@ -105,9 +105,9 @@ std::shared_ptr<PagesConnection> MakePagesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/pages_connection.h
+++ b/google/cloud/dialogflow_cx/pages_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -83,10 +84,9 @@ class PagesConnection {
  * A factory function to construct an object of type `PagesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of PagesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of PagesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `PagesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,12 +94,22 @@ class PagesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::PagesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `PagesConnection` created by
  * this function.
+ */
+std::shared_ptr<PagesConnection> MakePagesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<PagesConnection> MakePagesConnection(Options options = {});
 

--- a/google/cloud/dialogflow_cx/security_settings_connection.cc
+++ b/google/cloud/dialogflow_cx/security_settings_connection.cc
@@ -67,18 +67,25 @@ Status SecuritySettingsServiceConnection::DeleteSecuritySettings(
 }
 
 std::shared_ptr<SecuritySettingsServiceConnection>
-MakeSecuritySettingsServiceConnection(Options options) {
+MakeSecuritySettingsServiceConnection(std::string const& location,
+                                      Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  SecuritySettingsServicePolicyOptionList>(
       options, __func__);
   options = dialogflow_cx_internal::SecuritySettingsServiceDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultSecuritySettingsServiceStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_cx_internal::SecuritySettingsServiceConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<SecuritySettingsServiceConnection>
+MakeSecuritySettingsServiceConnection(Options options) {
+  return MakeSecuritySettingsServiceConnection(std::string{},
+                                               std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/security_settings_connection.h
+++ b/google/cloud/dialogflow_cx/security_settings_connection.h
@@ -119,9 +119,9 @@ MakeSecuritySettingsServiceConnection(std::string const& location,
                                       Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/security_settings_connection.h
+++ b/google/cloud/dialogflow_cx/security_settings_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -96,9 +97,9 @@ class SecuritySettingsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * SecuritySettingsServiceClient, and that class used instead.
+ * SecuritySettingsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SecuritySettingsServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -106,12 +107,23 @@ class SecuritySettingsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::SecuritySettingsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `SecuritySettingsServiceConnection`
  * created by this function.
+ */
+std::shared_ptr<SecuritySettingsServiceConnection>
+MakeSecuritySettingsServiceConnection(std::string const& location,
+                                      Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<SecuritySettingsServiceConnection>
 MakeSecuritySettingsServiceConnection(Options options = {});

--- a/google/cloud/dialogflow_cx/session_entity_types_connection.cc
+++ b/google/cloud/dialogflow_cx/session_entity_types_connection.cc
@@ -66,18 +66,23 @@ Status SessionEntityTypesConnection::DeleteSessionEntityType(
 }
 
 std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  SessionEntityTypesPolicyOptionList>(options,
                                                                      __func__);
   options = dialogflow_cx_internal::SessionEntityTypesDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultSessionEntityTypesStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_cx_internal::SessionEntityTypesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
+    Options options) {
+  return MakeSessionEntityTypesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/session_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/session_entity_types_connection.h
@@ -116,9 +116,9 @@ std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/session_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/session_entity_types_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -94,9 +95,9 @@ class SessionEntityTypesConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * SessionEntityTypesClient, and that class used instead.
+ * SessionEntityTypesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SessionEntityTypesConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -104,12 +105,22 @@ class SessionEntityTypesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::SessionEntityTypesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `SessionEntityTypesConnection`
  * created by this function.
+ */
+std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/sessions_connection.cc
+++ b/google/cloud/dialogflow_cx/sessions_connection.cc
@@ -62,15 +62,21 @@ SessionsConnection::FulfillIntent(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<SessionsConnection> MakeSessionsConnection(Options options) {
+std::shared_ptr<SessionsConnection> MakeSessionsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  SessionsPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::SessionsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::SessionsDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultSessionsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::SessionsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<SessionsConnection> MakeSessionsConnection(Options options) {
+  return MakeSessionsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/sessions_connection.h
+++ b/google/cloud/dialogflow_cx/sessions_connection.h
@@ -108,9 +108,9 @@ std::shared_ptr<SessionsConnection> MakeSessionsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/sessions_connection.h
+++ b/google/cloud/dialogflow_cx/sessions_connection.h
@@ -29,6 +29,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -86,10 +87,9 @@ class SessionsConnection {
  * A factory function to construct an object of type `SessionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of SessionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of SessionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SessionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -97,12 +97,22 @@ class SessionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::SessionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `SessionsConnection` created by
  * this function.
+ */
+std::shared_ptr<SessionsConnection> MakeSessionsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<SessionsConnection> MakeSessionsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/test_cases_connection.cc
+++ b/google/cloud/dialogflow_cx/test_cases_connection.cc
@@ -117,15 +117,21 @@ TestCasesConnection::GetTestCaseResult(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(Options options) {
+std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  TestCasesPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::TestCasesDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::TestCasesDefaultOptions(location,
+                                                            std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultTestCasesStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::TestCasesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(Options options) {
+  return MakeTestCasesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/test_cases_connection.h
+++ b/google/cloud/dialogflow_cx/test_cases_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -123,10 +124,9 @@ class TestCasesConnection {
  * A factory function to construct an object of type `TestCasesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of TestCasesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of TestCasesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TestCasesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -134,12 +134,22 @@ class TestCasesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::TestCasesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `TestCasesConnection` created by
  * this function.
+ */
+std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/test_cases_connection.h
+++ b/google/cloud/dialogflow_cx/test_cases_connection.h
@@ -145,9 +145,9 @@ std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/transition_route_groups_connection.cc
+++ b/google/cloud/dialogflow_cx/transition_route_groups_connection.cc
@@ -69,18 +69,24 @@ Status TransitionRouteGroupsConnection::DeleteTransitionRouteGroup(
 }
 
 std::shared_ptr<TransitionRouteGroupsConnection>
-MakeTransitionRouteGroupsConnection(Options options) {
+MakeTransitionRouteGroupsConnection(std::string const& location,
+                                    Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  TransitionRouteGroupsPolicyOptionList>(
       options, __func__);
   options = dialogflow_cx_internal::TransitionRouteGroupsDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultTransitionRouteGroupsStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_cx_internal::TransitionRouteGroupsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<TransitionRouteGroupsConnection>
+MakeTransitionRouteGroupsConnection(Options options) {
+  return MakeTransitionRouteGroupsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/transition_route_groups_connection.h
+++ b/google/cloud/dialogflow_cx/transition_route_groups_connection.h
@@ -119,9 +119,9 @@ MakeTransitionRouteGroupsConnection(std::string const& location,
                                     Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/transition_route_groups_connection.h
+++ b/google/cloud/dialogflow_cx/transition_route_groups_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -96,9 +97,9 @@ class TransitionRouteGroupsConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * TransitionRouteGroupsClient, and that class used instead.
+ * TransitionRouteGroupsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TransitionRouteGroupsConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -106,12 +107,23 @@ class TransitionRouteGroupsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::TransitionRouteGroupsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `TransitionRouteGroupsConnection`
  * created by this function.
+ */
+std::shared_ptr<TransitionRouteGroupsConnection>
+MakeTransitionRouteGroupsConnection(std::string const& location,
+                                    Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<TransitionRouteGroupsConnection>
 MakeTransitionRouteGroupsConnection(Options options = {});

--- a/google/cloud/dialogflow_cx/versions_connection.cc
+++ b/google/cloud/dialogflow_cx/versions_connection.cc
@@ -79,15 +79,21 @@ VersionsConnection::CompareVersions(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<VersionsConnection> MakeVersionsConnection(Options options) {
+std::shared_ptr<VersionsConnection> MakeVersionsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  VersionsPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::VersionsDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::VersionsDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultVersionsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::VersionsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<VersionsConnection> MakeVersionsConnection(Options options) {
+  return MakeVersionsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/versions_connection.h
+++ b/google/cloud/dialogflow_cx/versions_connection.h
@@ -116,9 +116,9 @@ std::shared_ptr<VersionsConnection> MakeVersionsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_cx/versions_connection.h
+++ b/google/cloud/dialogflow_cx/versions_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -94,10 +95,9 @@ class VersionsConnection {
  * A factory function to construct an object of type `VersionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of VersionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of VersionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VersionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -105,12 +105,22 @@ class VersionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::VersionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `VersionsConnection` created by
  * this function.
+ */
+std::shared_ptr<VersionsConnection> MakeVersionsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<VersionsConnection> MakeVersionsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/webhooks_connection.cc
+++ b/google/cloud/dialogflow_cx/webhooks_connection.cc
@@ -65,15 +65,21 @@ Status WebhooksConnection::DeleteWebhook(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(Options options) {
+std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  WebhooksPolicyOptionList>(options, __func__);
-  options = dialogflow_cx_internal::WebhooksDefaultOptions(std::move(options));
+  options = dialogflow_cx_internal::WebhooksDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_cx_internal::CreateDefaultWebhooksStub(
       background->cq(), options);
   return std::make_shared<dialogflow_cx_internal::WebhooksConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(Options options) {
+  return MakeWebhooksConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_cx/webhooks_connection.h
+++ b/google/cloud/dialogflow_cx/webhooks_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -83,10 +84,9 @@ class WebhooksConnection {
  * A factory function to construct an object of type `WebhooksConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of WebhooksClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of WebhooksClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `WebhooksConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,12 +94,22 @@ class WebhooksConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_cx::WebhooksPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `WebhooksConnection` created by
  * this function.
+ */
+std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(
     Options options = {});

--- a/google/cloud/dialogflow_cx/webhooks_connection.h
+++ b/google/cloud/dialogflow_cx/webhooks_connection.h
@@ -105,9 +105,9 @@ std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/agents_connection.cc
+++ b/google/cloud/dialogflow_es/agents_connection.cc
@@ -89,15 +89,21 @@ AgentsConnection::GetValidationResult(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<AgentsConnection> MakeAgentsConnection(Options options) {
+std::shared_ptr<AgentsConnection> MakeAgentsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  AgentsPolicyOptionList>(options, __func__);
-  options = dialogflow_es_internal::AgentsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::AgentsDefaultOptions(location,
+                                                         std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultAgentsStub(background->cq(),
                                                               options);
   return std::make_shared<dialogflow_es_internal::AgentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<AgentsConnection> MakeAgentsConnection(Options options) {
+  return MakeAgentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/agents_connection.h
+++ b/google/cloud/dialogflow_es/agents_connection.h
@@ -121,9 +121,9 @@ std::shared_ptr<AgentsConnection> MakeAgentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/agents_connection.h
+++ b/google/cloud/dialogflow_es/agents_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -99,10 +100,9 @@ class AgentsConnection {
  * A factory function to construct an object of type `AgentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AgentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AgentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AgentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -110,12 +110,22 @@ class AgentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::AgentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `AgentsConnection` created by
  * this function.
+ */
+std::shared_ptr<AgentsConnection> MakeAgentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<AgentsConnection> MakeAgentsConnection(Options options = {});
 

--- a/google/cloud/dialogflow_es/answer_records_connection.cc
+++ b/google/cloud/dialogflow_es/answer_records_connection.cc
@@ -49,17 +49,22 @@ AnswerRecordsConnection::UpdateAnswerRecord(
 }
 
 std::shared_ptr<AnswerRecordsConnection> MakeAnswerRecordsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  AnswerRecordsPolicyOptionList>(options,
                                                                 __func__);
-  options =
-      dialogflow_es_internal::AnswerRecordsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::AnswerRecordsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultAnswerRecordsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::AnswerRecordsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<AnswerRecordsConnection> MakeAnswerRecordsConnection(
+    Options options) {
+  return MakeAnswerRecordsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/answer_records_connection.h
+++ b/google/cloud/dialogflow_es/answer_records_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -77,10 +78,9 @@ class AnswerRecordsConnection {
  * A factory function to construct an object of type `AnswerRecordsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AnswerRecordsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AnswerRecordsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AnswerRecordsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -88,12 +88,22 @@ class AnswerRecordsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::AnswerRecordsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `AnswerRecordsConnection` created by
  * this function.
+ */
+std::shared_ptr<AnswerRecordsConnection> MakeAnswerRecordsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<AnswerRecordsConnection> MakeAnswerRecordsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/answer_records_connection.h
+++ b/google/cloud/dialogflow_es/answer_records_connection.h
@@ -99,9 +99,9 @@ std::shared_ptr<AnswerRecordsConnection> MakeAnswerRecordsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/contexts_connection.cc
+++ b/google/cloud/dialogflow_es/contexts_connection.cc
@@ -69,15 +69,21 @@ Status ContextsConnection::DeleteAllContexts(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<ContextsConnection> MakeContextsConnection(Options options) {
+std::shared_ptr<ContextsConnection> MakeContextsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ContextsPolicyOptionList>(options, __func__);
-  options = dialogflow_es_internal::ContextsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::ContextsDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultContextsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::ContextsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ContextsConnection> MakeContextsConnection(Options options) {
+  return MakeContextsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/contexts_connection.h
+++ b/google/cloud/dialogflow_es/contexts_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -86,10 +87,9 @@ class ContextsConnection {
  * A factory function to construct an object of type `ContextsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ContextsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ContextsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ContextsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -97,12 +97,22 @@ class ContextsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::ContextsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ContextsConnection` created by
  * this function.
+ */
+std::shared_ptr<ContextsConnection> MakeContextsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ContextsConnection> MakeContextsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/contexts_connection.h
+++ b/google/cloud/dialogflow_es/contexts_connection.h
@@ -108,9 +108,9 @@ std::shared_ptr<ContextsConnection> MakeContextsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/conversation_datasets_connection.cc
+++ b/google/cloud/dialogflow_es/conversation_datasets_connection.cc
@@ -76,18 +76,24 @@ ConversationDatasetsConnection::ImportConversationData(
 }
 
 std::shared_ptr<ConversationDatasetsConnection>
-MakeConversationDatasetsConnection(Options options) {
+MakeConversationDatasetsConnection(std::string const& location,
+                                   Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ConversationDatasetsPolicyOptionList>(
       options, __func__);
   options = dialogflow_es_internal::ConversationDatasetsDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultConversationDatasetsStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_es_internal::ConversationDatasetsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ConversationDatasetsConnection>
+MakeConversationDatasetsConnection(Options options) {
+  return MakeConversationDatasetsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/conversation_datasets_connection.h
+++ b/google/cloud/dialogflow_es/conversation_datasets_connection.h
@@ -123,9 +123,9 @@ MakeConversationDatasetsConnection(std::string const& location,
                                    Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/conversation_datasets_connection.h
+++ b/google/cloud/dialogflow_es/conversation_datasets_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -100,9 +101,9 @@ class ConversationDatasetsConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ConversationDatasetsClient, and that class used instead.
+ * ConversationDatasetsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ConversationDatasetsConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -110,12 +111,23 @@ class ConversationDatasetsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::ConversationDatasetsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ConversationDatasetsConnection`
  * created by this function.
+ */
+std::shared_ptr<ConversationDatasetsConnection>
+MakeConversationDatasetsConnection(std::string const& location,
+                                   Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ConversationDatasetsConnection>
 MakeConversationDatasetsConnection(Options options = {});

--- a/google/cloud/dialogflow_es/conversation_models_connection.cc
+++ b/google/cloud/dialogflow_es/conversation_models_connection.cc
@@ -109,18 +109,23 @@ ConversationModelsConnection::CreateConversationModelEvaluation(
 }
 
 std::shared_ptr<ConversationModelsConnection> MakeConversationModelsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ConversationModelsPolicyOptionList>(options,
                                                                      __func__);
   options = dialogflow_es_internal::ConversationModelsDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultConversationModelsStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_es_internal::ConversationModelsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ConversationModelsConnection> MakeConversationModelsConnection(
+    Options options) {
+  return MakeConversationModelsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/conversation_models_connection.h
+++ b/google/cloud/dialogflow_es/conversation_models_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -123,9 +124,9 @@ class ConversationModelsConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ConversationModelsClient, and that class used instead.
+ * ConversationModelsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ConversationModelsConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -133,12 +134,22 @@ class ConversationModelsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::ConversationModelsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ConversationModelsConnection`
  * created by this function.
+ */
+std::shared_ptr<ConversationModelsConnection> MakeConversationModelsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ConversationModelsConnection> MakeConversationModelsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/conversation_models_connection.h
+++ b/google/cloud/dialogflow_es/conversation_models_connection.h
@@ -145,9 +145,9 @@ std::shared_ptr<ConversationModelsConnection> MakeConversationModelsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/conversation_profiles_connection.cc
+++ b/google/cloud/dialogflow_es/conversation_profiles_connection.cc
@@ -82,18 +82,24 @@ ConversationProfilesConnection::ClearSuggestionFeatureConfig(
 }
 
 std::shared_ptr<ConversationProfilesConnection>
-MakeConversationProfilesConnection(Options options) {
+MakeConversationProfilesConnection(std::string const& location,
+                                   Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ConversationProfilesPolicyOptionList>(
       options, __func__);
   options = dialogflow_es_internal::ConversationProfilesDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultConversationProfilesStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_es_internal::ConversationProfilesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ConversationProfilesConnection>
+MakeConversationProfilesConnection(Options options) {
+  return MakeConversationProfilesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/conversation_profiles_connection.h
+++ b/google/cloud/dialogflow_es/conversation_profiles_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -107,9 +108,9 @@ class ConversationProfilesConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ConversationProfilesClient, and that class used instead.
+ * ConversationProfilesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ConversationProfilesConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -117,12 +118,23 @@ class ConversationProfilesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::ConversationProfilesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ConversationProfilesConnection`
  * created by this function.
+ */
+std::shared_ptr<ConversationProfilesConnection>
+MakeConversationProfilesConnection(std::string const& location,
+                                   Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ConversationProfilesConnection>
 MakeConversationProfilesConnection(Options options = {});

--- a/google/cloud/dialogflow_es/conversation_profiles_connection.h
+++ b/google/cloud/dialogflow_es/conversation_profiles_connection.h
@@ -130,9 +130,9 @@ MakeConversationProfilesConnection(std::string const& location,
                                    Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/conversations_connection.cc
+++ b/google/cloud/dialogflow_es/conversations_connection.cc
@@ -69,17 +69,22 @@ ConversationsConnection::ListMessages(
 }
 
 std::shared_ptr<ConversationsConnection> MakeConversationsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ConversationsPolicyOptionList>(options,
                                                                 __func__);
-  options =
-      dialogflow_es_internal::ConversationsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::ConversationsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultConversationsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::ConversationsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ConversationsConnection> MakeConversationsConnection(
+    Options options) {
+  return MakeConversationsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/conversations_connection.h
+++ b/google/cloud/dialogflow_es/conversations_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -88,10 +89,9 @@ class ConversationsConnection {
  * A factory function to construct an object of type `ConversationsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ConversationsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ConversationsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ConversationsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -99,12 +99,22 @@ class ConversationsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::ConversationsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ConversationsConnection` created by
  * this function.
+ */
+std::shared_ptr<ConversationsConnection> MakeConversationsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ConversationsConnection> MakeConversationsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/conversations_connection.h
+++ b/google/cloud/dialogflow_es/conversations_connection.h
@@ -110,9 +110,9 @@ std::shared_ptr<ConversationsConnection> MakeConversationsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/doc/main.dox
+++ b/google/cloud/dialogflow_es/doc/main.dox
@@ -44,71 +44,71 @@ which should give you a taste of the Dialogflow API C++ client library API.
 <!-- inject-endpoint-env-vars-start -->
 
 - `GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeAgentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_ANSWER_RECORDS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeAnswerRecordsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CONTEXTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeContextsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeConversationDatasetsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CONVERSATION_MODELS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeConversationModelsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CONVERSATION_PROFILES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeConversationProfilesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeConversationsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DOCUMENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeDocumentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeEntityTypesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeEnvironmentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_FULFILLMENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeFulfillmentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeIntentsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_KNOWLEDGE_BASES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeKnowledgeBasesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_PARTICIPANTS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeParticipantsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSessionEntityTypesConnection()`.
 
 - `GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeSessionsConnection()`.
 
 - `GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dialogflow.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dialogflow.googleapis.com")
   used by `MakeVersionsConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->

--- a/google/cloud/dialogflow_es/documents_connection.cc
+++ b/google/cloud/dialogflow_es/documents_connection.cc
@@ -96,15 +96,21 @@ DocumentsConnection::ExportDocument(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(Options options) {
+std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  DocumentsPolicyOptionList>(options, __func__);
-  options = dialogflow_es_internal::DocumentsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::DocumentsDefaultOptions(location,
+                                                            std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultDocumentsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::DocumentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(Options options) {
+  return MakeDocumentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/documents_connection.h
+++ b/google/cloud/dialogflow_es/documents_connection.h
@@ -125,9 +125,9 @@ std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/documents_connection.h
+++ b/google/cloud/dialogflow_es/documents_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -103,10 +104,9 @@ class DocumentsConnection {
  * A factory function to construct an object of type `DocumentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DocumentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DocumentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DocumentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -114,12 +114,22 @@ class DocumentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::DocumentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `DocumentsConnection` created by
  * this function.
+ */
+std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/entity_types_connection.cc
+++ b/google/cloud/dialogflow_es/entity_types_connection.cc
@@ -102,17 +102,22 @@ EntityTypesConnection::BatchDeleteEntities(
 }
 
 std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  EntityTypesPolicyOptionList>(options,
                                                               __func__);
-  options =
-      dialogflow_es_internal::EntityTypesDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::EntityTypesDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultEntityTypesStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::EntityTypesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
+    Options options) {
+  return MakeEntityTypesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/entity_types_connection.h
+++ b/google/cloud/dialogflow_es/entity_types_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -106,10 +107,9 @@ class EntityTypesConnection {
  * A factory function to construct an object of type `EntityTypesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EntityTypesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EntityTypesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EntityTypesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -117,12 +117,22 @@ class EntityTypesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::EntityTypesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `EntityTypesConnection` created by
  * this function.
+ */
+std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/entity_types_connection.h
+++ b/google/cloud/dialogflow_es/entity_types_connection.h
@@ -128,9 +128,9 @@ std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/environments_connection.cc
+++ b/google/cloud/dialogflow_es/environments_connection.cc
@@ -74,17 +74,22 @@ EnvironmentsConnection::GetEnvironmentHistory(
 }
 
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  EnvironmentsPolicyOptionList>(options,
                                                                __func__);
-  options =
-      dialogflow_es_internal::EnvironmentsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::EnvironmentsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultEnvironmentsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::EnvironmentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
+    Options options) {
+  return MakeEnvironmentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/environments_connection.h
+++ b/google/cloud/dialogflow_es/environments_connection.h
@@ -113,9 +113,9 @@ std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/environments_connection.h
+++ b/google/cloud/dialogflow_es/environments_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -91,10 +92,9 @@ class EnvironmentsConnection {
  * A factory function to construct an object of type `EnvironmentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EnvironmentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EnvironmentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EnvironmentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -102,12 +102,22 @@ class EnvironmentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::EnvironmentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `EnvironmentsConnection` created by
  * this function.
+ */
+std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/fulfillments_connection.cc
+++ b/google/cloud/dialogflow_es/fulfillments_connection.cc
@@ -46,17 +46,22 @@ FulfillmentsConnection::UpdateFulfillment(
 }
 
 std::shared_ptr<FulfillmentsConnection> MakeFulfillmentsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  FulfillmentsPolicyOptionList>(options,
                                                                __func__);
-  options =
-      dialogflow_es_internal::FulfillmentsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::FulfillmentsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultFulfillmentsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::FulfillmentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<FulfillmentsConnection> MakeFulfillmentsConnection(
+    Options options) {
+  return MakeFulfillmentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/fulfillments_connection.h
+++ b/google/cloud/dialogflow_es/fulfillments_connection.h
@@ -97,9 +97,9 @@ std::shared_ptr<FulfillmentsConnection> MakeFulfillmentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/fulfillments_connection.h
+++ b/google/cloud/dialogflow_es/fulfillments_connection.h
@@ -27,6 +27,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -75,10 +76,9 @@ class FulfillmentsConnection {
  * A factory function to construct an object of type `FulfillmentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of FulfillmentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of FulfillmentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `FulfillmentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -86,12 +86,22 @@ class FulfillmentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::FulfillmentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `FulfillmentsConnection` created by
  * this function.
+ */
+std::shared_ptr<FulfillmentsConnection> MakeFulfillmentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<FulfillmentsConnection> MakeFulfillmentsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/intents_connection.cc
+++ b/google/cloud/dialogflow_es/intents_connection.cc
@@ -77,15 +77,21 @@ IntentsConnection::BatchDeleteIntents(
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-std::shared_ptr<IntentsConnection> MakeIntentsConnection(Options options) {
+std::shared_ptr<IntentsConnection> MakeIntentsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  IntentsPolicyOptionList>(options, __func__);
-  options = dialogflow_es_internal::IntentsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::IntentsDefaultOptions(location,
+                                                          std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultIntentsStub(background->cq(),
                                                                options);
   return std::make_shared<dialogflow_es_internal::IntentsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<IntentsConnection> MakeIntentsConnection(Options options) {
+  return MakeIntentsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/intents_connection.h
+++ b/google/cloud/dialogflow_es/intents_connection.h
@@ -116,9 +116,9 @@ std::shared_ptr<IntentsConnection> MakeIntentsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/intents_connection.h
+++ b/google/cloud/dialogflow_es/intents_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -94,10 +95,9 @@ class IntentsConnection {
  * A factory function to construct an object of type `IntentsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IntentsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IntentsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IntentsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -105,12 +105,22 @@ class IntentsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::IntentsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `IntentsConnection` created by
  * this function.
+ */
+std::shared_ptr<IntentsConnection> MakeIntentsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<IntentsConnection> MakeIntentsConnection(Options options = {});
 

--- a/google/cloud/dialogflow_es/internal/agents_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/agents_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/agents_option_defaults.h"
 #include "google/cloud/dialogflow_es/agents_connection.h"
 #include "google/cloud/dialogflow_es/agents_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options AgentsDefaultOptions(Options options) {
+Options AgentsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_AGENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_AGENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_AGENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::AgentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/agents_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/agents_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options AgentsDefaultOptions(Options options);
+Options AgentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/answer_records_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/answer_records_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/answer_records_option_defaults.h"
 #include "google/cloud/dialogflow_es/answer_records_connection.h"
 #include "google/cloud/dialogflow_es/answer_records_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options AnswerRecordsDefaultOptions(Options options) {
+Options AnswerRecordsDefaultOptions(std::string const& location,
+                                    Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_ANSWER_RECORDS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_ANSWER_RECORDS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_ANSWER_RECORDS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::AnswerRecordsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/answer_records_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/answer_records_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options AnswerRecordsDefaultOptions(Options options);
+Options AnswerRecordsDefaultOptions(std::string const& location,
+                                    Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/contexts_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/contexts_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/contexts_option_defaults.h"
 #include "google/cloud/dialogflow_es/contexts_connection.h"
 #include "google/cloud/dialogflow_es/contexts_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ContextsDefaultOptions(Options options) {
+Options ContextsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CONTEXTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_CONTEXTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_CONTEXTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::ContextsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/contexts_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/contexts_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ContextsDefaultOptions(Options options);
+Options ContextsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/conversation_datasets_option_defaults.h"
 #include "google/cloud/dialogflow_es/conversation_datasets_connection.h"
 #include "google/cloud/dialogflow_es/conversation_datasets_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ConversationDatasetsDefaultOptions(Options options) {
+Options ConversationDatasetsDefaultOptions(std::string const& location,
+                                           Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_CONVERSATION_DATASETS_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::ConversationDatasetsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/conversation_datasets_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/conversation_datasets_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ConversationDatasetsDefaultOptions(Options options);
+Options ConversationDatasetsDefaultOptions(std::string const& location,
+                                           Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/conversation_models_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_models_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/conversation_models_option_defaults.h"
 #include "google/cloud/dialogflow_es/conversation_models_connection.h"
 #include "google/cloud/dialogflow_es/conversation_models_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ConversationModelsDefaultOptions(Options options) {
+Options ConversationModelsDefaultOptions(std::string const& location,
+                                         Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CONVERSATION_MODELS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_CONVERSATION_MODELS_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::ConversationModelsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/conversation_models_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/conversation_models_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ConversationModelsDefaultOptions(Options options);
+Options ConversationModelsDefaultOptions(std::string const& location,
+                                         Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/conversation_profiles_option_defaults.h"
 #include "google/cloud/dialogflow_es/conversation_profiles_connection.h"
 #include "google/cloud/dialogflow_es/conversation_profiles_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ConversationProfilesDefaultOptions(Options options) {
+Options ConversationProfilesDefaultOptions(std::string const& location,
+                                           Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CONVERSATION_PROFILES_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_CONVERSATION_PROFILES_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::ConversationProfilesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/conversation_profiles_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/conversation_profiles_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ConversationProfilesDefaultOptions(Options options);
+Options ConversationProfilesDefaultOptions(std::string const& location,
+                                           Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/conversations_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/conversations_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/conversations_option_defaults.h"
 #include "google/cloud/dialogflow_es/conversations_connection.h"
 #include "google/cloud/dialogflow_es/conversations_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ConversationsDefaultOptions(Options options) {
+Options ConversationsDefaultOptions(std::string const& location,
+                                    Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CONVERSATIONS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_CONVERSATIONS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_CONVERSATIONS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::ConversationsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/conversations_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/conversations_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ConversationsDefaultOptions(Options options);
+Options ConversationsDefaultOptions(std::string const& location,
+                                    Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/documents_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/documents_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/documents_option_defaults.h"
 #include "google/cloud/dialogflow_es/documents_connection.h"
 #include "google/cloud/dialogflow_es/documents_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options DocumentsDefaultOptions(Options options) {
+Options DocumentsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_DOCUMENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_DOCUMENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_DOCUMENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::DocumentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/documents_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/documents_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options DocumentsDefaultOptions(Options options);
+Options DocumentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/entity_types_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/entity_types_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/entity_types_option_defaults.h"
 #include "google/cloud/dialogflow_es/entity_types_connection.h"
 #include "google/cloud/dialogflow_es/entity_types_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options EntityTypesDefaultOptions(Options options) {
+Options EntityTypesDefaultOptions(std::string const& location,
+                                  Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_ENTITY_TYPES_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_ENTITY_TYPES_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_ENTITY_TYPES_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::EntityTypesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/entity_types_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/entity_types_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options EntityTypesDefaultOptions(Options options);
+Options EntityTypesDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/environments_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/environments_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/environments_option_defaults.h"
 #include "google/cloud/dialogflow_es/environments_connection.h"
 #include "google/cloud/dialogflow_es/environments_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options EnvironmentsDefaultOptions(Options options) {
+Options EnvironmentsDefaultOptions(std::string const& location,
+                                   Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_DIALOGFLOW_ENVIRONMENTS_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::EnvironmentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/environments_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/environments_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options EnvironmentsDefaultOptions(Options options);
+Options EnvironmentsDefaultOptions(std::string const& location,
+                                   Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/fulfillments_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/fulfillments_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/fulfillments_option_defaults.h"
 #include "google/cloud/dialogflow_es/fulfillments_connection.h"
 #include "google/cloud/dialogflow_es/fulfillments_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options FulfillmentsDefaultOptions(Options options) {
+Options FulfillmentsDefaultOptions(std::string const& location,
+                                   Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_FULFILLMENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_FULFILLMENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_FULFILLMENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::FulfillmentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/fulfillments_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/fulfillments_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options FulfillmentsDefaultOptions(Options options);
+Options FulfillmentsDefaultOptions(std::string const& location,
+                                   Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/intents_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/intents_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/intents_option_defaults.h"
 #include "google/cloud/dialogflow_es/intents_connection.h"
 #include "google/cloud/dialogflow_es/intents_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options IntentsDefaultOptions(Options options) {
+Options IntentsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_INTENTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_INTENTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_INTENTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::IntentsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/intents_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/intents_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options IntentsDefaultOptions(Options options);
+Options IntentsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/knowledge_bases_option_defaults.h"
 #include "google/cloud/dialogflow_es/knowledge_bases_connection.h"
 #include "google/cloud/dialogflow_es/knowledge_bases_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options KnowledgeBasesDefaultOptions(Options options) {
+Options KnowledgeBasesDefaultOptions(std::string const& location,
+                                     Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_KNOWLEDGE_BASES_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_KNOWLEDGE_BASES_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::KnowledgeBasesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/knowledge_bases_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/knowledge_bases_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options KnowledgeBasesDefaultOptions(Options options);
+Options KnowledgeBasesDefaultOptions(std::string const& location,
+                                     Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/participants_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/participants_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/participants_option_defaults.h"
 #include "google/cloud/dialogflow_es/participants_connection.h"
 #include "google/cloud/dialogflow_es/participants_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ParticipantsDefaultOptions(Options options) {
+Options ParticipantsDefaultOptions(std::string const& location,
+                                   Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_PARTICIPANTS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_PARTICIPANTS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_PARTICIPANTS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::ParticipantsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/participants_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/participants_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ParticipantsDefaultOptions(Options options);
+Options ParticipantsDefaultOptions(std::string const& location,
+                                   Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/session_entity_types_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/session_entity_types_option_defaults.h"
 #include "google/cloud/dialogflow_es/session_entity_types_connection.h"
 #include "google/cloud/dialogflow_es/session_entity_types_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options SessionEntityTypesDefaultOptions(Options options) {
+Options SessionEntityTypesDefaultOptions(std::string const& location,
+                                         Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_SESSION_ENTITY_TYPES_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::SessionEntityTypesRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/session_entity_types_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/session_entity_types_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options SessionEntityTypesDefaultOptions(Options options);
+Options SessionEntityTypesDefaultOptions(std::string const& location,
+                                         Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/sessions_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/sessions_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/sessions_option_defaults.h"
 #include "google/cloud/dialogflow_es/sessions_connection.h"
 #include "google/cloud/dialogflow_es/sessions_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options SessionsDefaultOptions(Options options) {
+Options SessionsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_SESSIONS_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_SESSIONS_AUTHORITY", "dialogflow.googleapis.com");
+      "GOOGLE_CLOUD_CPP_SESSIONS_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::SessionsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/sessions_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/sessions_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options SessionsDefaultOptions(Options options);
+Options SessionsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/internal/versions_option_defaults.cc
+++ b/google/cloud/dialogflow_es/internal/versions_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dialogflow_es/internal/versions_option_defaults.h"
 #include "google/cloud/dialogflow_es/versions_connection.h"
 #include "google/cloud/dialogflow_es/versions_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,12 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options VersionsDefaultOptions(Options options) {
+Options VersionsDefaultOptions(std::string const& location, Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_DIALOGFLOW_VERSIONS_AUTHORITY",
-      "dialogflow.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dialogflow.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dialogflow_es::VersionsRetryPolicyOption>()) {

--- a/google/cloud/dialogflow_es/internal/versions_option_defaults.h
+++ b/google/cloud/dialogflow_es/internal/versions_option_defaults.h
@@ -21,13 +21,14 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dialogflow_es_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options VersionsDefaultOptions(Options options);
+Options VersionsDefaultOptions(std::string const& location, Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dialogflow_es_internal

--- a/google/cloud/dialogflow_es/knowledge_bases_connection.cc
+++ b/google/cloud/dialogflow_es/knowledge_bases_connection.cc
@@ -66,17 +66,22 @@ KnowledgeBasesConnection::UpdateKnowledgeBase(
 }
 
 std::shared_ptr<KnowledgeBasesConnection> MakeKnowledgeBasesConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  KnowledgeBasesPolicyOptionList>(options,
                                                                  __func__);
-  options =
-      dialogflow_es_internal::KnowledgeBasesDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::KnowledgeBasesDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultKnowledgeBasesStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::KnowledgeBasesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<KnowledgeBasesConnection> MakeKnowledgeBasesConnection(
+    Options options) {
+  return MakeKnowledgeBasesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/knowledge_bases_connection.h
+++ b/google/cloud/dialogflow_es/knowledge_bases_connection.h
@@ -110,9 +110,9 @@ std::shared_ptr<KnowledgeBasesConnection> MakeKnowledgeBasesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/knowledge_bases_connection.h
+++ b/google/cloud/dialogflow_es/knowledge_bases_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -88,10 +89,9 @@ class KnowledgeBasesConnection {
  * A factory function to construct an object of type `KnowledgeBasesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of KnowledgeBasesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of KnowledgeBasesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `KnowledgeBasesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -99,12 +99,22 @@ class KnowledgeBasesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::KnowledgeBasesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `KnowledgeBasesConnection` created by
  * this function.
+ */
+std::shared_ptr<KnowledgeBasesConnection> MakeKnowledgeBasesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<KnowledgeBasesConnection> MakeKnowledgeBasesConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/participants_connection.cc
+++ b/google/cloud/dialogflow_es/participants_connection.cc
@@ -85,17 +85,22 @@ ParticipantsConnection::SuggestSmartReplies(
 }
 
 std::shared_ptr<ParticipantsConnection> MakeParticipantsConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  ParticipantsPolicyOptionList>(options,
                                                                __func__);
-  options =
-      dialogflow_es_internal::ParticipantsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::ParticipantsDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultParticipantsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::ParticipantsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ParticipantsConnection> MakeParticipantsConnection(
+    Options options) {
+  return MakeParticipantsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/participants_connection.h
+++ b/google/cloud/dialogflow_es/participants_connection.h
@@ -122,9 +122,9 @@ std::shared_ptr<ParticipantsConnection> MakeParticipantsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/participants_connection.h
+++ b/google/cloud/dialogflow_es/participants_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -100,10 +101,9 @@ class ParticipantsConnection {
  * A factory function to construct an object of type `ParticipantsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ParticipantsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ParticipantsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ParticipantsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -111,12 +111,22 @@ class ParticipantsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::ParticipantsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ParticipantsConnection` created by
  * this function.
+ */
+std::shared_ptr<ParticipantsConnection> MakeParticipantsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ParticipantsConnection> MakeParticipantsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/session_entity_types_connection.cc
+++ b/google/cloud/dialogflow_es/session_entity_types_connection.cc
@@ -66,18 +66,23 @@ Status SessionEntityTypesConnection::DeleteSessionEntityType(
 }
 
 std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  SessionEntityTypesPolicyOptionList>(options,
                                                                      __func__);
   options = dialogflow_es_internal::SessionEntityTypesDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultSessionEntityTypesStub(
       background->cq(), options);
   return std::make_shared<
       dialogflow_es_internal::SessionEntityTypesConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
+    Options options) {
+  return MakeSessionEntityTypesConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/session_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/session_entity_types_connection.h
@@ -116,9 +116,9 @@ std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/session_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/session_entity_types_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -94,9 +95,9 @@ class SessionEntityTypesConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * SessionEntityTypesClient, and that class used instead.
+ * SessionEntityTypesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SessionEntityTypesConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -104,12 +105,22 @@ class SessionEntityTypesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::SessionEntityTypesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `SessionEntityTypesConnection`
  * created by this function.
+ */
+std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/sessions_connection.cc
+++ b/google/cloud/dialogflow_es/sessions_connection.cc
@@ -50,15 +50,21 @@ SessionsConnection::AsyncStreamingDetectIntent(ExperimentalTag) {
       Status(StatusCode::kUnimplemented, "not implemented"));
 }
 
-std::shared_ptr<SessionsConnection> MakeSessionsConnection(Options options) {
+std::shared_ptr<SessionsConnection> MakeSessionsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  SessionsPolicyOptionList>(options, __func__);
-  options = dialogflow_es_internal::SessionsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::SessionsDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultSessionsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::SessionsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<SessionsConnection> MakeSessionsConnection(Options options) {
+  return MakeSessionsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/sessions_connection.h
+++ b/google/cloud/dialogflow_es/sessions_connection.h
@@ -100,9 +100,9 @@ std::shared_ptr<SessionsConnection> MakeSessionsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/sessions_connection.h
+++ b/google/cloud/dialogflow_es/sessions_connection.h
@@ -29,6 +29,7 @@
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -78,10 +79,9 @@ class SessionsConnection {
  * A factory function to construct an object of type `SessionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of SessionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of SessionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SessionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -89,12 +89,22 @@ class SessionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::SessionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `SessionsConnection` created by
  * this function.
+ */
+std::shared_ptr<SessionsConnection> MakeSessionsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<SessionsConnection> MakeSessionsConnection(
     Options options = {});

--- a/google/cloud/dialogflow_es/versions_connection.cc
+++ b/google/cloud/dialogflow_es/versions_connection.cc
@@ -64,15 +64,21 @@ Status VersionsConnection::DeleteVersion(
   return Status(StatusCode::kUnimplemented, "not implemented");
 }
 
-std::shared_ptr<VersionsConnection> MakeVersionsConnection(Options options) {
+std::shared_ptr<VersionsConnection> MakeVersionsConnection(
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  VersionsPolicyOptionList>(options, __func__);
-  options = dialogflow_es_internal::VersionsDefaultOptions(std::move(options));
+  options = dialogflow_es_internal::VersionsDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dialogflow_es_internal::CreateDefaultVersionsStub(
       background->cq(), options);
   return std::make_shared<dialogflow_es_internal::VersionsConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<VersionsConnection> MakeVersionsConnection(Options options) {
+  return MakeVersionsConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dialogflow_es/versions_connection.h
+++ b/google/cloud/dialogflow_es/versions_connection.h
@@ -105,9 +105,9 @@ std::shared_ptr<VersionsConnection> MakeVersionsConnection(
     std::string const& location, Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/dialogflow_es/versions_connection.h
+++ b/google/cloud/dialogflow_es/versions_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -83,10 +84,9 @@ class VersionsConnection {
  * A factory function to construct an object of type `VersionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of VersionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of VersionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VersionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,12 +94,22 @@ class VersionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dialogflow_es::VersionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `VersionsConnection` created by
  * this function.
+ */
+std::shared_ptr<VersionsConnection> MakeVersionsConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<VersionsConnection> MakeVersionsConnection(
     Options options = {});

--- a/google/cloud/dlp/dlp_connection.h
+++ b/google/cloud/dlp/dlp_connection.h
@@ -186,10 +186,9 @@ class DlpServiceConnection {
  * A factory function to construct an object of type `DlpServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DlpServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DlpServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DlpServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -197,9 +196,8 @@ class DlpServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::dlp::DlpServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DlpServiceConnection` created by
  * this function.

--- a/google/cloud/documentai/doc/main.dox
+++ b/google/cloud/documentai/doc/main.dox
@@ -42,7 +42,7 @@ which should give you a taste of the Cloud Document AI API C++ client library AP
 <!-- inject-endpoint-env-vars-start -->
 
 - `GOOGLE_CLOUD_CPP_DOCUMENT_PROCESSOR_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "documentai.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-documentai.googleapis.com")
   used by `MakeDocumentProcessorServiceConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->

--- a/google/cloud/documentai/document_processor_connection.cc
+++ b/google/cloud/documentai/document_processor_connection.cc
@@ -57,18 +57,25 @@ DocumentProcessorServiceConnection::ReviewDocument(
 }
 
 std::shared_ptr<DocumentProcessorServiceConnection>
-MakeDocumentProcessorServiceConnection(Options options) {
+MakeDocumentProcessorServiceConnection(std::string const& location,
+                                       Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  DocumentProcessorServicePolicyOptionList>(
       options, __func__);
   options = documentai_internal::DocumentProcessorServiceDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = documentai_internal::CreateDefaultDocumentProcessorServiceStub(
       background->cq(), options);
   return std::make_shared<
       documentai_internal::DocumentProcessorServiceConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<DocumentProcessorServiceConnection>
+MakeDocumentProcessorServiceConnection(Options options) {
+  return MakeDocumentProcessorServiceConnection(std::string{},
+                                                std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/documentai/document_processor_connection.h
+++ b/google/cloud/documentai/document_processor_connection.h
@@ -30,6 +30,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -87,9 +88,9 @@ class DocumentProcessorServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * DocumentProcessorServiceClient, and that class used instead.
+ * DocumentProcessorServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DocumentProcessorServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -97,12 +98,23 @@ class DocumentProcessorServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::documentai::DocumentProcessorServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `DocumentProcessorServiceConnection`
  * created by this function.
+ */
+std::shared_ptr<DocumentProcessorServiceConnection>
+MakeDocumentProcessorServiceConnection(std::string const& location,
+                                       Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function. The
+ * default value of the `EndpointOption` is useless in this case, and so
+ * must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<DocumentProcessorServiceConnection>
 MakeDocumentProcessorServiceConnection(Options options = {});

--- a/google/cloud/documentai/document_processor_connection.h
+++ b/google/cloud/documentai/document_processor_connection.h
@@ -110,9 +110,9 @@ MakeDocumentProcessorServiceConnection(std::string const& location,
                                        Options options = {});
 
 /**
- * A backwards-compatible version of the previous factory function. The
- * default value of the `EndpointOption` is useless in this case, and so
- * must be overridden.
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
  *
  * @deprecated Please use the `location` overload instead.
  */

--- a/google/cloud/documentai/internal/document_processor_option_defaults.cc
+++ b/google/cloud/documentai/internal/document_processor_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/documentai/internal/document_processor_option_defaults.h"
 #include "google/cloud/documentai/document_processor_connection.h"
 #include "google/cloud/documentai/document_processor_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,12 +33,14 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options DocumentProcessorServiceDefaultOptions(Options options) {
+Options DocumentProcessorServiceDefaultOptions(std::string const& location,
+                                               Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options),
       "GOOGLE_CLOUD_CPP_DOCUMENT_PROCESSOR_SERVICE_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_DOCUMENT_PROCESSOR_SERVICE_AUTHORITY",
-      "documentai.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "documentai.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<documentai::DocumentProcessorServiceRetryPolicyOption>()) {

--- a/google/cloud/documentai/internal/document_processor_option_defaults.h
+++ b/google/cloud/documentai/internal/document_processor_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace documentai_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options DocumentProcessorServiceDefaultOptions(Options options);
+Options DocumentProcessorServiceDefaultOptions(std::string const& location,
+                                               Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace documentai_internal

--- a/google/cloud/eventarc/eventarc_connection.h
+++ b/google/cloud/eventarc/eventarc_connection.h
@@ -125,10 +125,9 @@ class EventarcConnection {
  * A factory function to construct an object of type `EventarcConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EventarcClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EventarcClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EventarcConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -136,9 +135,8 @@ class EventarcConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::eventarc::EventarcPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `EventarcConnection` created by
  * this function.

--- a/google/cloud/eventarc/publisher_connection.h
+++ b/google/cloud/eventarc/publisher_connection.h
@@ -79,10 +79,9 @@ class PublisherConnection {
  * A factory function to construct an object of type `PublisherConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of PublisherClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of PublisherClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `PublisherConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -90,9 +89,8 @@ class PublisherConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::eventarc::PublisherPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `PublisherConnection` created by
  * this function.

--- a/google/cloud/filestore/cloud_filestore_manager_connection.h
+++ b/google/cloud/filestore/cloud_filestore_manager_connection.h
@@ -113,9 +113,9 @@ class CloudFilestoreManagerConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * CloudFilestoreManagerClient, and that class used instead.
+ * CloudFilestoreManagerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudFilestoreManagerConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -123,9 +123,8 @@ class CloudFilestoreManagerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::filestore::CloudFilestoreManagerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudFilestoreManagerConnection`
  * created by this function.

--- a/google/cloud/functions/cloud_functions_connection.h
+++ b/google/cloud/functions/cloud_functions_connection.h
@@ -114,9 +114,9 @@ class CloudFunctionsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * CloudFunctionsServiceClient, and that class used instead.
+ * CloudFunctionsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudFunctionsServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -124,9 +124,8 @@ class CloudFunctionsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::functions::CloudFunctionsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudFunctionsServiceConnection`
  * created by this function.

--- a/google/cloud/gameservices/game_server_clusters_connection.h
+++ b/google/cloud/gameservices/game_server_clusters_connection.h
@@ -115,9 +115,9 @@ class GameServerClustersServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * GameServerClustersServiceClient, and that class used instead.
+ * GameServerClustersServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GameServerClustersServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -125,9 +125,8 @@ class GameServerClustersServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::gameservices::GameServerClustersServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GameServerClustersServiceConnection`
  * created by this function.

--- a/google/cloud/gameservices/game_server_configs_connection.h
+++ b/google/cloud/gameservices/game_server_configs_connection.h
@@ -93,9 +93,9 @@ class GameServerConfigsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * GameServerConfigsServiceClient, and that class used instead.
+ * GameServerConfigsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GameServerConfigsServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -103,9 +103,8 @@ class GameServerConfigsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::gameservices::GameServerConfigsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GameServerConfigsServiceConnection`
  * created by this function.

--- a/google/cloud/gameservices/game_server_deployments_connection.h
+++ b/google/cloud/gameservices/game_server_deployments_connection.h
@@ -120,9 +120,9 @@ class GameServerDeploymentsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * GameServerDeploymentsServiceClient, and that class used instead.
+ * GameServerDeploymentsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GameServerDeploymentsServiceConnection`. Expected options are any
  * of the types in the following option lists:
  *
@@ -130,9 +130,8 @@ class GameServerDeploymentsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::gameservices::GameServerDeploymentsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `GameServerDeploymentsServiceConnection` created by this function.

--- a/google/cloud/gameservices/realms_connection.h
+++ b/google/cloud/gameservices/realms_connection.h
@@ -91,10 +91,9 @@ class RealmsServiceConnection {
  * A factory function to construct an object of type `RealmsServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of RealmsServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of RealmsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `RealmsServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -102,9 +101,8 @@ class RealmsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::gameservices::RealmsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `RealmsServiceConnection` created by
  * this function.

--- a/google/cloud/gkehub/gke_hub_connection.h
+++ b/google/cloud/gkehub/gke_hub_connection.h
@@ -108,10 +108,9 @@ class GkeHubConnection {
  * A factory function to construct an object of type `GkeHubConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of GkeHubClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of GkeHubClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GkeHubConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -119,9 +118,8 @@ class GkeHubConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::gkehub::GkeHubPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GkeHubConnection` created by
  * this function.

--- a/google/cloud/iam/iam_connection.h
+++ b/google/cloud/iam/iam_connection.h
@@ -154,10 +154,9 @@ class IAMConnection {
  * A factory function to construct an object of type `IAMConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IAMClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IAMClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IAMConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -165,9 +164,8 @@ class IAMConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::iam::IAMPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `IAMConnection` created by
  * this function.

--- a/google/cloud/iam/iam_credentials_connection.h
+++ b/google/cloud/iam/iam_credentials_connection.h
@@ -82,10 +82,9 @@ class IAMCredentialsConnection {
  * A factory function to construct an object of type `IAMCredentialsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IAMCredentialsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IAMCredentialsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IAMCredentialsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -93,9 +92,8 @@ class IAMCredentialsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::iam::IAMCredentialsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `IAMCredentialsConnection` created by
  * this function.

--- a/google/cloud/iam/iam_policy_connection.h
+++ b/google/cloud/iam/iam_policy_connection.h
@@ -76,10 +76,9 @@ class IAMPolicyConnection {
  * A factory function to construct an object of type `IAMPolicyConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IAMPolicyClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IAMPolicyClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IAMPolicyConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -87,9 +86,8 @@ class IAMPolicyConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::iam::IAMPolicyPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `IAMPolicyConnection` created by
  * this function.

--- a/google/cloud/iap/identity_aware_proxy_admin_connection.h
+++ b/google/cloud/iap/identity_aware_proxy_admin_connection.h
@@ -106,9 +106,9 @@ class IdentityAwareProxyAdminServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * IdentityAwareProxyAdminServiceClient, and that class used instead.
+ * IdentityAwareProxyAdminServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IdentityAwareProxyAdminServiceConnection`. Expected options are any
  * of the types in the following option lists:
  *
@@ -116,9 +116,8 @@ class IdentityAwareProxyAdminServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::iap::IdentityAwareProxyAdminServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `IdentityAwareProxyAdminServiceConnection` created by this function.

--- a/google/cloud/iap/identity_aware_proxy_o_auth_connection.h
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_connection.h
@@ -105,9 +105,9 @@ class IdentityAwareProxyOAuthServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * IdentityAwareProxyOAuthServiceClient, and that class used instead.
+ * IdentityAwareProxyOAuthServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IdentityAwareProxyOAuthServiceConnection`. Expected options are any
  * of the types in the following option lists:
  *
@@ -115,9 +115,8 @@ class IdentityAwareProxyOAuthServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::iap::IdentityAwareProxyOAuthServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `IdentityAwareProxyOAuthServiceConnection` created by this function.

--- a/google/cloud/ids/ids_connection.h
+++ b/google/cloud/ids/ids_connection.h
@@ -83,10 +83,9 @@ class IDSConnection {
  * A factory function to construct an object of type `IDSConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IDSClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IDSClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IDSConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -94,9 +93,8 @@ class IDSConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::ids::IDSPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `IDSConnection` created by
  * this function.

--- a/google/cloud/iot/device_manager_connection.h
+++ b/google/cloud/iot/device_manager_connection.h
@@ -133,10 +133,9 @@ class DeviceManagerConnection {
  * A factory function to construct an object of type `DeviceManagerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DeviceManagerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DeviceManagerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DeviceManagerConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -144,9 +143,8 @@ class DeviceManagerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::iot::DeviceManagerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DeviceManagerConnection` created by
  * this function.

--- a/google/cloud/kms/ekm_connection.h
+++ b/google/cloud/kms/ekm_connection.h
@@ -80,10 +80,9 @@ class EkmServiceConnection {
  * A factory function to construct an object of type `EkmServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EkmServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EkmServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EkmServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -91,9 +90,8 @@ class EkmServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::kms::EkmServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `EkmServiceConnection` created by
  * this function.

--- a/google/cloud/kms/key_management_connection.h
+++ b/google/cloud/kms/key_management_connection.h
@@ -160,9 +160,9 @@ class KeyManagementServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * KeyManagementServiceClient, and that class used instead.
+ * KeyManagementServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `KeyManagementServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -170,9 +170,8 @@ class KeyManagementServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::kms::KeyManagementServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `KeyManagementServiceConnection`
  * created by this function.

--- a/google/cloud/language/language_connection.h
+++ b/google/cloud/language/language_connection.h
@@ -92,10 +92,9 @@ class LanguageServiceConnection {
  * `LanguageServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of LanguageServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of LanguageServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `LanguageServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -103,9 +102,8 @@ class LanguageServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::language::LanguageServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `LanguageServiceConnection` created
  * by this function.

--- a/google/cloud/logging/logging_service_v2_connection.h
+++ b/google/cloud/logging/logging_service_v2_connection.h
@@ -93,10 +93,9 @@ class LoggingServiceV2Connection {
  * `LoggingServiceV2Connection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of LoggingServiceV2Client,
- * and that class used instead.
+ * should be passed as an argument to the constructor of LoggingServiceV2Client.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `LoggingServiceV2Connection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -104,9 +103,8 @@ class LoggingServiceV2Connection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::logging::LoggingServiceV2PolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `LoggingServiceV2Connection` created
  * by this function.

--- a/google/cloud/managedidentities/managed_identities_connection.h
+++ b/google/cloud/managedidentities/managed_identities_connection.h
@@ -119,9 +119,9 @@ class ManagedIdentitiesServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ManagedIdentitiesServiceClient, and that class used instead.
+ * ManagedIdentitiesServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ManagedIdentitiesServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -130,9 +130,8 @@ class ManagedIdentitiesServiceConnection {
  * -
  * `google::cloud::managedidentities::ManagedIdentitiesServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ManagedIdentitiesServiceConnection`
  * created by this function.

--- a/google/cloud/memcache/cloud_memcache_connection.h
+++ b/google/cloud/memcache/cloud_memcache_connection.h
@@ -98,10 +98,9 @@ class CloudMemcacheConnection {
  * A factory function to construct an object of type `CloudMemcacheConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudMemcacheClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudMemcacheClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudMemcacheConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -109,9 +108,8 @@ class CloudMemcacheConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::memcache::CloudMemcachePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudMemcacheConnection` created by
  * this function.

--- a/google/cloud/monitoring/alert_policy_connection.h
+++ b/google/cloud/monitoring/alert_policy_connection.h
@@ -86,9 +86,9 @@ class AlertPolicyServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AlertPolicyServiceClient, and that class used instead.
+ * AlertPolicyServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AlertPolicyServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -96,9 +96,8 @@ class AlertPolicyServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::AlertPolicyServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AlertPolicyServiceConnection`
  * created by this function.

--- a/google/cloud/monitoring/dashboards_connection.h
+++ b/google/cloud/monitoring/dashboards_connection.h
@@ -89,9 +89,9 @@ class DashboardsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * DashboardsServiceClient, and that class used instead.
+ * DashboardsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DashboardsServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -99,9 +99,8 @@ class DashboardsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::DashboardsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DashboardsServiceConnection` created
  * by this function.

--- a/google/cloud/monitoring/group_connection.h
+++ b/google/cloud/monitoring/group_connection.h
@@ -87,10 +87,9 @@ class GroupServiceConnection {
  * A factory function to construct an object of type `GroupServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of GroupServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of GroupServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `GroupServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -98,9 +97,8 @@ class GroupServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::GroupServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `GroupServiceConnection` created by
  * this function.

--- a/google/cloud/monitoring/metric_connection.h
+++ b/google/cloud/monitoring/metric_connection.h
@@ -102,10 +102,9 @@ class MetricServiceConnection {
  * A factory function to construct an object of type `MetricServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of MetricServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of MetricServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `MetricServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -113,9 +112,8 @@ class MetricServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::MetricServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `MetricServiceConnection` created by
  * this function.

--- a/google/cloud/monitoring/metrics_scopes_connection.h
+++ b/google/cloud/monitoring/metrics_scopes_connection.h
@@ -94,10 +94,9 @@ class MetricsScopesConnection {
  * A factory function to construct an object of type `MetricsScopesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of MetricsScopesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of MetricsScopesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `MetricsScopesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -105,9 +104,8 @@ class MetricsScopesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::MetricsScopesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `MetricsScopesConnection` created by
  * this function.

--- a/google/cloud/monitoring/notification_channel_connection.h
+++ b/google/cloud/monitoring/notification_channel_connection.h
@@ -117,9 +117,9 @@ class NotificationChannelServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * NotificationChannelServiceClient, and that class used instead.
+ * NotificationChannelServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `NotificationChannelServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -127,9 +127,8 @@ class NotificationChannelServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::NotificationChannelServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `NotificationChannelServiceConnection` created by this function.

--- a/google/cloud/monitoring/query_connection.h
+++ b/google/cloud/monitoring/query_connection.h
@@ -72,10 +72,9 @@ class QueryServiceConnection {
  * A factory function to construct an object of type `QueryServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of QueryServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of QueryServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `QueryServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -83,9 +82,8 @@ class QueryServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::QueryServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `QueryServiceConnection` created by
  * this function.

--- a/google/cloud/monitoring/service_monitoring_connection.h
+++ b/google/cloud/monitoring/service_monitoring_connection.h
@@ -110,9 +110,9 @@ class ServiceMonitoringServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ServiceMonitoringServiceClient, and that class used instead.
+ * ServiceMonitoringServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ServiceMonitoringServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -120,9 +120,8 @@ class ServiceMonitoringServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::ServiceMonitoringServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ServiceMonitoringServiceConnection`
  * created by this function.

--- a/google/cloud/monitoring/uptime_check_connection.h
+++ b/google/cloud/monitoring/uptime_check_connection.h
@@ -93,9 +93,9 @@ class UptimeCheckServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * UptimeCheckServiceClient, and that class used instead.
+ * UptimeCheckServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `UptimeCheckServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -103,9 +103,8 @@ class UptimeCheckServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::monitoring::UptimeCheckServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `UptimeCheckServiceConnection`
  * created by this function.

--- a/google/cloud/networkmanagement/reachability_connection.h
+++ b/google/cloud/networkmanagement/reachability_connection.h
@@ -109,9 +109,9 @@ class ReachabilityServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ReachabilityServiceClient, and that class used instead.
+ * ReachabilityServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ReachabilityServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -119,9 +119,8 @@ class ReachabilityServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::networkmanagement::ReachabilityServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ReachabilityServiceConnection`
  * created by this function.

--- a/google/cloud/notebooks/managed_notebook_connection.h
+++ b/google/cloud/notebooks/managed_notebook_connection.h
@@ -110,9 +110,9 @@ class ManagedNotebookServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ManagedNotebookServiceClient, and that class used instead.
+ * ManagedNotebookServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ManagedNotebookServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -120,9 +120,8 @@ class ManagedNotebookServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::notebooks::ManagedNotebookServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ManagedNotebookServiceConnection`
  * created by this function.

--- a/google/cloud/notebooks/notebook_connection.h
+++ b/google/cloud/notebooks/notebook_connection.h
@@ -204,10 +204,9 @@ class NotebookServiceConnection {
  * `NotebookServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of NotebookServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of NotebookServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `NotebookServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -215,9 +214,8 @@ class NotebookServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::notebooks::NotebookServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `NotebookServiceConnection` created
  * by this function.

--- a/google/cloud/optimization/fleet_routing_connection.h
+++ b/google/cloud/optimization/fleet_routing_connection.h
@@ -81,10 +81,9 @@ class FleetRoutingConnection {
  * A factory function to construct an object of type `FleetRoutingConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of FleetRoutingClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of FleetRoutingClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `FleetRoutingConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -92,9 +91,8 @@ class FleetRoutingConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::optimization::FleetRoutingPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `FleetRoutingConnection` created by
  * this function.

--- a/google/cloud/orgpolicy/org_policy_connection.h
+++ b/google/cloud/orgpolicy/org_policy_connection.h
@@ -89,10 +89,9 @@ class OrgPolicyConnection {
  * A factory function to construct an object of type `OrgPolicyConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of OrgPolicyClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of OrgPolicyClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `OrgPolicyConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -100,9 +99,8 @@ class OrgPolicyConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::orgpolicy::OrgPolicyPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `OrgPolicyConnection` created by
  * this function.

--- a/google/cloud/osconfig/agent_endpoint_connection.h
+++ b/google/cloud/osconfig/agent_endpoint_connection.h
@@ -104,9 +104,9 @@ class AgentEndpointServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * AgentEndpointServiceClient, and that class used instead.
+ * AgentEndpointServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AgentEndpointServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -114,9 +114,8 @@ class AgentEndpointServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::osconfig::AgentEndpointServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AgentEndpointServiceConnection`
  * created by this function.

--- a/google/cloud/osconfig/os_config_connection.h
+++ b/google/cloud/osconfig/os_config_connection.h
@@ -113,10 +113,9 @@ class OsConfigServiceConnection {
  * `OsConfigServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of OsConfigServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of OsConfigServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `OsConfigServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -124,9 +123,8 @@ class OsConfigServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::osconfig::OsConfigServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `OsConfigServiceConnection` created
  * by this function.

--- a/google/cloud/oslogin/os_login_connection.h
+++ b/google/cloud/oslogin/os_login_connection.h
@@ -89,10 +89,9 @@ class OsLoginServiceConnection {
  * A factory function to construct an object of type `OsLoginServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of OsLoginServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of OsLoginServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `OsLoginServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -100,9 +99,8 @@ class OsLoginServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::oslogin::OsLoginServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `OsLoginServiceConnection` created by
  * this function.

--- a/google/cloud/policytroubleshooter/iam_checker_connection.h
+++ b/google/cloud/policytroubleshooter/iam_checker_connection.h
@@ -72,10 +72,9 @@ class IamCheckerConnection {
  * A factory function to construct an object of type `IamCheckerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of IamCheckerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of IamCheckerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `IamCheckerConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -83,9 +82,8 @@ class IamCheckerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::policytroubleshooter::IamCheckerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `IamCheckerConnection` created by
  * this function.

--- a/google/cloud/privateca/certificate_authority_connection.h
+++ b/google/cloud/privateca/certificate_authority_connection.h
@@ -233,9 +233,9 @@ class CertificateAuthorityServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * CertificateAuthorityServiceClient, and that class used instead.
+ * CertificateAuthorityServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CertificateAuthorityServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -243,9 +243,8 @@ class CertificateAuthorityServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::privateca::CertificateAuthorityServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the
  * `CertificateAuthorityServiceConnection` created by this function.

--- a/google/cloud/profiler/profiler_connection.h
+++ b/google/cloud/profiler/profiler_connection.h
@@ -80,10 +80,9 @@ class ProfilerServiceConnection {
  * `ProfilerServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ProfilerServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ProfilerServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ProfilerServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -91,9 +90,8 @@ class ProfilerServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::profiler::ProfilerServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ProfilerServiceConnection` created
  * by this function.

--- a/google/cloud/pubsublite/admin_connection.h
+++ b/google/cloud/pubsublite/admin_connection.h
@@ -142,10 +142,9 @@ class AdminServiceConnection {
  * A factory function to construct an object of type `AdminServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of AdminServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of AdminServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `AdminServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -153,9 +152,8 @@ class AdminServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::pubsublite::AdminServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `AdminServiceConnection` created by
  * this function.

--- a/google/cloud/pubsublite/topic_stats_connection.h
+++ b/google/cloud/pubsublite/topic_stats_connection.h
@@ -82,9 +82,9 @@ class TopicStatsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * TopicStatsServiceClient, and that class used instead.
+ * TopicStatsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TopicStatsServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -92,9 +92,8 @@ class TopicStatsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::pubsublite::TopicStatsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TopicStatsServiceConnection` created
  * by this function.

--- a/google/cloud/recommender/recommender_connection.h
+++ b/google/cloud/recommender/recommender_connection.h
@@ -121,10 +121,9 @@ class RecommenderConnection {
  * A factory function to construct an object of type `RecommenderConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of RecommenderClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of RecommenderClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `RecommenderConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -132,9 +131,8 @@ class RecommenderConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::recommender::RecommenderPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `RecommenderConnection` created by
  * this function.

--- a/google/cloud/redis/cloud_redis_connection.h
+++ b/google/cloud/redis/cloud_redis_connection.h
@@ -107,10 +107,9 @@ class CloudRedisConnection {
  * A factory function to construct an object of type `CloudRedisConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudRedisClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudRedisClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudRedisConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -118,9 +117,8 @@ class CloudRedisConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::redis::CloudRedisPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudRedisConnection` created by
  * this function.

--- a/google/cloud/resourcemanager/folders_connection.h
+++ b/google/cloud/resourcemanager/folders_connection.h
@@ -109,10 +109,9 @@ class FoldersConnection {
  * A factory function to construct an object of type `FoldersConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of FoldersClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of FoldersClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `FoldersConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -120,9 +119,8 @@ class FoldersConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::resourcemanager::FoldersPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `FoldersConnection` created by
  * this function.

--- a/google/cloud/resourcemanager/organizations_connection.h
+++ b/google/cloud/resourcemanager/organizations_connection.h
@@ -87,10 +87,9 @@ class OrganizationsConnection {
  * A factory function to construct an object of type `OrganizationsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of OrganizationsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of OrganizationsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `OrganizationsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -98,9 +97,8 @@ class OrganizationsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::resourcemanager::OrganizationsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `OrganizationsConnection` created by
  * this function.

--- a/google/cloud/resourcemanager/projects_connection.h
+++ b/google/cloud/resourcemanager/projects_connection.h
@@ -111,10 +111,9 @@ class ProjectsConnection {
  * A factory function to construct an object of type `ProjectsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ProjectsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ProjectsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ProjectsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -122,9 +121,8 @@ class ProjectsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::resourcemanager::ProjectsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ProjectsConnection` created by
  * this function.

--- a/google/cloud/resourcesettings/resource_settings_connection.h
+++ b/google/cloud/resourcesettings/resource_settings_connection.h
@@ -83,9 +83,9 @@ class ResourceSettingsServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ResourceSettingsServiceClient, and that class used instead.
+ * ResourceSettingsServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ResourceSettingsServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -93,9 +93,8 @@ class ResourceSettingsServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::resourcesettings::ResourceSettingsServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ResourceSettingsServiceConnection`
  * created by this function.

--- a/google/cloud/retail/catalog_connection.h
+++ b/google/cloud/retail/catalog_connection.h
@@ -82,10 +82,9 @@ class CatalogServiceConnection {
  * A factory function to construct an object of type `CatalogServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CatalogServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CatalogServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CatalogServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -93,9 +92,8 @@ class CatalogServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::retail::CatalogServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CatalogServiceConnection` created by
  * this function.

--- a/google/cloud/retail/completion_connection.h
+++ b/google/cloud/retail/completion_connection.h
@@ -81,9 +81,9 @@ class CompletionServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * CompletionServiceClient, and that class used instead.
+ * CompletionServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CompletionServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -91,9 +91,8 @@ class CompletionServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::retail::CompletionServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CompletionServiceConnection` created
  * by this function.

--- a/google/cloud/retail/prediction_connection.h
+++ b/google/cloud/retail/prediction_connection.h
@@ -73,9 +73,9 @@ class PredictionServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * PredictionServiceClient, and that class used instead.
+ * PredictionServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `PredictionServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -83,9 +83,8 @@ class PredictionServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::retail::PredictionServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `PredictionServiceConnection` created
  * by this function.

--- a/google/cloud/retail/product_connection.h
+++ b/google/cloud/retail/product_connection.h
@@ -114,10 +114,9 @@ class ProductServiceConnection {
  * A factory function to construct an object of type `ProductServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ProductServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ProductServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ProductServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -125,9 +124,8 @@ class ProductServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::retail::ProductServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ProductServiceConnection` created by
  * this function.

--- a/google/cloud/retail/search_connection.h
+++ b/google/cloud/retail/search_connection.h
@@ -72,10 +72,9 @@ class SearchServiceConnection {
  * A factory function to construct an object of type `SearchServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of SearchServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of SearchServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SearchServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -83,9 +82,8 @@ class SearchServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::retail::SearchServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `SearchServiceConnection` created by
  * this function.

--- a/google/cloud/retail/user_event_connection.h
+++ b/google/cloud/retail/user_event_connection.h
@@ -90,10 +90,9 @@ class UserEventServiceConnection {
  * `UserEventServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of UserEventServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of UserEventServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `UserEventServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -101,9 +100,8 @@ class UserEventServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::retail::UserEventServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `UserEventServiceConnection` created
  * by this function.

--- a/google/cloud/run/revisions_connection.h
+++ b/google/cloud/run/revisions_connection.h
@@ -80,10 +80,9 @@ class RevisionsConnection {
  * A factory function to construct an object of type `RevisionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of RevisionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of RevisionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `RevisionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -91,9 +90,8 @@ class RevisionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::run::RevisionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `RevisionsConnection` created by
  * this function.

--- a/google/cloud/run/services_connection.h
+++ b/google/cloud/run/services_connection.h
@@ -95,10 +95,9 @@ class ServicesConnection {
  * A factory function to construct an object of type `ServicesConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ServicesClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ServicesClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ServicesConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -106,9 +105,8 @@ class ServicesConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::run::ServicesPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ServicesConnection` created by
  * this function.

--- a/google/cloud/scheduler/cloud_scheduler_connection.h
+++ b/google/cloud/scheduler/cloud_scheduler_connection.h
@@ -93,10 +93,9 @@ class CloudSchedulerConnection {
  * A factory function to construct an object of type `CloudSchedulerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudSchedulerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudSchedulerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudSchedulerConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -104,9 +103,8 @@ class CloudSchedulerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::scheduler::CloudSchedulerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudSchedulerConnection` created by
  * this function.

--- a/google/cloud/secretmanager/secret_manager_connection.h
+++ b/google/cloud/secretmanager/secret_manager_connection.h
@@ -128,9 +128,9 @@ class SecretManagerServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * SecretManagerServiceClient, and that class used instead.
+ * SecretManagerServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SecretManagerServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -138,9 +138,8 @@ class SecretManagerServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::secretmanager::SecretManagerServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `SecretManagerServiceConnection`
  * created by this function.

--- a/google/cloud/securitycenter/security_center_connection.h
+++ b/google/cloud/securitycenter/security_center_connection.h
@@ -220,10 +220,9 @@ class SecurityCenterConnection {
  * A factory function to construct an object of type `SecurityCenterConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of SecurityCenterClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of SecurityCenterClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SecurityCenterConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -231,9 +230,8 @@ class SecurityCenterConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::securitycenter::SecurityCenterPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `SecurityCenterConnection` created by
  * this function.

--- a/google/cloud/servicecontrol/quota_controller_connection.h
+++ b/google/cloud/servicecontrol/quota_controller_connection.h
@@ -73,10 +73,9 @@ class QuotaControllerConnection {
  * `QuotaControllerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of QuotaControllerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of QuotaControllerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `QuotaControllerConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -84,9 +83,8 @@ class QuotaControllerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::servicecontrol::QuotaControllerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `QuotaControllerConnection` created
  * by this function.

--- a/google/cloud/servicecontrol/service_controller_connection.h
+++ b/google/cloud/servicecontrol/service_controller_connection.h
@@ -76,9 +76,9 @@ class ServiceControllerConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * ServiceControllerClient, and that class used instead.
+ * ServiceControllerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ServiceControllerConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -86,9 +86,8 @@ class ServiceControllerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::servicecontrol::ServiceControllerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ServiceControllerConnection` created
  * by this function.

--- a/google/cloud/servicedirectory/lookup_connection.h
+++ b/google/cloud/servicedirectory/lookup_connection.h
@@ -73,10 +73,9 @@ class LookupServiceConnection {
  * A factory function to construct an object of type `LookupServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of LookupServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of LookupServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `LookupServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -84,9 +83,8 @@ class LookupServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::servicedirectory::LookupServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `LookupServiceConnection` created by
  * this function.

--- a/google/cloud/servicedirectory/registration_connection.h
+++ b/google/cloud/servicedirectory/registration_connection.h
@@ -138,9 +138,9 @@ class RegistrationServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * RegistrationServiceClient, and that class used instead.
+ * RegistrationServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `RegistrationServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -148,9 +148,8 @@ class RegistrationServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::servicedirectory::RegistrationServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `RegistrationServiceConnection`
  * created by this function.

--- a/google/cloud/servicemanagement/service_manager_connection.h
+++ b/google/cloud/servicemanagement/service_manager_connection.h
@@ -131,10 +131,9 @@ class ServiceManagerConnection {
  * A factory function to construct an object of type `ServiceManagerConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ServiceManagerClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ServiceManagerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ServiceManagerConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -142,9 +141,8 @@ class ServiceManagerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::servicemanagement::ServiceManagerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ServiceManagerConnection` created by
  * this function.

--- a/google/cloud/serviceusage/service_usage_connection.h
+++ b/google/cloud/serviceusage/service_usage_connection.h
@@ -96,10 +96,9 @@ class ServiceUsageConnection {
  * A factory function to construct an object of type `ServiceUsageConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ServiceUsageClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ServiceUsageClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ServiceUsageConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -107,9 +106,8 @@ class ServiceUsageConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::serviceusage::ServiceUsagePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ServiceUsageConnection` created by
  * this function.

--- a/google/cloud/shell/cloud_shell_connection.h
+++ b/google/cloud/shell/cloud_shell_connection.h
@@ -92,9 +92,9 @@ class CloudShellServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * CloudShellServiceClient, and that class used instead.
+ * CloudShellServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudShellServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -102,9 +102,8 @@ class CloudShellServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::shell::CloudShellServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudShellServiceConnection` created
  * by this function.

--- a/google/cloud/spanner/admin/database_admin_connection.h
+++ b/google/cloud/spanner/admin/database_admin_connection.h
@@ -144,10 +144,9 @@ class DatabaseAdminConnection {
  * A factory function to construct an object of type `DatabaseAdminConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of DatabaseAdminClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of DatabaseAdminClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `DatabaseAdminConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -155,9 +154,8 @@ class DatabaseAdminConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::spanner_admin::DatabaseAdminPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `DatabaseAdminConnection` created by
  * this function.

--- a/google/cloud/spanner/admin/instance_admin_connection.h
+++ b/google/cloud/spanner/admin/instance_admin_connection.h
@@ -111,10 +111,9 @@ class InstanceAdminConnection {
  * A factory function to construct an object of type `InstanceAdminConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of InstanceAdminClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of InstanceAdminClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `InstanceAdminConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -122,9 +121,8 @@ class InstanceAdminConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::spanner_admin::InstanceAdminPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `InstanceAdminConnection` created by
  * this function.

--- a/google/cloud/speech/speech_connection.h
+++ b/google/cloud/speech/speech_connection.h
@@ -85,10 +85,9 @@ class SpeechConnection {
  * A factory function to construct an object of type `SpeechConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of SpeechClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of SpeechClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `SpeechConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -96,9 +95,8 @@ class SpeechConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::speech::SpeechPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `SpeechConnection` created by
  * this function.

--- a/google/cloud/storagetransfer/storage_transfer_connection.h
+++ b/google/cloud/storagetransfer/storage_transfer_connection.h
@@ -121,9 +121,9 @@ class StorageTransferServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * StorageTransferServiceClient, and that class used instead.
+ * StorageTransferServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `StorageTransferServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -131,9 +131,8 @@ class StorageTransferServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::storagetransfer::StorageTransferServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `StorageTransferServiceConnection`
  * created by this function.

--- a/google/cloud/talent/company_connection.h
+++ b/google/cloud/talent/company_connection.h
@@ -84,10 +84,9 @@ class CompanyServiceConnection {
  * A factory function to construct an object of type `CompanyServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CompanyServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CompanyServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CompanyServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -95,9 +94,8 @@ class CompanyServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::talent::CompanyServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CompanyServiceConnection` created by
  * this function.

--- a/google/cloud/talent/completion_connection.h
+++ b/google/cloud/talent/completion_connection.h
@@ -70,10 +70,9 @@ class CompletionConnection {
  * A factory function to construct an object of type `CompletionConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CompletionClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CompletionClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CompletionConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -81,9 +80,8 @@ class CompletionConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::talent::CompletionPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CompletionConnection` created by
  * this function.

--- a/google/cloud/talent/event_connection.h
+++ b/google/cloud/talent/event_connection.h
@@ -71,10 +71,9 @@ class EventServiceConnection {
  * A factory function to construct an object of type `EventServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of EventServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of EventServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `EventServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -82,9 +81,8 @@ class EventServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::talent::EventServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `EventServiceConnection` created by
  * this function.

--- a/google/cloud/talent/job_connection.h
+++ b/google/cloud/talent/job_connection.h
@@ -105,10 +105,9 @@ class JobServiceConnection {
  * A factory function to construct an object of type `JobServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of JobServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of JobServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `JobServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -116,9 +115,8 @@ class JobServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::talent::JobServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `JobServiceConnection` created by
  * this function.

--- a/google/cloud/talent/tenant_connection.h
+++ b/google/cloud/talent/tenant_connection.h
@@ -84,10 +84,9 @@ class TenantServiceConnection {
  * A factory function to construct an object of type `TenantServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of TenantServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of TenantServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TenantServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -95,9 +94,8 @@ class TenantServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::talent::TenantServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TenantServiceConnection` created by
  * this function.

--- a/google/cloud/tasks/cloud_tasks_connection.h
+++ b/google/cloud/tasks/cloud_tasks_connection.h
@@ -116,10 +116,9 @@ class CloudTasksConnection {
  * A factory function to construct an object of type `CloudTasksConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of CloudTasksClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of CloudTasksClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `CloudTasksConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -127,9 +126,8 @@ class CloudTasksConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::tasks::CloudTasksPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `CloudTasksConnection` created by
  * this function.

--- a/google/cloud/texttospeech/text_to_speech_connection.h
+++ b/google/cloud/texttospeech/text_to_speech_connection.h
@@ -75,10 +75,9 @@ class TextToSpeechConnection {
  * A factory function to construct an object of type `TextToSpeechConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of TextToSpeechClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of TextToSpeechClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TextToSpeechConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -86,9 +85,8 @@ class TextToSpeechConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::texttospeech::TextToSpeechPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TextToSpeechConnection` created by
  * this function.

--- a/google/cloud/tpu/tpu_connection.h
+++ b/google/cloud/tpu/tpu_connection.h
@@ -107,10 +107,9 @@ class TpuConnection {
  * A factory function to construct an object of type `TpuConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of TpuClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of TpuClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TpuConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -118,9 +117,8 @@ class TpuConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::tpu::TpuPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TpuConnection` created by
  * this function.

--- a/google/cloud/trace/trace_connection.h
+++ b/google/cloud/trace/trace_connection.h
@@ -74,10 +74,9 @@ class TraceServiceConnection {
  * A factory function to construct an object of type `TraceServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of TraceServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of TraceServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TraceServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -85,9 +84,8 @@ class TraceServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::trace::TraceServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TraceServiceConnection` created by
  * this function.

--- a/google/cloud/translate/translation_connection.h
+++ b/google/cloud/translate/translation_connection.h
@@ -117,9 +117,9 @@ class TranslationServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * TranslationServiceClient, and that class used instead.
+ * TranslationServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TranslationServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -127,9 +127,8 @@ class TranslationServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::translate::TranslationServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TranslationServiceConnection`
  * created by this function.

--- a/google/cloud/video/livestream_connection.h
+++ b/google/cloud/video/livestream_connection.h
@@ -138,9 +138,9 @@ class LivestreamServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * LivestreamServiceClient, and that class used instead.
+ * LivestreamServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `LivestreamServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -148,9 +148,8 @@ class LivestreamServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::video::LivestreamServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `LivestreamServiceConnection` created
  * by this function.

--- a/google/cloud/video/transcoder_connection.h
+++ b/google/cloud/video/transcoder_connection.h
@@ -101,9 +101,9 @@ class TranscoderServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * TranscoderServiceClient, and that class used instead.
+ * TranscoderServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `TranscoderServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -111,9 +111,8 @@ class TranscoderServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::video::TranscoderServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `TranscoderServiceConnection` created
  * by this function.

--- a/google/cloud/video/video_stitcher_connection.h
+++ b/google/cloud/video/video_stitcher_connection.h
@@ -146,9 +146,9 @@ class VideoStitcherServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * VideoStitcherServiceClient, and that class used instead.
+ * VideoStitcherServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VideoStitcherServiceConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -156,9 +156,8 @@ class VideoStitcherServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::video::VideoStitcherServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `VideoStitcherServiceConnection`
  * created by this function.

--- a/google/cloud/videointelligence/video_intelligence_connection.h
+++ b/google/cloud/videointelligence/video_intelligence_connection.h
@@ -82,9 +82,9 @@ class VideoIntelligenceServiceConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * VideoIntelligenceServiceClient, and that class used instead.
+ * VideoIntelligenceServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VideoIntelligenceServiceConnection`. Expected options are any of
  * the types in the following option lists:
  *
@@ -93,9 +93,8 @@ class VideoIntelligenceServiceConnection {
  * -
  * `google::cloud::videointelligence::VideoIntelligenceServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `VideoIntelligenceServiceConnection`
  * created by this function.

--- a/google/cloud/vision/image_annotator_connection.h
+++ b/google/cloud/vision/image_annotator_connection.h
@@ -90,10 +90,9 @@ class ImageAnnotatorConnection {
  * A factory function to construct an object of type `ImageAnnotatorConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ImageAnnotatorClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ImageAnnotatorClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ImageAnnotatorConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -101,9 +100,8 @@ class ImageAnnotatorConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::vision::ImageAnnotatorPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ImageAnnotatorConnection` created by
  * this function.

--- a/google/cloud/vision/product_search_connection.h
+++ b/google/cloud/vision/product_search_connection.h
@@ -134,10 +134,9 @@ class ProductSearchConnection {
  * A factory function to construct an object of type `ProductSearchConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ProductSearchClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ProductSearchClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ProductSearchConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -145,9 +144,8 @@ class ProductSearchConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::vision::ProductSearchPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ProductSearchConnection` created by
  * this function.

--- a/google/cloud/vmmigration/vm_migration_connection.h
+++ b/google/cloud/vmmigration/vm_migration_connection.h
@@ -254,10 +254,9 @@ class VmMigrationConnection {
  * A factory function to construct an object of type `VmMigrationConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of VmMigrationClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of VmMigrationClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VmMigrationConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -265,9 +264,8 @@ class VmMigrationConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::vmmigration::VmMigrationPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `VmMigrationConnection` created by
  * this function.

--- a/google/cloud/vpcaccess/vpc_access_connection.h
+++ b/google/cloud/vpcaccess/vpc_access_connection.h
@@ -87,10 +87,9 @@ class VpcAccessServiceConnection {
  * `VpcAccessServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of VpcAccessServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of VpcAccessServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `VpcAccessServiceConnection`. Expected options are any of the types
  * in the following option lists:
  *
@@ -98,9 +97,8 @@ class VpcAccessServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::vpcaccess::VpcAccessServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `VpcAccessServiceConnection` created
  * by this function.

--- a/google/cloud/webrisk/web_risk_connection.h
+++ b/google/cloud/webrisk/web_risk_connection.h
@@ -81,10 +81,9 @@ class WebRiskServiceConnection {
  * A factory function to construct an object of type `WebRiskServiceConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of WebRiskServiceClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of WebRiskServiceClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `WebRiskServiceConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -92,9 +91,8 @@ class WebRiskServiceConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::webrisk::WebRiskServicePolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `WebRiskServiceConnection` created by
  * this function.

--- a/google/cloud/websecurityscanner/web_security_scanner_connection.h
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection.h
@@ -126,9 +126,9 @@ class WebSecurityScannerConnection {
  *
  * The returned connection object should not be used directly; instead it
  * should be passed as an argument to the constructor of
- * WebSecurityScannerClient, and that class used instead.
+ * WebSecurityScannerClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `WebSecurityScannerConnection`. Expected options are any of the
  * types in the following option lists:
  *
@@ -136,9 +136,8 @@ class WebSecurityScannerConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::websecurityscanner::WebSecurityScannerPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `WebSecurityScannerConnection`
  * created by this function.

--- a/google/cloud/workflows/executions_connection.h
+++ b/google/cloud/workflows/executions_connection.h
@@ -87,10 +87,9 @@ class ExecutionsConnection {
  * A factory function to construct an object of type `ExecutionsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of ExecutionsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of ExecutionsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `ExecutionsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -98,9 +97,8 @@ class ExecutionsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::workflows::ExecutionsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `ExecutionsConnection` created by
  * this function.

--- a/google/cloud/workflows/workflows_connection.h
+++ b/google/cloud/workflows/workflows_connection.h
@@ -89,10 +89,9 @@ class WorkflowsConnection {
  * A factory function to construct an object of type `WorkflowsConnection`.
  *
  * The returned connection object should not be used directly; instead it
- * should be passed as an argument to the constructor of WorkflowsClient,
- * and that class used instead.
+ * should be passed as an argument to the constructor of WorkflowsClient.
  *
- * The optional @p opts argument may be used to configure aspects of the
+ * The optional @p options argument may be used to configure aspects of the
  * returned `WorkflowsConnection`. Expected options are any of the types in
  * the following option lists:
  *
@@ -100,9 +99,8 @@ class WorkflowsConnection {
  * - `google::cloud::GrpcOptionList`
  * - `google::cloud::workflows::WorkflowsPolicyOptionList`
  *
- * @note Unrecognized options will be ignored. To debug issues with options set
- *     `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment and unexpected
- *     options will be logged.
+ * @note Unexpected options will be ignored. To log unexpected options instead,
+ *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
  * @param options (optional) Configure the `WorkflowsConnection` created by
  * this function.


### PR DESCRIPTION
Add generator support for services with location-dependent default
endpoints.  A new `MakeServiceConnection()` overload is generated with
a required `location` parameter, which is used to build the default
`EndpointOption` of `"<location>-<normal-service-endpoint>"` (for
example, "us-documentai.googleapis.com" in the Cloud Document AI API).

For backwards compatibility in already-released libraries, the old
`MakeServiceConnection()` signature is still available, but it, as
before, requires setting `EndpointOption` and `AuthorityOption` to
get something that works.

Fixes #7976 and #8704.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9625)
<!-- Reviewable:end -->
