### PR TITLE
feat(bigtable): per-operation Options (pt. 2)

### DIFF
--- a/google/cloud/bigtable/legacy_table_test.cc
+++ b/google/cloud/bigtable/legacy_table_test.cc
@@ -360,6 +360,20 @@ TEST_F(TableTest, AsyncSampleRowsWithOptions) {
   EXPECT_THAT(rows.get(), StatusIs(StatusCode::kInvalidArgument));
 }
 
+TEST_F(TableTest, ReadModifyWriteRowWithOptions) {
+  Table table(client_, kTableId);
+  auto r = ReadModifyWriteRule::AppendValue("cf", "cq", "v");
+  auto row = table.ReadModifyWriteRow("row", r, r, NonEmptyOptions(), r);
+  EXPECT_THAT(row, StatusIs(StatusCode::kInvalidArgument));
+}
+
+TEST_F(TableTest, AsyncReadModifyWriteRowWithOptions) {
+  Table table(client_, kTableId);
+  auto r = ReadModifyWriteRule::AppendValue("cf", "cq", "v");
+  auto row = table.AsyncReadModifyWriteRow("row", r, r, NonEmptyOptions(), r);
+  EXPECT_THAT(row.get(), StatusIs(StatusCode::kInvalidArgument));
+}
+
 TEST_F(TableTest, AsyncReadRowsWithOptions) {
   MockFunction<future<bool>(bigtable::Row const&)> on_row;
   EXPECT_CALL(on_row, Call).Times(0);


### PR DESCRIPTION
Fixes #7688  

Accept `Options` in the `(Async)ReadModifyWriteRow(..., Args&& rules_and_options)` parameter packs. (I dare you to improve on the name: `rules_and_options`).

We extract the options using `GroupOptions(...)`. And ignore `Options` when we are adding rules to the `request` proto.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9627)
<!-- Reviewable:end -->
