### PR TITLE
cleanup(bigtable): default options like the generator does

### DIFF
--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -156,21 +156,3 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace bigtable
 }  // namespace cloud
 }  // namespace google
-
-namespace google {
-namespace cloud {
-namespace bigtable_internal {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-std::shared_ptr<bigtable::DataConnection> MakeDataConnection(
-    std::shared_ptr<BigtableStub> stub, Options options) {
-  options = bigtable::internal::DefaultDataOptions(std::move(options));
-  auto background = internal::MakeBackgroundThreadsFactory(options)();
-  return std::make_shared<DataConnectionImpl>(
-      std::move(background), std::move(stub), std::move(options));
-}
-
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_internal
-}  // namespace cloud
-}  // namespace google

--- a/google/cloud/bigtable/data_connection.h
+++ b/google/cloud/bigtable/data_connection.h
@@ -165,17 +165,4 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace cloud
 }  // namespace google
 
-namespace google {
-namespace cloud {
-namespace bigtable_internal {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-
-std::shared_ptr<bigtable::DataConnection> MakeDataConnection(
-    std::shared_ptr<BigtableStub> stub, Options options);
-
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace bigtable_internal
-}  // namespace cloud
-}  // namespace google
-
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_DATA_CONNECTION_H

--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -55,9 +55,8 @@ DataConnectionImpl::DataConnectionImpl(
     std::shared_ptr<BigtableStub> stub, Options options)
     : background_(std::move(background)),
       stub_(std::move(stub)),
-      options_(internal::MergeOptions(
-          std::move(options),
-          bigtable::internal::DefaultDataOptions(DataConnection::options()))) {}
+      options_(internal::MergeOptions(std::move(options),
+                                      DataConnection::options())) {}
 
 Status DataConnectionImpl::Apply(std::string const& table_name,
                                  bigtable::SingleRowMutation mut) {

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -208,9 +208,8 @@ class Table {
       : table_(std::move(tr)),
         table_name_(table_.FullName()),
         connection_(std::move(conn)),
-        options_(google::cloud::internal::MergeOptions(
-            std::move(options),
-            internal::DefaultDataOptions(connection_->options()))),
+        options_(google::cloud::internal::MergeOptions(std::move(options),
+                                                       connection_->options())),
         metadata_update_policy_(bigtable_internal::MakeMetadataUpdatePolicy(
             table_name_, app_profile_id())) {}
 


### PR DESCRIPTION
Follow the lead of the generator and:
1. Remove `bigtable_internal::MakeDataConnection(...)` (which I wasn't even using).
2. Default the `Options` exactly once - in `bigtable::MakeDataConnection(...)`. Adjust tests accordingly.

I also modified a unit test to check that `Options` are defaulted by `MakeDataConnection`. Ideally we wouldn't construct a `DataConnection` in the test, we would just verify that defauted options are passed to it... but that is ok. If we didn't have this test and we forgot to default the options [here](https://github.com/googleapis/google-cloud-cpp/blob/e14aed697ecc8924d4d2fafeea45fefd152065eb/google/cloud/bigtable/data_connection.cc#L145), we would only learn about it from an integration test segfaulting.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9636)
<!-- Reviewable:end -->
