### PR TITLE
feat: group GUAC `Options` in an `OptionsList`

### DIFF
--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.cc
@@ -23,6 +23,7 @@
 #include "generator/integration_tests/golden/internal/golden_kitchen_sink_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -106,6 +107,7 @@ GoldenKitchenSinkConnection::ExplicitRouting2(
 std::shared_ptr<GoldenKitchenSinkConnection> MakeGoldenKitchenSinkConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+      UnifiedCredentialsOptionList,
       GoldenKitchenSinkPolicyOptionList>(options, __func__);
   options = golden_internal::GoldenKitchenSinkDefaultOptions(
       std::move(options));

--- a/generator/integration_tests/golden/golden_kitchen_sink_connection.h
+++ b/generator/integration_tests/golden/golden_kitchen_sink_connection.h
@@ -109,6 +109,7 @@ class GoldenKitchenSinkConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::golden::GoldenKitchenSinkPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/generator/integration_tests/golden/golden_thing_admin_connection.cc
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.cc
@@ -23,6 +23,7 @@
 #include "generator/integration_tests/golden/internal/golden_thing_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -170,6 +171,7 @@ GoldenThingAdminConnection::AsyncDropDatabase(
 std::shared_ptr<GoldenThingAdminConnection> MakeGoldenThingAdminConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+      UnifiedCredentialsOptionList,
       GoldenThingAdminPolicyOptionList>(options, __func__);
   options = golden_internal::GoldenThingAdminDefaultOptions(
       std::move(options));

--- a/generator/integration_tests/golden/golden_thing_admin_connection.h
+++ b/generator/integration_tests/golden/golden_thing_admin_connection.h
@@ -138,6 +138,7 @@ class GoldenThingAdminConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::golden::GoldenThingAdminPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/generator/internal/connection_generator.cc
+++ b/generator/internal/connection_generator.cc
@@ -225,6 +225,7 @@ class $connection_class_name$ {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::$product_namespace$::$service_name$PolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,
@@ -296,7 +297,8 @@ Status ConnectionGenerator::GenerateCc() {
       {vars("connection_header_path"), vars("options_header_path"),
        vars("connection_impl_header_path"), vars("option_defaults_header_path"),
        vars("stub_factory_header_path"), "google/cloud/background_threads.h",
-       "google/cloud/common_options.h", "google/cloud/grpc_options.h",
+       "google/cloud/common_options.h", "google/cloud/credentials.h",
+       "google/cloud/grpc_options.h",
        HasPaginatedMethod() ? "google/cloud/internal/pagination_range.h" : ""});
   CcSystemIncludes({"memory"});
 
@@ -443,6 +445,7 @@ std::shared_ptr<$connection_class_name$> Make$connection_class_name$(
   CcPrint("Options options) {");
   CcPrint(R"""(
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+      UnifiedCredentialsOptionList,
       $service_name$PolicyOptionList>(options, __func__);
   options = $product_internal_namespace$::$service_name$DefaultOptions(
 )""");

--- a/google/cloud/accessapproval/access_approval_connection.cc
+++ b/google/cloud/accessapproval/access_approval_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/accessapproval/internal/access_approval_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -97,6 +98,7 @@ AccessApprovalConnection::GetAccessApprovalServiceAccount(
 std::shared_ptr<AccessApprovalConnection> MakeAccessApprovalConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AccessApprovalPolicyOptionList>(options,
                                                                  __func__);
   options =

--- a/google/cloud/accessapproval/access_approval_connection.h
+++ b/google/cloud/accessapproval/access_approval_connection.h
@@ -121,6 +121,7 @@ class AccessApprovalConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::accessapproval::AccessApprovalPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/accesscontextmanager/access_context_manager_connection.cc
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/accesscontextmanager/internal/access_context_manager_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -244,6 +245,7 @@ AccessContextManagerConnection::DeleteGcpUserAccessBinding(
 std::shared_ptr<AccessContextManagerConnection>
 MakeAccessContextManagerConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AccessContextManagerPolicyOptionList>(
       options, __func__);
   options = accesscontextmanager_internal::AccessContextManagerDefaultOptions(

--- a/google/cloud/accesscontextmanager/access_context_manager_connection.h
+++ b/google/cloud/accesscontextmanager/access_context_manager_connection.h
@@ -201,6 +201,7 @@ class AccessContextManagerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::accesscontextmanager::AccessContextManagerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/apigateway/api_gateway_connection.cc
+++ b/google/cloud/apigateway/api_gateway_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/apigateway/internal/api_gateway_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -151,6 +152,7 @@ ApiGatewayServiceConnection::DeleteApiConfig(
 std::shared_ptr<ApiGatewayServiceConnection> MakeApiGatewayServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ApiGatewayServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/apigateway/api_gateway_connection.h
+++ b/google/cloud/apigateway/api_gateway_connection.h
@@ -133,6 +133,7 @@ class ApiGatewayServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::apigateway::ApiGatewayServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/apigeeconnect/connection_connection.cc
+++ b/google/cloud/apigeeconnect/connection_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/apigeeconnect/internal/connection_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -45,6 +46,7 @@ ConnectionServiceConnection::ListConnections(
 std::shared_ptr<ConnectionServiceConnection> MakeConnectionServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ConnectionServicePolicyOptionList>(options,
                                                                     __func__);
   options = apigeeconnect_internal::ConnectionServiceDefaultOptions(

--- a/google/cloud/apigeeconnect/connection_connection.h
+++ b/google/cloud/apigeeconnect/connection_connection.h
@@ -83,6 +83,7 @@ class ConnectionServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::apigeeconnect::ConnectionServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/applications_connection.cc
+++ b/google/cloud/appengine/applications_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/internal/applications_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -66,6 +67,7 @@ ApplicationsConnection::RepairApplication(
 std::shared_ptr<ApplicationsConnection> MakeApplicationsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ApplicationsPolicyOptionList>(options,
                                                                __func__);
   options = appengine_internal::ApplicationsDefaultOptions(std::move(options));

--- a/google/cloud/appengine/applications_connection.h
+++ b/google/cloud/appengine/applications_connection.h
@@ -94,6 +94,7 @@ class ApplicationsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::ApplicationsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/authorized_certificates_connection.cc
+++ b/google/cloud/appengine/authorized_certificates_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/internal/authorized_certificates_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status AuthorizedCertificatesConnection::DeleteAuthorizedCertificate(
 std::shared_ptr<AuthorizedCertificatesConnection>
 MakeAuthorizedCertificatesConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AuthorizedCertificatesPolicyOptionList>(
       options, __func__);
   options = appengine_internal::AuthorizedCertificatesDefaultOptions(

--- a/google/cloud/appengine/authorized_certificates_connection.h
+++ b/google/cloud/appengine/authorized_certificates_connection.h
@@ -99,6 +99,7 @@ class AuthorizedCertificatesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::AuthorizedCertificatesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/authorized_domains_connection.cc
+++ b/google/cloud/appengine/authorized_domains_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/internal/authorized_domains_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -45,6 +46,7 @@ AuthorizedDomainsConnection::ListAuthorizedDomains(
 std::shared_ptr<AuthorizedDomainsConnection> MakeAuthorizedDomainsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AuthorizedDomainsPolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/appengine/authorized_domains_connection.h
+++ b/google/cloud/appengine/authorized_domains_connection.h
@@ -83,6 +83,7 @@ class AuthorizedDomainsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::AuthorizedDomainsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/domain_mappings_connection.cc
+++ b/google/cloud/appengine/domain_mappings_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/internal/domain_mappings_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -75,6 +76,7 @@ DomainMappingsConnection::DeleteDomainMapping(
 std::shared_ptr<DomainMappingsConnection> MakeDomainMappingsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DomainMappingsPolicyOptionList>(options,
                                                                  __func__);
   options =

--- a/google/cloud/appengine/domain_mappings_connection.h
+++ b/google/cloud/appengine/domain_mappings_connection.h
@@ -98,6 +98,7 @@ class DomainMappingsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::DomainMappingsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/firewall_connection.cc
+++ b/google/cloud/appengine/firewall_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/internal/firewall_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -73,6 +74,7 @@ Status FirewallConnection::DeleteIngressRule(
 
 std::shared_ptr<FirewallConnection> MakeFirewallConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  FirewallPolicyOptionList>(options, __func__);
   options = appengine_internal::FirewallDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/appengine/firewall_connection.h
+++ b/google/cloud/appengine/firewall_connection.h
@@ -95,6 +95,7 @@ class FirewallConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::FirewallPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/instances_connection.cc
+++ b/google/cloud/appengine/instances_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/internal/instances_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -64,6 +65,7 @@ InstancesConnection::DebugInstance(
 
 std::shared_ptr<InstancesConnection> MakeInstancesConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  InstancesPolicyOptionList>(options, __func__);
   options = appengine_internal::InstancesDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/appengine/instances_connection.h
+++ b/google/cloud/appengine/instances_connection.h
@@ -91,6 +91,7 @@ class InstancesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::InstancesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/services_connection.cc
+++ b/google/cloud/appengine/services_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/services_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -64,6 +65,7 @@ ServicesConnection::DeleteService(
 
 std::shared_ptr<ServicesConnection> MakeServicesConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ServicesPolicyOptionList>(options, __func__);
   options = appengine_internal::ServicesDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/appengine/services_connection.h
+++ b/google/cloud/appengine/services_connection.h
@@ -91,6 +91,7 @@ class ServicesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::ServicesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/appengine/versions_connection.cc
+++ b/google/cloud/appengine/versions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/appengine/versions_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -72,6 +73,7 @@ VersionsConnection::DeleteVersion(
 
 std::shared_ptr<VersionsConnection> MakeVersionsConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VersionsPolicyOptionList>(options, __func__);
   options = appengine_internal::VersionsDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/appengine/versions_connection.h
+++ b/google/cloud/appengine/versions_connection.h
@@ -94,6 +94,7 @@ class VersionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::appengine::VersionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/artifactregistry/artifact_registry_connection.cc
+++ b/google/cloud/artifactregistry/artifact_registry_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/artifactregistry/internal/artifact_registry_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -223,6 +224,7 @@ ArtifactRegistryConnection::UpdateProjectSettings(
 std::shared_ptr<ArtifactRegistryConnection> MakeArtifactRegistryConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ArtifactRegistryPolicyOptionList>(options,
                                                                    __func__);
   options = artifactregistry_internal::ArtifactRegistryDefaultOptions(

--- a/google/cloud/artifactregistry/artifact_registry_connection.h
+++ b/google/cloud/artifactregistry/artifact_registry_connection.h
@@ -192,6 +192,7 @@ class ArtifactRegistryConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::artifactregistry::ArtifactRegistryPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/asset/asset_connection.cc
+++ b/google/cloud/asset/asset_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/asset/internal/asset_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -157,6 +158,7 @@ AssetServiceConnection::BatchGetEffectiveIamPolicies(
 std::shared_ptr<AssetServiceConnection> MakeAssetServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AssetServicePolicyOptionList>(options,
                                                                __func__);
   options = asset_internal::AssetServiceDefaultOptions(std::move(options));

--- a/google/cloud/asset/asset_connection.h
+++ b/google/cloud/asset/asset_connection.h
@@ -147,6 +147,7 @@ class AssetServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::asset::AssetServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/assuredworkloads/assured_workloads_connection.cc
+++ b/google/cloud/assuredworkloads/assured_workloads_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/assuredworkloads/internal/assured_workloads_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -71,6 +72,7 @@ AssuredWorkloadsServiceConnection::ListWorkloads(
 std::shared_ptr<AssuredWorkloadsServiceConnection>
 MakeAssuredWorkloadsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AssuredWorkloadsServicePolicyOptionList>(
       options, __func__);
   options = assuredworkloads_internal::AssuredWorkloadsServiceDefaultOptions(

--- a/google/cloud/assuredworkloads/assured_workloads_connection.h
+++ b/google/cloud/assuredworkloads/assured_workloads_connection.h
@@ -105,6 +105,7 @@ class AssuredWorkloadsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::assuredworkloads::AssuredWorkloadsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/automl/auto_ml_connection.cc
+++ b/google/cloud/automl/auto_ml_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/automl/internal/auto_ml_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -162,6 +163,7 @@ AutoMlConnection::ListModelEvaluations(
 
 std::shared_ptr<AutoMlConnection> MakeAutoMlConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AutoMlPolicyOptionList>(options, __func__);
   options = automl_internal::AutoMlDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/automl/auto_ml_connection.h
+++ b/google/cloud/automl/auto_ml_connection.h
@@ -135,6 +135,7 @@ class AutoMlConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::automl::AutoMlPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/automl/prediction_connection.cc
+++ b/google/cloud/automl/prediction_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/automl/prediction_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -50,6 +51,7 @@ PredictionServiceConnection::BatchPredict(
 std::shared_ptr<PredictionServiceConnection> MakePredictionServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PredictionServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/automl/prediction_connection.h
+++ b/google/cloud/automl/prediction_connection.h
@@ -87,6 +87,7 @@ class PredictionServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::automl::PredictionServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/baremetalsolution/bare_metal_solution_connection.cc
+++ b/google/cloud/baremetalsolution/bare_metal_solution_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/baremetalsolution/internal/bare_metal_solution_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -185,6 +186,7 @@ BareMetalSolutionConnection::UpdateNfsShare(
 std::shared_ptr<BareMetalSolutionConnection> MakeBareMetalSolutionConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BareMetalSolutionPolicyOptionList>(options,
                                                                     __func__);
   options = baremetalsolution_internal::BareMetalSolutionDefaultOptions(

--- a/google/cloud/baremetalsolution/bare_metal_solution_connection.h
+++ b/google/cloud/baremetalsolution/bare_metal_solution_connection.h
@@ -165,6 +165,7 @@ class BareMetalSolutionConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::baremetalsolution::BareMetalSolutionPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/batch/batch_connection.cc
+++ b/google/cloud/batch/batch_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/batch/internal/batch_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -74,6 +75,7 @@ StreamRange<google::cloud::batch::v1::Task> BatchServiceConnection::ListTasks(
 std::shared_ptr<BatchServiceConnection> MakeBatchServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BatchServicePolicyOptionList>(options,
                                                                __func__);
   options = batch_internal::BatchServiceDefaultOptions(std::move(options));

--- a/google/cloud/batch/batch_connection.h
+++ b/google/cloud/batch/batch_connection.h
@@ -98,6 +98,7 @@ class BatchServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::batch::BatchServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/beyondcorp/app_connections_connection.cc
+++ b/google/cloud/beyondcorp/app_connections_connection.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/beyondcorp/internal/app_connections_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -92,6 +93,7 @@ AppConnectionsServiceConnection::ResolveAppConnections(
 std::shared_ptr<AppConnectionsServiceConnection>
 MakeAppConnectionsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AppConnectionsServicePolicyOptionList>(
       options, __func__);
   options = beyondcorp_internal::AppConnectionsServiceDefaultOptions(

--- a/google/cloud/beyondcorp/app_connections_connection.h
+++ b/google/cloud/beyondcorp/app_connections_connection.h
@@ -114,6 +114,7 @@ class AppConnectionsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::beyondcorp::AppConnectionsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/beyondcorp/app_connectors_connection.cc
+++ b/google/cloud/beyondcorp/app_connectors_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/beyondcorp/internal/app_connectors_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -89,6 +90,7 @@ AppConnectorsServiceConnection::ReportStatus(
 std::shared_ptr<AppConnectorsServiceConnection>
 MakeAppConnectorsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AppConnectorsServicePolicyOptionList>(
       options, __func__);
   options = beyondcorp_internal::AppConnectorsServiceDefaultOptions(

--- a/google/cloud/beyondcorp/app_connectors_connection.h
+++ b/google/cloud/beyondcorp/app_connectors_connection.h
@@ -113,6 +113,7 @@ class AppConnectorsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::beyondcorp::AppConnectorsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/beyondcorp/app_gateways_connection.cc
+++ b/google/cloud/beyondcorp/app_gateways_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/beyondcorp/internal/app_gateways_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -70,6 +71,7 @@ AppGatewaysServiceConnection::DeleteAppGateway(
 std::shared_ptr<AppGatewaysServiceConnection> MakeAppGatewaysServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AppGatewaysServicePolicyOptionList>(options,
                                                                      __func__);
   options =

--- a/google/cloud/beyondcorp/app_gateways_connection.h
+++ b/google/cloud/beyondcorp/app_gateways_connection.h
@@ -104,6 +104,7 @@ class AppGatewaysServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::beyondcorp::AppGatewaysServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/beyondcorp/client_connector_services_connection.cc
+++ b/google/cloud/beyondcorp/client_connector_services_connection.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/beyondcorp/internal/client_connector_services_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -90,7 +91,7 @@ ClientConnectorServicesServiceConnection::DeleteClientConnectorService(
 std::shared_ptr<ClientConnectorServicesServiceConnection>
 MakeClientConnectorServicesServiceConnection(Options options) {
   internal::CheckExpectedOptions<
-      CommonOptionList, GrpcOptionList,
+      CommonOptionList, GrpcOptionList, UnifiedCredentialsOptionList,
       ClientConnectorServicesServicePolicyOptionList>(options, __func__);
   options = beyondcorp_internal::ClientConnectorServicesServiceDefaultOptions(
       std::move(options));

--- a/google/cloud/beyondcorp/client_connector_services_connection.h
+++ b/google/cloud/beyondcorp/client_connector_services_connection.h
@@ -116,6 +116,7 @@ class ClientConnectorServicesServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::beyondcorp::ClientConnectorServicesServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/beyondcorp/client_gateways_connection.cc
+++ b/google/cloud/beyondcorp/client_gateways_connection.cc
@@ -24,6 +24,7 @@
 #include "google/cloud/beyondcorp/internal/client_gateways_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -73,6 +74,7 @@ ClientGatewaysServiceConnection::DeleteClientGateway(
 std::shared_ptr<ClientGatewaysServiceConnection>
 MakeClientGatewaysServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ClientGatewaysServicePolicyOptionList>(
       options, __func__);
   options = beyondcorp_internal::ClientGatewaysServiceDefaultOptions(

--- a/google/cloud/beyondcorp/client_gateways_connection.h
+++ b/google/cloud/beyondcorp/client_gateways_connection.h
@@ -104,6 +104,7 @@ class ClientGatewaysServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::beyondcorp::ClientGatewaysServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigquery/bigquery_read_connection.cc
+++ b/google/cloud/bigquery/bigquery_read_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigquery/internal/bigquery_read_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -66,6 +67,7 @@ BigQueryReadConnection::SplitReadStream(
 std::shared_ptr<BigQueryReadConnection> MakeBigQueryReadConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BigQueryReadPolicyOptionList>(options,
                                                                __func__);
   options = bigquery_internal::BigQueryReadDefaultOptions(std::move(options));

--- a/google/cloud/bigquery/bigquery_read_connection.h
+++ b/google/cloud/bigquery/bigquery_read_connection.h
@@ -100,6 +100,7 @@ class BigQueryReadConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigquery::BigQueryReadPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigquery/bigquery_write_connection.cc
+++ b/google/cloud/bigquery/bigquery_write_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigquery/internal/bigquery_write_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -78,6 +79,7 @@ BigQueryWriteConnection::FlushRows(
 std::shared_ptr<BigQueryWriteConnection> MakeBigQueryWriteConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BigQueryWritePolicyOptionList>(options,
                                                                 __func__);
   options = bigquery_internal::BigQueryWriteDefaultOptions(std::move(options));

--- a/google/cloud/bigquery/bigquery_write_connection.h
+++ b/google/cloud/bigquery/bigquery_write_connection.h
@@ -108,6 +108,7 @@ class BigQueryWriteConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigquery::BigQueryWritePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigquery/connection_connection.cc
+++ b/google/cloud/bigquery/connection_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigquery/internal/connection_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -84,6 +85,7 @@ ConnectionServiceConnection::TestIamPermissions(
 std::shared_ptr<ConnectionServiceConnection> MakeConnectionServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ConnectionServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/bigquery/connection_connection.h
+++ b/google/cloud/bigquery/connection_connection.h
@@ -111,6 +111,7 @@ class ConnectionServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigquery::ConnectionServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigquery/data_transfer_connection.cc
+++ b/google/cloud/bigquery/data_transfer_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigquery/internal/data_transfer_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -142,6 +143,7 @@ Status DataTransferServiceConnection::EnrollDataSources(
 std::shared_ptr<DataTransferServiceConnection>
 MakeDataTransferServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DataTransferServicePolicyOptionList>(options,
                                                                       __func__);
   options =

--- a/google/cloud/bigquery/data_transfer_connection.h
+++ b/google/cloud/bigquery/data_transfer_connection.h
@@ -151,6 +151,7 @@ class DataTransferServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigquery::DataTransferServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigquery/model_connection.cc
+++ b/google/cloud/bigquery/model_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigquery/model_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -57,6 +58,7 @@ Status ModelServiceConnection::DeleteModel(
 std::shared_ptr<ModelServiceConnection> MakeModelServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ModelServicePolicyOptionList>(options,
                                                                __func__);
   options = bigquery_internal::ModelServiceDefaultOptions(std::move(options));

--- a/google/cloud/bigquery/model_connection.h
+++ b/google/cloud/bigquery/model_connection.h
@@ -88,6 +88,7 @@ class ModelServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigquery::ModelServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigquery/reservation_connection.cc
+++ b/google/cloud/bigquery/reservation_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigquery/reservation_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -178,6 +179,7 @@ ReservationServiceConnection::UpdateBiReservation(
 std::shared_ptr<ReservationServiceConnection> MakeReservationServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ReservationServicePolicyOptionList>(options,
                                                                      __func__);
   options =

--- a/google/cloud/bigquery/reservation_connection.h
+++ b/google/cloud/bigquery/reservation_connection.h
@@ -176,6 +176,7 @@ class ReservationServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigquery::ReservationServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigtable/admin/internal/bigtable_instance_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -174,6 +175,7 @@ BigtableInstanceAdminConnection::ListHotTablets(
 std::shared_ptr<BigtableInstanceAdminConnection>
 MakeBigtableInstanceAdminConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BigtableInstanceAdminPolicyOptionList>(
       options, __func__);
   options = bigtable_admin_internal::BigtableInstanceAdminDefaultOptions(

--- a/google/cloud/bigtable/admin/bigtable_instance_admin_connection.h
+++ b/google/cloud/bigtable/admin/bigtable_instance_admin_connection.h
@@ -151,6 +151,7 @@ class BigtableInstanceAdminConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigtable_admin::BigtableInstanceAdminPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/bigtable/admin/internal/bigtable_table_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -158,6 +159,7 @@ BigtableTableAdminConnection::AsyncCheckConsistency(
 std::shared_ptr<BigtableTableAdminConnection> MakeBigtableTableAdminConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BigtableTableAdminPolicyOptionList>(options,
                                                                      __func__);
   options = bigtable_admin_internal::BigtableTableAdminDefaultOptions(

--- a/google/cloud/bigtable/admin/bigtable_table_admin_connection.h
+++ b/google/cloud/bigtable/admin/bigtable_table_admin_connection.h
@@ -145,6 +145,7 @@ class BigtableTableAdminConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::bigtable_admin::BigtableTableAdminPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/bigtable/data_connection.cc
+++ b/google/cloud/bigtable/data_connection.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/bigtable/options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -140,8 +141,9 @@ future<StatusOr<std::pair<bool, Row>>> DataConnection::AsyncReadRow(
 
 std::shared_ptr<DataConnection> MakeDataConnection(Options options) {
   google::cloud::internal::CheckExpectedOptions<
-      CommonOptionList, GrpcOptionList, DataPolicyOptionList>(options,
-                                                              __func__);
+      AppProfileIdOption, CommonOptionList, GrpcOptionList,
+      UnifiedCredentialsOptionList, ClientOptionList, DataPolicyOptionList>(
+      options, __func__);
   options = bigtable::internal::DefaultDataOptions(std::move(options));
   auto background =
       google::cloud::internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/bigtable/data_connection.h
+++ b/google/cloud/bigtable/data_connection.h
@@ -141,11 +141,13 @@ class DataConnection {
  * `Table`.
  *
  * The optional @p opts argument may be used to configure aspects of the
- * returned `DataConnection`. Expected options are any of the types in the
- * following option lists.
+ * returned `DataConnection`. Expected options are any of the following options
+ * or types in the option lists.
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
+ * - `google::cloud::bigtable::AppProfileIdOption`
  * - `google::cloud::bigtable::ClientOptionsList`
  * - `google::cloud::bigtable::DataPolicyOptionList`
  *

--- a/google/cloud/billing/budget_connection.cc
+++ b/google/cloud/billing/budget_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/billing/internal/budget_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status BudgetServiceConnection::DeleteBudget(
 std::shared_ptr<BudgetServiceConnection> MakeBudgetServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BudgetServicePolicyOptionList>(options,
                                                                 __func__);
   options = billing_internal::BudgetServiceDefaultOptions(std::move(options));

--- a/google/cloud/billing/budget_connection.h
+++ b/google/cloud/billing/budget_connection.h
@@ -92,6 +92,7 @@ class BudgetServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::billing::BudgetServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/billing/cloud_billing_connection.cc
+++ b/google/cloud/billing/cloud_billing_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/billing/internal/cloud_billing_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -99,6 +100,7 @@ CloudBillingConnection::TestIamPermissions(
 std::shared_ptr<CloudBillingConnection> MakeCloudBillingConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudBillingPolicyOptionList>(options,
                                                                __func__);
   options = billing_internal::CloudBillingDefaultOptions(std::move(options));

--- a/google/cloud/billing/cloud_billing_connection.h
+++ b/google/cloud/billing/cloud_billing_connection.h
@@ -115,6 +115,7 @@ class CloudBillingConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::billing::CloudBillingPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/billing/cloud_catalog_connection.cc
+++ b/google/cloud/billing/cloud_catalog_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/billing/internal/cloud_catalog_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -52,6 +53,7 @@ StreamRange<google::cloud::billing::v1::Sku> CloudCatalogConnection::ListSkus(
 std::shared_ptr<CloudCatalogConnection> MakeCloudCatalogConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudCatalogPolicyOptionList>(options,
                                                                __func__);
   options = billing_internal::CloudCatalogDefaultOptions(std::move(options));

--- a/google/cloud/billing/cloud_catalog_connection.h
+++ b/google/cloud/billing/cloud_catalog_connection.h
@@ -83,6 +83,7 @@ class CloudCatalogConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::billing::CloudCatalogPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.cc
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/binaryauthorization/internal/binauthz_management_service_v1_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -81,6 +82,7 @@ Status BinauthzManagementServiceV1Connection::DeleteAttestor(
 std::shared_ptr<BinauthzManagementServiceV1Connection>
 MakeBinauthzManagementServiceV1Connection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BinauthzManagementServiceV1PolicyOptionList>(
       options, __func__);
   options =

--- a/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.h
+++ b/google/cloud/binaryauthorization/binauthz_management_service_v1_connection.h
@@ -111,6 +111,7 @@ class BinauthzManagementServiceV1Connection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * -
  * `google::cloud::binaryauthorization::BinauthzManagementServiceV1PolicyOptionList`
  *

--- a/google/cloud/binaryauthorization/system_policy_v1_connection.cc
+++ b/google/cloud/binaryauthorization/system_policy_v1_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/binaryauthorization/system_policy_v1_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -42,6 +43,7 @@ SystemPolicyV1Connection::GetSystemPolicy(
 std::shared_ptr<SystemPolicyV1Connection> MakeSystemPolicyV1Connection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SystemPolicyV1PolicyOptionList>(options,
                                                                  __func__);
   options = binaryauthorization_internal::SystemPolicyV1DefaultOptions(

--- a/google/cloud/binaryauthorization/system_policy_v1_connection.h
+++ b/google/cloud/binaryauthorization/system_policy_v1_connection.h
@@ -81,6 +81,7 @@ class SystemPolicyV1Connection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::binaryauthorization::SystemPolicyV1PolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/binaryauthorization/validation_helper_v1_connection.cc
+++ b/google/cloud/binaryauthorization/validation_helper_v1_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/binaryauthorization/validation_helper_v1_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -44,6 +45,7 @@ ValidationHelperV1Connection::ValidateAttestationOccurrence(
 std::shared_ptr<ValidationHelperV1Connection> MakeValidationHelperV1Connection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ValidationHelperV1PolicyOptionList>(options,
                                                                      __func__);
   options = binaryauthorization_internal::ValidationHelperV1DefaultOptions(

--- a/google/cloud/binaryauthorization/validation_helper_v1_connection.h
+++ b/google/cloud/binaryauthorization/validation_helper_v1_connection.h
@@ -85,6 +85,7 @@ class ValidationHelperV1Connection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::binaryauthorization::ValidationHelperV1PolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/channel/cloud_channel_connection.cc
+++ b/google/cloud/channel/cloud_channel_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/channel/internal/cloud_channel_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -355,6 +356,7 @@ StreamRange<std::string> CloudChannelServiceConnection::ListSubscribers(
 std::shared_ptr<CloudChannelServiceConnection>
 MakeCloudChannelServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudChannelServicePolicyOptionList>(options,
                                                                       __func__);
   options =

--- a/google/cloud/channel/cloud_channel_connection.h
+++ b/google/cloud/channel/cloud_channel_connection.h
@@ -261,6 +261,7 @@ class CloudChannelServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::channel::CloudChannelServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/cloudbuild/cloud_build_connection.cc
+++ b/google/cloud/cloudbuild/cloud_build_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/cloudbuild/internal/cloud_build_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -165,6 +166,7 @@ CloudBuildConnection::ListWorkerPools(
 std::shared_ptr<CloudBuildConnection> MakeCloudBuildConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudBuildPolicyOptionList>(options, __func__);
   options = cloudbuild_internal::CloudBuildDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/cloudbuild/cloud_build_connection.h
+++ b/google/cloud/cloudbuild/cloud_build_connection.h
@@ -150,6 +150,7 @@ class CloudBuildConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::cloudbuild::CloudBuildPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/composer/environments_connection.cc
+++ b/google/cloud/composer/environments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/composer/internal/environments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -82,6 +83,7 @@ EnvironmentsConnection::DeleteEnvironment(
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EnvironmentsPolicyOptionList>(options,
                                                                __func__);
   options = composer_internal::EnvironmentsDefaultOptions(std::move(options));

--- a/google/cloud/composer/environments_connection.h
+++ b/google/cloud/composer/environments_connection.h
@@ -105,6 +105,7 @@ class EnvironmentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::composer::EnvironmentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/composer/image_versions_connection.cc
+++ b/google/cloud/composer/image_versions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/composer/internal/image_versions_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -45,6 +46,7 @@ ImageVersionsConnection::ListImageVersions(
 std::shared_ptr<ImageVersionsConnection> MakeImageVersionsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ImageVersionsPolicyOptionList>(options,
                                                                 __func__);
   options = composer_internal::ImageVersionsDefaultOptions(std::move(options));

--- a/google/cloud/composer/image_versions_connection.h
+++ b/google/cloud/composer/image_versions_connection.h
@@ -82,6 +82,7 @@ class ImageVersionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::composer::ImageVersionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/contactcenterinsights/contact_center_insights_connection.cc
+++ b/google/cloud/contactcenterinsights/contact_center_insights_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/contactcenterinsights/internal/contact_center_insights_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -271,6 +272,7 @@ Status ContactCenterInsightsConnection::DeleteView(
 std::shared_ptr<ContactCenterInsightsConnection>
 MakeContactCenterInsightsConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ContactCenterInsightsPolicyOptionList>(
       options, __func__);
   options = contactcenterinsights_internal::ContactCenterInsightsDefaultOptions(

--- a/google/cloud/contactcenterinsights/contact_center_insights_connection.h
+++ b/google/cloud/contactcenterinsights/contact_center_insights_connection.h
@@ -243,6 +243,7 @@ class ContactCenterInsightsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * -
  * `google::cloud::contactcenterinsights::ContactCenterInsightsPolicyOptionList`
  *

--- a/google/cloud/container/cluster_manager_connection.cc
+++ b/google/cloud/container/cluster_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/container/internal/cluster_manager_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -232,6 +233,7 @@ ClusterManagerConnection::ListUsableSubnetworks(
 std::shared_ptr<ClusterManagerConnection> MakeClusterManagerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ClusterManagerPolicyOptionList>(options,
                                                                  __func__);
   options =

--- a/google/cloud/container/cluster_manager_connection.h
+++ b/google/cloud/container/cluster_manager_connection.h
@@ -177,6 +177,7 @@ class ClusterManagerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::container::ClusterManagerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/containeranalysis/container_analysis_connection.cc
+++ b/google/cloud/containeranalysis/container_analysis_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/containeranalysis/internal/container_analysis_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -60,6 +61,7 @@ ContainerAnalysisConnection::GetVulnerabilityOccurrencesSummary(
 std::shared_ptr<ContainerAnalysisConnection> MakeContainerAnalysisConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ContainerAnalysisPolicyOptionList>(options,
                                                                     __func__);
   options = containeranalysis_internal::ContainerAnalysisDefaultOptions(

--- a/google/cloud/containeranalysis/container_analysis_connection.h
+++ b/google/cloud/containeranalysis/container_analysis_connection.h
@@ -93,6 +93,7 @@ class ContainerAnalysisConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::containeranalysis::ContainerAnalysisPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/containeranalysis/grafeas_connection.cc
+++ b/google/cloud/containeranalysis/grafeas_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/containeranalysis/internal/grafeas_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -113,6 +114,7 @@ StreamRange<grafeas::v1::Occurrence> GrafeasConnection::ListNoteOccurrences(
 
 std::shared_ptr<GrafeasConnection> MakeGrafeasConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  GrafeasPolicyOptionList>(options, __func__);
   options =
       containeranalysis_internal::GrafeasDefaultOptions(std::move(options));

--- a/google/cloud/containeranalysis/grafeas_connection.h
+++ b/google/cloud/containeranalysis/grafeas_connection.h
@@ -118,6 +118,7 @@ class GrafeasConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::containeranalysis::GrafeasPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/credentials.h
+++ b/google/cloud/credentials.h
@@ -295,6 +295,11 @@ struct CARootsFilePathOption {
   using Type = std::string;
 };
 
+/// A list of GUAC options.
+using UnifiedCredentialsOptionList =
+    OptionList<AccessTokenLifetimeOption, CARootsFilePathOption,
+               DelegatesOption, ScopesOption, UnifiedCredentialsOption>;
+
 namespace internal {
 
 /**

--- a/google/cloud/datacatalog/data_catalog_connection.cc
+++ b/google/cloud/datacatalog/data_catalog_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/datacatalog/internal/data_catalog_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -228,6 +229,7 @@ DataCatalogConnection::TestIamPermissions(
 std::shared_ptr<DataCatalogConnection> MakeDataCatalogConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DataCatalogPolicyOptionList>(options,
                                                               __func__);
   options = datacatalog_internal::DataCatalogDefaultOptions(std::move(options));

--- a/google/cloud/datacatalog/data_catalog_connection.h
+++ b/google/cloud/datacatalog/data_catalog_connection.h
@@ -189,6 +189,7 @@ class DataCatalogConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::datacatalog::DataCatalogPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/datacatalog/policy_tag_manager_connection.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/datacatalog/policy_tag_manager_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -115,6 +116,7 @@ PolicyTagManagerConnection::TestIamPermissions(
 std::shared_ptr<PolicyTagManagerConnection> MakePolicyTagManagerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PolicyTagManagerPolicyOptionList>(options,
                                                                    __func__);
   options =

--- a/google/cloud/datacatalog/policy_tag_manager_connection.h
+++ b/google/cloud/datacatalog/policy_tag_manager_connection.h
@@ -117,6 +117,7 @@ class PolicyTagManagerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::datacatalog::PolicyTagManagerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_connection.cc
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/datacatalog/policy_tag_manager_serialization_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -55,6 +56,7 @@ PolicyTagManagerSerializationConnection::ExportTaxonomies(
 std::shared_ptr<PolicyTagManagerSerializationConnection>
 MakePolicyTagManagerSerializationConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PolicyTagManagerSerializationPolicyOptionList>(
       options, __func__);
   options = datacatalog_internal::PolicyTagManagerSerializationDefaultOptions(

--- a/google/cloud/datacatalog/policy_tag_manager_serialization_connection.h
+++ b/google/cloud/datacatalog/policy_tag_manager_serialization_connection.h
@@ -92,6 +92,7 @@ class PolicyTagManagerSerializationConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::datacatalog::PolicyTagManagerSerializationPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/datamigration/data_migration_connection.cc
+++ b/google/cloud/datamigration/data_migration_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/datamigration/internal/data_migration_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -167,6 +168,7 @@ DataMigrationServiceConnection::DeleteConnectionProfile(
 std::shared_ptr<DataMigrationServiceConnection>
 MakeDataMigrationServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DataMigrationServicePolicyOptionList>(
       options, __func__);
   options = datamigration_internal::DataMigrationServiceDefaultOptions(

--- a/google/cloud/datamigration/data_migration_connection.h
+++ b/google/cloud/datamigration/data_migration_connection.h
@@ -151,6 +151,7 @@ class DataMigrationServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::datamigration::DataMigrationServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataplex/content_connection.cc
+++ b/google/cloud/dataplex/content_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataplex/internal/content_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -84,6 +85,7 @@ ContentServiceConnection::ListContent(
 std::shared_ptr<ContentServiceConnection> MakeContentServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ContentServicePolicyOptionList>(options,
                                                                  __func__);
   options = dataplex_internal::ContentServiceDefaultOptions(std::move(options));

--- a/google/cloud/dataplex/content_connection.h
+++ b/google/cloud/dataplex/content_connection.h
@@ -101,6 +101,7 @@ class ContentServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataplex::ContentServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataplex/dataplex_connection.cc
+++ b/google/cloud/dataplex/dataplex_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataplex/internal/dataplex_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -274,6 +275,7 @@ DataplexServiceConnection::ListSessions(
 std::shared_ptr<DataplexServiceConnection> MakeDataplexServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DataplexServicePolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/dataplex/dataplex_connection.h
+++ b/google/cloud/dataplex/dataplex_connection.h
@@ -181,6 +181,7 @@ class DataplexServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataplex::DataplexServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataplex/metadata_connection.cc
+++ b/google/cloud/dataplex/metadata_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataplex/metadata_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -93,6 +94,7 @@ MetadataServiceConnection::ListPartitions(
 std::shared_ptr<MetadataServiceConnection> MakeMetadataServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  MetadataServicePolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/dataplex/metadata_connection.h
+++ b/google/cloud/dataplex/metadata_connection.h
@@ -105,6 +105,7 @@ class MetadataServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataplex::MetadataServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataproc/autoscaling_policy_connection.cc
+++ b/google/cloud/dataproc/autoscaling_policy_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataproc/internal/autoscaling_policy_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -69,6 +70,7 @@ Status AutoscalingPolicyServiceConnection::DeleteAutoscalingPolicy(
 std::shared_ptr<AutoscalingPolicyServiceConnection>
 MakeAutoscalingPolicyServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AutoscalingPolicyServicePolicyOptionList>(
       options, __func__);
   options = dataproc_internal::AutoscalingPolicyServiceDefaultOptions(

--- a/google/cloud/dataproc/autoscaling_policy_connection.h
+++ b/google/cloud/dataproc/autoscaling_policy_connection.h
@@ -103,6 +103,7 @@ class AutoscalingPolicyServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataproc::AutoscalingPolicyServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataproc/batch_controller_connection.cc
+++ b/google/cloud/dataproc/batch_controller_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataproc/internal/batch_controller_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -64,6 +65,7 @@ Status BatchControllerConnection::DeleteBatch(
 std::shared_ptr<BatchControllerConnection> MakeBatchControllerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  BatchControllerPolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/dataproc/batch_controller_connection.h
+++ b/google/cloud/dataproc/batch_controller_connection.h
@@ -93,6 +93,7 @@ class BatchControllerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataproc::BatchControllerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataproc/cluster_controller_connection.cc
+++ b/google/cloud/dataproc/cluster_controller_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataproc/internal/cluster_controller_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -99,6 +100,7 @@ ClusterControllerConnection::DiagnoseCluster(
 std::shared_ptr<ClusterControllerConnection> MakeClusterControllerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ClusterControllerPolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/dataproc/cluster_controller_connection.h
+++ b/google/cloud/dataproc/cluster_controller_connection.h
@@ -109,6 +109,7 @@ class ClusterControllerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataproc::ClusterControllerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataproc/job_controller_connection.cc
+++ b/google/cloud/dataproc/job_controller_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataproc/job_controller_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -77,6 +78,7 @@ Status JobControllerConnection::DeleteJob(
 std::shared_ptr<JobControllerConnection> MakeJobControllerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  JobControllerPolicyOptionList>(options,
                                                                 __func__);
   options = dataproc_internal::JobControllerDefaultOptions(std::move(options));

--- a/google/cloud/dataproc/job_controller_connection.h
+++ b/google/cloud/dataproc/job_controller_connection.h
@@ -102,6 +102,7 @@ class JobControllerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataproc::JobControllerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dataproc/workflow_template_connection.cc
+++ b/google/cloud/dataproc/workflow_template_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dataproc/workflow_template_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -86,6 +87,7 @@ Status WorkflowTemplateServiceConnection::DeleteWorkflowTemplate(
 std::shared_ptr<WorkflowTemplateServiceConnection>
 MakeWorkflowTemplateServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  WorkflowTemplateServicePolicyOptionList>(
       options, __func__);
   options = dataproc_internal::WorkflowTemplateServiceDefaultOptions(

--- a/google/cloud/dataproc/workflow_template_connection.h
+++ b/google/cloud/dataproc/workflow_template_connection.h
@@ -115,6 +115,7 @@ class WorkflowTemplateServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dataproc::WorkflowTemplateServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/debugger/controller2_connection.cc
+++ b/google/cloud/debugger/controller2_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/debugger/internal/controller2_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -54,6 +55,7 @@ Controller2Connection::UpdateActiveBreakpoint(
 std::shared_ptr<Controller2Connection> MakeController2Connection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  Controller2PolicyOptionList>(options,
                                                               __func__);
   options = debugger_internal::Controller2DefaultOptions(std::move(options));

--- a/google/cloud/debugger/controller2_connection.h
+++ b/google/cloud/debugger/controller2_connection.h
@@ -93,6 +93,7 @@ class Controller2Connection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::debugger::Controller2PolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/debugger/debugger2_connection.cc
+++ b/google/cloud/debugger/debugger2_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/debugger/internal/debugger2_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -64,6 +65,7 @@ Debugger2Connection::ListDebuggees(
 
 std::shared_ptr<Debugger2Connection> MakeDebugger2Connection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  Debugger2PolicyOptionList>(options, __func__);
   options = debugger_internal::Debugger2DefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/debugger/debugger2_connection.h
+++ b/google/cloud/debugger/debugger2_connection.h
@@ -96,6 +96,7 @@ class Debugger2Connection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::debugger::Debugger2PolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/agents_connection.cc
+++ b/google/cloud/dialogflow_cx/agents_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/agents_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -93,6 +94,7 @@ AgentsConnection::GetAgentValidationResult(
 std::shared_ptr<AgentsConnection> MakeAgentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AgentsPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::AgentsDefaultOptions(location,
                                                          std::move(options));

--- a/google/cloud/dialogflow_cx/agents_connection.h
+++ b/google/cloud/dialogflow_cx/agents_connection.h
@@ -112,6 +112,7 @@ class AgentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::AgentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/changelogs_connection.cc
+++ b/google/cloud/dialogflow_cx/changelogs_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/changelogs_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -51,6 +52,7 @@ ChangelogsConnection::GetChangelog(
 std::shared_ptr<ChangelogsConnection> MakeChangelogsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ChangelogsPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::ChangelogsDefaultOptions(
       location, std::move(options));

--- a/google/cloud/dialogflow_cx/changelogs_connection.h
+++ b/google/cloud/dialogflow_cx/changelogs_connection.h
@@ -84,6 +84,7 @@ class ChangelogsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::ChangelogsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/deployments_connection.cc
+++ b/google/cloud/dialogflow_cx/deployments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/deployments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -51,6 +52,7 @@ DeploymentsConnection::GetDeployment(
 std::shared_ptr<DeploymentsConnection> MakeDeploymentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DeploymentsPolicyOptionList>(options,
                                                               __func__);
   options = dialogflow_cx_internal::DeploymentsDefaultOptions(

--- a/google/cloud/dialogflow_cx/deployments_connection.h
+++ b/google/cloud/dialogflow_cx/deployments_connection.h
@@ -84,6 +84,7 @@ class DeploymentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::DeploymentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/entity_types_connection.cc
+++ b/google/cloud/dialogflow_cx/entity_types_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/entity_types_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status EntityTypesConnection::DeleteEntityType(
 std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EntityTypesPolicyOptionList>(options,
                                                               __func__);
   options = dialogflow_cx_internal::EntityTypesDefaultOptions(

--- a/google/cloud/dialogflow_cx/entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/entity_types_connection.h
@@ -98,6 +98,7 @@ class EntityTypesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::EntityTypesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/environments_connection.cc
+++ b/google/cloud/dialogflow_cx/environments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/environments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -104,6 +105,7 @@ EnvironmentsConnection::DeployFlow(
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EnvironmentsPolicyOptionList>(options,
                                                                __func__);
   options = dialogflow_cx_internal::EnvironmentsDefaultOptions(

--- a/google/cloud/dialogflow_cx/environments_connection.h
+++ b/google/cloud/dialogflow_cx/environments_connection.h
@@ -124,6 +124,7 @@ class EnvironmentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::EnvironmentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/experiments_connection.cc
+++ b/google/cloud/dialogflow_cx/experiments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/experiments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -80,6 +81,7 @@ ExperimentsConnection::StopExperiment(
 std::shared_ptr<ExperimentsConnection> MakeExperimentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ExperimentsPolicyOptionList>(options,
                                                               __func__);
   options = dialogflow_cx_internal::ExperimentsDefaultOptions(

--- a/google/cloud/dialogflow_cx/experiments_connection.h
+++ b/google/cloud/dialogflow_cx/experiments_connection.h
@@ -106,6 +106,7 @@ class ExperimentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::ExperimentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/flows_connection.cc
+++ b/google/cloud/dialogflow_cx/flows_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/flows_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -98,6 +99,7 @@ FlowsConnection::ExportFlow(
 std::shared_ptr<FlowsConnection> MakeFlowsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  FlowsPolicyOptionList>(options, __func__);
   options =
       dialogflow_cx_internal::FlowsDefaultOptions(location, std::move(options));

--- a/google/cloud/dialogflow_cx/flows_connection.h
+++ b/google/cloud/dialogflow_cx/flows_connection.h
@@ -117,6 +117,7 @@ class FlowsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::FlowsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/intents_connection.cc
+++ b/google/cloud/dialogflow_cx/intents_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/internal/intents_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status IntentsConnection::DeleteIntent(
 std::shared_ptr<IntentsConnection> MakeIntentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IntentsPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::IntentsDefaultOptions(location,
                                                           std::move(options));

--- a/google/cloud/dialogflow_cx/intents_connection.h
+++ b/google/cloud/dialogflow_cx/intents_connection.h
@@ -92,6 +92,7 @@ class IntentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::IntentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/pages_connection.cc
+++ b/google/cloud/dialogflow_cx/pages_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/pages_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -64,6 +65,7 @@ Status PagesConnection::DeletePage(
 std::shared_ptr<PagesConnection> MakePagesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PagesPolicyOptionList>(options, __func__);
   options =
       dialogflow_cx_internal::PagesDefaultOptions(location, std::move(options));

--- a/google/cloud/dialogflow_cx/pages_connection.h
+++ b/google/cloud/dialogflow_cx/pages_connection.h
@@ -92,6 +92,7 @@ class PagesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::PagesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/security_settings_connection.cc
+++ b/google/cloud/dialogflow_cx/security_settings_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/security_settings_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -70,6 +71,7 @@ std::shared_ptr<SecuritySettingsServiceConnection>
 MakeSecuritySettingsServiceConnection(std::string const& location,
                                       Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SecuritySettingsServicePolicyOptionList>(
       options, __func__);
   options = dialogflow_cx_internal::SecuritySettingsServiceDefaultOptions(

--- a/google/cloud/dialogflow_cx/security_settings_connection.h
+++ b/google/cloud/dialogflow_cx/security_settings_connection.h
@@ -105,6 +105,7 @@ class SecuritySettingsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::SecuritySettingsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/session_entity_types_connection.cc
+++ b/google/cloud/dialogflow_cx/session_entity_types_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/session_entity_types_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status SessionEntityTypesConnection::DeleteSessionEntityType(
 std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SessionEntityTypesPolicyOptionList>(options,
                                                                      __func__);
   options = dialogflow_cx_internal::SessionEntityTypesDefaultOptions(

--- a/google/cloud/dialogflow_cx/session_entity_types_connection.h
+++ b/google/cloud/dialogflow_cx/session_entity_types_connection.h
@@ -103,6 +103,7 @@ class SessionEntityTypesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::SessionEntityTypesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/sessions_connection.cc
+++ b/google/cloud/dialogflow_cx/sessions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/sessions_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -65,6 +66,7 @@ SessionsConnection::FulfillIntent(
 std::shared_ptr<SessionsConnection> MakeSessionsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SessionsPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::SessionsDefaultOptions(location,
                                                            std::move(options));

--- a/google/cloud/dialogflow_cx/sessions_connection.h
+++ b/google/cloud/dialogflow_cx/sessions_connection.h
@@ -95,6 +95,7 @@ class SessionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::SessionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/test_cases_connection.cc
+++ b/google/cloud/dialogflow_cx/test_cases_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/test_cases_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -120,6 +121,7 @@ TestCasesConnection::GetTestCaseResult(
 std::shared_ptr<TestCasesConnection> MakeTestCasesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TestCasesPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::TestCasesDefaultOptions(location,
                                                             std::move(options));

--- a/google/cloud/dialogflow_cx/test_cases_connection.h
+++ b/google/cloud/dialogflow_cx/test_cases_connection.h
@@ -132,6 +132,7 @@ class TestCasesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::TestCasesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/transition_route_groups_connection.cc
+++ b/google/cloud/dialogflow_cx/transition_route_groups_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/transition_route_groups_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -72,6 +73,7 @@ std::shared_ptr<TransitionRouteGroupsConnection>
 MakeTransitionRouteGroupsConnection(std::string const& location,
                                     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TransitionRouteGroupsPolicyOptionList>(
       options, __func__);
   options = dialogflow_cx_internal::TransitionRouteGroupsDefaultOptions(

--- a/google/cloud/dialogflow_cx/transition_route_groups_connection.h
+++ b/google/cloud/dialogflow_cx/transition_route_groups_connection.h
@@ -105,6 +105,7 @@ class TransitionRouteGroupsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::TransitionRouteGroupsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/versions_connection.cc
+++ b/google/cloud/dialogflow_cx/versions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/versions_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -82,6 +83,7 @@ VersionsConnection::CompareVersions(
 std::shared_ptr<VersionsConnection> MakeVersionsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VersionsPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::VersionsDefaultOptions(location,
                                                            std::move(options));

--- a/google/cloud/dialogflow_cx/versions_connection.h
+++ b/google/cloud/dialogflow_cx/versions_connection.h
@@ -103,6 +103,7 @@ class VersionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::VersionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_cx/webhooks_connection.cc
+++ b/google/cloud/dialogflow_cx/webhooks_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_cx/webhooks_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status WebhooksConnection::DeleteWebhook(
 std::shared_ptr<WebhooksConnection> MakeWebhooksConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  WebhooksPolicyOptionList>(options, __func__);
   options = dialogflow_cx_internal::WebhooksDefaultOptions(location,
                                                            std::move(options));

--- a/google/cloud/dialogflow_cx/webhooks_connection.h
+++ b/google/cloud/dialogflow_cx/webhooks_connection.h
@@ -92,6 +92,7 @@ class WebhooksConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_cx::WebhooksPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/agents_connection.cc
+++ b/google/cloud/dialogflow_es/agents_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/agents_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -92,6 +93,7 @@ AgentsConnection::GetValidationResult(
 std::shared_ptr<AgentsConnection> MakeAgentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AgentsPolicyOptionList>(options, __func__);
   options = dialogflow_es_internal::AgentsDefaultOptions(location,
                                                          std::move(options));

--- a/google/cloud/dialogflow_es/agents_connection.h
+++ b/google/cloud/dialogflow_es/agents_connection.h
@@ -108,6 +108,7 @@ class AgentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::AgentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/answer_records_connection.cc
+++ b/google/cloud/dialogflow_es/answer_records_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/answer_records_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -51,6 +52,7 @@ AnswerRecordsConnection::UpdateAnswerRecord(
 std::shared_ptr<AnswerRecordsConnection> MakeAnswerRecordsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AnswerRecordsPolicyOptionList>(options,
                                                                 __func__);
   options = dialogflow_es_internal::AnswerRecordsDefaultOptions(

--- a/google/cloud/dialogflow_es/answer_records_connection.h
+++ b/google/cloud/dialogflow_es/answer_records_connection.h
@@ -86,6 +86,7 @@ class AnswerRecordsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::AnswerRecordsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/contexts_connection.cc
+++ b/google/cloud/dialogflow_es/contexts_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/contexts_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -72,6 +73,7 @@ Status ContextsConnection::DeleteAllContexts(
 std::shared_ptr<ContextsConnection> MakeContextsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ContextsPolicyOptionList>(options, __func__);
   options = dialogflow_es_internal::ContextsDefaultOptions(location,
                                                            std::move(options));

--- a/google/cloud/dialogflow_es/contexts_connection.h
+++ b/google/cloud/dialogflow_es/contexts_connection.h
@@ -95,6 +95,7 @@ class ContextsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::ContextsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/conversation_datasets_connection.cc
+++ b/google/cloud/dialogflow_es/conversation_datasets_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/conversation_datasets_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -79,6 +80,7 @@ std::shared_ptr<ConversationDatasetsConnection>
 MakeConversationDatasetsConnection(std::string const& location,
                                    Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ConversationDatasetsPolicyOptionList>(
       options, __func__);
   options = dialogflow_es_internal::ConversationDatasetsDefaultOptions(

--- a/google/cloud/dialogflow_es/conversation_datasets_connection.h
+++ b/google/cloud/dialogflow_es/conversation_datasets_connection.h
@@ -109,6 +109,7 @@ class ConversationDatasetsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::ConversationDatasetsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/conversation_models_connection.cc
+++ b/google/cloud/dialogflow_es/conversation_models_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/conversation_models_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -111,6 +112,7 @@ ConversationModelsConnection::CreateConversationModelEvaluation(
 std::shared_ptr<ConversationModelsConnection> MakeConversationModelsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ConversationModelsPolicyOptionList>(options,
                                                                      __func__);
   options = dialogflow_es_internal::ConversationModelsDefaultOptions(

--- a/google/cloud/dialogflow_es/conversation_models_connection.h
+++ b/google/cloud/dialogflow_es/conversation_models_connection.h
@@ -132,6 +132,7 @@ class ConversationModelsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::ConversationModelsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/conversation_profiles_connection.cc
+++ b/google/cloud/dialogflow_es/conversation_profiles_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/conversation_profiles_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -85,6 +86,7 @@ std::shared_ptr<ConversationProfilesConnection>
 MakeConversationProfilesConnection(std::string const& location,
                                    Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ConversationProfilesPolicyOptionList>(
       options, __func__);
   options = dialogflow_es_internal::ConversationProfilesDefaultOptions(

--- a/google/cloud/dialogflow_es/conversation_profiles_connection.h
+++ b/google/cloud/dialogflow_es/conversation_profiles_connection.h
@@ -116,6 +116,7 @@ class ConversationProfilesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::ConversationProfilesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/conversations_connection.cc
+++ b/google/cloud/dialogflow_es/conversations_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/conversations_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -71,6 +72,7 @@ ConversationsConnection::ListMessages(
 std::shared_ptr<ConversationsConnection> MakeConversationsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ConversationsPolicyOptionList>(options,
                                                                 __func__);
   options = dialogflow_es_internal::ConversationsDefaultOptions(

--- a/google/cloud/dialogflow_es/conversations_connection.h
+++ b/google/cloud/dialogflow_es/conversations_connection.h
@@ -97,6 +97,7 @@ class ConversationsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::ConversationsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/documents_connection.cc
+++ b/google/cloud/dialogflow_es/documents_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/documents_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -99,6 +100,7 @@ DocumentsConnection::ExportDocument(
 std::shared_ptr<DocumentsConnection> MakeDocumentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DocumentsPolicyOptionList>(options, __func__);
   options = dialogflow_es_internal::DocumentsDefaultOptions(location,
                                                             std::move(options));

--- a/google/cloud/dialogflow_es/documents_connection.h
+++ b/google/cloud/dialogflow_es/documents_connection.h
@@ -112,6 +112,7 @@ class DocumentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::DocumentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/entity_types_connection.cc
+++ b/google/cloud/dialogflow_es/entity_types_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/entity_types_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -104,6 +105,7 @@ EntityTypesConnection::BatchDeleteEntities(
 std::shared_ptr<EntityTypesConnection> MakeEntityTypesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EntityTypesPolicyOptionList>(options,
                                                               __func__);
   options = dialogflow_es_internal::EntityTypesDefaultOptions(

--- a/google/cloud/dialogflow_es/entity_types_connection.h
+++ b/google/cloud/dialogflow_es/entity_types_connection.h
@@ -115,6 +115,7 @@ class EntityTypesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::EntityTypesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/environments_connection.cc
+++ b/google/cloud/dialogflow_es/environments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/environments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -76,6 +77,7 @@ EnvironmentsConnection::GetEnvironmentHistory(
 std::shared_ptr<EnvironmentsConnection> MakeEnvironmentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EnvironmentsPolicyOptionList>(options,
                                                                __func__);
   options = dialogflow_es_internal::EnvironmentsDefaultOptions(

--- a/google/cloud/dialogflow_es/environments_connection.h
+++ b/google/cloud/dialogflow_es/environments_connection.h
@@ -100,6 +100,7 @@ class EnvironmentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::EnvironmentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/fulfillments_connection.cc
+++ b/google/cloud/dialogflow_es/fulfillments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/fulfillments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -48,6 +49,7 @@ FulfillmentsConnection::UpdateFulfillment(
 std::shared_ptr<FulfillmentsConnection> MakeFulfillmentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  FulfillmentsPolicyOptionList>(options,
                                                                __func__);
   options = dialogflow_es_internal::FulfillmentsDefaultOptions(

--- a/google/cloud/dialogflow_es/fulfillments_connection.h
+++ b/google/cloud/dialogflow_es/fulfillments_connection.h
@@ -84,6 +84,7 @@ class FulfillmentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::FulfillmentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/intents_connection.cc
+++ b/google/cloud/dialogflow_es/intents_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/internal/intents_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -80,6 +81,7 @@ IntentsConnection::BatchDeleteIntents(
 std::shared_ptr<IntentsConnection> MakeIntentsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IntentsPolicyOptionList>(options, __func__);
   options = dialogflow_es_internal::IntentsDefaultOptions(location,
                                                           std::move(options));

--- a/google/cloud/dialogflow_es/intents_connection.h
+++ b/google/cloud/dialogflow_es/intents_connection.h
@@ -103,6 +103,7 @@ class IntentsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::IntentsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/knowledge_bases_connection.cc
+++ b/google/cloud/dialogflow_es/knowledge_bases_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/knowledge_bases_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ KnowledgeBasesConnection::UpdateKnowledgeBase(
 std::shared_ptr<KnowledgeBasesConnection> MakeKnowledgeBasesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  KnowledgeBasesPolicyOptionList>(options,
                                                                  __func__);
   options = dialogflow_es_internal::KnowledgeBasesDefaultOptions(

--- a/google/cloud/dialogflow_es/knowledge_bases_connection.h
+++ b/google/cloud/dialogflow_es/knowledge_bases_connection.h
@@ -97,6 +97,7 @@ class KnowledgeBasesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::KnowledgeBasesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/participants_connection.cc
+++ b/google/cloud/dialogflow_es/participants_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/participants_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -87,6 +88,7 @@ ParticipantsConnection::SuggestSmartReplies(
 std::shared_ptr<ParticipantsConnection> MakeParticipantsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ParticipantsPolicyOptionList>(options,
                                                                __func__);
   options = dialogflow_es_internal::ParticipantsDefaultOptions(

--- a/google/cloud/dialogflow_es/participants_connection.h
+++ b/google/cloud/dialogflow_es/participants_connection.h
@@ -109,6 +109,7 @@ class ParticipantsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::ParticipantsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/session_entity_types_connection.cc
+++ b/google/cloud/dialogflow_es/session_entity_types_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/session_entity_types_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ Status SessionEntityTypesConnection::DeleteSessionEntityType(
 std::shared_ptr<SessionEntityTypesConnection> MakeSessionEntityTypesConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SessionEntityTypesPolicyOptionList>(options,
                                                                      __func__);
   options = dialogflow_es_internal::SessionEntityTypesDefaultOptions(

--- a/google/cloud/dialogflow_es/session_entity_types_connection.h
+++ b/google/cloud/dialogflow_es/session_entity_types_connection.h
@@ -103,6 +103,7 @@ class SessionEntityTypesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::SessionEntityTypesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/sessions_connection.cc
+++ b/google/cloud/dialogflow_es/sessions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/sessions_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -53,6 +54,7 @@ SessionsConnection::AsyncStreamingDetectIntent(ExperimentalTag) {
 std::shared_ptr<SessionsConnection> MakeSessionsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SessionsPolicyOptionList>(options, __func__);
   options = dialogflow_es_internal::SessionsDefaultOptions(location,
                                                            std::move(options));

--- a/google/cloud/dialogflow_es/sessions_connection.h
+++ b/google/cloud/dialogflow_es/sessions_connection.h
@@ -87,6 +87,7 @@ class SessionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::SessionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dialogflow_es/versions_connection.cc
+++ b/google/cloud/dialogflow_es/versions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dialogflow_es/versions_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -67,6 +68,7 @@ Status VersionsConnection::DeleteVersion(
 std::shared_ptr<VersionsConnection> MakeVersionsConnection(
     std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VersionsPolicyOptionList>(options, __func__);
   options = dialogflow_es_internal::VersionsDefaultOptions(location,
                                                            std::move(options));

--- a/google/cloud/dialogflow_es/versions_connection.h
+++ b/google/cloud/dialogflow_es/versions_connection.h
@@ -92,6 +92,7 @@ class VersionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dialogflow_es::VersionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/dlp/dlp_connection.cc
+++ b/google/cloud/dlp/dlp_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/dlp/internal/dlp_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -241,6 +242,7 @@ Status DlpServiceConnection::FinishDlpJob(
 std::shared_ptr<DlpServiceConnection> MakeDlpServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DlpServicePolicyOptionList>(options, __func__);
   options = dlp_internal::DlpServiceDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/dlp/dlp_connection.h
+++ b/google/cloud/dlp/dlp_connection.h
@@ -194,6 +194,7 @@ class DlpServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::dlp::DlpServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/documentai/document_processor_connection.cc
+++ b/google/cloud/documentai/document_processor_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/documentai/internal/document_processor_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -60,6 +61,7 @@ std::shared_ptr<DocumentProcessorServiceConnection>
 MakeDocumentProcessorServiceConnection(std::string const& location,
                                        Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DocumentProcessorServicePolicyOptionList>(
       options, __func__);
   options = documentai_internal::DocumentProcessorServiceDefaultOptions(

--- a/google/cloud/documentai/document_processor_connection.h
+++ b/google/cloud/documentai/document_processor_connection.h
@@ -96,6 +96,7 @@ class DocumentProcessorServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::documentai::DocumentProcessorServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/eventarc/eventarc_connection.cc
+++ b/google/cloud/eventarc/eventarc_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/eventarc/internal/eventarc_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -153,6 +154,7 @@ EventarcConnection::DeleteChannelConnection(
 
 std::shared_ptr<EventarcConnection> MakeEventarcConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EventarcPolicyOptionList>(options, __func__);
   options = eventarc_internal::EventarcDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/eventarc/eventarc_connection.h
+++ b/google/cloud/eventarc/eventarc_connection.h
@@ -133,6 +133,7 @@ class EventarcConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::eventarc::EventarcPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/eventarc/publisher_connection.cc
+++ b/google/cloud/eventarc/publisher_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/eventarc/publisher_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -49,6 +50,7 @@ PublisherConnection::PublishEvents(
 
 std::shared_ptr<PublisherConnection> MakePublisherConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PublisherPolicyOptionList>(options, __func__);
   options = eventarc_internal::PublisherDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/eventarc/publisher_connection.h
+++ b/google/cloud/eventarc/publisher_connection.h
@@ -87,6 +87,7 @@ class PublisherConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::eventarc::PublisherPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/filestore/cloud_filestore_manager_connection.cc
+++ b/google/cloud/filestore/cloud_filestore_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/filestore/internal/cloud_filestore_manager_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -121,6 +122,7 @@ CloudFilestoreManagerConnection::UpdateBackup(
 std::shared_ptr<CloudFilestoreManagerConnection>
 MakeCloudFilestoreManagerConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudFilestoreManagerPolicyOptionList>(
       options, __func__);
   options = filestore_internal::CloudFilestoreManagerDefaultOptions(

--- a/google/cloud/filestore/cloud_filestore_manager_connection.h
+++ b/google/cloud/filestore/cloud_filestore_manager_connection.h
@@ -121,6 +121,7 @@ class CloudFilestoreManagerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::filestore::CloudFilestoreManagerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/functions/cloud_functions_connection.cc
+++ b/google/cloud/functions/cloud_functions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/functions/internal/cloud_functions_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -109,6 +110,7 @@ CloudFunctionsServiceConnection::TestIamPermissions(
 std::shared_ptr<CloudFunctionsServiceConnection>
 MakeCloudFunctionsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudFunctionsServicePolicyOptionList>(
       options, __func__);
   options = functions_internal::CloudFunctionsServiceDefaultOptions(

--- a/google/cloud/functions/cloud_functions_connection.h
+++ b/google/cloud/functions/cloud_functions_connection.h
@@ -122,6 +122,7 @@ class CloudFunctionsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::functions::CloudFunctionsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/gameservices/game_server_clusters_connection.cc
+++ b/google/cloud/gameservices/game_server_clusters_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/gameservices/internal/game_server_clusters_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -94,6 +95,7 @@ GameServerClustersServiceConnection::PreviewUpdateGameServerCluster(
 std::shared_ptr<GameServerClustersServiceConnection>
 MakeGameServerClustersServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  GameServerClustersServicePolicyOptionList>(
       options, __func__);
   options = gameservices_internal::GameServerClustersServiceDefaultOptions(

--- a/google/cloud/gameservices/game_server_clusters_connection.h
+++ b/google/cloud/gameservices/game_server_clusters_connection.h
@@ -123,6 +123,7 @@ class GameServerClustersServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::gameservices::GameServerClustersServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/gameservices/game_server_configs_connection.cc
+++ b/google/cloud/gameservices/game_server_configs_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/gameservices/internal/game_server_configs_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ GameServerConfigsServiceConnection::DeleteGameServerConfig(
 std::shared_ptr<GameServerConfigsServiceConnection>
 MakeGameServerConfigsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  GameServerConfigsServicePolicyOptionList>(
       options, __func__);
   options = gameservices_internal::GameServerConfigsServiceDefaultOptions(

--- a/google/cloud/gameservices/game_server_configs_connection.h
+++ b/google/cloud/gameservices/game_server_configs_connection.h
@@ -101,6 +101,7 @@ class GameServerConfigsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::gameservices::GameServerConfigsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/gameservices/game_server_deployments_connection.cc
+++ b/google/cloud/gameservices/game_server_deployments_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/gameservices/internal/game_server_deployments_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -104,6 +105,7 @@ GameServerDeploymentsServiceConnection::FetchDeploymentState(
 std::shared_ptr<GameServerDeploymentsServiceConnection>
 MakeGameServerDeploymentsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  GameServerDeploymentsServicePolicyOptionList>(
       options, __func__);
   options = gameservices_internal::GameServerDeploymentsServiceDefaultOptions(

--- a/google/cloud/gameservices/game_server_deployments_connection.h
+++ b/google/cloud/gameservices/game_server_deployments_connection.h
@@ -128,6 +128,7 @@ class GameServerDeploymentsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::gameservices::GameServerDeploymentsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/gameservices/realms_connection.cc
+++ b/google/cloud/gameservices/realms_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/gameservices/realms_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -80,6 +81,7 @@ RealmsServiceConnection::PreviewRealmUpdate(
 std::shared_ptr<RealmsServiceConnection> MakeRealmsServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  RealmsServicePolicyOptionList>(options,
                                                                 __func__);
   options =

--- a/google/cloud/gameservices/realms_connection.h
+++ b/google/cloud/gameservices/realms_connection.h
@@ -99,6 +99,7 @@ class RealmsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::gameservices::RealmsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/gkehub/gke_hub_connection.cc
+++ b/google/cloud/gkehub/gke_hub_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/gkehub/internal/gke_hub_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -115,6 +116,7 @@ GkeHubConnection::GenerateConnectManifest(
 
 std::shared_ptr<GkeHubConnection> MakeGkeHubConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  GkeHubPolicyOptionList>(options, __func__);
   options = gkehub_internal::GkeHubDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/gkehub/gke_hub_connection.h
+++ b/google/cloud/gkehub/gke_hub_connection.h
@@ -116,6 +116,7 @@ class GkeHubConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::gkehub::GkeHubPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/iam/iam_connection.cc
+++ b/google/cloud/iam/iam_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/iam/internal/iam_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -186,6 +187,7 @@ StatusOr<google::iam::admin::v1::LintPolicyResponse> IAMConnection::LintPolicy(
 
 std::shared_ptr<IAMConnection> MakeIAMConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IAMPolicyOptionList>(options, __func__);
   options = iam_internal::IAMDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/iam/iam_connection.h
+++ b/google/cloud/iam/iam_connection.h
@@ -162,6 +162,7 @@ class IAMConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::iam::IAMPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/iam/iam_credentials_connection.cc
+++ b/google/cloud/iam/iam_credentials_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/iam/internal/iam_credentials_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -60,6 +61,7 @@ IAMCredentialsConnection::SignJwt(
 std::shared_ptr<IAMCredentialsConnection> MakeIAMCredentialsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IAMCredentialsPolicyOptionList>(options,
                                                                  __func__);
   options = iam_internal::IAMCredentialsDefaultOptions(std::move(options));

--- a/google/cloud/iam/iam_credentials_connection.h
+++ b/google/cloud/iam/iam_credentials_connection.h
@@ -90,6 +90,7 @@ class IAMCredentialsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::iam::IAMCredentialsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/iam/iam_policy_connection.cc
+++ b/google/cloud/iam/iam_policy_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/iam/internal/iam_policy_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -51,6 +52,7 @@ IAMPolicyConnection::TestIamPermissions(
 
 std::shared_ptr<IAMPolicyConnection> MakeIAMPolicyConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IAMPolicyPolicyOptionList>(options, __func__);
   options = iam_internal::IAMPolicyDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/iam/iam_policy_connection.h
+++ b/google/cloud/iam/iam_policy_connection.h
@@ -84,6 +84,7 @@ class IAMPolicyConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::iam::IAMPolicyPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/iap/identity_aware_proxy_admin_connection.cc
+++ b/google/cloud/iap/identity_aware_proxy_admin_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/iap/internal/identity_aware_proxy_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -99,7 +100,7 @@ IdentityAwareProxyAdminServiceConnection::UpdateTunnelDestGroup(
 std::shared_ptr<IdentityAwareProxyAdminServiceConnection>
 MakeIdentityAwareProxyAdminServiceConnection(Options options) {
   internal::CheckExpectedOptions<
-      CommonOptionList, GrpcOptionList,
+      CommonOptionList, GrpcOptionList, UnifiedCredentialsOptionList,
       IdentityAwareProxyAdminServicePolicyOptionList>(options, __func__);
   options = iap_internal::IdentityAwareProxyAdminServiceDefaultOptions(
       std::move(options));

--- a/google/cloud/iap/identity_aware_proxy_admin_connection.h
+++ b/google/cloud/iap/identity_aware_proxy_admin_connection.h
@@ -114,6 +114,7 @@ class IdentityAwareProxyAdminServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::iap::IdentityAwareProxyAdminServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/iap/identity_aware_proxy_o_auth_connection.cc
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/iap/internal/identity_aware_proxy_o_auth_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -87,7 +88,7 @@ Status IdentityAwareProxyOAuthServiceConnection::DeleteIdentityAwareProxyClient(
 std::shared_ptr<IdentityAwareProxyOAuthServiceConnection>
 MakeIdentityAwareProxyOAuthServiceConnection(Options options) {
   internal::CheckExpectedOptions<
-      CommonOptionList, GrpcOptionList,
+      CommonOptionList, GrpcOptionList, UnifiedCredentialsOptionList,
       IdentityAwareProxyOAuthServicePolicyOptionList>(options, __func__);
   options = iap_internal::IdentityAwareProxyOAuthServiceDefaultOptions(
       std::move(options));

--- a/google/cloud/iap/identity_aware_proxy_o_auth_connection.h
+++ b/google/cloud/iap/identity_aware_proxy_o_auth_connection.h
@@ -113,6 +113,7 @@ class IdentityAwareProxyOAuthServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::iap::IdentityAwareProxyOAuthServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/ids/ids_connection.cc
+++ b/google/cloud/ids/ids_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/ids/internal/ids_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -64,6 +65,7 @@ IDSConnection::DeleteEndpoint(
 
 std::shared_ptr<IDSConnection> MakeIDSConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IDSPolicyOptionList>(options, __func__);
   options = ids_internal::IDSDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/ids/ids_connection.h
+++ b/google/cloud/ids/ids_connection.h
@@ -91,6 +91,7 @@ class IDSConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::ids::IDSPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/iot/device_manager_connection.cc
+++ b/google/cloud/iot/device_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/iot/internal/device_manager_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -148,6 +149,7 @@ DeviceManagerConnection::UnbindDeviceFromGateway(
 std::shared_ptr<DeviceManagerConnection> MakeDeviceManagerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DeviceManagerPolicyOptionList>(options,
                                                                 __func__);
   options = iot_internal::DeviceManagerDefaultOptions(std::move(options));

--- a/google/cloud/iot/device_manager_connection.h
+++ b/google/cloud/iot/device_manager_connection.h
@@ -141,6 +141,7 @@ class DeviceManagerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::iot::DeviceManagerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/kms/ekm_connection.cc
+++ b/google/cloud/kms/ekm_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/kms/internal/ekm_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -63,6 +64,7 @@ EkmServiceConnection::UpdateEkmConnection(
 std::shared_ptr<EkmServiceConnection> MakeEkmServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EkmServicePolicyOptionList>(options, __func__);
   options = kms_internal::EkmServiceDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/kms/ekm_connection.h
+++ b/google/cloud/kms/ekm_connection.h
@@ -88,6 +88,7 @@ class EkmServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::kms::EkmServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/kms/key_management_connection.cc
+++ b/google/cloud/kms/key_management_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/kms/key_management_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -201,6 +202,7 @@ KeyManagementServiceConnection::GenerateRandomBytes(
 std::shared_ptr<KeyManagementServiceConnection>
 MakeKeyManagementServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  KeyManagementServicePolicyOptionList>(
       options, __func__);
   options =

--- a/google/cloud/kms/key_management_connection.h
+++ b/google/cloud/kms/key_management_connection.h
@@ -168,6 +168,7 @@ class KeyManagementServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::kms::KeyManagementServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/language/language_connection.cc
+++ b/google/cloud/language/language_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/language/language_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -72,6 +73,7 @@ LanguageServiceConnection::AnnotateText(
 std::shared_ptr<LanguageServiceConnection> MakeLanguageServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  LanguageServicePolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/language/language_connection.h
+++ b/google/cloud/language/language_connection.h
@@ -100,6 +100,7 @@ class LanguageServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::language::LanguageServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/logging/logging_service_v2_connection.cc
+++ b/google/cloud/logging/logging_service_v2_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/logging/logging_service_v2_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -82,6 +83,7 @@ LoggingServiceV2Connection::AsyncTailLogEntries(ExperimentalTag) {
 std::shared_ptr<LoggingServiceV2Connection> MakeLoggingServiceV2Connection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  LoggingServiceV2PolicyOptionList>(options,
                                                                    __func__);
   options =

--- a/google/cloud/logging/logging_service_v2_connection.h
+++ b/google/cloud/logging/logging_service_v2_connection.h
@@ -101,6 +101,7 @@ class LoggingServiceV2Connection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::logging::LoggingServiceV2PolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/managedidentities/managed_identities_connection.cc
+++ b/google/cloud/managedidentities/managed_identities_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/managedidentities/managed_identities_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -115,6 +116,7 @@ ManagedIdentitiesServiceConnection::ValidateTrust(
 std::shared_ptr<ManagedIdentitiesServiceConnection>
 MakeManagedIdentitiesServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ManagedIdentitiesServicePolicyOptionList>(
       options, __func__);
   options = managedidentities_internal::ManagedIdentitiesServiceDefaultOptions(

--- a/google/cloud/managedidentities/managed_identities_connection.h
+++ b/google/cloud/managedidentities/managed_identities_connection.h
@@ -127,6 +127,7 @@ class ManagedIdentitiesServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * -
  * `google::cloud::managedidentities::ManagedIdentitiesServicePolicyOptionList`
  *

--- a/google/cloud/memcache/cloud_memcache_connection.cc
+++ b/google/cloud/memcache/cloud_memcache_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/memcache/internal/cloud_memcache_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -91,6 +92,7 @@ CloudMemcacheConnection::ApplyParameters(
 std::shared_ptr<CloudMemcacheConnection> MakeCloudMemcacheConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudMemcachePolicyOptionList>(options,
                                                                 __func__);
   options = memcache_internal::CloudMemcacheDefaultOptions(std::move(options));

--- a/google/cloud/memcache/cloud_memcache_connection.h
+++ b/google/cloud/memcache/cloud_memcache_connection.h
@@ -106,6 +106,7 @@ class CloudMemcacheConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::memcache::CloudMemcachePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/alert_policy_connection.cc
+++ b/google/cloud/monitoring/alert_policy_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/internal/alert_policy_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ AlertPolicyServiceConnection::UpdateAlertPolicy(
 std::shared_ptr<AlertPolicyServiceConnection> MakeAlertPolicyServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AlertPolicyServicePolicyOptionList>(options,
                                                                      __func__);
   options =

--- a/google/cloud/monitoring/alert_policy_connection.h
+++ b/google/cloud/monitoring/alert_policy_connection.h
@@ -94,6 +94,7 @@ class AlertPolicyServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::AlertPolicyServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/dashboards_connection.cc
+++ b/google/cloud/monitoring/dashboards_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/internal/dashboards_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ DashboardsServiceConnection::UpdateDashboard(
 std::shared_ptr<DashboardsServiceConnection> MakeDashboardsServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DashboardsServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/monitoring/dashboards_connection.h
+++ b/google/cloud/monitoring/dashboards_connection.h
@@ -97,6 +97,7 @@ class DashboardsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::DashboardsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/group_connection.cc
+++ b/google/cloud/monitoring/group_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/internal/group_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -72,6 +73,7 @@ GroupServiceConnection::ListGroupMembers(
 std::shared_ptr<GroupServiceConnection> MakeGroupServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  GroupServicePolicyOptionList>(options,
                                                                __func__);
   options = monitoring_internal::GroupServiceDefaultOptions(std::move(options));

--- a/google/cloud/monitoring/group_connection.h
+++ b/google/cloud/monitoring/group_connection.h
@@ -95,6 +95,7 @@ class GroupServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::GroupServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/metric_connection.cc
+++ b/google/cloud/monitoring/metric_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/metric_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -100,6 +101,7 @@ future<Status> MetricServiceConnection::AsyncCreateTimeSeries(
 std::shared_ptr<MetricServiceConnection> MakeMetricServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  MetricServicePolicyOptionList>(options,
                                                                 __func__);
   options =

--- a/google/cloud/monitoring/metric_connection.h
+++ b/google/cloud/monitoring/metric_connection.h
@@ -110,6 +110,7 @@ class MetricServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::MetricServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/metrics_scopes_connection.cc
+++ b/google/cloud/monitoring/metrics_scopes_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/metrics_scopes_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -68,6 +69,7 @@ MetricsScopesConnection::DeleteMonitoredProject(
 std::shared_ptr<MetricsScopesConnection> MakeMetricsScopesConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  MetricsScopesPolicyOptionList>(options,
                                                                 __func__);
   options =

--- a/google/cloud/monitoring/metrics_scopes_connection.h
+++ b/google/cloud/monitoring/metrics_scopes_connection.h
@@ -102,6 +102,7 @@ class MetricsScopesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::MetricsScopesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/notification_channel_connection.cc
+++ b/google/cloud/monitoring/notification_channel_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/notification_channel_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -103,6 +104,7 @@ NotificationChannelServiceConnection::VerifyNotificationChannel(
 std::shared_ptr<NotificationChannelServiceConnection>
 MakeNotificationChannelServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  NotificationChannelServicePolicyOptionList>(
       options, __func__);
   options = monitoring_internal::NotificationChannelServiceDefaultOptions(

--- a/google/cloud/monitoring/notification_channel_connection.h
+++ b/google/cloud/monitoring/notification_channel_connection.h
@@ -125,6 +125,7 @@ class NotificationChannelServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::NotificationChannelServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/query_connection.cc
+++ b/google/cloud/monitoring/query_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/query_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -45,6 +46,7 @@ QueryServiceConnection::QueryTimeSeries(
 std::shared_ptr<QueryServiceConnection> MakeQueryServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  QueryServicePolicyOptionList>(options,
                                                                __func__);
   options = monitoring_internal::QueryServiceDefaultOptions(std::move(options));

--- a/google/cloud/monitoring/query_connection.h
+++ b/google/cloud/monitoring/query_connection.h
@@ -80,6 +80,7 @@ class QueryServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::QueryServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/service_monitoring_connection.cc
+++ b/google/cloud/monitoring/service_monitoring_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/service_monitoring_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -100,6 +101,7 @@ Status ServiceMonitoringServiceConnection::DeleteServiceLevelObjective(
 std::shared_ptr<ServiceMonitoringServiceConnection>
 MakeServiceMonitoringServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ServiceMonitoringServicePolicyOptionList>(
       options, __func__);
   options = monitoring_internal::ServiceMonitoringServiceDefaultOptions(

--- a/google/cloud/monitoring/service_monitoring_connection.h
+++ b/google/cloud/monitoring/service_monitoring_connection.h
@@ -118,6 +118,7 @@ class ServiceMonitoringServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::ServiceMonitoringServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/monitoring/uptime_check_connection.cc
+++ b/google/cloud/monitoring/uptime_check_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/monitoring/uptime_check_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -76,6 +77,7 @@ UptimeCheckServiceConnection::ListUptimeCheckIps(
 std::shared_ptr<UptimeCheckServiceConnection> MakeUptimeCheckServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  UptimeCheckServicePolicyOptionList>(options,
                                                                      __func__);
   options =

--- a/google/cloud/monitoring/uptime_check_connection.h
+++ b/google/cloud/monitoring/uptime_check_connection.h
@@ -101,6 +101,7 @@ class UptimeCheckServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::monitoring::UptimeCheckServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/networkmanagement/reachability_connection.cc
+++ b/google/cloud/networkmanagement/reachability_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/networkmanagement/reachability_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -86,6 +87,7 @@ ReachabilityServiceConnection::DeleteConnectivityTest(
 std::shared_ptr<ReachabilityServiceConnection>
 MakeReachabilityServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ReachabilityServicePolicyOptionList>(options,
                                                                       __func__);
   options = networkmanagement_internal::ReachabilityServiceDefaultOptions(

--- a/google/cloud/networkmanagement/reachability_connection.h
+++ b/google/cloud/networkmanagement/reachability_connection.h
@@ -117,6 +117,7 @@ class ReachabilityServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::networkmanagement::ReachabilityServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/notebooks/managed_notebook_connection.cc
+++ b/google/cloud/notebooks/managed_notebook_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/notebooks/managed_notebook_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -113,6 +114,7 @@ ManagedNotebookServiceConnection::RefreshRuntimeTokenInternal(
 std::shared_ptr<ManagedNotebookServiceConnection>
 MakeManagedNotebookServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ManagedNotebookServicePolicyOptionList>(
       options, __func__);
   options = notebooks_internal::ManagedNotebookServiceDefaultOptions(

--- a/google/cloud/notebooks/managed_notebook_connection.h
+++ b/google/cloud/notebooks/managed_notebook_connection.h
@@ -118,6 +118,7 @@ class ManagedNotebookServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::notebooks::ManagedNotebookServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/notebooks/notebook_connection.cc
+++ b/google/cloud/notebooks/notebook_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/notebooks/notebook_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -287,6 +288,7 @@ NotebookServiceConnection::CreateExecution(
 std::shared_ptr<NotebookServiceConnection> MakeNotebookServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  NotebookServicePolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/notebooks/notebook_connection.h
+++ b/google/cloud/notebooks/notebook_connection.h
@@ -212,6 +212,7 @@ class NotebookServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::notebooks::NotebookServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/optimization/fleet_routing_connection.cc
+++ b/google/cloud/optimization/fleet_routing_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/optimization/internal/fleet_routing_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -50,6 +51,7 @@ FleetRoutingConnection::BatchOptimizeTours(
 std::shared_ptr<FleetRoutingConnection> MakeFleetRoutingConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  FleetRoutingPolicyOptionList>(options,
                                                                __func__);
   options =

--- a/google/cloud/optimization/fleet_routing_connection.h
+++ b/google/cloud/optimization/fleet_routing_connection.h
@@ -89,6 +89,7 @@ class FleetRoutingConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::optimization::FleetRoutingPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/orgpolicy/org_policy_connection.cc
+++ b/google/cloud/orgpolicy/org_policy_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/orgpolicy/org_policy_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -80,6 +81,7 @@ Status OrgPolicyConnection::DeletePolicy(
 
 std::shared_ptr<OrgPolicyConnection> MakeOrgPolicyConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  OrgPolicyPolicyOptionList>(options, __func__);
   options = orgpolicy_internal::OrgPolicyDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/orgpolicy/org_policy_connection.h
+++ b/google/cloud/orgpolicy/org_policy_connection.h
@@ -97,6 +97,7 @@ class OrgPolicyConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::orgpolicy::OrgPolicyPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/osconfig/agent_endpoint_connection.cc
+++ b/google/cloud/osconfig/agent_endpoint_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/osconfig/internal/agent_endpoint_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -82,6 +83,7 @@ AgentEndpointServiceConnection::ReportInventory(
 std::shared_ptr<AgentEndpointServiceConnection>
 MakeAgentEndpointServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AgentEndpointServicePolicyOptionList>(
       options, __func__);
   options =

--- a/google/cloud/osconfig/agent_endpoint_connection.h
+++ b/google/cloud/osconfig/agent_endpoint_connection.h
@@ -112,6 +112,7 @@ class AgentEndpointServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::osconfig::AgentEndpointServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/osconfig/os_config_connection.cc
+++ b/google/cloud/osconfig/os_config_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/osconfig/os_config_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -114,6 +115,7 @@ OsConfigServiceConnection::ResumePatchDeployment(
 std::shared_ptr<OsConfigServiceConnection> MakeOsConfigServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  OsConfigServicePolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/osconfig/os_config_connection.h
+++ b/google/cloud/osconfig/os_config_connection.h
@@ -121,6 +121,7 @@ class OsConfigServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::osconfig::OsConfigServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/oslogin/os_login_connection.cc
+++ b/google/cloud/oslogin/os_login_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/oslogin/os_login_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -70,6 +71,7 @@ OsLoginServiceConnection::UpdateSshPublicKey(
 std::shared_ptr<OsLoginServiceConnection> MakeOsLoginServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  OsLoginServicePolicyOptionList>(options,
                                                                  __func__);
   options = oslogin_internal::OsLoginServiceDefaultOptions(std::move(options));

--- a/google/cloud/oslogin/os_login_connection.h
+++ b/google/cloud/oslogin/os_login_connection.h
@@ -97,6 +97,7 @@ class OsLoginServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::oslogin::OsLoginServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/policytroubleshooter/iam_checker_connection.cc
+++ b/google/cloud/policytroubleshooter/iam_checker_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/policytroubleshooter/internal/iam_checker_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -43,6 +44,7 @@ IamCheckerConnection::TroubleshootIamPolicy(
 std::shared_ptr<IamCheckerConnection> MakeIamCheckerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  IamCheckerPolicyOptionList>(options, __func__);
   options = policytroubleshooter_internal::IamCheckerDefaultOptions(
       std::move(options));

--- a/google/cloud/policytroubleshooter/iam_checker_connection.h
+++ b/google/cloud/policytroubleshooter/iam_checker_connection.h
@@ -80,6 +80,7 @@ class IamCheckerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::policytroubleshooter::IamCheckerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/privateca/certificate_authority_connection.cc
+++ b/google/cloud/privateca/certificate_authority_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/privateca/internal/certificate_authority_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -267,6 +268,7 @@ CertificateAuthorityServiceConnection::UpdateCertificateTemplate(
 std::shared_ptr<CertificateAuthorityServiceConnection>
 MakeCertificateAuthorityServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CertificateAuthorityServicePolicyOptionList>(
       options, __func__);
   options = privateca_internal::CertificateAuthorityServiceDefaultOptions(

--- a/google/cloud/privateca/certificate_authority_connection.h
+++ b/google/cloud/privateca/certificate_authority_connection.h
@@ -241,6 +241,7 @@ class CertificateAuthorityServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::privateca::CertificateAuthorityServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/profiler/profiler_connection.cc
+++ b/google/cloud/profiler/profiler_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/profiler/profiler_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -54,6 +55,7 @@ ProfilerServiceConnection::UpdateProfile(
 std::shared_ptr<ProfilerServiceConnection> MakeProfilerServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ProfilerServicePolicyOptionList>(options,
                                                                   __func__);
   options =

--- a/google/cloud/profiler/profiler_connection.h
+++ b/google/cloud/profiler/profiler_connection.h
@@ -88,6 +88,7 @@ class ProfilerServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::profiler::ProfilerServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/pubsub/publisher_connection.cc
+++ b/google/cloud/pubsub/publisher_connection.cc
@@ -28,6 +28,7 @@
 #include "google/cloud/pubsub/internal/rejects_with_ordering_key.h"
 #include "google/cloud/pubsub/internal/sequential_batch_sink.h"
 #include "google/cloud/pubsub/options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/future_void.h"
 #include "google/cloud/internal/non_constructible.h"
 #include "google/cloud/log.h"
@@ -117,8 +118,8 @@ std::shared_ptr<PublisherConnection> MakePublisherConnection(
 std::shared_ptr<PublisherConnection> MakePublisherConnection(Topic topic,
                                                              Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 PolicyOptionList, PublisherOptionList>(
-      opts, __func__);
+                                 UnifiedCredentialsOptionList, PolicyOptionList,
+                                 PublisherOptionList>(opts, __func__);
   opts = pubsub_internal::DefaultPublisherOptions(std::move(opts));
 
   auto background = internal::MakeBackgroundThreadsFactory(opts)();

--- a/google/cloud/pubsub/schema_admin_connection.cc
+++ b/google/cloud/pubsub/schema_admin_connection.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/pubsub/internal/schema_stub.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/retry_policy.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
 #include <memory>
@@ -181,6 +182,7 @@ std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(
 
 std::shared_ptr<SchemaAdminConnection> MakeSchemaAdminConnection(Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PolicyOptionList>(opts, __func__);
   opts = pubsub_internal::DefaultCommonOptions(std::move(opts));
 

--- a/google/cloud/pubsub/subscriber_connection.cc
+++ b/google/cloud/pubsub/subscriber_connection.cc
@@ -22,6 +22,7 @@
 #include "google/cloud/pubsub/internal/subscription_session.h"
 #include "google/cloud/pubsub/options.h"
 #include "google/cloud/pubsub/retry_policy.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/random.h"
 #include "google/cloud/log.h"
 #include <algorithm>
@@ -122,8 +123,8 @@ std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
 std::shared_ptr<SubscriberConnection> MakeSubscriberConnection(
     Subscription subscription, Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
-                                 PolicyOptionList, SubscriberOptionList>(
-      opts, __func__);
+                                 UnifiedCredentialsOptionList, PolicyOptionList,
+                                 SubscriberOptionList>(opts, __func__);
   opts = pubsub_internal::DefaultSubscriberOptions(std::move(opts));
 
   auto background = internal::MakeBackgroundThreadsFactory(opts)();

--- a/google/cloud/pubsub/subscription_admin_connection.cc
+++ b/google/cloud/pubsub/subscription_admin_connection.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/pubsub/internal/subscriber_metadata.h"
 #include "google/cloud/pubsub/internal/subscriber_stub.h"
 #include "google/cloud/pubsub/options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
 #include <memory>
@@ -351,6 +352,7 @@ std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
 std::shared_ptr<SubscriptionAdminConnection> MakeSubscriptionAdminConnection(
     Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PolicyOptionList>(opts, __func__);
   opts = pubsub_internal::DefaultCommonOptions(std::move(opts));
   auto background = internal::MakeBackgroundThreadsFactory(opts)();

--- a/google/cloud/pubsub/topic_admin_connection.cc
+++ b/google/cloud/pubsub/topic_admin_connection.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/pubsub/internal/publisher_metadata.h"
 #include "google/cloud/pubsub/internal/publisher_stub.h"
 #include "google/cloud/pubsub/options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
 #include "absl/strings/str_split.h"
@@ -303,6 +304,7 @@ std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(
 
 std::shared_ptr<TopicAdminConnection> MakeTopicAdminConnection(Options opts) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PolicyOptionList>(opts, __func__);
   opts = pubsub_internal::DefaultCommonOptions(std::move(opts));
 

--- a/google/cloud/pubsublite/admin_connection.cc
+++ b/google/cloud/pubsublite/admin_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/pubsublite/internal/admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -165,6 +166,7 @@ AdminServiceConnection::AsyncGetTopicPartitions(
 std::shared_ptr<AdminServiceConnection> MakeAdminServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  AdminServicePolicyOptionList>(options,
                                                                __func__);
   options = pubsublite_internal::AdminServiceDefaultOptions(std::move(options));

--- a/google/cloud/pubsublite/admin_connection.h
+++ b/google/cloud/pubsublite/admin_connection.h
@@ -150,6 +150,7 @@ class AdminServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::pubsublite::AdminServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/pubsublite/topic_stats_connection.cc
+++ b/google/cloud/pubsublite/topic_stats_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/pubsublite/topic_stats_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -54,6 +55,7 @@ TopicStatsServiceConnection::ComputeTimeCursor(
 std::shared_ptr<TopicStatsServiceConnection> MakeTopicStatsServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TopicStatsServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/pubsublite/topic_stats_connection.h
+++ b/google/cloud/pubsublite/topic_stats_connection.h
@@ -90,6 +90,7 @@ class TopicStatsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::pubsublite::TopicStatsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/recommender/recommender_connection.cc
+++ b/google/cloud/recommender/recommender_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/recommender/recommender_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -113,6 +114,7 @@ RecommenderConnection::UpdateInsightTypeConfig(
 std::shared_ptr<RecommenderConnection> MakeRecommenderConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  RecommenderPolicyOptionList>(options,
                                                               __func__);
   options = recommender_internal::RecommenderDefaultOptions(std::move(options));

--- a/google/cloud/recommender/recommender_connection.h
+++ b/google/cloud/recommender/recommender_connection.h
@@ -129,6 +129,7 @@ class RecommenderConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::recommender::RecommenderPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/redis/cloud_redis_connection.cc
+++ b/google/cloud/redis/cloud_redis_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/redis/internal/cloud_redis_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -120,6 +121,7 @@ CloudRedisConnection::RescheduleMaintenance(
 std::shared_ptr<CloudRedisConnection> MakeCloudRedisConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudRedisPolicyOptionList>(options, __func__);
   options = redis_internal::CloudRedisDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/redis/cloud_redis_connection.h
+++ b/google/cloud/redis/cloud_redis_connection.h
@@ -115,6 +115,7 @@ class CloudRedisConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::redis::CloudRedisPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/resourcemanager/folders_connection.cc
+++ b/google/cloud/resourcemanager/folders_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/resourcemanager/internal/folders_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -114,6 +115,7 @@ FoldersConnection::TestIamPermissions(
 
 std::shared_ptr<FoldersConnection> MakeFoldersConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  FoldersPolicyOptionList>(options, __func__);
   options = resourcemanager_internal::FoldersDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/resourcemanager/folders_connection.h
+++ b/google/cloud/resourcemanager/folders_connection.h
@@ -117,6 +117,7 @@ class FoldersConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::resourcemanager::FoldersPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/resourcemanager/organizations_connection.cc
+++ b/google/cloud/resourcemanager/organizations_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/resourcemanager/organizations_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -67,6 +68,7 @@ OrganizationsConnection::TestIamPermissions(
 std::shared_ptr<OrganizationsConnection> MakeOrganizationsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  OrganizationsPolicyOptionList>(options,
                                                                 __func__);
   options =

--- a/google/cloud/resourcemanager/organizations_connection.h
+++ b/google/cloud/resourcemanager/organizations_connection.h
@@ -95,6 +95,7 @@ class OrganizationsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::resourcemanager::OrganizationsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/resourcemanager/projects_connection.cc
+++ b/google/cloud/resourcemanager/projects_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/resourcemanager/projects_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -114,6 +115,7 @@ ProjectsConnection::TestIamPermissions(
 
 std::shared_ptr<ProjectsConnection> MakeProjectsConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ProjectsPolicyOptionList>(options, __func__);
   options =
       resourcemanager_internal::ProjectsDefaultOptions(std::move(options));

--- a/google/cloud/resourcemanager/projects_connection.h
+++ b/google/cloud/resourcemanager/projects_connection.h
@@ -119,6 +119,7 @@ class ProjectsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::resourcemanager::ProjectsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/resourcesettings/resource_settings_connection.cc
+++ b/google/cloud/resourcesettings/resource_settings_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/resourcesettings/resource_settings_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -58,6 +59,7 @@ ResourceSettingsServiceConnection::UpdateSetting(
 std::shared_ptr<ResourceSettingsServiceConnection>
 MakeResourceSettingsServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ResourceSettingsServicePolicyOptionList>(
       options, __func__);
   options = resourcesettings_internal::ResourceSettingsServiceDefaultOptions(

--- a/google/cloud/resourcesettings/resource_settings_connection.h
+++ b/google/cloud/resourcesettings/resource_settings_connection.h
@@ -91,6 +91,7 @@ class ResourceSettingsServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::resourcesettings::ResourceSettingsServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/retail/catalog_connection.cc
+++ b/google/cloud/retail/catalog_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/retail/internal/catalog_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -62,6 +63,7 @@ CatalogServiceConnection::GetDefaultBranch(
 std::shared_ptr<CatalogServiceConnection> MakeCatalogServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CatalogServicePolicyOptionList>(options,
                                                                  __func__);
   options = retail_internal::CatalogServiceDefaultOptions(std::move(options));

--- a/google/cloud/retail/catalog_connection.h
+++ b/google/cloud/retail/catalog_connection.h
@@ -90,6 +90,7 @@ class CatalogServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::retail::CatalogServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/retail/completion_connection.cc
+++ b/google/cloud/retail/completion_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/retail/internal/completion_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -50,6 +51,7 @@ CompletionServiceConnection::ImportCompletionData(
 std::shared_ptr<CompletionServiceConnection> MakeCompletionServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CompletionServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/retail/completion_connection.h
+++ b/google/cloud/retail/completion_connection.h
@@ -89,6 +89,7 @@ class CompletionServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::retail::CompletionServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/retail/prediction_connection.cc
+++ b/google/cloud/retail/prediction_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/retail/prediction_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -42,6 +43,7 @@ PredictionServiceConnection::Predict(
 std::shared_ptr<PredictionServiceConnection> MakePredictionServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  PredictionServicePolicyOptionList>(options,
                                                                     __func__);
   options =

--- a/google/cloud/retail/prediction_connection.h
+++ b/google/cloud/retail/prediction_connection.h
@@ -81,6 +81,7 @@ class PredictionServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::retail::PredictionServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/retail/product_connection.cc
+++ b/google/cloud/retail/product_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/retail/product_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -116,6 +117,7 @@ ProductServiceConnection::RemoveLocalInventories(
 std::shared_ptr<ProductServiceConnection> MakeProductServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ProductServicePolicyOptionList>(options,
                                                                  __func__);
   options = retail_internal::ProductServiceDefaultOptions(std::move(options));

--- a/google/cloud/retail/product_connection.h
+++ b/google/cloud/retail/product_connection.h
@@ -122,6 +122,7 @@ class ProductServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::retail::ProductServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/retail/search_connection.cc
+++ b/google/cloud/retail/search_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/retail/search_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -45,6 +46,7 @@ SearchServiceConnection::Search(
 std::shared_ptr<SearchServiceConnection> MakeSearchServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SearchServicePolicyOptionList>(options,
                                                                 __func__);
   options = retail_internal::SearchServiceDefaultOptions(std::move(options));

--- a/google/cloud/retail/search_connection.h
+++ b/google/cloud/retail/search_connection.h
@@ -80,6 +80,7 @@ class SearchServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::retail::SearchServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/retail/user_event_connection.cc
+++ b/google/cloud/retail/user_event_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/retail/user_event_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -71,6 +72,7 @@ UserEventServiceConnection::RejoinUserEvents(
 std::shared_ptr<UserEventServiceConnection> MakeUserEventServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  UserEventServicePolicyOptionList>(options,
                                                                    __func__);
   options = retail_internal::UserEventServiceDefaultOptions(std::move(options));

--- a/google/cloud/retail/user_event_connection.h
+++ b/google/cloud/retail/user_event_connection.h
@@ -98,6 +98,7 @@ class UserEventServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::retail::UserEventServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/run/revisions_connection.cc
+++ b/google/cloud/run/revisions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/run/revisions_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -57,6 +58,7 @@ RevisionsConnection::DeleteRevision(
 
 std::shared_ptr<RevisionsConnection> MakeRevisionsConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  RevisionsPolicyOptionList>(options, __func__);
   options = run_internal::RevisionsDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/run/revisions_connection.h
+++ b/google/cloud/run/revisions_connection.h
@@ -88,6 +88,7 @@ class RevisionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::run::RevisionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/run/services_connection.cc
+++ b/google/cloud/run/services_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/run/services_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -88,6 +89,7 @@ ServicesConnection::TestIamPermissions(
 
 std::shared_ptr<ServicesConnection> MakeServicesConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ServicesPolicyOptionList>(options, __func__);
   options = run_internal::ServicesDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/run/services_connection.h
+++ b/google/cloud/run/services_connection.h
@@ -103,6 +103,7 @@ class ServicesConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::run::ServicesPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/scheduler/cloud_scheduler_connection.cc
+++ b/google/cloud/scheduler/cloud_scheduler_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/scheduler/internal/cloud_scheduler_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -80,6 +81,7 @@ StatusOr<google::cloud::scheduler::v1::Job> CloudSchedulerConnection::RunJob(
 std::shared_ptr<CloudSchedulerConnection> MakeCloudSchedulerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudSchedulerPolicyOptionList>(options,
                                                                  __func__);
   options =

--- a/google/cloud/scheduler/cloud_scheduler_connection.h
+++ b/google/cloud/scheduler/cloud_scheduler_connection.h
@@ -101,6 +101,7 @@ class CloudSchedulerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::scheduler::CloudSchedulerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/secretmanager/secret_manager_connection.cc
+++ b/google/cloud/secretmanager/secret_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/secretmanager/secret_manager_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -128,6 +129,7 @@ SecretManagerServiceConnection::TestIamPermissions(
 std::shared_ptr<SecretManagerServiceConnection>
 MakeSecretManagerServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SecretManagerServicePolicyOptionList>(
       options, __func__);
   options = secretmanager_internal::SecretManagerServiceDefaultOptions(

--- a/google/cloud/secretmanager/secret_manager_connection.h
+++ b/google/cloud/secretmanager/secret_manager_connection.h
@@ -136,6 +136,7 @@ class SecretManagerServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::secretmanager::SecretManagerServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/securitycenter/security_center_connection.cc
+++ b/google/cloud/securitycenter/security_center_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/securitycenter/security_center_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -273,6 +274,7 @@ SecurityCenterConnection::ListBigQueryExports(
 std::shared_ptr<SecurityCenterConnection> MakeSecurityCenterConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SecurityCenterPolicyOptionList>(options,
                                                                  __func__);
   options =

--- a/google/cloud/securitycenter/security_center_connection.h
+++ b/google/cloud/securitycenter/security_center_connection.h
@@ -228,6 +228,7 @@ class SecurityCenterConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::securitycenter::SecurityCenterPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/servicecontrol/quota_controller_connection.cc
+++ b/google/cloud/servicecontrol/quota_controller_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/servicecontrol/quota_controller_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -42,6 +43,7 @@ QuotaControllerConnection::AllocateQuota(
 std::shared_ptr<QuotaControllerConnection> MakeQuotaControllerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  QuotaControllerPolicyOptionList>(options,
                                                                   __func__);
   options = servicecontrol_internal::QuotaControllerDefaultOptions(

--- a/google/cloud/servicecontrol/quota_controller_connection.h
+++ b/google/cloud/servicecontrol/quota_controller_connection.h
@@ -81,6 +81,7 @@ class QuotaControllerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::servicecontrol::QuotaControllerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/servicecontrol/service_controller_connection.cc
+++ b/google/cloud/servicecontrol/service_controller_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/servicecontrol/service_controller_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -48,6 +49,7 @@ ServiceControllerConnection::Report(
 std::shared_ptr<ServiceControllerConnection> MakeServiceControllerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ServiceControllerPolicyOptionList>(options,
                                                                     __func__);
   options = servicecontrol_internal::ServiceControllerDefaultOptions(

--- a/google/cloud/servicecontrol/service_controller_connection.h
+++ b/google/cloud/servicecontrol/service_controller_connection.h
@@ -84,6 +84,7 @@ class ServiceControllerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::servicecontrol::ServiceControllerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/servicedirectory/lookup_connection.cc
+++ b/google/cloud/servicedirectory/lookup_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/servicedirectory/lookup_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -42,6 +43,7 @@ LookupServiceConnection::ResolveService(
 std::shared_ptr<LookupServiceConnection> MakeLookupServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  LookupServicePolicyOptionList>(options,
                                                                 __func__);
   options = servicedirectory_internal::LookupServiceDefaultOptions(

--- a/google/cloud/servicedirectory/lookup_connection.h
+++ b/google/cloud/servicedirectory/lookup_connection.h
@@ -81,6 +81,7 @@ class LookupServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::servicedirectory::LookupServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/servicedirectory/registration_connection.cc
+++ b/google/cloud/servicedirectory/registration_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/servicedirectory/registration_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -146,6 +147,7 @@ RegistrationServiceConnection::TestIamPermissions(
 std::shared_ptr<RegistrationServiceConnection>
 MakeRegistrationServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  RegistrationServicePolicyOptionList>(options,
                                                                       __func__);
   options = servicedirectory_internal::RegistrationServiceDefaultOptions(

--- a/google/cloud/servicedirectory/registration_connection.h
+++ b/google/cloud/servicedirectory/registration_connection.h
@@ -146,6 +146,7 @@ class RegistrationServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::servicedirectory::RegistrationServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/servicemanagement/service_manager_connection.cc
+++ b/google/cloud/servicemanagement/service_manager_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/servicemanagement/service_manager_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -128,6 +129,7 @@ ServiceManagerConnection::GenerateConfigReport(
 std::shared_ptr<ServiceManagerConnection> MakeServiceManagerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ServiceManagerPolicyOptionList>(options,
                                                                  __func__);
   options = servicemanagement_internal::ServiceManagerDefaultOptions(

--- a/google/cloud/servicemanagement/service_manager_connection.h
+++ b/google/cloud/servicemanagement/service_manager_connection.h
@@ -139,6 +139,7 @@ class ServiceManagerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::servicemanagement::ServiceManagerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/serviceusage/service_usage_connection.cc
+++ b/google/cloud/serviceusage/service_usage_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/serviceusage/service_usage_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -81,6 +82,7 @@ ServiceUsageConnection::BatchGetServices(
 std::shared_ptr<ServiceUsageConnection> MakeServiceUsageConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ServiceUsagePolicyOptionList>(options,
                                                                __func__);
   options =

--- a/google/cloud/serviceusage/service_usage_connection.h
+++ b/google/cloud/serviceusage/service_usage_connection.h
@@ -104,6 +104,7 @@ class ServiceUsageConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::serviceusage::ServiceUsagePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/shell/cloud_shell_connection.cc
+++ b/google/cloud/shell/cloud_shell_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/shell/internal/cloud_shell_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -74,6 +75,7 @@ CloudShellServiceConnection::RemovePublicKey(
 std::shared_ptr<CloudShellServiceConnection> MakeCloudShellServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudShellServicePolicyOptionList>(options,
                                                                     __func__);
   options = shell_internal::CloudShellServiceDefaultOptions(std::move(options));

--- a/google/cloud/shell/cloud_shell_connection.h
+++ b/google/cloud/shell/cloud_shell_connection.h
@@ -100,6 +100,7 @@ class CloudShellServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::shell::CloudShellServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/spanner/admin/database_admin_connection.cc
+++ b/google/cloud/spanner/admin/database_admin_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/spanner/admin/internal/database_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -168,6 +169,7 @@ DatabaseAdminConnection::ListDatabaseRoles(
 std::shared_ptr<DatabaseAdminConnection> MakeDatabaseAdminConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  DatabaseAdminPolicyOptionList>(options,
                                                                 __func__);
   options =

--- a/google/cloud/spanner/admin/database_admin_connection.h
+++ b/google/cloud/spanner/admin/database_admin_connection.h
@@ -152,6 +152,7 @@ class DatabaseAdminConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::spanner_admin::DatabaseAdminPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/spanner/admin/instance_admin_connection.cc
+++ b/google/cloud/spanner/admin/instance_admin_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/spanner/admin/internal/instance_admin_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -102,6 +103,7 @@ InstanceAdminConnection::TestIamPermissions(
 std::shared_ptr<InstanceAdminConnection> MakeInstanceAdminConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  InstanceAdminPolicyOptionList>(options,
                                                                 __func__);
   options =

--- a/google/cloud/spanner/admin/instance_admin_connection.h
+++ b/google/cloud/spanner/admin/instance_admin_connection.h
@@ -119,6 +119,7 @@ class InstanceAdminConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::spanner_admin::InstanceAdminPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/spanner/client.cc
+++ b/google/cloud/spanner/client.cc
@@ -20,6 +20,7 @@
 #include "google/cloud/spanner/retry_policy.h"
 #include "google/cloud/spanner/transaction.h"
 #include "google/cloud/backoff_policy.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/retry_loop.h"
 #include "google/cloud/log.h"
@@ -332,9 +333,9 @@ StatusOr<PartitionedDmlResult> Client::ExecutePartitionedDml(
 std::shared_ptr<spanner::Connection> MakeConnection(spanner::Database const& db,
                                                     Options opts) {
   internal::CheckExpectedOptions<
-      CommonOptionList, GrpcOptionList, SessionPoolOptionList,
-      spanner_internal::SessionPoolClockOption, SpannerPolicyOptionList>(
-      opts, __func__);
+      CommonOptionList, GrpcOptionList, UnifiedCredentialsOptionList,
+      SessionPoolOptionList, spanner_internal::SessionPoolClockOption,
+      SpannerPolicyOptionList>(opts, __func__);
   opts = spanner_internal::DefaultOptions(std::move(opts));
 
   auto background = internal::MakeBackgroundThreadsFactory(opts)();

--- a/google/cloud/speech/speech_connection.cc
+++ b/google/cloud/speech/speech_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/speech/speech_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -60,6 +61,7 @@ SpeechConnection::AsyncStreamingRecognize(ExperimentalTag) {
 
 std::shared_ptr<SpeechConnection> MakeSpeechConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  SpeechPolicyOptionList>(options, __func__);
   options = speech_internal::SpeechDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/speech/speech_connection.h
+++ b/google/cloud/speech/speech_connection.h
@@ -93,6 +93,7 @@ class SpeechConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::speech::SpeechPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/storagetransfer/storage_transfer_connection.cc
+++ b/google/cloud/storagetransfer/storage_transfer_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/storagetransfer/storage_transfer_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -118,6 +119,7 @@ Status StorageTransferServiceConnection::DeleteAgentPool(
 std::shared_ptr<StorageTransferServiceConnection>
 MakeStorageTransferServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  StorageTransferServicePolicyOptionList>(
       options, __func__);
   options = storagetransfer_internal::StorageTransferServiceDefaultOptions(

--- a/google/cloud/storagetransfer/storage_transfer_connection.h
+++ b/google/cloud/storagetransfer/storage_transfer_connection.h
@@ -129,6 +129,7 @@ class StorageTransferServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::storagetransfer::StorageTransferServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/talent/company_connection.cc
+++ b/google/cloud/talent/company_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/talent/internal/company_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -68,6 +69,7 @@ CompanyServiceConnection::ListCompanies(
 std::shared_ptr<CompanyServiceConnection> MakeCompanyServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CompanyServicePolicyOptionList>(options,
                                                                  __func__);
   options = talent_internal::CompanyServiceDefaultOptions(std::move(options));

--- a/google/cloud/talent/company_connection.h
+++ b/google/cloud/talent/company_connection.h
@@ -92,6 +92,7 @@ class CompanyServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::talent::CompanyServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/talent/completion_connection.cc
+++ b/google/cloud/talent/completion_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/talent/internal/completion_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -42,6 +43,7 @@ CompletionConnection::CompleteQuery(
 std::shared_ptr<CompletionConnection> MakeCompletionConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CompletionPolicyOptionList>(options, __func__);
   options = talent_internal::CompletionDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/talent/completion_connection.h
+++ b/google/cloud/talent/completion_connection.h
@@ -78,6 +78,7 @@ class CompletionConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::talent::CompletionPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/talent/event_connection.cc
+++ b/google/cloud/talent/event_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/talent/internal/event_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -42,6 +43,7 @@ EventServiceConnection::CreateClientEvent(
 std::shared_ptr<EventServiceConnection> MakeEventServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  EventServicePolicyOptionList>(options,
                                                                __func__);
   options = talent_internal::EventServiceDefaultOptions(std::move(options));

--- a/google/cloud/talent/event_connection.h
+++ b/google/cloud/talent/event_connection.h
@@ -79,6 +79,7 @@ class EventServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::talent::EventServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/talent/job_connection.cc
+++ b/google/cloud/talent/job_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/talent/job_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -100,6 +101,7 @@ JobServiceConnection::SearchJobsForAlert(
 std::shared_ptr<JobServiceConnection> MakeJobServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  JobServicePolicyOptionList>(options, __func__);
   options = talent_internal::JobServiceDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/talent/job_connection.h
+++ b/google/cloud/talent/job_connection.h
@@ -113,6 +113,7 @@ class JobServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::talent::JobServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/talent/tenant_connection.cc
+++ b/google/cloud/talent/tenant_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/talent/tenant_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -67,6 +68,7 @@ TenantServiceConnection::ListTenants(
 std::shared_ptr<TenantServiceConnection> MakeTenantServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TenantServicePolicyOptionList>(options,
                                                                 __func__);
   options = talent_internal::TenantServiceDefaultOptions(std::move(options));

--- a/google/cloud/talent/tenant_connection.h
+++ b/google/cloud/talent/tenant_connection.h
@@ -92,6 +92,7 @@ class TenantServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::talent::TenantServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/tasks/cloud_tasks_connection.cc
+++ b/google/cloud/tasks/cloud_tasks_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/tasks/internal/cloud_tasks_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -122,6 +123,7 @@ StatusOr<google::cloud::tasks::v2::Task> CloudTasksConnection::RunTask(
 std::shared_ptr<CloudTasksConnection> MakeCloudTasksConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  CloudTasksPolicyOptionList>(options, __func__);
   options = tasks_internal::CloudTasksDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/tasks/cloud_tasks_connection.h
+++ b/google/cloud/tasks/cloud_tasks_connection.h
@@ -124,6 +124,7 @@ class CloudTasksConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::tasks::CloudTasksPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/texttospeech/text_to_speech_connection.cc
+++ b/google/cloud/texttospeech/text_to_speech_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/texttospeech/text_to_speech_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -48,6 +49,7 @@ TextToSpeechConnection::SynthesizeSpeech(
 std::shared_ptr<TextToSpeechConnection> MakeTextToSpeechConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TextToSpeechPolicyOptionList>(options,
                                                                __func__);
   options =

--- a/google/cloud/texttospeech/text_to_speech_connection.h
+++ b/google/cloud/texttospeech/text_to_speech_connection.h
@@ -83,6 +83,7 @@ class TextToSpeechConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::texttospeech::TextToSpeechPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/tpu/tpu_connection.cc
+++ b/google/cloud/tpu/tpu_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/tpu/tpu_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -111,6 +112,7 @@ TpuConnection::GetAcceleratorType(
 
 std::shared_ptr<TpuConnection> MakeTpuConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TpuPolicyOptionList>(options, __func__);
   options = tpu_internal::TpuDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/tpu/tpu_connection.h
+++ b/google/cloud/tpu/tpu_connection.h
@@ -115,6 +115,7 @@ class TpuConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::tpu::TpuPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/trace/trace_connection.cc
+++ b/google/cloud/trace/trace_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/trace/trace_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -47,6 +48,7 @@ TraceServiceConnection::CreateSpan(
 std::shared_ptr<TraceServiceConnection> MakeTraceServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TraceServicePolicyOptionList>(options,
                                                                __func__);
   options = trace_internal::TraceServiceDefaultOptions(std::move(options));

--- a/google/cloud/trace/trace_connection.h
+++ b/google/cloud/trace/trace_connection.h
@@ -82,6 +82,7 @@ class TraceServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::trace::TraceServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/translate/translation_connection.cc
+++ b/google/cloud/translate/translation_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/translate/translation_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -107,6 +108,7 @@ TranslationServiceConnection::DeleteGlossary(
 std::shared_ptr<TranslationServiceConnection> MakeTranslationServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TranslationServicePolicyOptionList>(options,
                                                                      __func__);
   options =

--- a/google/cloud/translate/translation_connection.h
+++ b/google/cloud/translate/translation_connection.h
@@ -125,6 +125,7 @@ class TranslationServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::translate::TranslationServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/video/livestream_connection.cc
+++ b/google/cloud/video/livestream_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/video/livestream_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -154,6 +155,7 @@ Status LivestreamServiceConnection::DeleteEvent(
 std::shared_ptr<LivestreamServiceConnection> MakeLivestreamServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  LivestreamServicePolicyOptionList>(options,
                                                                     __func__);
   options = video_internal::LivestreamServiceDefaultOptions(std::move(options));

--- a/google/cloud/video/livestream_connection.h
+++ b/google/cloud/video/livestream_connection.h
@@ -146,6 +146,7 @@ class LivestreamServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::video::LivestreamServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/video/transcoder_connection.cc
+++ b/google/cloud/video/transcoder_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/video/transcoder_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -87,6 +88,7 @@ Status TranscoderServiceConnection::DeleteJobTemplate(
 std::shared_ptr<TranscoderServiceConnection> MakeTranscoderServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  TranscoderServicePolicyOptionList>(options,
                                                                     __func__);
   options = video_internal::TranscoderServiceDefaultOptions(std::move(options));

--- a/google/cloud/video/transcoder_connection.h
+++ b/google/cloud/video/transcoder_connection.h
@@ -109,6 +109,7 @@ class TranscoderServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::video::TranscoderServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/video/video_stitcher_connection.cc
+++ b/google/cloud/video/video_stitcher_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/video/video_stitcher_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -165,6 +166,7 @@ VideoStitcherServiceConnection::GetLiveSession(
 std::shared_ptr<VideoStitcherServiceConnection>
 MakeVideoStitcherServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VideoStitcherServicePolicyOptionList>(
       options, __func__);
   options =

--- a/google/cloud/video/video_stitcher_connection.h
+++ b/google/cloud/video/video_stitcher_connection.h
@@ -154,6 +154,7 @@ class VideoStitcherServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::video::VideoStitcherServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/videointelligence/video_intelligence_connection.cc
+++ b/google/cloud/videointelligence/video_intelligence_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/videointelligence/video_intelligence_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -45,6 +46,7 @@ VideoIntelligenceServiceConnection::AnnotateVideo(
 std::shared_ptr<VideoIntelligenceServiceConnection>
 MakeVideoIntelligenceServiceConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VideoIntelligenceServicePolicyOptionList>(
       options, __func__);
   options = videointelligence_internal::VideoIntelligenceServiceDefaultOptions(

--- a/google/cloud/videointelligence/video_intelligence_connection.h
+++ b/google/cloud/videointelligence/video_intelligence_connection.h
@@ -90,6 +90,7 @@ class VideoIntelligenceServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * -
  * `google::cloud::videointelligence::VideoIntelligenceServicePolicyOptionList`
  *

--- a/google/cloud/vision/image_annotator_connection.cc
+++ b/google/cloud/vision/image_annotator_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/vision/internal/image_annotator_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -64,6 +65,7 @@ ImageAnnotatorConnection::AsyncBatchAnnotateFiles(
 std::shared_ptr<ImageAnnotatorConnection> MakeImageAnnotatorConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ImageAnnotatorPolicyOptionList>(options,
                                                                  __func__);
   options = vision_internal::ImageAnnotatorDefaultOptions(std::move(options));

--- a/google/cloud/vision/image_annotator_connection.h
+++ b/google/cloud/vision/image_annotator_connection.h
@@ -98,6 +98,7 @@ class ImageAnnotatorConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::vision::ImageAnnotatorPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/vision/product_search_connection.cc
+++ b/google/cloud/vision/product_search_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/vision/product_search_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -158,6 +159,7 @@ ProductSearchConnection::PurgeProducts(
 std::shared_ptr<ProductSearchConnection> MakeProductSearchConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ProductSearchPolicyOptionList>(options,
                                                                 __func__);
   options = vision_internal::ProductSearchDefaultOptions(std::move(options));

--- a/google/cloud/vision/product_search_connection.h
+++ b/google/cloud/vision/product_search_connection.h
@@ -142,6 +142,7 @@ class ProductSearchConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::vision::ProductSearchPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/vmmigration/vm_migration_connection.cc
+++ b/google/cloud/vmmigration/vm_migration_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/vmmigration/vm_migration_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -370,6 +371,7 @@ VmMigrationConnection::DeleteTargetProject(
 std::shared_ptr<VmMigrationConnection> MakeVmMigrationConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VmMigrationPolicyOptionList>(options,
                                                               __func__);
   options = vmmigration_internal::VmMigrationDefaultOptions(std::move(options));

--- a/google/cloud/vmmigration/vm_migration_connection.h
+++ b/google/cloud/vmmigration/vm_migration_connection.h
@@ -262,6 +262,7 @@ class VmMigrationConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::vmmigration::VmMigrationPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/vpcaccess/vpc_access_connection.cc
+++ b/google/cloud/vpcaccess/vpc_access_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/vpcaccess/vpc_access_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -67,6 +68,7 @@ VpcAccessServiceConnection::DeleteConnector(
 std::shared_ptr<VpcAccessServiceConnection> MakeVpcAccessServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  VpcAccessServicePolicyOptionList>(options,
                                                                    __func__);
   options =

--- a/google/cloud/vpcaccess/vpc_access_connection.h
+++ b/google/cloud/vpcaccess/vpc_access_connection.h
@@ -95,6 +95,7 @@ class VpcAccessServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::vpcaccess::VpcAccessServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/webrisk/web_risk_connection.cc
+++ b/google/cloud/webrisk/web_risk_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/webrisk/web_risk_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include <memory>
 
@@ -60,6 +61,7 @@ WebRiskServiceConnection::CreateSubmission(
 std::shared_ptr<WebRiskServiceConnection> MakeWebRiskServiceConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  WebRiskServicePolicyOptionList>(options,
                                                                  __func__);
   options = webrisk_internal::WebRiskServiceDefaultOptions(std::move(options));

--- a/google/cloud/webrisk/web_risk_connection.h
+++ b/google/cloud/webrisk/web_risk_connection.h
@@ -89,6 +89,7 @@ class WebRiskServiceConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::webrisk::WebRiskServicePolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/websecurityscanner/web_security_scanner_connection.cc
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/websecurityscanner/web_security_scanner_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -122,6 +123,7 @@ WebSecurityScannerConnection::ListFindingTypeStats(
 std::shared_ptr<WebSecurityScannerConnection> MakeWebSecurityScannerConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  WebSecurityScannerPolicyOptionList>(options,
                                                                      __func__);
   options = websecurityscanner_internal::WebSecurityScannerDefaultOptions(

--- a/google/cloud/websecurityscanner/web_security_scanner_connection.h
+++ b/google/cloud/websecurityscanner/web_security_scanner_connection.h
@@ -134,6 +134,7 @@ class WebSecurityScannerConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::websecurityscanner::WebSecurityScannerPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/workflows/executions_connection.cc
+++ b/google/cloud/workflows/executions_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/workflows/internal/executions_stub_factory.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -63,6 +64,7 @@ ExecutionsConnection::CancelExecution(
 std::shared_ptr<ExecutionsConnection> MakeExecutionsConnection(
     Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  ExecutionsPolicyOptionList>(options, __func__);
   options = workflows_internal::ExecutionsDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/workflows/executions_connection.h
+++ b/google/cloud/workflows/executions_connection.h
@@ -95,6 +95,7 @@ class ExecutionsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::workflows::ExecutionsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,

--- a/google/cloud/workflows/workflows_connection.cc
+++ b/google/cloud/workflows/workflows_connection.cc
@@ -23,6 +23,7 @@
 #include "google/cloud/workflows/workflows_options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/common_options.h"
+#include "google/cloud/credentials.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/pagination_range.h"
 #include <memory>
@@ -74,6 +75,7 @@ WorkflowsConnection::UpdateWorkflow(
 
 std::shared_ptr<WorkflowsConnection> MakeWorkflowsConnection(Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
+                                 UnifiedCredentialsOptionList,
                                  WorkflowsPolicyOptionList>(options, __func__);
   options = workflows_internal::WorkflowsDefaultOptions(std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();

--- a/google/cloud/workflows/workflows_connection.h
+++ b/google/cloud/workflows/workflows_connection.h
@@ -97,6 +97,7 @@ class WorkflowsConnection {
  *
  * - `google::cloud::CommonOptionList`
  * - `google::cloud::GrpcOptionList`
+ * - `google::cloud::UnifiedCredentialsOptionList`
  * - `google::cloud::workflows::WorkflowsPolicyOptionList`
  *
  * @note Unexpected options will be ignored. To log unexpected options instead,


### PR DESCRIPTION
Fixes #8240

Add an `OptionsList` for the GUAC `Options` and check for it in generated and hand-written connections. (Unless the handwritten connection is deprecated).

Also add a missing `OptionsList` and `Options` from the expected Bigtable options

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9643)
<!-- Reviewable:end -->
