### PR TITLE
feat(bigtable): define equality operator for some classes

### DIFF
--- a/google/cloud/bigtable/column_family.h
+++ b/google/cloud/bigtable/column_family.h
@@ -19,6 +19,7 @@
 #include "absl/meta/type_traits.h"
 #include <google/bigtable/admin/v2/bigtable_table_admin.pb.h>
 #include <google/bigtable/admin/v2/table.pb.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <chrono>
 #include <memory>
 #include <string>
@@ -149,6 +150,14 @@ class GcRule {
   GcRule& operator=(GcRule const&) = default;
   //@}
 
+  friend bool operator==(GcRule const& a, GcRule const& b) noexcept {
+    return google::protobuf::util::MessageDifferencer::Equivalent(a.gc_rule_,
+                                                                  b.gc_rule_);
+  }
+  friend bool operator!=(GcRule const& a, GcRule const& b) noexcept {
+    return !(a == b);
+  }
+
  private:
   GcRule() = default;
 
@@ -213,6 +222,16 @@ class ColumnFamilyModification {
   ColumnFamilyModification& operator=(ColumnFamilyModification const&) =
       default;
   //@}
+
+  friend bool operator==(ColumnFamilyModification const& a,
+                         ColumnFamilyModification const& b) noexcept {
+    return google::protobuf::util::MessageDifferencer::Equivalent(a.mod_,
+                                                                  b.mod_);
+  }
+  friend bool operator!=(ColumnFamilyModification const& a,
+                         ColumnFamilyModification const& b) noexcept {
+    return !(a == b);
+  }
 
  private:
   ColumnFamilyModification() = default;

--- a/google/cloud/bigtable/column_family_test.cc
+++ b/google/cloud/bigtable/column_family_test.cc
@@ -29,6 +29,15 @@ using ::google::cloud::testing_util::chrono_literals::operator"" _s;   // NOLINT
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 using ::google::cloud::testing_util::chrono_literals::operator"" _ns;  // NOLINT
 
+TEST(GcRule, Equality) {
+  auto gc1 = GcRule::MaxNumVersions(3);
+  auto gc2 = GcRule::MaxAge(1_h);
+  EXPECT_NE(gc1, gc2);
+
+  gc2 = gc1;
+  EXPECT_EQ(gc1, gc2);
+}
+
 TEST(GcRule, MaxNumVersions) {
   auto proto = GcRule::MaxNumVersions(3).as_proto();
   EXPECT_EQ(3, proto.max_num_versions());
@@ -120,6 +129,16 @@ TEST(GcRule, UnionNone) {
   auto proto = GC::Union().as_proto();
   EXPECT_TRUE(proto.has_union_());
   EXPECT_EQ(0, proto.union_().rules_size());
+}
+
+TEST(ColumnFamilyModification, Equality) {
+  using M = ColumnFamilyModification;
+  auto m1 = M::Drop("m1");
+  auto m2 = M::Drop("m2");
+  EXPECT_NE(m1, m2);
+
+  m2 = m1;
+  EXPECT_EQ(m1, m2);
 }
 
 TEST(ColumnFamilyModification, Create) {

--- a/google/cloud/bigtable/filters.h
+++ b/google/cloud/bigtable/filters.h
@@ -18,6 +18,7 @@
 #include "google/cloud/bigtable/version.h"
 #include "absl/meta/type_traits.h"
 #include <google/bigtable/v2/data.pb.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <chrono>
 #include <string>
 
@@ -25,6 +26,7 @@ namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Define the interfaces to create filter expressions.
  *
@@ -56,6 +58,14 @@ class Filter {
   Filter& operator=(Filter&&) = default;
   Filter(Filter const&) = default;
   Filter& operator=(Filter const&) = default;
+
+  friend bool operator==(Filter const& a, Filter const& b) noexcept {
+    return google::protobuf::util::MessageDifferencer::Equivalent(a.filter_,
+                                                                  b.filter_);
+  }
+  friend bool operator!=(Filter const& a, Filter const& b) noexcept {
+    return !(a == b);
+  }
 
   /// Return a filter that passes on all data.
   static Filter PassAllFilter() {

--- a/google/cloud/bigtable/filters_test.cc
+++ b/google/cloud/bigtable/filters_test.cc
@@ -29,6 +29,15 @@ using ::google::cloud::testing_util::IsProtoEqual;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 
+TEST(FiltersTest, Equality) {
+  auto f1 = Filter::PassAllFilter();
+  auto f2 = Filter::Latest(10);
+  EXPECT_NE(f1, f2);
+
+  f2 = f1;
+  EXPECT_EQ(f1, f2);
+}
+
 TEST(FiltersTest, PassAllFilter) {
   auto proto = Filter::PassAllFilter().as_proto();
   EXPECT_TRUE(proto.pass_all_filter());

--- a/google/cloud/bigtable/mutations.h
+++ b/google/cloud/bigtable/mutations.h
@@ -25,6 +25,7 @@
 #include "absl/meta/type_traits.h"
 #include <google/bigtable/v2/bigtable.pb.h>
 #include <google/bigtable/v2/data.pb.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <grpcpp/grpcpp.h>
 #include <chrono>
 #include <string>
@@ -355,6 +356,16 @@ class SingleRowMutation {
   SingleRowMutation(SingleRowMutation const&) = default;
   SingleRowMutation& operator=(SingleRowMutation const&) = default;
 
+  friend bool operator==(SingleRowMutation const& a,
+                         SingleRowMutation const& b) noexcept {
+    return google::protobuf::util::MessageDifferencer::Equivalent(a.request_,
+                                                                  b.request_);
+  }
+  friend bool operator!=(SingleRowMutation const& a,
+                         SingleRowMutation const& b) noexcept {
+    return !(a == b);
+  }
+
   /// Move the contents into a bigtable::v2::MutateRowsRequest::Entry.
   void MoveTo(google::bigtable::v2::MutateRowsRequest::Entry* entry) {
     entry->set_row_key(std::move(*request_.mutable_row_key()));
@@ -403,6 +414,15 @@ class FailedMutation {
   FailedMutation& operator=(FailedMutation&&) = default;
   FailedMutation(FailedMutation const&) = default;
   FailedMutation& operator=(FailedMutation const&) = default;
+
+  friend bool operator==(FailedMutation const& a,
+                         FailedMutation const& b) noexcept {
+    return a.status_ == b.status_ && a.original_index_ == b.original_index_;
+  }
+  friend bool operator!=(FailedMutation const& a,
+                         FailedMutation const& b) noexcept {
+    return !(a == b);
+  }
 
   //@{
   /// @name accessors

--- a/google/cloud/bigtable/mutations_test.cc
+++ b/google/cloud/bigtable/mutations_test.cc
@@ -30,6 +30,27 @@ namespace btproto = ::google::bigtable::v2;
 using ::google::cloud::testing_util::chrono_literals::operator"" _ms;  // NOLINT
 using ::google::cloud::testing_util::chrono_literals::operator"" _us;  // NOLINT
 
+TEST(SingleRowMutation, Equality) {
+  auto m1 = SingleRowMutation("m1", DeleteFromRow());
+  auto m2 = SingleRowMutation("m2", DeleteFromRow());
+  EXPECT_NE(m1, m2);
+
+  m2 = m1;
+  EXPECT_EQ(m1, m2);
+}
+
+TEST(FailedMutation, Equality) {
+  auto m1 = FailedMutation(Status(), 0);
+  auto m2 = FailedMutation(Status(), 1);
+  auto m3 = FailedMutation(Status(StatusCode::kAborted, "fail"), 0);
+  EXPECT_NE(m1, m2);
+  EXPECT_NE(m1, m3);
+  EXPECT_NE(m2, m3);
+
+  m2 = m1;
+  EXPECT_EQ(m1, m2);
+}
+
 /// @test Verify that SetCell() works as expected.
 TEST(MutationsTest, SetCell) {
   auto actual = SetCell("family", "col", 1234_ms, "value");

--- a/google/cloud/bigtable/read_modify_write_rule.h
+++ b/google/cloud/bigtable/read_modify_write_rule.h
@@ -17,12 +17,14 @@
 
 #include "google/cloud/bigtable/version.h"
 #include <google/bigtable/v2/data.pb.h>
+#include <google/protobuf/util/message_differencer.h>
 #include <string>
 
 namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Define the interfaces to create ReadWriteModifyRule operations.
  *
@@ -38,6 +40,16 @@ class ReadModifyWriteRule {
   ReadModifyWriteRule& operator=(ReadModifyWriteRule&&) = default;
   ReadModifyWriteRule(ReadModifyWriteRule const&) = default;
   ReadModifyWriteRule& operator=(ReadModifyWriteRule const&) = default;
+
+  friend bool operator==(ReadModifyWriteRule const& a,
+                         ReadModifyWriteRule const& b) noexcept {
+    return google::protobuf::util::MessageDifferencer::Equivalent(a.rule_,
+                                                                  b.rule_);
+  }
+  friend bool operator!=(ReadModifyWriteRule const& a,
+                         ReadModifyWriteRule const& b) noexcept {
+    return !(a == b);
+  }
 
   /// Create an operation that appends a string value.
   static ReadModifyWriteRule AppendValue(std::string family_name,

--- a/google/cloud/bigtable/read_modify_write_rule_test.cc
+++ b/google/cloud/bigtable/read_modify_write_rule_test.cc
@@ -23,6 +23,15 @@ namespace {
 
 namespace btproto = ::google::bigtable::v2;
 
+TEST(ReadModifyWriteRuleTest, Equality) {
+  auto r1 = ReadModifyWriteRule::AppendValue("fam", "col", "foo");
+  auto r2 = ReadModifyWriteRule::IncrementAmount("fam", "col", 42);
+  EXPECT_NE(r1, r2);
+
+  r2 = r1;
+  EXPECT_EQ(r1, r2);
+}
+
 TEST(ReadModifyWriteRuleTest, AppendValue) {
   auto const proto =
       ReadModifyWriteRule::AppendValue("fam", "col", "foo").as_proto();

--- a/google/cloud/bigtable/row_set.h
+++ b/google/cloud/bigtable/row_set.h
@@ -17,11 +17,13 @@
 
 #include "google/cloud/bigtable/row_range.h"
 #include "google/cloud/bigtable/version.h"
+#include <google/protobuf/util/message_differencer.h>
 
 namespace google {
 namespace cloud {
 namespace bigtable {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Represent a (possibly non-continuous) set of row keys.
  *
@@ -37,6 +39,14 @@ class RowSet {
   RowSet& operator=(RowSet&&) = default;
   RowSet(RowSet const&) = default;
   RowSet& operator=(RowSet const&) = default;
+
+  friend bool operator==(RowSet const& a, RowSet const& b) noexcept {
+    return google::protobuf::util::MessageDifferencer::Equivalent(a.row_set_,
+                                                                  b.row_set_);
+  }
+  friend bool operator!=(RowSet const& a, RowSet const& b) noexcept {
+    return !(a == b);
+  }
 
   template <typename... Arg>
   RowSet(Arg&&... a) {  // NOLINT(google-explicit-constructor)

--- a/google/cloud/bigtable/row_set_test.cc
+++ b/google/cloud/bigtable/row_set_test.cc
@@ -27,6 +27,15 @@ TEST(RowSetTest, DefaultConstructor) {
   EXPECT_EQ(0, proto.row_ranges_size());
 }
 
+TEST(RowSetTest, Equality) {
+  auto rs1 = RowSet("rs1");
+  auto rs2 = RowSet("rs2");
+  EXPECT_NE(rs1, rs2);
+
+  rs2 = rs1;
+  EXPECT_EQ(rs1, rs2);
+}
+
 TEST(RowSetTest, AppendRange) {
   RowSet row_set;
   row_set.Append(RowRange::Range("a", "b"));

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -115,6 +115,12 @@ enum class Consistency {
  *
  * [backoff-link]: https://cloud.google.com/storage/docs/exponential-backoff
  *
+ * @par Equality
+ * `TableAdmin` objects will compare equal iff they were created with the
+ * same `DataClient` and target the same Instance resource. Note that
+ * `TableAdmin` objects can compare equal with different retry/backoff/polling
+ * policies.
+ *
  * @see https://cloud.google.com/bigtable/ for an overview of Cloud Bigtable.
  *
  * @see https://cloud.google.com/bigtable/docs/overview for an overview of the
@@ -212,6 +218,14 @@ class TableAdmin {
 
   TableAdmin(TableAdmin const&) = default;
   TableAdmin& operator=(TableAdmin const&) = default;
+
+  friend bool operator==(TableAdmin const& a, TableAdmin const& b) noexcept {
+    return a.connection_ == b.connection_ &&
+           a.instance_name_ == b.instance_name_;
+  }
+  friend bool operator!=(TableAdmin const& a, TableAdmin const& b) noexcept {
+    return !(a == b);
+  }
 
   //@{
   /// @name Convenience shorthands for the schema views.

--- a/google/cloud/bigtable/table_admin_test.cc
+++ b/google/cloud/bigtable/table_admin_test.cc
@@ -24,6 +24,7 @@
 #include <google/protobuf/text_format.h>
 #include <gmock/gmock.h>
 #include <chrono>
+#include <memory>
 
 namespace google {
 namespace cloud {
@@ -134,6 +135,20 @@ class TableAdminTest : public ::testing::Test {
   std::shared_ptr<MockConnection> connection_ =
       std::make_shared<MockConnection>();
 };
+
+TEST_F(TableAdminTest, Equality) {
+  auto client1 = MakeAdminClient(kProjectId, TestOptions());
+  auto client2 = MakeAdminClient(kProjectId, TestOptions());
+  auto ta1 = TableAdmin(client1, "i1");
+  auto ta2 = TableAdmin(client1, "i2");
+  auto ta3 = TableAdmin(client2, "i1");
+  EXPECT_NE(ta1, ta2);
+  EXPECT_NE(ta1, ta3);
+  EXPECT_NE(ta2, ta3);
+
+  ta2 = ta1;
+  EXPECT_EQ(ta1, ta2);
+}
 
 TEST_F(TableAdminTest, ResourceNames) {
   auto admin = DefaultTableAdmin();


### PR DESCRIPTION
Part of the work for #2310 

The types are:
* `ColumnFamilyModification`
* `FailedMutation`
* `Filter`
* `GcRule`
* `ReadModifyWriteRule`
* `RowSet`
* `SingleRowMutation`
* `TableAdmin`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9647)
<!-- Reviewable:end -->
