### PR TITLE
feat(storage): equality for Native IAM types

### DIFF
--- a/google/cloud/storage/iam_policy.cc
+++ b/google/cloud/storage/iam_policy.cc
@@ -143,6 +143,14 @@ NativeExpression& NativeExpression::operator=(NativeExpression&& rhs) noexcept {
   return *this;
 }
 
+bool operator==(NativeExpression const& a, NativeExpression const& b) noexcept {
+  return a.pimpl_->native_json == b.pimpl_->native_json;
+}
+
+bool operator!=(NativeExpression const& a, NativeExpression const& b) noexcept {
+  return !(a == b);
+}
+
 std::string NativeExpression::expression() const {
   return pimpl_->native_json.value("expression", "");
 }
@@ -292,6 +300,16 @@ NativeIamBinding& NativeIamBinding::operator=(NativeIamBinding&& rhs) noexcept {
   return *this;
 }
 
+bool operator==(NativeIamBinding const& a, NativeIamBinding const& b) noexcept {
+  return a.pimpl_->native_json == b.pimpl_->native_json &&
+         a.members() == b.members() &&
+         a.pimpl_->condition == b.pimpl_->condition;
+}
+
+bool operator!=(NativeIamBinding const& a, NativeIamBinding const& b) noexcept {
+  return !(a == b);
+}
+
 std::string NativeIamBinding::role() const {
   return pimpl_->native_json.value("role", "");
 }
@@ -426,6 +444,15 @@ std::string NativeIamPolicy::ToJson() const { return pimpl_->ToJson().dump(); }
 NativeIamPolicy& NativeIamPolicy::operator=(NativeIamPolicy const& other) {
   *pimpl_ = *other.pimpl_;
   return *this;
+}
+
+bool operator==(NativeIamPolicy const& a, NativeIamPolicy const& b) noexcept {
+  return a.pimpl_->native_json == b.pimpl_->native_json &&
+         a.bindings() == b.bindings();
+}
+
+bool operator!=(NativeIamPolicy const& a, NativeIamPolicy const& b) noexcept {
+  return !(a == b);
 }
 
 std::int32_t NativeIamPolicy::version() const {

--- a/google/cloud/storage/iam_policy.h
+++ b/google/cloud/storage/iam_policy.h
@@ -60,8 +60,10 @@ class NativeExpression {
   NativeExpression(NativeExpression&&) noexcept;
   NativeExpression& operator=(NativeExpression&&) noexcept;
 
-  friend bool operator==(NativeExpression const& a, NativeExpression const& b) noexcept;
-  friend bool operator!=(NativeExpression const& a, NativeExpression const& b) noexcept;
+  friend bool operator==(NativeExpression const& a,
+                         NativeExpression const& b) noexcept;
+  friend bool operator!=(NativeExpression const& a,
+                         NativeExpression const& b) noexcept;
 
   std::string expression() const;
   void set_expression(std::string expression);
@@ -105,8 +107,10 @@ class NativeIamBinding {
   NativeIamBinding(NativeIamBinding&&) noexcept;
   NativeIamBinding& operator=(NativeIamBinding&&) noexcept;
 
-  friend bool operator==(NativeIamBinding const& a, NativeIamBinding const& b) noexcept;
-  friend bool operator!=(NativeIamBinding const& a, NativeIamBinding const& b) noexcept;
+  friend bool operator==(NativeIamBinding const& a,
+                         NativeIamBinding const& b) noexcept;
+  friend bool operator!=(NativeIamBinding const& a,
+                         NativeIamBinding const& b) noexcept;
 
   std::string role() const;
   void set_role(std::string role);
@@ -154,8 +158,10 @@ class NativeIamPolicy {
 
   NativeIamPolicy& operator=(NativeIamPolicy const& other);
 
-  friend bool operator==(NativeIamPolicy const& a, NativeIamPolicy const& b) noexcept;
-  friend bool operator!=(NativeIamPolicy const& a, NativeIamPolicy const& b) noexcept;
+  friend bool operator==(NativeIamPolicy const& a,
+                         NativeIamPolicy const& b) noexcept;
+  friend bool operator!=(NativeIamPolicy const& a,
+                         NativeIamPolicy const& b) noexcept;
 
   std::int32_t version() const;
   void set_version(std::int32_t version);

--- a/google/cloud/storage/iam_policy.h
+++ b/google/cloud/storage/iam_policy.h
@@ -25,6 +25,7 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
 /**
  * Represents a google::type::Expr.
  *
@@ -54,10 +55,13 @@ class NativeExpression {
   NativeExpression(NativeExpression const& other);
   NativeExpression& operator=(NativeExpression const& other);
 
-  // This have to be declared explicitly and defined out of line because `Impl`
+  // These have to be declared explicitly and defined out of line because `Impl`
   // is incomplete at this point.
   NativeExpression(NativeExpression&&) noexcept;
   NativeExpression& operator=(NativeExpression&&) noexcept;
+
+  friend bool operator==(NativeExpression const& a, NativeExpression const& b) noexcept;
+  friend bool operator!=(NativeExpression const& a, NativeExpression const& b) noexcept;
 
   std::string expression() const;
   void set_expression(std::string expression);
@@ -100,6 +104,9 @@ class NativeIamBinding {
   // is incomplete at this point.
   NativeIamBinding(NativeIamBinding&&) noexcept;
   NativeIamBinding& operator=(NativeIamBinding&&) noexcept;
+
+  friend bool operator==(NativeIamBinding const& a, NativeIamBinding const& b) noexcept;
+  friend bool operator!=(NativeIamBinding const& a, NativeIamBinding const& b) noexcept;
 
   std::string role() const;
   void set_role(std::string role);
@@ -146,6 +153,9 @@ class NativeIamPolicy {
   std::string ToJson() const;
 
   NativeIamPolicy& operator=(NativeIamPolicy const& other);
+
+  friend bool operator==(NativeIamPolicy const& a, NativeIamPolicy const& b) noexcept;
+  friend bool operator!=(NativeIamPolicy const& a, NativeIamPolicy const& b) noexcept;
 
   std::int32_t version() const;
   void set_version(std::int32_t version);

--- a/google/cloud/storage/internal/patch_builder.cc
+++ b/google/cloud/storage/internal/patch_builder.cc
@@ -142,6 +142,14 @@ PatchBuilder& PatchBuilder::operator=(PatchBuilder&& rhs) noexcept {
   return *this;
 }
 
+bool operator==(PatchBuilder const& a, PatchBuilder const& b) noexcept {
+  return a.pimpl_->patch_ == b.pimpl_->patch_;
+}
+
+bool operator!=(PatchBuilder const& a, PatchBuilder const& b) noexcept {
+  return !(a == b);
+}
+
 std::string PatchBuilder::ToString() const { return pimpl_->ToString(); }
 
 bool PatchBuilder::empty() const { return pimpl_->empty(); }

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -25,6 +25,7 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+
 /**
  * Prepares a patch for the '<Resource Type>: patch' APIs in Google Cloud
  * Storage.
@@ -49,6 +50,9 @@ class PatchBuilder {
   // is incomplete at this point.
   PatchBuilder(PatchBuilder&&) noexcept;
   PatchBuilder& operator=(PatchBuilder&&) noexcept;
+
+  friend bool operator==(PatchBuilder const& a, PatchBuilder const& b) noexcept;
+  friend bool operator!=(PatchBuilder const& a, PatchBuilder const& b) noexcept;
 
   /// Return the patch as a string.
   std::string ToString() const;

--- a/google/cloud/storage/internal/patch_builder_test.cc
+++ b/google/cloud/storage/internal/patch_builder_test.cc
@@ -24,6 +24,16 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
+
+TEST(PatchBuilderTest, Equality) {
+  auto b1 = PatchBuilder{}.AddStringField("field1", "lhs", "rhs");
+  auto b2 = PatchBuilder{};
+  EXPECT_NE(b1, b2);
+
+  b2 = b1;
+  EXPECT_EQ(b1, b2);
+}
+
 TEST(PatchBuilderTest, Empty) {
   PatchBuilder builder;
   EXPECT_TRUE(builder.empty());

--- a/google/cloud/storage/storage_iam_policy_test.cc
+++ b/google/cloud/storage/storage_iam_policy_test.cc
@@ -77,6 +77,15 @@ TEST(NativeIamExpression, CtorAndAccessors) {
   EXPECT_EQ("loc3", const_expr.location());
 }
 
+TEST(NativeIamExpression, Equality) {
+  NativeExpression e1("expr", "title", "descr", "loc");
+  NativeExpression e2("expr");
+  EXPECT_NE(e1, e2);
+
+  e2 = e1;
+  EXPECT_EQ(e1, e2);
+}
+
 TEST(NativeIamExpression, Printing) {
   NativeExpression expr("expr");
   NativeExpression const& const_expr = expr;
@@ -135,6 +144,19 @@ TEST(NativeIamBinding, CtorAndAccessors) {
   ASSERT_FALSE(binding.has_condition());
 }
 
+TEST(NativeIamBinding, Equality) {
+  NativeIamBinding b1("role1", {"member1"}, NativeExpression("expr1"));
+  NativeIamBinding b2("role2", {"member1"}, NativeExpression("expr1"));
+  NativeIamBinding b3("role1", {"member2"}, NativeExpression("expr1"));
+  NativeIamBinding b4("role1", {"member1"}, NativeExpression("expr2"));
+  EXPECT_NE(b1, b2);
+  EXPECT_NE(b1, b3);
+  EXPECT_NE(b1, b4);
+
+  b2 = b1;
+  EXPECT_EQ(b1, b2);
+}
+
 TEST(NativeIamBinding, Printing) {
   NativeIamBinding binding("role", {"member1", "member2"});
   NativeIamBinding const& const_binding = binding;
@@ -169,6 +191,18 @@ TEST(NativeIamPolicy, CtorAndAccessors) {
   ASSERT_EQ(2U, const_policy.bindings().size());
   ASSERT_EQ("role1", const_policy.bindings()[0].role());
   ASSERT_EQ("role2", const_policy.bindings()[1].role());
+}
+
+TEST(NativeIamPolicy, Equality) {
+  NativeIamPolicy p1({NativeIamBinding("role1", {"member"})});
+  NativeIamPolicy p2({NativeIamBinding("role2", {"member"})});
+  NativeIamPolicy p3({NativeIamBinding("role1", {"member"})}, "etag");
+
+  EXPECT_NE(p1, p2);
+  EXPECT_NE(p1, p3);
+
+  p2 = p1;
+  EXPECT_EQ(p1, p2);
 }
 
 TEST(NativeIamPolicy, Json) {


### PR DESCRIPTION
Part of the work for #2310

The types are:
* `storage::NativeExpression`
* `storage::NativeIamBinding`
* `storage::NativeIamPolicy`

And I was too lazy to do this internal type in a separate PR:
* `storage::internal::PatchBuilder`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9649)
<!-- Reviewable:end -->
