### PR TITLE
test(storage): cleanup options for aggregate download benchmark

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -120,7 +120,7 @@ class Iteration {
 
 gcs::Client MakeClient(AggregateDownloadThroughputOptions const& options) {
   auto opts = google::cloud::Options{options.client_options}
-                  // Make the upload buffer size small, the library will flush
+                  // Make the upload buffer size small so the library will flush
                   // on almost all `.write()` requests.
                   .set<gcs::UploadBufferSizeOption>(256 * gcs_bm::kKiB);
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -119,10 +119,7 @@ class Iteration {
 };
 
 gcs::Client MakeClient(AggregateDownloadThroughputOptions const& options) {
-  auto opts = google::cloud::Options{options.client_options}
-                  // Make the upload buffer size small so the library will flush
-                  // on almost all `.write()` requests.
-                  .set<gcs::UploadBufferSizeOption>(256 * gcs_bm::kKiB);
+  auto opts = options.client_options;
 #if GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
   if (options.api == "GRPC") {
     return DefaultGrpcClient(

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -133,7 +133,7 @@ ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
       {"--download-stall-timeout",
        "configure `storage::DownloadStallTimeoutOption`: the maximum time"
        " allowed for data to 'stall' (make insufficient progress) on downloads."
-       " This option is intended for troubleshooting, most of the time the"
+       " This option is intended for troubleshooting. Most of the time the"
        " value is not expected to change the library performance.",
        [&options](std::string const& val) {
          options.client_options.set<gcs::DownloadStallTimeoutOption>(

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/aggregate_download_throughput_options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include <iterator>
 #include <sstream>
@@ -21,7 +22,50 @@ namespace google {
 namespace cloud {
 namespace storage_benchmarks {
 
+namespace gcs = ::google::cloud::storage;
+namespace gcs_ex = ::google::cloud::storage_experimental;
 using ::google::cloud::testing_util::OptionDescriptor;
+
+StatusOr<AggregateDownloadThroughputOptions> ValidateOptions(
+    std::string const& usage, AggregateDownloadThroughputOptions options) {
+  auto make_status = [](std::ostringstream& os) {
+    return Status{StatusCode::kInvalidArgument, std::move(os).str()};
+  };
+
+  if (options.bucket_name.empty()) {
+    std::ostringstream os;
+    os << "Missing --bucket-name option\n" << usage << "\n";
+    return make_status(os);
+  }
+  if (options.thread_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of threads (" << options.thread_count
+       << "), check your --thread-count option\n";
+    return make_status(os);
+  }
+  if (options.iteration_count <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of iterations (" << options.iteration_count
+       << "), check your --iteration-count option\n";
+    return make_status(os);
+  }
+  if (options.repeats_per_iteration <= 0) {
+    std::ostringstream os;
+    os << "Invalid number of repeats per iteration ("
+       << options.repeats_per_iteration
+       << "), check your --repeats-per-iteration option\n";
+    return make_status(os);
+  }
+  if (options.client_options.get<GrpcNumChannelsOption>() < 0) {
+    std::ostringstream os;
+    os << "Invalid number of gRPC channels ("
+       << options.client_options.get<GrpcNumChannelsOption>()
+       << "), check your --grpc-channel-count option\n";
+    return make_status(os);
+  }
+
+  return options;
+}
 
 google::cloud::StatusOr<AggregateDownloadThroughputOptions>
 ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
@@ -63,30 +107,51 @@ ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
          options.read_buffer_size = ParseBufferSize(val);
        }},
       {"--api", "select the API (JSON, XML, or GRPC) for the benchmark",
-       [&options](std::string const& val) {
-         options.api = ParseApiName(val).value();
-       }},
-      {"--grpc-channel-count", "controls the number of gRPC channels",
-       [&options](std::string const& val) {
-         options.grpc_channel_count = std::stoi(val);
-       }},
-      {"--grpc-plugin-config",
-       "low-level experimental settings for the GCS+gRPC plugin",
-       [&options](std::string const& val) {
-         options.grpc_plugin_config = val;
-       }},
-      {"--rest-http-version", "change the preferred HTTP version",
-       [&options](std::string const& val) { options.rest_http_version = val; }},
+       [&options](std::string const& val) { options.api = val; }},
       {"--client-per-thread",
        "use a different storage::Client object in each thread",
        [&options](std::string const& val) {
          options.client_per_thread =
              testing_util::ParseBoolean(val).value_or("true");
        }},
-      {"--download-stall-timeout",
-       "abort downloads stalled for more than this time",
+      {"--grpc-channel-count", "controls the number of gRPC channels",
        [&options](std::string const& val) {
-         options.download_stall_timeout = testing_util::ParseDuration(val);
+         options.client_options.set<GrpcNumChannelsOption>(std::stoi(val));
+       }},
+      {"--rest-http-version", "change the preferred HTTP version",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs_ex::HttpVersionOption>(val);
+       }},
+      {"--rest-endpoint", "change the REST endpoint",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs::RestEndpointOption>(val);
+       }},
+      {"--grpc-endpoint", "change the gRPC endpoint",
+       [&options](std::string const& val) {
+         options.client_options.set<EndpointOption>(val);
+       }},
+      {"--download-stall-timeout",
+       "configure `storage::DownloadStallTimeoutOption`: the maximum time"
+       " allowed for data to 'stall' (make insufficient progress) on downloads."
+       " This option is intended for troubleshooting, most of the time the"
+       " value is not expected to change the library performance.",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs::DownloadStallTimeoutOption>(
+             ParseDuration(val));
+       }},
+      {"--download-stall-minimum-rate",
+       "configure `storage::DownloadStallMinimumRateOption`: the transfer"
+       " is aborted if the average transfer rate is below this limit for"
+       " the period set via `storage::DownloadStallTimeoutOption`.",
+       [&options](std::string const& val) {
+         options.client_options.set<gcs_ex::DownloadStallMinimumRateOption>(
+             static_cast<std::uint32_t>(ParseBufferSize(val)));
+       }},
+      {"--grpc-background-threads",
+       "change the default number of gRPC background threads",
+       [&options](std::string const& val) {
+         options.client_options.set<GrpcBackgroundThreadPoolSizeOption>(
+             std::stoi(val));
        }},
   };
   auto usage = BuildUsage(desc, argv[0]);
@@ -97,58 +162,20 @@ ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
     options.exit_after_parse = true;
     return options;
   }
-
   if (wants_description) {
     std::cout << description << "\n";
     options.exit_after_parse = true;
     return options;
   }
-
-  auto make_status = [](std::ostringstream& os) {
-    auto const code = google::cloud::StatusCode::kInvalidArgument;
-    return google::cloud::Status{code, std::move(os).str()};
-  };
-
   if (unparsed.size() != 1) {
     std::ostringstream os;
     os << "Unknown arguments or options: "
        << absl::StrJoin(std::next(unparsed.begin()), unparsed.end(), ", ")
        << "\n"
        << usage << "\n";
-    return make_status(os);
+    return Status{StatusCode::kInvalidArgument, std::move(os).str()};
   }
-  if (options.bucket_name.empty()) {
-    std::ostringstream os;
-    os << "Missing --bucket option\n" << usage << "\n";
-    return make_status(os);
-  }
-  if (options.thread_count <= 0) {
-    std::ostringstream os;
-    os << "Invalid number of threads (" << options.thread_count
-       << "), check your --thread-count option\n";
-    return make_status(os);
-  }
-  if (options.iteration_count <= 0) {
-    std::ostringstream os;
-    os << "Invalid number of iterations (" << options.iteration_count
-       << "), check your --iteration-count option\n";
-    return make_status(os);
-  }
-  if (options.repeats_per_iteration <= 0) {
-    std::ostringstream os;
-    os << "Invalid number of repeats per iteration ("
-       << options.repeats_per_iteration
-       << "), check your --repeats-per-iteration option\n";
-    return make_status(os);
-  }
-  if (options.grpc_channel_count < 0) {
-    std::ostringstream os;
-    os << "Invalid number of gRPC channels (" << options.grpc_channel_count
-       << "), check your --grpc-channel-count option\n";
-    return make_status(os);
-  }
-
-  return options;
+  return ValidateOptions(usage, std::move(options));
 }
 
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.h
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.h
@@ -33,12 +33,9 @@ struct AggregateDownloadThroughputOptions {
   int repeats_per_iteration = 1;
   std::int64_t read_size = 0;  // 0 means "read the whole file"
   std::size_t read_buffer_size = 4 * kMiB;
-  ApiName api = ApiName::kApiGrpc;
-  int grpc_channel_count = 0;
-  std::string grpc_plugin_config;
-  std::string rest_http_version;
+  std::string api;
   bool client_per_thread = false;
-  std::chrono::seconds download_stall_timeout = std::chrono::seconds(60);
+  Options client_options;
   bool exit_after_parse = false;
 };
 

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/aggregate_download_throughput_options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/testing_util/status_matchers.h"
 #include <gmock/gmock.h>
 #include <thread>
@@ -21,6 +22,9 @@ namespace google {
 namespace cloud {
 namespace storage_benchmarks {
 namespace {
+
+namespace gcs = ::google::cloud::storage;
+namespace gcs_ex = ::google::cloud::storage_experimental;
 
 TEST(AggregateDownloadThroughputOptions, Basic) {
   auto options = ParseAggregateDownloadThroughputOptions(
@@ -35,11 +39,14 @@ TEST(AggregateDownloadThroughputOptions, Basic) {
           "--read-size=4MiB",
           "--read-buffer-size=1MiB",
           "--api=XML",
-          "--grpc-channel-count=16",
-          "--grpc-plugin-config=default",
-          "--rest-http-version=1.1",
           "--client-per-thread",
-          "--download-stall-timeout=120s",
+          "--grpc-channel-count=16",
+          "--rest-http-version=1.1",
+          "--rest-endpoint=https://us-central-storage.googleapis.com",
+          "--grpc-endpoint=google-c2p:///storage.googleapis.com",
+          "--download-stall-timeout=10s",
+          "--download-stall-minimum-rate=100KiB",
+          "--grpc-background-threads=4",
       },
       "");
   ASSERT_STATUS_OK(options);
@@ -52,12 +59,21 @@ TEST(AggregateDownloadThroughputOptions, Basic) {
   EXPECT_EQ(2, options->repeats_per_iteration);
   EXPECT_EQ(4 * kMiB, options->read_size);
   EXPECT_EQ(1 * kMiB, options->read_buffer_size);
-  EXPECT_EQ(ApiName::kApiXml, options->api);
-  EXPECT_EQ(16, options->grpc_channel_count);
-  EXPECT_EQ("default", options->grpc_plugin_config);
-  EXPECT_EQ("1.1", options->rest_http_version);
+  EXPECT_EQ("XML", options->api);
   EXPECT_EQ(true, options->client_per_thread);
-  EXPECT_EQ(std::chrono::seconds(120), options->download_stall_timeout);
+  EXPECT_EQ(16, options->client_options.get<GrpcNumChannelsOption>());
+  EXPECT_EQ("1.1", options->client_options.get<gcs_ex::HttpVersionOption>());
+  EXPECT_EQ("https://us-central-storage.googleapis.com",
+            options->client_options.get<gcs::RestEndpointOption>());
+  EXPECT_EQ("google-c2p:///storage.googleapis.com",
+            options->client_options.get<EndpointOption>());
+  EXPECT_EQ(std::chrono::seconds(10),
+            options->client_options.get<gcs::DownloadStallTimeoutOption>());
+  EXPECT_EQ(
+      100 * kKiB,
+      options->client_options.get<gcs_ex::DownloadStallMinimumRateOption>());
+  EXPECT_EQ(4,
+            options->client_options.get<GrpcBackgroundThreadPoolSizeOption>());
 }
 
 TEST(AggregateDownloadThroughputOptions, Description) {


### PR DESCRIPTION
Use `google::cloud::Options` directly. Simplifies the initialization and
the parsing code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9651)
<!-- Reviewable:end -->
