### PR TITLE
refactor(impl): move `UserIp` out of `internal/`

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -129,6 +129,7 @@ google_cloud_cpp_storage_hdrs = [
     "signed_url_options.h",
     "storage_class.h",
     "upload_options.h",
+    "user_ip_option.h",
     "version.h",
     "version_info.h",
     "well_known_headers.h",

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -219,6 +219,7 @@ add_library(
     signed_url_options.h
     storage_class.h
     upload_options.h
+    user_ip_option.h
     version.cc
     version.h
     version_info.h

--- a/google/cloud/storage/internal/generic_request.h
+++ b/google/cloud/storage/internal/generic_request.h
@@ -15,7 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_REQUEST_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GENERIC_REQUEST_H
 
-#include "google/cloud/storage/internal/complex_option.h"
+#include "google/cloud/storage/user_ip_option.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/storage/well_known_headers.h"
 #include "google/cloud/storage/well_known_parameters.h"
@@ -33,25 +33,6 @@ class Options;
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-/**
- * Sets the user IP on an operation for quota enforcement purposes.
- *
- * This parameter lets you enforce per-user quotas when calling the API from a
- * server-side application. This parameter is overridden by `UserQuota` if both
- * are set.
- *
- * If you set this parameter to an empty string, the client library will
- * automatically select one of the user IP addresses of your server to include
- * in the request.
- *
- * @see https://cloud.google.com/apis/docs/capping-api-usage for an introduction
- *     to quotas in Google Cloud Platform.
- */
-struct UserIp : public internal::ComplexOption<UserIp, std::string> {
-  using ComplexOption<UserIp, std::string>::ComplexOption;
-  static char const* name() { return "userIp"; }
-};
-
 namespace internal {
 // Forward declare the template so we can specialize it first. Defining the
 // specialization first, which is the base class, should be more readable.

--- a/google/cloud/storage/user_ip_option.h
+++ b/google/cloud/storage/user_ip_option.h
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_USER_IP_OPTION_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_USER_IP_OPTION_H
+
+#include "google/cloud/storage/internal/complex_option.h"
+#include "google/cloud/version.h"
+#include <string>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Sets the user IP on an operation for quota enforcement purposes.
+ *
+ * This parameter lets you enforce per-user quotas when calling the API from a
+ * server-side application.
+ *
+ * @note The recommended practice is to use `QuotaUser`. This parameter is
+ * overridden by `QuotaUser` if both are set.
+ *
+ * If you set this parameter to an empty string, the client library will
+ * automatically select one of the user IP addresses of your server to include
+ * in the request.
+ *
+ * @see https://cloud.google.com/apis/docs/capping-api-usage for an introduction
+ *     to quotas in Google Cloud Platform.
+ */
+struct UserIp : public internal::ComplexOption<UserIp, std::string> {
+  using ComplexOption<UserIp, std::string>::ComplexOption;
+  static char const* name() { return "userIp"; }
+};
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_USER_IP_OPTION_H


### PR DESCRIPTION
The `storage::UserIp` class, while not recommended, is part of the
public API and, to be discoverable, needs to be in the same directory
as all public APIs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9652)
<!-- Reviewable:end -->
