### PR TITLE
refactor(bigtable): `TableAdmin` receives Connection `Options`

### DIFF
--- a/google/cloud/bigtable/table_admin.cc
+++ b/google/cloud/bigtable/table_admin.cc
@@ -46,7 +46,7 @@ constexpr TableAdmin::TableView TableAdmin::VIEW_UNSPECIFIED;
 
 StatusOr<btadmin::Table> TableAdmin::CreateTable(std::string table_id,
                                                  TableConfig config) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   auto request = std::move(config).as_proto();
   request.set_parent(instance_name());
   request.set_table_id(std::move(table_id));
@@ -55,7 +55,7 @@ StatusOr<btadmin::Table> TableAdmin::CreateTable(std::string table_id,
 
 StatusOr<std::vector<btadmin::Table>> TableAdmin::ListTables(
     btadmin::Table::View view) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   std::vector<btadmin::Table> result;
 
   btadmin::ListTablesRequest request;
@@ -71,7 +71,7 @@ StatusOr<std::vector<btadmin::Table>> TableAdmin::ListTables(
 
 StatusOr<btadmin::Table> TableAdmin::GetTable(std::string const& table_id,
                                               btadmin::Table::View view) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::GetTableRequest request;
   request.set_name(TableName(table_id));
   request.set_view(view);
@@ -79,7 +79,7 @@ StatusOr<btadmin::Table> TableAdmin::GetTable(std::string const& table_id,
 }
 
 Status TableAdmin::DeleteTable(std::string const& table_id) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::DeleteTableRequest request;
   request.set_name(TableName(table_id));
   return connection_->DeleteTable(request);
@@ -99,14 +99,14 @@ btadmin::CreateBackupRequest TableAdmin::CreateBackupParams::AsProto(
 
 StatusOr<btadmin::Backup> TableAdmin::CreateBackup(
     CreateBackupParams const& params) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   auto request = params.AsProto(instance_name());
   return connection_->CreateBackup(request).get();
 }
 
 StatusOr<btadmin::Backup> TableAdmin::GetBackup(std::string const& cluster_id,
                                                 std::string const& backup_id) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::GetBackupRequest request;
   request.set_name(BackupName(cluster_id, backup_id));
   return connection_->GetBackup(request);
@@ -125,13 +125,13 @@ btadmin::UpdateBackupRequest TableAdmin::UpdateBackupParams::AsProto(
 
 StatusOr<btadmin::Backup> TableAdmin::UpdateBackup(
     UpdateBackupParams const& params) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::UpdateBackupRequest request = params.AsProto(instance_name());
   return connection_->UpdateBackup(request);
 }
 
 Status TableAdmin::DeleteBackup(btadmin::Backup const& backup) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::DeleteBackupRequest request;
   request.set_name(backup.name());
   return connection_->DeleteBackup(request);
@@ -139,7 +139,7 @@ Status TableAdmin::DeleteBackup(btadmin::Backup const& backup) {
 
 Status TableAdmin::DeleteBackup(std::string const& cluster_id,
                                 std::string const& backup_id) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::DeleteBackupRequest request;
   request.set_name(BackupName(cluster_id, backup_id));
   return connection_->DeleteBackup(request);
@@ -157,7 +157,7 @@ btadmin::ListBackupsRequest TableAdmin::ListBackupsParams::AsProto(
 
 StatusOr<std::vector<btadmin::Backup>> TableAdmin::ListBackups(
     ListBackupsParams const& params) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   std::vector<btadmin::Backup> result;
 
   btadmin::ListBackupsRequest request = params.AsProto(instance_name());
@@ -198,7 +198,7 @@ btadmin::RestoreTableRequest AsProto(
 
 StatusOr<btadmin::Table> TableAdmin::RestoreTable(
     RestoreTableFromInstanceParams params) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   auto request = AsProto(instance_name(), std::move(params));
   return connection_->RestoreTable(request).get();
 }
@@ -206,11 +206,11 @@ StatusOr<btadmin::Table> TableAdmin::RestoreTable(
 StatusOr<btadmin::Table> TableAdmin::ModifyColumnFamilies(
     std::string const& table_id,
     std::vector<ColumnFamilyModification> modifications) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::ModifyColumnFamiliesRequest request;
   request.set_name(TableName(table_id));
   for (auto& m : modifications) {
-    google::cloud::internal::OptionsSpan span(policies_);
+    google::cloud::internal::OptionsSpan span(options_);
     *request.add_modifications() = std::move(m).as_proto();
   }
   return connection_->ModifyColumnFamilies(request);
@@ -218,7 +218,7 @@ StatusOr<btadmin::Table> TableAdmin::ModifyColumnFamilies(
 
 Status TableAdmin::DropRowsByPrefix(std::string const& table_id,
                                     std::string row_key_prefix) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::DropRowRangeRequest request;
   request.set_name(TableName(table_id));
   request.set_row_key_prefix(std::move(row_key_prefix));
@@ -236,7 +236,7 @@ future<StatusOr<Consistency>> TableAdmin::WaitForConsistency(
   auto client = bigtable_admin::BigtableTableAdminClient(connection_);
   return bigtable_admin::AsyncWaitForConsistency(cq_, std::move(client),
                                                  TableName(table_id),
-                                                 consistency_token, policies_)
+                                                 consistency_token, options_)
       .then([](future<Status> f) -> StatusOr<Consistency> {
         auto s = f.get();
         if (!s.ok()) return s;
@@ -245,7 +245,7 @@ future<StatusOr<Consistency>> TableAdmin::WaitForConsistency(
 }
 
 Status TableAdmin::DropAllRows(std::string const& table_id) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::DropRowRangeRequest request;
   request.set_name(TableName(table_id));
   request.set_delete_all_data_from_table(true);
@@ -254,7 +254,7 @@ Status TableAdmin::DropAllRows(std::string const& table_id) {
 
 StatusOr<std::string> TableAdmin::GenerateConsistencyToken(
     std::string const& table_id) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::GenerateConsistencyTokenRequest request;
   request.set_name(TableName(table_id));
   auto sor = connection_->GenerateConsistencyToken(request);
@@ -264,7 +264,7 @@ StatusOr<std::string> TableAdmin::GenerateConsistencyToken(
 
 StatusOr<Consistency> TableAdmin::CheckConsistency(
     std::string const& table_id, std::string const& consistency_token) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   btadmin::CheckConsistencyRequest request;
   request.set_name(TableName(table_id));
   request.set_consistency_token(consistency_token);
@@ -286,7 +286,7 @@ StatusOr<google::iam::v1::Policy> TableAdmin::GetIamPolicy(
 
 StatusOr<google::iam::v1::Policy> TableAdmin::GetIamPolicyImpl(
     std::string resource) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   ::google::iam::v1::GetIamPolicyRequest request;
   request.set_resource(std::move(resource));
   return connection_->GetIamPolicy(request);
@@ -305,7 +305,7 @@ StatusOr<google::iam::v1::Policy> TableAdmin::SetIamPolicy(
 
 StatusOr<google::iam::v1::Policy> TableAdmin::SetIamPolicyImpl(
     std::string resource, google::iam::v1::Policy const& iam_policy) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   ::google::iam::v1::SetIamPolicyRequest request;
   request.set_resource(std::move(resource));
   *request.mutable_policy() = iam_policy;
@@ -325,7 +325,7 @@ StatusOr<std::vector<std::string>> TableAdmin::TestIamPermissions(
 
 StatusOr<std::vector<std::string>> TableAdmin::TestIamPermissionsImpl(
     std::string resource, std::vector<std::string> const& permissions) {
-  google::cloud::internal::OptionsSpan span(policies_);
+  google::cloud::internal::OptionsSpan span(options_);
   ::google::iam::v1::TestIamPermissionsRequest request;
   request.set_resource(std::move(resource));
   for (auto const& permission : permissions) {

--- a/google/cloud/bigtable/table_admin.h
+++ b/google/cloud/bigtable/table_admin.h
@@ -166,8 +166,10 @@ class TableAdmin {
             DefaultRPCBackoffPolicy(internal::kBigtableTableAdminLimits)),
         polling_prototype_(
             DefaultPollingPolicy(internal::kBigtableTableAdminLimits)),
-        policies_(bigtable_internal::MakeTableAdminOptions(
-            retry_prototype_, backoff_prototype_, polling_prototype_)) {}
+        options_(google::cloud::internal::MergeOptions(
+            bigtable_internal::MakeTableAdminOptions(
+                retry_prototype_, backoff_prototype_, polling_prototype_),
+            connection_->options())) {}
 
   /**
    * Create a new TableAdmin using explicit policies to handle RPC errors.
@@ -212,8 +214,10 @@ class TableAdmin {
         polling_prototype_(
             DefaultPollingPolicy(internal::kBigtableTableAdminLimits)) {
     ChangePolicies(std::forward<Policies>(policies)...);
-    policies_ = bigtable_internal::MakeTableAdminOptions(
-        retry_prototype_, backoff_prototype_, polling_prototype_);
+    options_ = google::cloud::internal::MergeOptions(
+        bigtable_internal::MakeTableAdminOptions(
+            retry_prototype_, backoff_prototype_, polling_prototype_),
+        connection_->options());
   }
 
   TableAdmin(TableAdmin const&) = default;
@@ -1073,8 +1077,10 @@ class TableAdmin {
             DefaultRPCBackoffPolicy(internal::kBigtableTableAdminLimits)),
         polling_prototype_(
             DefaultPollingPolicy(internal::kBigtableTableAdminLimits)),
-        policies_(bigtable_internal::MakeTableAdminOptions(
-            retry_prototype_, backoff_prototype_, polling_prototype_)) {}
+        options_(google::cloud::internal::MergeOptions(
+            bigtable_internal::MakeTableAdminOptions(
+                retry_prototype_, backoff_prototype_, polling_prototype_),
+            connection_->options())) {}
 
   //@{
   /// @name Helper functions to implement constructors with changed policies.
@@ -1115,10 +1121,14 @@ class TableAdmin {
   std::string project_id_;
   std::string instance_id_;
   std::string instance_name_;
+  //@{
+  /// These prototypes are only used as temporary storage during construction of
+  /// the class, where they are consolidated as common policies in `options_`.
   std::shared_ptr<RPCRetryPolicy> retry_prototype_;
   std::shared_ptr<RPCBackoffPolicy> backoff_prototype_;
   std::shared_ptr<PollingPolicy> polling_prototype_;
-  Options policies_;
+  //}
+  Options options_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #9168. This PR unblocks the generator refactor.

Same story as #9653 - merge in options coming from the connection and put them in an `OptionsSpan` for each client call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9656)
<!-- Reviewable:end -->
