### PR TITLE
test(storage): use Options to store client configuration

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_benchmark.cc
@@ -148,7 +148,7 @@ int main(int argc, char* argv[]) {
     std::cerr << options.status() << "\n";
     return 1;
   }
-  if (options->exit_after_parse) return 1;
+  if (options->exit_after_parse) return 0;
 
   auto client = MakeClient(*options);
   std::vector<gcs::ObjectMetadata> dataset;
@@ -183,9 +183,11 @@ int main(int argc, char* argv[]) {
             << "\n# Read Buffer Size: " << options->read_buffer_size
             << "\n# API: " << options->api
             << "\n# Client Per Thread: " << std::boolalpha
-            << options->client_per_thread << "\n# Build Info: " << notes
+            << options->client_per_thread
             << "\n# Object Count: " << dataset.size()
-            << "\n# Dataset size: " << FormatSize(dataset_size) << std::endl;
+            << "\n# Dataset size: " << FormatSize(dataset_size);
+  gcs_bm::PrintOptions(std::cout, "Client Options", options->client_options);
+  std::cout << "\n# Build Info: " << notes << std::endl;
 
   auto configs = [](AggregateDownloadThroughputOptions const& options,
                     gcs::Client const& default_client) {

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_benchmark.cc
@@ -161,8 +161,9 @@ int main(int argc, char* argv[]) {
             << "\n# Iterations: " << options->iteration_count
             << "\n# API: " << options->api
             << "\n# Client Per Thread: " << std::boolalpha
-            << options->client_per_thread << "\n# Build Info: " << notes
-            << std::endl;
+            << options->client_per_thread;
+  gcs_bm::PrintOptions(std::cout, "Client Options", options->client_options);
+  std::cout << "\n# Build Info: " << notes << std::endl;
 
   auto configs = [](AggregateUploadThroughputOptions const& options,
                     gcs::Client const& default_client) {

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -14,7 +14,10 @@
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/benchmarks/bounded_queue.h"
+#include "google/cloud/storage/options.h"
+#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/throw_delegate.h"
+#include "google/cloud/options.h"
 #include "absl/types/optional.h"
 #include <cctype>
 #include <future>
@@ -25,6 +28,9 @@
 namespace google {
 namespace cloud {
 namespace storage_benchmarks {
+
+namespace gcs = ::google::cloud::storage;
+namespace gcs_ex = ::google::cloud::storage_experimental;
 
 void DeleteAllObjects(google::cloud::storage::Client client,
                       std::string const& bucket_name, int thread_count) {
@@ -156,6 +162,52 @@ std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
                                          "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                          "0123456789") +
          ".txt";
+}
+
+void PrintOptions(std::ostream& os, std::string const& prefix,
+                  Options const& options) {
+  if (options.has<GrpcBackgroundThreadPoolSizeOption>()) {
+    os << "#\n " << prefix << " Grpc Background Threads: "
+       << options.get<GrpcBackgroundThreadPoolSizeOption>();
+  }
+  if (options.has<GrpcNumChannelsOption>()) {
+    os << "\n# " << prefix
+       << " gRPC Channel Count: " << options.get<GrpcNumChannelsOption>();
+  }
+  if (options.has<EndpointOption>()) {
+    os << "\n# " << prefix
+       << " Grpc Endpoint: " << options.get<EndpointOption>();
+  }
+  if (options.has<gcs::RestEndpointOption>()) {
+    os << "\n# " << prefix
+       << "REST Endpoint: " << options.get<gcs::RestEndpointOption>();
+  }
+  if (options.has<gcs::TransferStallTimeoutOption>()) {
+    os << "\n# " << prefix << " Transfer Stall Timeout: "
+       << absl::FormatDuration(
+              absl::FromChrono(options.get<gcs::TransferStallTimeoutOption>()));
+  }
+  if (options.has<gcs_ex::TransferStallMinimumRateOption>()) {
+    os << "\n# " << prefix << " Transfer Stall Minimum Rate: "
+       << testing_util::FormatSize(
+              options.get<gcs_ex::TransferStallMinimumRateOption>());
+  }
+  if (options.has<gcs::DownloadStallTimeoutOption>()) {
+    os << "\n# " << prefix << " Download Stall Timeout: "
+       << absl::FormatDuration(
+              absl::FromChrono(options.get<gcs::DownloadStallTimeoutOption>()));
+  }
+  if (options.has<gcs_ex::DownloadStallMinimumRateOption>()) {
+    os << "\n# " << prefix << " Download Stall Minimum Rate: "
+       << testing_util::FormatSize(
+              options.get<gcs_ex::DownloadStallMinimumRateOption>());
+  }
+
+  if (options.has<google::cloud::storage::internal::TargetApiVersionOption>()) {
+    os << "#\n " << prefix << " Api Version Path: "
+       << options
+              .has<google::cloud::storage::internal::TargetApiVersionOption>();
+  }
 }
 
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -18,10 +18,9 @@
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/options.h"
+#include "absl/time/time.h"
 #include "absl/types/optional.h"
-#include <cctype>
 #include <future>
-#include <limits>
 #include <sstream>
 #include <stdexcept>
 

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -166,7 +166,7 @@ std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen) {
 void PrintOptions(std::ostream& os, std::string const& prefix,
                   Options const& options) {
   if (options.has<GrpcBackgroundThreadPoolSizeOption>()) {
-    os << "#\n " << prefix << " Grpc Background Threads: "
+    os << "\n# " << prefix << " Grpc Background Threads: "
        << options.get<GrpcBackgroundThreadPoolSizeOption>();
   }
   if (options.has<GrpcNumChannelsOption>()) {
@@ -203,7 +203,7 @@ void PrintOptions(std::ostream& os, std::string const& prefix,
   }
 
   if (options.has<google::cloud::storage::internal::TargetApiVersionOption>()) {
-    os << "#\n " << prefix << " Api Version Path: "
+    os << "\n# " << prefix << " Api Version Path: "
        << options
               .has<google::cloud::storage::internal::TargetApiVersionOption>();
   }

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -122,7 +122,7 @@ std::string FormatBandwidthGbPerSecond(
   return std::move(os).str();
 }
 
-// Print any well known options.
+// Print any well-known options.
 void PrintOptions(std::ostream& os, std::string const& prefix,
                   Options const& options);
 

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -18,12 +18,14 @@
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/testing/random_names.h"
 #include "google/cloud/internal/random.h"
+#include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/testing_util/command_line_parsing.h"
 #include "google/cloud/testing_util/timer.h"
 #include <chrono>
 #include <cstdint>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -119,6 +121,10 @@ std::string FormatBandwidthGbPerSecond(
   os << std::fixed << std::setprecision(2) << bandwidth;
   return std::move(os).str();
 }
+
+// Print any well known options.
+void PrintOptions(std::ostream& os, std::string const& prefix,
+                  Options const& options);
 
 }  // namespace storage_benchmarks
 }  // namespace cloud

--- a/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
+++ b/google/cloud/storage/benchmarks/storage_throughput_vs_cpu_benchmark.cc
@@ -18,7 +18,6 @@
 #include "google/cloud/storage/benchmarks/throughput_result.h"
 #include "google/cloud/storage/client.h"
 #include "google/cloud/storage/grpc_plugin.h"
-#include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/build_info.h"
 #include "google/cloud/internal/format_time_point.h"

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -16,7 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_BENCHMARKS_THROUGHPUT_OPTIONS_H
 
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
-#include "absl/types/optional.h"
+#include "google/cloud/options.h"
 #include <chrono>
 #include <string>
 #include <vector>
@@ -33,8 +33,6 @@ struct ThroughputOptions {
       std::chrono::seconds(std::chrono::minutes(15));
   int thread_count = 1;
   bool client_per_thread = false;
-  int grpc_channel_count = 0;
-  int direct_path_channel_count = 0;
   std::int64_t minimum_object_size = 32 * kMiB;
   std::int64_t maximum_object_size = 256 * kMiB;
   // Control the size of the read and write buffers in the application.
@@ -57,13 +55,6 @@ struct ThroughputOptions {
   std::vector<std::string> upload_functions = {"InsertObject", "WriteObject"};
   std::vector<bool> enabled_crc32c = {false, true};
   std::vector<bool> enabled_md5 = {false, true};
-  std::string rest_endpoint = "https://storage.googleapis.com";
-  std::string grpc_endpoint = "storage.googleapis.com";
-  std::string direct_path_endpoint = "google-c2p:///storage.googleapis.com";
-  std::chrono::seconds transfer_stall_timeout{};
-  absl::optional<std::uint32_t> transfer_stall_minimum_rate;
-  std::chrono::seconds download_stall_timeout{};
-  absl::optional<std::uint32_t> download_stall_minimum_rate;
   std::chrono::milliseconds minimum_sample_delay{};
   std::int64_t minimum_read_offset = 0;
   std::int64_t maximum_read_offset = 0;
@@ -71,9 +62,12 @@ struct ThroughputOptions {
   std::int64_t minimum_read_size = 0;
   std::int64_t maximum_read_size = 0;
   std::int64_t read_size_quantum = 128 * kKiB;
-  absl::optional<std::string> target_api_version_path;
-  absl::optional<int> grpc_background_threads;
-  bool enable_retry_loop = true;
+  Options client_options;
+  Options rest_options;
+  Options grpc_options;
+  Options direct_path_options =
+      Options{}.set<EndpointOption>("google-c2p:///storage.googleapis.com");
+  bool exit_after_parse = false;
 };
 
 google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(


### PR DESCRIPTION
This completes the changes to store the client configuration in
`Options`.  The benchmark specific options are still in a struct, which
maybe I want to change in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9658)
<!-- Reviewable:end -->
