### PR TITLE
cleanup(bigtable): assume call options

### DIFF
--- a/google/cloud/bigtable/internal/data_connection_impl.cc
+++ b/google/cloud/bigtable/internal/data_connection_impl.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/bigtable/internal/bulk_mutator.h"
 #include "google/cloud/bigtable/internal/default_row_reader.h"
 #include "google/cloud/bigtable/internal/defaults.h"
+#include "google/cloud/bigtable/options.h"
 #include "google/cloud/background_threads.h"
 #include "google/cloud/idempotency.h"
 #include "google/cloud/internal/async_retry_loop.h"
@@ -29,6 +30,32 @@ namespace google {
 namespace cloud {
 namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+inline std::string const& app_profile_id() {
+  return internal::CurrentOptions().get<bigtable::AppProfileIdOption>();
+}
+
+inline std::unique_ptr<bigtable::DataRetryPolicy> retry_policy() {
+  return internal::CurrentOptions()
+      .get<bigtable::DataRetryPolicyOption>()
+      ->clone();
+}
+
+inline std::unique_ptr<BackoffPolicy> backoff_policy() {
+  return internal::CurrentOptions()
+      .get<bigtable::DataBackoffPolicyOption>()
+      ->clone();
+}
+
+inline std::unique_ptr<bigtable::IdempotentMutationPolicy>
+idempotency_policy() {
+  return internal::CurrentOptions()
+      .get<bigtable::IdempotentMutationPolicyOption>()
+      ->clone();
+}
+
+}  // namespace
 
 bigtable::Row TransformReadModifyWriteRowResponse(
     google::bigtable::v2::ReadModifyWriteRowResponse response) {

--- a/google/cloud/bigtable/internal/data_connection_impl.h
+++ b/google/cloud/bigtable/internal/data_connection_impl.h
@@ -18,7 +18,6 @@
 #include "google/cloud/bigtable/data_connection.h"
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
 #include "google/cloud/background_threads.h"
-#include "google/cloud/backoff_policy.h"
 #include "google/cloud/options.h"
 #include "google/cloud/status_or.h"
 #include "google/cloud/version.h"
@@ -95,34 +94,6 @@ class DataConnectionImpl : public bigtable::DataConnection {
       bigtable::Filter filter) override;
 
  private:
-  static std::string const& app_profile_id() {
-    return internal::CurrentOptions().get<bigtable::AppProfileIdOption>();
-  }
-
-  std::unique_ptr<bigtable::DataRetryPolicy> retry_policy() {
-    auto const& options = internal::CurrentOptions();
-    if (options.has<bigtable::DataRetryPolicyOption>()) {
-      return options.get<bigtable::DataRetryPolicyOption>()->clone();
-    }
-    return options_.get<bigtable::DataRetryPolicyOption>()->clone();
-  }
-
-  std::unique_ptr<BackoffPolicy> backoff_policy() {
-    auto const& options = internal::CurrentOptions();
-    if (options.has<bigtable::DataBackoffPolicyOption>()) {
-      return options.get<bigtable::DataBackoffPolicyOption>()->clone();
-    }
-    return options_.get<bigtable::DataBackoffPolicyOption>()->clone();
-  }
-
-  std::unique_ptr<bigtable::IdempotentMutationPolicy> idempotency_policy() {
-    auto const& options = internal::CurrentOptions();
-    if (options.has<bigtable::IdempotentMutationPolicyOption>()) {
-      return options.get<bigtable::IdempotentMutationPolicyOption>()->clone();
-    }
-    return options_.get<bigtable::IdempotentMutationPolicyOption>()->clone();
-  }
-
   std::unique_ptr<BackgroundThreads> background_;
   std::shared_ptr<BigtableStub> stub_;
   Options options_;


### PR DESCRIPTION
Part of the work for #9168 

Basically #9655 but in bigtable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9663)
<!-- Reviewable:end -->
