### PR TITLE
ci: fix `retry-command.sh` for macOS

### DIFF
--- a/ci/retry-command.sh
+++ b/ci/retry-command.sh
@@ -40,7 +40,7 @@ while (((retries--) > 0)); do
   # apply +/- 50% jitter to min_wait
   period=$((min_wait * (50 + (RANDOM % 100)) / 100))
   echo "${PROGRAM} failed; trying again in ${period} seconds."
-  sleep ${period}s
+  sleep ${period}
   min_wait=$((min_wait * 2))
   "${PROGRAM}" "$@" && exit 0
   status=${?}


### PR DESCRIPTION
macOS does not support a `s` suffix for `sleep(1)`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9667)
<!-- Reviewable:end -->
