### PR TITLE
test(spanner): revert matching of interim database prefixes

### DIFF
--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -21,8 +21,7 @@ namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string RandomDatabasePrefixRegex() {
-  // Temporarily, we match both styles of separators.
-  return R"re(^db[-_]\d{4}[-_]\d{2}[-_]\d{2}[-_])re";
+  return R"re(^db-\d{4,}-\d{2}-\d{2}-)re";
 }
 
 std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {


### PR DESCRIPTION
It has been over four months since we settled on using only dash
separators in the prefixes of random database names (db-YYYY-MM-DD-),
so we can now remove the allowance for matching underscores as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9670)
<!-- Reviewable:end -->
