### PR TITLE
impl(storage): make both Xml and XmlV2 set Fields option in benchmarks

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -68,7 +68,8 @@ class ResumableUpload : public ThroughputExperiment {
                        std::string const& object_name,
                        ThroughputExperimentConfig const& config) override {
     auto api_selector = gcs::Fields();
-    if (transport_ == ExperimentTransport::kXml) {
+    if (transport_ == ExperimentTransport::kXml ||
+        transport_ == ExperimentTransport::kXmlV2) {
       // The default API is JSON, we force XML by not using features that XML
       // does not implement:
       api_selector = gcs::Fields("");
@@ -144,7 +145,8 @@ class SimpleUpload : public ThroughputExperiment {
       return fallback_.Run(bucket_name, object_name, config);
     }
     auto api_selector = gcs::Fields();
-    if (transport_ == ExperimentTransport::kXml) {
+    if (transport_ == ExperimentTransport::kXml ||
+        transport_ == ExperimentTransport::kXmlV2) {
       // The default API is JSON, we force XML by not using features that XML
       // does not implement:
       api_selector = gcs::Fields("");


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9677)
<!-- Reviewable:end -->
