### PR TITLE
test(storage): add details to aggregate benchmarks

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -19,7 +19,6 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/options.h"
 #include "absl/time/time.h"
-#include "absl/types/optional.h"
 #include <future>
 #include <sstream>
 #include <stdexcept>
@@ -211,6 +210,12 @@ void PrintOptions(std::ostream& os, std::string const& prefix,
        << options
               .has<google::cloud::storage::internal::TargetApiVersionOption>();
   }
+}
+// Format a timestamp
+std::string FormatTimestamp(std::chrono::system_clock::time_point tp) {
+  auto constexpr kFormat = "%E4Y-%m-%dT%H:%M:%E*SZ";
+  auto const t = absl::FromChrono(tp);
+  return absl::FormatTime(kFormat, t, absl::UTCTimeZone());
 }
 
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -126,6 +126,9 @@ std::string FormatBandwidthGbPerSecond(
 void PrintOptions(std::ostream& os, std::string const& prefix,
                   Options const& options);
 
+// Format a timestamp
+std::string FormatTimestamp(std::chrono::system_clock::time_point tp);
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/storage/benchmarks/throughput_result.h"
-#include "absl/time/time.h"
-#include <algorithm>
+#include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include <sstream>
 #include <string>
 
@@ -34,9 +33,7 @@ std::string CleanupCsv(std::string v) {
 }  // namespace
 
 void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
-  auto constexpr kFormat = "%E4Y-%m-%dT%H:%M:%E*SZ";
-  auto const start =
-      absl::FormatTime(kFormat, absl::FromChrono(r.start), absl::UTCTimeZone());
+  auto const start = FormatTimestamp(r.start);
 
   os << ToString(r.library)                    // clang-format hack
      << ',' << ToString(r.transport)           //


### PR DESCRIPTION
Add some timestamps which are handy when trying to correlate with
external graphs or other logs.  Refactored some code to print
timestamps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9684)
<!-- Reviewable:end -->
