### PR TITLE
cleanup(bigtable): reclaim vertical space

### DIFF
--- a/google/cloud/bigtable/internal/readrowsparser.cc
+++ b/google/cloud/bigtable/internal/readrowsparser.cc
@@ -63,12 +63,8 @@ void ReadRowsParser::HandleChunk(ReadRowsResponse_CellChunk chunk,
 
   if (cell_first_chunk_) {
     cell_.timestamp = chunk.timestamp_micros();
-  }
-
-  std::move(chunk.mutable_labels()->begin(), chunk.mutable_labels()->end(),
-            std::back_inserter(cell_.labels));
-
-  if (cell_first_chunk_) {
+    std::move(chunk.mutable_labels()->begin(), chunk.mutable_labels()->end(),
+              std::back_inserter(cell_.labels));
     // Most common case, move the value
     using std::swap;
     swap(*chunk.mutable_value(), cell_.value);


### PR DESCRIPTION
The proto says: "Labels are only set on the first CellChunk per cell.". So we can include it in the if statement.

https://github.com/googleapis/googleapis/blob/e6e875a456c046e94eeb5a76211daa046a8e72c9/google/bigtable/v2/bigtable.proto#L268-L271

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9687)
<!-- Reviewable:end -->
