### PR TITLE
impl(bigtable): `BulkMutator` keeps pending mutations' last status

### DIFF
--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -99,7 +99,7 @@ class BulkMutatorState {
      * status, we return a `FailedMutation` made from `original_index` and
      * `status`. The value is meaningless if `has_mutation_result` is false.
      */
-    Status status;
+    Status const status;
   };
 
   /// The annotations about the current bulk request.

--- a/google/cloud/bigtable/internal/bulk_mutator.h
+++ b/google/cloud/bigtable/internal/bulk_mutator.h
@@ -99,7 +99,7 @@ class BulkMutatorState {
      * status, we return a `FailedMutation` made from `original_index` and
      * `status`. The value is meaningless if `has_mutation_result` is false.
      */
-    Status const status;
+    Status status;
   };
 
   /// The annotations about the current bulk request.


### PR DESCRIPTION
Part of the work for #7479 

In order to report the proper errors for bulk mutations that end on OK streams, the `BulkMutator` needs to keep track of the last known status for a mutation it may or may not retry. There is always one copy translating from `grpc::Status` -> `google::cloud::Status`. `std::move()` the `Status` from then on.

In the case where a mutation fails in a stream that also fails, I return the mutation error. My guess is that it will be more informative. But we accept either in the unit test.

Note that we retry all OK streams at the moment. This will be fixed in either 1, 2, or 4 follow up PRs. (I haven't decided)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9688)
<!-- Reviewable:end -->
