### PR TITLE
impl(bigtable): AsyncRowSampler continues CurrentOptions

### DIFF
--- a/google/cloud/bigtable/internal/async_row_sampler.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler.cc
@@ -54,6 +54,7 @@ void AsyncRowSampler::StartIteration() {
   request.set_app_profile_id(app_profile_id_);
   request.set_table_name(table_name_);
 
+  internal::OptionsSpan span(options_);
   auto context = absl::make_unique<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
 

--- a/google/cloud/bigtable/internal/async_row_sampler.h
+++ b/google/cloud/bigtable/internal/async_row_sampler.h
@@ -63,6 +63,7 @@ class AsyncRowSampler : public std::enable_shared_from_this<AsyncRowSampler> {
   std::atomic<bool> keep_reading_{true};
   std::vector<bigtable::RowKeySample> samples_;
   promise<StatusOr<std::vector<bigtable::RowKeySample>>> promise_;
+  Options options_ = internal::CurrentOptions();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Part of the work for #9692 

`AsyncRowSampler` continues the `CurrentOptions` on retries.

I am sure this will call `ConfigureContext()` with the right options. I am less sure that this is the "right" way to continue the `Options`. It seems like any `.then()` in this or `PerformAsyncStreamingRead<>` *could* continue the `Options`. I don't think it is necessary though. I think we only need the `Options` for when we are creating the `internal::AsyncStreamingReadRpc<>` and configuring the context.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9693)
<!-- Reviewable:end -->
