### PR TITLE
feat(GCS+gRPC): routing headers for WriteObject

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.bzl
@@ -57,6 +57,7 @@ google_cloud_cpp_storage_grpc_srcs = [
     "internal/grpc_bucket_metadata_parser.cc",
     "internal/grpc_bucket_request_parser.cc",
     "internal/grpc_client.cc",
+    "internal/grpc_configure_client_context.cc",
     "internal/grpc_hmac_key_metadata_parser.cc",
     "internal/grpc_hmac_key_request_parser.cc",
     "internal/grpc_notification_metadata_parser.cc",

--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -44,6 +44,7 @@ else ()
         internal/grpc_bucket_request_parser.h
         internal/grpc_client.cc
         internal/grpc_client.h
+        internal/grpc_configure_client_context.cc
         internal/grpc_configure_client_context.h
         internal/grpc_hmac_key_metadata_parser.cc
         internal/grpc_hmac_key_metadata_parser.h

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -375,6 +375,7 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
   // extra prefix to ApplyQueryParameters sends the right filtering instructions
   // to the gRPC API.
   ApplyQueryParameters(*context, request, "resource");
+  ApplyRoutingHeaders(*context, request);
   auto stream = stub_->WriteObject(std::move(context));
 
   auto const& contents = request.contents();
@@ -635,6 +636,7 @@ StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
 
   auto context = absl::make_unique<grpc::ClientContext>();
   ApplyQueryParameters(*context, request, "resource");
+  ApplyRoutingHeaders(*context, request);
   auto writer = stub_->WriteObject(std::move(context));
 
   std::size_t const maximum_chunk_size =

--- a/google/cloud/storage/internal/grpc_configure_client_context.cc
+++ b/google/cloud/storage/internal/grpc_configure_client_context.cc
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/grpc_configure_client_context.h"
+#include <regex>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+void ApplyRoutingHeaders(grpc::ClientContext& context,
+                         InsertObjectMediaRequest const& request) {
+  context.AddMetadata("x-goog-request-params",
+                      "bucket=projects/_/buckets/" + request.bucket_name());
+}
+
+void ApplyRoutingHeaders(grpc::ClientContext& context,
+                         UploadChunkRequest const& request) {
+  static auto* bucket_regex =
+      new std::regex{"(projects/[^/]+/buckets/[^/]+)/.*", std::regex::optimize};
+  std::smatch match;
+  if (std::regex_match(request.upload_session_url(), match, *bucket_regex)) {
+    context.AddMetadata("x-goog-request-params", "bucket=" + match[1].str());
+  }
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/grpc_configure_client_context.h
+++ b/google/cloud/storage/internal/grpc_configure_client_context.h
@@ -16,6 +16,7 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_GRPC_CONFIGURE_CLIENT_CONTEXT_H
 
 #include "google/cloud/storage/internal/generic_request.h"
+#include "google/cloud/storage/internal/object_requests.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/grpc_options.h"
 #include <grpcpp/client_context.h>
@@ -30,7 +31,7 @@ namespace internal {
  * Inject request query parameters into grpc::ClientContext.
  *
  * The REST API has a number of "standard" query parameters that are not part of
- * the gRPC request body, instead they are send via metadata headers in the gRPC
+ * the gRPC request body, instead they are sent via metadata headers in the gRPC
  * request.
  *
  * @see https://cloud.google.com/apis/docs/system-parameters
@@ -62,6 +63,22 @@ void ApplyQueryParameters(grpc::ClientContext& context, Request const& request,
   google::cloud::internal::ConfigureContext(
       context, google::cloud::internal::CurrentOptions());
 }
+
+/**
+ * The generated `StorageMetadata` stub can not handle dynamic routing headers
+ * for client side streaming. So we manually match and extract the headers in
+ * this function.
+ */
+void ApplyRoutingHeaders(grpc::ClientContext& context,
+                         InsertObjectMediaRequest const& request);
+
+/**
+ * The generated `StorageMetadata` stub can not handle dynamic routing headers
+ * for client side streaming. So we manually match and extract the headers in
+ * this function.
+ */
+void ApplyRoutingHeaders(grpc::ClientContext& context,
+                         UploadChunkRequest const& request);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Fixes b/238793833

Routing rules are here: https://github.com/googleapis/googleapis/blob/b7cb84f5d42e6dba0fdcc2d8689313f6a8c9d7b9/google/storage/v2/storage.proto#L340-L349

I did the logic by hand, instead of using what the generator might produce. I did this because the two fields are a `oneof` that our code is already split on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9694)
<!-- Reviewable:end -->
