### PR TITLE
impl(bigtable): `AsyncBulkApplier`, `AsyncRowReader` continue `CurrentOptions()`

### DIFF
--- a/google/cloud/bigtable/internal/async_bulk_apply.cc
+++ b/google/cloud/bigtable/internal/async_bulk_apply.cc
@@ -55,6 +55,7 @@ AsyncBulkApplier::AsyncBulkApplier(
       promise_([this] { keep_reading_ = false; }) {}
 
 void AsyncBulkApplier::StartIteration() {
+  internal::OptionsSpan span(options_);
   auto context = absl::make_unique<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
 

--- a/google/cloud/bigtable/internal/async_bulk_apply.h
+++ b/google/cloud/bigtable/internal/async_bulk_apply.h
@@ -67,6 +67,7 @@ class AsyncBulkApplier : public std::enable_shared_from_this<AsyncBulkApplier> {
   bigtable::internal::BulkMutatorState state_;
   std::atomic<bool> keep_reading_{true};
   promise<std::vector<bigtable::FailedMutation>> promise_;
+  Options options_ = internal::CurrentOptions();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/async_row_reader.cc
+++ b/google/cloud/bigtable/internal/async_row_reader.cc
@@ -40,6 +40,7 @@ void AsyncRowReader::MakeRequest() {
   }
   parser_ = bigtable::internal::ReadRowsParserFactory().Create();
 
+  internal::OptionsSpan span(options_);
   auto context = absl::make_unique<grpc::ClientContext>();
   internal::ConfigureContext(*context, internal::CurrentOptions());
 

--- a/google/cloud/bigtable/internal/async_row_reader.h
+++ b/google/cloud/bigtable/internal/async_row_reader.h
@@ -159,6 +159,7 @@ class AsyncRowReader : public std::enable_shared_from_this<AsyncRowReader> {
   Status status_;
   /// Tracks the level of recursion of TryGiveRowToUser
   int recursion_level_ = 0;
+  Options options_ = internal::CurrentOptions();
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/async_row_sampler_test.cc
+++ b/google/cloud/bigtable/internal/async_row_sampler_test.cc
@@ -421,7 +421,13 @@ TEST(AsyncSampleRowKeysTest, CurrentOptionsContinuedOnRetries) {
   auto mock_b = absl::make_unique<MockBackoffPolicy>();
   EXPECT_CALL(*mock_b, OnCompletion).Times(1);
 
-  internal::OptionsSpan span(Options{}.set<TestOption>(5));
+  MockFunction<void(grpc::ClientContext&)> mock_setup;
+  EXPECT_CALL(mock_setup, Call).Times(2);
+
+  internal::OptionsSpan span(
+      Options{}
+          .set<internal::GrpcSetupOption>(mock_setup.AsStdFunction())
+          .set<TestOption>(5));
   auto fut = AsyncRowSampler::Create(
       cq, mock, std::move(retry), std::move(mock_b), kAppProfile, kTableName);
 


### PR DESCRIPTION
Fixes #9692 

The same as #9693, but for `AsyncBulkApplier` and `AsyncRowReader`.

Also, verify that the `GrpcSetupOption` is invoked twice in these tests, as this is the behavior we really care about.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9700)
<!-- Reviewable:end -->
