### PR TITLE
fix(bigtable): Use retry policy on streams with failing mutations

### DIFF
--- a/google/cloud/bigtable/table.cc
+++ b/google/cloud/bigtable/table.cc
@@ -181,10 +181,8 @@ std::vector<FailedMutation> Table::BulkApply(BulkMutation mut, Options opts) {
     retry_policy->Setup(client_context);
     metadata_update_policy_.Setup(client_context);
     status = mutator.MakeOneRequest(*client_, client_context);
-    if (!status.ok() && !retry_policy->OnFailure(status)) {
-      break;
-    }
     if (!mutator.HasPendingMutations()) break;
+    if (!retry_policy->OnFailure(status)) break;
     auto delay = backoff_policy->OnCompletion(status);
     std::this_thread::sleep_for(delay);
   }

--- a/google/cloud/bigtable/table.h
+++ b/google/cloud/bigtable/table.h
@@ -472,12 +472,6 @@ class Table {
    * It is possible that some mutations may not be attempted at all. These
    * mutations are considered failing and will be returned.
    *
-   * @note The retry policy is only impacted by the result of the gRPC stream.
-   *     Let's say you have a `LimitedErrorCountRetryPolicy` of 2. If an
-   *     idempotent mutation fails with a retryable error and the stream itself
-   *     succeeds, it may be retried more than 2 times. Only when the stream
-   *     fails twice will we give up and consider the mutation to be failed.
-   *
    * @note This function takes ownership (and then discards) the data in the
    *     mutation. In general, a `BulkMutation` can modify multiple rows, and
    *     the modifications for each row can change (or create) multiple cells,
@@ -516,12 +510,6 @@ class Table {
    *
    * It is possible that some mutations may not be attempted at all. These
    * mutations are considered failing and will be returned.
-   *
-   * @note The retry policy is only impacted by the result of the gRPC stream.
-   *     Let's say you have a `LimitedErrorCountRetryPolicy` of 2. If an
-   *     idempotent mutation fails with a retryable error and the stream itself
-   *     succeeds, it may be retried more than 2 times. Only when the stream
-   *     fails twice will we give up and consider the mutation to be failed.
    *
    * @note This function takes ownership (and then discards) the data in the
    *     mutation. In general, a `BulkMutation` can modify multiple rows, and


### PR DESCRIPTION
Fixes #7479 

Streams with an OK status, but failing mutations count towards the retry policy. 

While the 4 tests don't look like each other, they are consistent with the other tests in their fixtures, namely the `TooManyFailures` or `*Exhausted` tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9706)
<!-- Reviewable:end -->
