### PR TITLE
impl(oauth2): refactor Credentials for Rest transport with P12 support

### DIFF
--- a/ci/cloudbuild/builds/lib/integration.sh
+++ b/ci/cloudbuild/builds/lib/integration.sh
@@ -96,6 +96,7 @@ function integration::bazel_args() {
     # corresponding endpoints (e.g., https://private.googleapis.com) are not
     # always available in Kokoro.
     "--test_env=GOOGLE_CLOUD_CPP_STORAGE_TEST_ALTERNATIVE_HOSTS=private.googleapis.com,restricted.googleapis.com"
+    "--test_env=GOOGLE_CLOUD_CPP_EXPERIMENTAL_STORAGE_NEW_CREDENTIALS=yes"
 
     # Spanner
     "--test_env=GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS=${GOOGLE_CLOUD_CPP_SPANNER_SLOW_INTEGRATION_TESTS:-}"

--- a/google/cloud/internal/oauth2_google_credentials.cc
+++ b/google/cloud/internal/oauth2_google_credentials.cc
@@ -24,6 +24,9 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "absl/memory/memory.h"
 #include <nlohmann/json.hpp>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs12.h>
 #include <fstream>
 #include <iterator>
 #include <memory>
@@ -33,6 +36,117 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
+
+auto constexpr kP12PrivateKeyIdMarker = "--unknown--";
+
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
+StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
+    std::string const& source) {
+  OpenSSL_add_all_algorithms();
+
+  PKCS12* p12_raw = [](std::string const& source) {
+    FILE* fp = std::fopen(source.c_str(), "rb");
+    if (fp == nullptr) {
+      return static_cast<PKCS12*>(nullptr);
+    }
+    auto* result = d2i_PKCS12_fp(fp, nullptr);
+    fclose(fp);
+    return result;
+  }(source);
+
+  std::unique_ptr<PKCS12, decltype(&PKCS12_free)> p12(p12_raw, &PKCS12_free);
+
+  auto capture_openssl_errors = []() {
+    std::string msg;
+    while (auto code = ERR_get_error()) {
+      // OpenSSL guarantees that 256 bytes is enough:
+      //   https://www.openssl.org/docs/man1.1.1/man3/ERR_error_string_n.html
+      //   https://www.openssl.org/docs/man1.0.2/man3/ERR_error_string_n.html
+      // we could not find a macro or constant to replace the 256 literal.
+      auto constexpr kMaxOpenSslErrorLength = 256;
+      std::array<char, kMaxOpenSslErrorLength> buf{};
+      ERR_error_string_n(code, buf.data(), buf.size());
+      msg += buf.data();
+    }
+    return msg;
+  };
+
+  if (p12 == nullptr) {
+    std::string msg = "Cannot open PKCS#12 file (" + source + "): ";
+    msg += capture_openssl_errors();
+    return Status(StatusCode::kInvalidArgument, msg);
+  }
+
+  EVP_PKEY* pkey_raw;
+  X509* cert_raw;
+  if (PKCS12_parse(p12.get(), "notasecret", &pkey_raw, &cert_raw, nullptr) !=
+      1) {
+    std::string msg = "Cannot parse PKCS#12 file (" + source + "): ";
+    msg += capture_openssl_errors();
+    return Status(StatusCode::kInvalidArgument, msg);
+  }
+
+  std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(pkey_raw,
+                                                           &EVP_PKEY_free);
+  std::unique_ptr<X509, decltype(&X509_free)> cert(cert_raw, &X509_free);
+
+  if (pkey_raw == nullptr) {
+    return Status(StatusCode::kInvalidArgument,
+                  "No private key found in PKCS#12 file (" + source + ")");
+  }
+  if (cert_raw == nullptr) {
+    return Status(StatusCode::kInvalidArgument,
+                  "No private key found in PKCS#12 file (" + source + ")");
+  }
+
+  // This is automatically deleted by `cert`.
+  X509_NAME* name = X509_get_subject_name(cert.get());
+
+  std::string service_account_id = [&name]() -> std::string {
+    auto openssl_free = [](void* addr) { OPENSSL_free(addr); };
+    std::unique_ptr<char, decltype(openssl_free)> oneline(
+        X509_NAME_oneline(name, nullptr, 0), openssl_free);
+    // We expect the name to be simply CN/ followed by a (small) number of
+    // digits.
+    if (strncmp("/CN=", oneline.get(), 4) != 0) {
+      return "";
+    }
+    return oneline.get() + 4;
+  }();
+
+  if (service_account_id.find_first_not_of("0123456789") != std::string::npos ||
+      service_account_id.empty()) {
+    return Status(
+        StatusCode::kInvalidArgument,
+        "Invalid PKCS#12 file (" + source +
+            "): service account id missing or not not formatted correctly");
+  }
+
+  std::unique_ptr<BIO, decltype(&BIO_free)> mem_io(BIO_new(BIO_s_mem()),
+                                                   &BIO_free);
+
+  if (PEM_write_bio_PKCS8PrivateKey(mem_io.get(), pkey.get(), nullptr, nullptr,
+                                    0, nullptr, nullptr) == 0) {
+    std::string msg =
+        "Cannot print private key in PKCS#12 file (" + source + "): ";
+    msg += capture_openssl_errors();
+    return Status(StatusCode::kUnknown, msg);
+  }
+
+  // This buffer belongs to the BIO chain and is freed upon its destruction.
+  BUF_MEM* buf_mem;
+  BIO_get_mem_ptr(mem_io.get(), &buf_mem);
+
+  std::string private_key(buf_mem->data, buf_mem->length);
+
+  return ServiceAccountCredentialsInfo{std::move(service_account_id),
+                                       kP12PrivateKeyIdMarker,
+                                       std::move(private_key),
+                                       GoogleOAuthRefreshEndpoint(),
+                                       /*scopes*/ {},
+                                       /*subject*/ {}};
+}
+#include "google/cloud/internal/diagnostics_pop.inc"
 
 // Parses the JSON at `path` and creates the appropriate
 // Credentials type.
@@ -52,8 +166,20 @@ StatusOr<std::unique_ptr<Credentials>> LoadCredsFromPath(
   std::string contents(std::istreambuf_iterator<char>{ifs}, {});
   auto cred_json = nlohmann::json::parse(contents, nullptr, false);
   if (!cred_json.is_object()) {
-    return Status(StatusCode::kInvalidArgument,
-                  "Invalid credentials file " + path);
+    // This is not a JSON file, try to load it as a P12 service account.
+    auto info = ParseServiceAccountP12File(path);
+    if (!info) {
+      return Status(
+          StatusCode::kInvalidArgument,
+          "Cannot open credentials file " + path +
+              ", it does not contain a JSON object, nor can be parsed "
+              "as a PKCS#12 file. " +
+              info.status().message());
+    }
+    info->scopes = {};
+    info->subject = {};
+    auto credentials = absl::make_unique<ServiceAccountCredentials>(*info);
+    return std::unique_ptr<Credentials>(std::move(credentials));
   }
   std::string cred_type = cred_json.value("type", "no type given");
   // If non_service_account_ok==false and the cred_type is authorized_user,

--- a/google/cloud/internal/oauth2_google_credentials.cc
+++ b/google/cloud/internal/oauth2_google_credentials.cc
@@ -24,9 +24,6 @@
 #include "google/cloud/internal/throw_delegate.h"
 #include "absl/memory/memory.h"
 #include <nlohmann/json.hpp>
-#include <openssl/err.h>
-#include <openssl/pem.h>
-#include <openssl/pkcs12.h>
 #include <fstream>
 #include <iterator>
 #include <memory>
@@ -36,117 +33,6 @@ namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
-
-auto constexpr kP12PrivateKeyIdMarker = "--unknown--";
-
-#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
-StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
-    std::string const& source) {
-  OpenSSL_add_all_algorithms();
-
-  PKCS12* p12_raw = [](std::string const& source) {
-    FILE* fp = std::fopen(source.c_str(), "rb");
-    if (fp == nullptr) {
-      return static_cast<PKCS12*>(nullptr);
-    }
-    auto* result = d2i_PKCS12_fp(fp, nullptr);
-    fclose(fp);
-    return result;
-  }(source);
-
-  std::unique_ptr<PKCS12, decltype(&PKCS12_free)> p12(p12_raw, &PKCS12_free);
-
-  auto capture_openssl_errors = []() {
-    std::string msg;
-    while (auto code = ERR_get_error()) {
-      // OpenSSL guarantees that 256 bytes is enough:
-      //   https://www.openssl.org/docs/man1.1.1/man3/ERR_error_string_n.html
-      //   https://www.openssl.org/docs/man1.0.2/man3/ERR_error_string_n.html
-      // we could not find a macro or constant to replace the 256 literal.
-      auto constexpr kMaxOpenSslErrorLength = 256;
-      std::array<char, kMaxOpenSslErrorLength> buf{};
-      ERR_error_string_n(code, buf.data(), buf.size());
-      msg += buf.data();
-    }
-    return msg;
-  };
-
-  if (p12 == nullptr) {
-    std::string msg = "Cannot open PKCS#12 file (" + source + "): ";
-    msg += capture_openssl_errors();
-    return Status(StatusCode::kInvalidArgument, msg);
-  }
-
-  EVP_PKEY* pkey_raw;
-  X509* cert_raw;
-  if (PKCS12_parse(p12.get(), "notasecret", &pkey_raw, &cert_raw, nullptr) !=
-      1) {
-    std::string msg = "Cannot parse PKCS#12 file (" + source + "): ";
-    msg += capture_openssl_errors();
-    return Status(StatusCode::kInvalidArgument, msg);
-  }
-
-  std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(pkey_raw,
-                                                           &EVP_PKEY_free);
-  std::unique_ptr<X509, decltype(&X509_free)> cert(cert_raw, &X509_free);
-
-  if (pkey_raw == nullptr) {
-    return Status(StatusCode::kInvalidArgument,
-                  "No private key found in PKCS#12 file (" + source + ")");
-  }
-  if (cert_raw == nullptr) {
-    return Status(StatusCode::kInvalidArgument,
-                  "No private key found in PKCS#12 file (" + source + ")");
-  }
-
-  // This is automatically deleted by `cert`.
-  X509_NAME* name = X509_get_subject_name(cert.get());
-
-  std::string service_account_id = [&name]() -> std::string {
-    auto openssl_free = [](void* addr) { OPENSSL_free(addr); };
-    std::unique_ptr<char, decltype(openssl_free)> oneline(
-        X509_NAME_oneline(name, nullptr, 0), openssl_free);
-    // We expect the name to be simply CN/ followed by a (small) number of
-    // digits.
-    if (strncmp("/CN=", oneline.get(), 4) != 0) {
-      return "";
-    }
-    return oneline.get() + 4;
-  }();
-
-  if (service_account_id.find_first_not_of("0123456789") != std::string::npos ||
-      service_account_id.empty()) {
-    return Status(
-        StatusCode::kInvalidArgument,
-        "Invalid PKCS#12 file (" + source +
-            "): service account id missing or not not formatted correctly");
-  }
-
-  std::unique_ptr<BIO, decltype(&BIO_free)> mem_io(BIO_new(BIO_s_mem()),
-                                                   &BIO_free);
-
-  if (PEM_write_bio_PKCS8PrivateKey(mem_io.get(), pkey.get(), nullptr, nullptr,
-                                    0, nullptr, nullptr) == 0) {
-    std::string msg =
-        "Cannot print private key in PKCS#12 file (" + source + "): ";
-    msg += capture_openssl_errors();
-    return Status(StatusCode::kUnknown, msg);
-  }
-
-  // This buffer belongs to the BIO chain and is freed upon its destruction.
-  BUF_MEM* buf_mem;
-  BIO_get_mem_ptr(mem_io.get(), &buf_mem);
-
-  std::string private_key(buf_mem->data, buf_mem->length);
-
-  return ServiceAccountCredentialsInfo{std::move(service_account_id),
-                                       kP12PrivateKeyIdMarker,
-                                       std::move(private_key),
-                                       GoogleOAuthRefreshEndpoint(),
-                                       /*scopes*/ {},
-                                       /*subject*/ {}};
-}
-#include "google/cloud/internal/diagnostics_pop.inc"
 
 // Parses the JSON at `path` and creates the appropriate
 // Credentials type.

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -16,9 +16,13 @@
 #include "google/cloud/internal/absl_str_join_quiet.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/internal/make_jwt_assertion.h"
+#include "google/cloud/internal/oauth2_google_credentials.h"
 #include "google/cloud/internal/openssl_util.h"
 #include "google/cloud/internal/rest_response.h"
 #include <nlohmann/json.hpp>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/pkcs12.h>
 
 namespace google {
 namespace cloud {
@@ -27,13 +31,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 auto constexpr kP12PrivateKeyIdMarker = "--unknown--";
-
-bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info) {
-  if (info.private_key_id == kP12PrivateKeyIdMarker) return true;
-  auto disable_jwt = google::cloud::internal::GetEnv(
-      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT");
-  return disable_jwt.has_value();
-}
 
 }  // namespace
 
@@ -235,6 +232,122 @@ StatusOr<std::vector<std::uint8_t>> ServiceAccountCredentials::SignBlob(
         "The current_credentials cannot sign blobs for " + signing_account);
   }
   return internal::SignUsingSha256(blob, info_.private_key);
+}
+
+#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
+StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
+    std::string const& source) {
+  OpenSSL_add_all_algorithms();
+
+  PKCS12* p12_raw = [](std::string const& source) {
+    FILE* fp = std::fopen(source.c_str(), "rb");
+    if (fp == nullptr) {
+      return static_cast<PKCS12*>(nullptr);
+    }
+    auto* result = d2i_PKCS12_fp(fp, nullptr);
+    fclose(fp);
+    return result;
+  }(source);
+
+  std::unique_ptr<PKCS12, decltype(&PKCS12_free)> p12(p12_raw, &PKCS12_free);
+
+  auto capture_openssl_errors = []() {
+    std::string msg;
+    while (auto code = ERR_get_error()) {
+      // OpenSSL guarantees that 256 bytes is enough:
+      //   https://www.openssl.org/docs/man1.1.1/man3/ERR_error_string_n.html
+      //   https://www.openssl.org/docs/man1.0.2/man3/ERR_error_string_n.html
+      // we could not find a macro or constant to replace the 256 literal.
+      auto constexpr kMaxOpenSslErrorLength = 256;
+      std::array<char, kMaxOpenSslErrorLength> buf{};
+      ERR_error_string_n(code, buf.data(), buf.size());
+      msg += buf.data();
+    }
+    return msg;
+  };
+
+  if (p12 == nullptr) {
+    std::string msg = "Cannot open PKCS#12 file (" + source + "): ";
+    msg += capture_openssl_errors();
+    return Status(StatusCode::kInvalidArgument, msg);
+  }
+
+  EVP_PKEY* pkey_raw;
+  X509* cert_raw;
+  if (PKCS12_parse(p12.get(), "notasecret", &pkey_raw, &cert_raw, nullptr) !=
+      1) {
+    std::string msg = "Cannot parse PKCS#12 file (" + source + "): ";
+    msg += capture_openssl_errors();
+    return Status(StatusCode::kInvalidArgument, msg);
+  }
+
+  std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(pkey_raw,
+                                                           &EVP_PKEY_free);
+  std::unique_ptr<X509, decltype(&X509_free)> cert(cert_raw, &X509_free);
+
+  if (pkey_raw == nullptr) {
+    return Status(StatusCode::kInvalidArgument,
+                  "No private key found in PKCS#12 file (" + source + ")");
+  }
+  if (cert_raw == nullptr) {
+    return Status(StatusCode::kInvalidArgument,
+                  "No private key found in PKCS#12 file (" + source + ")");
+  }
+
+  // This is automatically deleted by `cert`.
+  X509_NAME* name = X509_get_subject_name(cert.get());
+
+  std::string service_account_id = [&name]() -> std::string {
+    auto openssl_free = [](void* addr) { OPENSSL_free(addr); };
+    std::unique_ptr<char, decltype(openssl_free)> oneline(
+        X509_NAME_oneline(name, nullptr, 0), openssl_free);
+    // We expect the name to be simply CN/ followed by a (small) number of
+    // digits.
+    if (strncmp("/CN=", oneline.get(), 4) != 0) {
+      return "";
+    }
+    return oneline.get() + 4;
+  }();
+
+  if (service_account_id.find_first_not_of("0123456789") != std::string::npos ||
+      service_account_id.empty()) {
+    return Status(
+        StatusCode::kInvalidArgument,
+        "Invalid PKCS#12 file (" + source +
+            "): service account id missing or not not formatted correctly");
+  }
+
+  std::unique_ptr<BIO, decltype(&BIO_free)> mem_io(BIO_new(BIO_s_mem()),
+                                                   &BIO_free);
+
+  if (PEM_write_bio_PKCS8PrivateKey(mem_io.get(), pkey.get(), nullptr, nullptr,
+                                    0, nullptr, nullptr) == 0) {
+    std::string msg =
+        "Cannot print private key in PKCS#12 file (" + source + "): ";
+    msg += capture_openssl_errors();
+    return Status(StatusCode::kUnknown, msg);
+  }
+
+  // This buffer belongs to the BIO chain and is freed upon its destruction.
+  BUF_MEM* buf_mem;
+  BIO_get_mem_ptr(mem_io.get(), &buf_mem);
+
+  std::string private_key(buf_mem->data, buf_mem->length);
+
+  return ServiceAccountCredentialsInfo{std::move(service_account_id),
+                                       kP12PrivateKeyIdMarker,
+                                       std::move(private_key),
+                                       GoogleOAuthRefreshEndpoint(),
+                                       /*scopes*/ {},
+                                       /*subject*/ {}};
+}
+#include "google/cloud/internal/diagnostics_pop.inc"
+
+bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info) {
+  if (info.private_key_id == kP12PrivateKeyIdMarker) return true;
+  auto disable_jwt = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT");
+  return disable_jwt.has_value();
 }
 
 bool ServiceAccountCredentials::UseOAuth() {

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -24,6 +24,18 @@ namespace google {
 namespace cloud {
 namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace {
+
+auto constexpr kP12PrivateKeyIdMarker = "--unknown--";
+
+bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info) {
+  if (info.private_key_id == kP12PrivateKeyIdMarker) return true;
+  auto disable_jwt = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT");
+  return disable_jwt.has_value();
+}
+
+}  // namespace
 
 using ::google::cloud::internal::MakeJWTAssertionNoThrow;
 
@@ -226,9 +238,7 @@ StatusOr<std::vector<std::uint8_t>> ServiceAccountCredentials::SignBlob(
 }
 
 bool ServiceAccountCredentials::UseOAuth() {
-  auto disable_jwt = google::cloud::internal::GetEnv(
-      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_DISABLE_SELF_SIGNED_JWT");
-  return disable_jwt.has_value();
+  return ServiceAccountUseOAuth(info_);
 }
 
 StatusOr<RefreshingCredentialsWrapper::TemporaryToken>

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -228,7 +228,7 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
   std::string KeyId() const override { return info_.private_key_id; }
 
  private:
-  static bool UseOAuth();
+  bool UseOAuth();
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> Refresh();
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> RefreshOAuth() const;
   StatusOr<RefreshingCredentialsWrapper::TemporaryToken> RefreshSelfSigned()

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -53,6 +53,14 @@ struct ServiceAccountCredentialsInfo {
   absl::optional<std::string> subject;
 };
 
+/// Indicates whether or not to use a self-signed JWT or issue a request to
+/// OAuth2.
+bool ServiceAccountUseOAuth(ServiceAccountCredentialsInfo const& info);
+
+/// Parses the contents of a P12 keyfile into a ServiceAccountCredentialsInfo.
+StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
+    std::string const& source);
+
 /// Parses the contents of a JSON keyfile into a ServiceAccountCredentialsInfo.
 StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
     std::string const& content, std::string const& source,

--- a/google/cloud/storage/internal/unified_rest_credentials.cc
+++ b/google/cloud/storage/internal/unified_rest_credentials.cc
@@ -17,13 +17,18 @@
 #include "google/cloud/storage/internal/error_credentials.h"
 #include "google/cloud/storage/internal/impersonate_service_account_credentials.h"
 #include "google/cloud/storage/oauth2/google_credentials.h"
-#include <nlohmann/json.hpp>
+#include "google/cloud/storage/oauth2/service_account_credentials.h"
+#include "google/cloud/internal/getenv.h"
+#include "google/cloud/internal/oauth2_credentials.h"
+#include "google/cloud/internal/oauth2_google_credentials.h"
+#include "google/cloud/internal/oauth2_service_account_credentials.h"
 
 namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+namespace {
 
 using ::google::cloud::internal::AccessTokenConfig;
 using ::google::cloud::internal::CredentialsVisitor;
@@ -32,42 +37,123 @@ using ::google::cloud::internal::ImpersonateServiceAccountConfig;
 using ::google::cloud::internal::InsecureCredentialsConfig;
 using ::google::cloud::internal::ServiceAccountConfig;
 
+class WrapRestCredentials : public oauth2::Credentials {
+ public:
+  explicit WrapRestCredentials(
+      std::shared_ptr<oauth2_internal::Credentials> impl)
+      : impl_(std::move(impl)) {}
+
+  StatusOr<std::string> AuthorizationHeader() override {
+    auto header = impl_->AuthorizationHeader();
+    if (!header) return std::move(header).status();
+    return header->first + ": " + header->second;
+  }
+
+  StatusOr<std::vector<std::uint8_t>> SignBlob(
+      SigningAccount const& signing_account,
+      std::string const& blob) const override {
+    return impl_->SignBlob(signing_account.value_or(impl_->AccountEmail()),
+                           blob);
+  }
+
+  std::string AccountEmail() const override { return impl_->AccountEmail(); }
+  std::string KeyId() const override { return impl_->KeyId(); }
+
+ private:
+  std::shared_ptr<oauth2_internal::Credentials> impl_;
+};
+
+oauth2_internal::ServiceAccountCredentialsInfo MapInfo(
+    oauth2::ServiceAccountCredentialsInfo info) {
+  oauth2_internal::ServiceAccountCredentialsInfo result;
+  result.client_email = std::move(info.client_email);
+  result.private_key_id = std::move(info.private_key_id);
+  result.private_key = std::move(info.private_key);
+  result.token_uri = std::move(info.token_uri);
+  result.scopes = std::move(info.scopes);
+  result.subject = std::move(info.subject);
+  return result;
+}
+
+struct RestVisitor : public CredentialsVisitor {
+  std::shared_ptr<oauth2::Credentials> result;
+
+  void visit(InsecureCredentialsConfig&) override {
+    result = google::cloud::storage::oauth2::CreateAnonymousCredentials();
+  }
+  void visit(GoogleDefaultCredentialsConfig&) override {
+    auto credentials = oauth2_internal::GoogleDefaultCredentials();
+    if (credentials) {
+      result = std::make_shared<WrapRestCredentials>(*std::move(credentials));
+      return;
+    }
+    result =
+        std::make_shared<ErrorCredentials>(std::move(credentials).status());
+  }
+  void visit(AccessTokenConfig& config) override {
+    result = std::make_shared<AccessTokenCredentials>(config.access_token());
+  }
+  void visit(ImpersonateServiceAccountConfig& config) override {
+    result = std::make_shared<ImpersonateServiceAccountCredentials>(config);
+  }
+  void visit(ServiceAccountConfig& cfg) override {
+    auto info = oauth2::ParseServiceAccountCredentials(cfg.json_object(), {});
+    if (!info) {
+      result = std::make_shared<ErrorCredentials>(std::move(info).status());
+      return;
+    }
+    result = std::make_shared<WrapRestCredentials>(
+        std::make_shared<oauth2_internal::ServiceAccountCredentials>(
+            MapInfo(*std::move(info))));
+  }
+};
+
+struct LegacyVisitor : public CredentialsVisitor {
+  std::shared_ptr<oauth2::Credentials> result;
+
+  void visit(InsecureCredentialsConfig&) override {
+    result = google::cloud::storage::oauth2::CreateAnonymousCredentials();
+  }
+  void visit(GoogleDefaultCredentialsConfig&) override {
+    auto credentials =
+        google::cloud::storage::oauth2::GoogleDefaultCredentials();
+    if (credentials) {
+      result = *std::move(credentials);
+      return;
+    }
+    result =
+        std::make_shared<ErrorCredentials>(std::move(credentials).status());
+  }
+  void visit(AccessTokenConfig& config) override {
+    result = std::make_shared<AccessTokenCredentials>(config.access_token());
+  }
+  void visit(ImpersonateServiceAccountConfig& config) override {
+    result = std::make_shared<ImpersonateServiceAccountCredentials>(config);
+  }
+  void visit(ServiceAccountConfig& cfg) override {
+    auto credentials = google::cloud::storage::oauth2::
+        CreateServiceAccountCredentialsFromJsonContents(cfg.json_object());
+    if (credentials) {
+      result = *std::move(credentials);
+      return;
+    }
+    result =
+        std::make_shared<ErrorCredentials>(std::move(credentials).status());
+  }
+};
+
+}  // namespace
+
 std::shared_ptr<oauth2::Credentials> MapCredentials(
     std::shared_ptr<google::cloud::Credentials> const& credentials) {
-  struct Visitor : public CredentialsVisitor {
-    std::shared_ptr<oauth2::Credentials> result;
-
-    void visit(InsecureCredentialsConfig&) override {
-      result = google::cloud::storage::oauth2::CreateAnonymousCredentials();
-    }
-    void visit(GoogleDefaultCredentialsConfig&) override {
-      auto credentials =
-          google::cloud::storage::oauth2::GoogleDefaultCredentials();
-      if (credentials) {
-        result = *std::move(credentials);
-        return;
-      }
-      result =
-          std::make_shared<ErrorCredentials>(std::move(credentials).status());
-    }
-    void visit(AccessTokenConfig& config) override {
-      result = std::make_shared<AccessTokenCredentials>(config.access_token());
-    }
-    void visit(ImpersonateServiceAccountConfig& config) override {
-      result = std::make_shared<ImpersonateServiceAccountCredentials>(config);
-    }
-    void visit(ServiceAccountConfig& cfg) override {
-      auto credentials = google::cloud::storage::oauth2::
-          CreateServiceAccountCredentialsFromJsonContents(cfg.json_object());
-      if (credentials) {
-        result = *std::move(credentials);
-        return;
-      }
-      result =
-          std::make_shared<ErrorCredentials>(std::move(credentials).status());
-    }
-  } visitor;
-
+  auto env = google::cloud::internal::GetEnv(
+      "GOOGLE_CLOUD_CPP_EXPERIMENTAL_STORAGE_NEW_CREDENTIALS");
+  if (!env.has_value()) {
+    LegacyVisitor visitor;
+    CredentialsVisitor::dispatch(*credentials, visitor);
+    return std::move(visitor.result);
+  }
+  RestVisitor visitor;
   CredentialsVisitor::dispatch(*credentials, visitor);
   return std::move(visitor.result);
 }

--- a/google/cloud/storage/oauth2/service_account_credentials.cc
+++ b/google/cloud/storage/oauth2/service_account_credentials.cc
@@ -80,114 +80,14 @@ StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountCredentials(
       /*subject*/ {}};
 }
 
-#include "google/cloud/internal/disable_msvc_crt_secure_warnings.inc"
 StatusOr<ServiceAccountCredentialsInfo> ParseServiceAccountP12File(
-    std::string const& source, std::string const& default_token_uri) {
-  OpenSSL_add_all_algorithms();
-
-  PKCS12* p12_raw = [](std::string const& source) {
-    FILE* fp = std::fopen(source.c_str(), "rb");
-    if (fp == nullptr) {
-      return static_cast<PKCS12*>(nullptr);
-    }
-    auto* result = d2i_PKCS12_fp(fp, nullptr);
-    fclose(fp);
-    return result;
-  }(source);
-
-  std::unique_ptr<PKCS12, decltype(&PKCS12_free)> p12(p12_raw, &PKCS12_free);
-
-  auto capture_openssl_errors = []() {
-    std::string msg;
-    while (auto code = ERR_get_error()) {
-      // OpenSSL guarantees that 256 bytes is enough:
-      //   https://www.openssl.org/docs/man1.1.1/man3/ERR_error_string_n.html
-      //   https://www.openssl.org/docs/man1.0.2/man3/ERR_error_string_n.html
-      // we could not find a macro or constant to replace the 256 literal.
-      auto constexpr kMaxOpenSslErrorLength = 256;
-      std::array<char, kMaxOpenSslErrorLength> buf{};
-      ERR_error_string_n(code, buf.data(), buf.size());
-      msg += buf.data();
-    }
-    return msg;
-  };
-
-  if (p12 == nullptr) {
-    std::string msg = "Cannot open PKCS#12 file (" + source + "): ";
-    msg += capture_openssl_errors();
-    return Status(StatusCode::kInvalidArgument, msg);
-  }
-
-  EVP_PKEY* pkey_raw;
-  X509* cert_raw;
-  if (PKCS12_parse(p12.get(), "notasecret", &pkey_raw, &cert_raw, nullptr) !=
-      1) {
-    std::string msg = "Cannot parse PKCS#12 file (" + source + "): ";
-    msg += capture_openssl_errors();
-    return Status(StatusCode::kInvalidArgument, msg);
-  }
-
-  std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)> pkey(pkey_raw,
-                                                           &EVP_PKEY_free);
-  std::unique_ptr<X509, decltype(&X509_free)> cert(cert_raw, &X509_free);
-
-  if (pkey_raw == nullptr) {
-    return Status(StatusCode::kInvalidArgument,
-                  "No private key found in PKCS#12 file (" + source + ")");
-  }
-  if (cert_raw == nullptr) {
-    return Status(StatusCode::kInvalidArgument,
-                  "No private key found in PKCS#12 file (" + source + ")");
-  }
-
-  // This is automatically deleted by `cert`.
-  X509_NAME* name = X509_get_subject_name(cert.get());
-
-  std::string service_account_id = [&name]() -> std::string {
-    auto openssl_free = [](void* addr) { OPENSSL_free(addr); };
-    std::unique_ptr<char, decltype(openssl_free)> oneline(
-        X509_NAME_oneline(name, nullptr, 0), openssl_free);
-    // We expect the name to be simply CN/ followed by a (small) number of
-    // digits.
-    if (strncmp("/CN=", oneline.get(), 4) != 0) {
-      return "";
-    }
-    return oneline.get() + 4;
-  }();
-
-  if (service_account_id.find_first_not_of("0123456789") != std::string::npos ||
-      service_account_id.empty()) {
-    return Status(
-        StatusCode::kInvalidArgument,
-        "Invalid PKCS#12 file (" + source +
-            "): service account id missing or not not formatted correctly");
-  }
-
-  std::unique_ptr<BIO, decltype(&BIO_free)> mem_io(BIO_new(BIO_s_mem()),
-                                                   &BIO_free);
-
-  if (PEM_write_bio_PKCS8PrivateKey(mem_io.get(), pkey.get(), nullptr, nullptr,
-                                    0, nullptr, nullptr) == 0) {
-    std::string msg =
-        "Cannot print private key in PKCS#12 file (" + source + "): ";
-    msg += capture_openssl_errors();
-    return Status(StatusCode::kUnknown, msg);
-  }
-
-  // This buffer belongs to the BIO chain and is freed upon its destruction.
-  BUF_MEM* buf_mem;
-  BIO_get_mem_ptr(mem_io.get(), &buf_mem);
-
-  std::string private_key(buf_mem->data, buf_mem->length);
-
-  return ServiceAccountCredentialsInfo{std::move(service_account_id),
-                                       kP12PrivateKeyIdMarker,
-                                       std::move(private_key),
-                                       default_token_uri,
-                                       /*scopes*/ {},
-                                       /*subject*/ {}};
+    std::string const& source, std::string const&) {
+  auto info = oauth2_internal::ParseServiceAccountP12File(source);
+  if (!info.ok()) return info.status();
+  return ServiceAccountCredentialsInfo{info->client_email, info->private_key_id,
+                                       info->private_key,  info->token_uri,
+                                       info->scopes,       info->subject};
 }
-#include "google/cloud/internal/diagnostics_pop.inc"
 
 std::pair<std::string, std::string> AssertionComponentsFromInfo(
     ServiceAccountCredentialsInfo const& info,


### PR DESCRIPTION
In order to migrate to the Rest library, we need to create `storage::oauth2::Credentials` from `oauth2_internal::Credentials`. The difficulty comes from the inability to overload `AuthorizationHeader` between the two types because only the return type is different, thus the wrapper and visitor pattern to map between the two.

Additionally, while we intend to phase out P12 support, we need to add support for it back in to `oauth2_internal` until we formally remove P12 support. Without P12 support, the mapping between the two types is incomplete.

Part of the work for #9689

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9709)
<!-- Reviewable:end -->
