### PR TITLE
fix(bigtable): `DataConnection` refreshes channels

### DIFF
--- a/google/cloud/bigtable/internal/common_client.h
+++ b/google/cloud/bigtable/internal/common_client.h
@@ -58,8 +58,8 @@ class CommonClient {
       : opts_(std::move(opts)),
         background_threads_(
             google::cloud::internal::DefaultBackgroundThreads(1)),
-        refresh_cq_(
-            std::make_shared<CompletionQueue>(background_threads_->cq())),
+        refresh_cq_(google::cloud::internal::GetCompletionQueueImpl(
+            background_threads_->cq())),
         refresh_state_(
             std::make_shared<bigtable_internal::ConnectionRefreshState>(
                 refresh_cq_, opts_.get<MinConnectionRefreshOption>(),
@@ -173,7 +173,6 @@ class CommonClient {
   }
 
   std::mutex mu_;
-  std::size_t num_pending_refreshes_ = 0;
   google::cloud::Options opts_;
   std::vector<ChannelPtr> channels_;
   std::vector<StubPtr> stubs_;
@@ -185,7 +184,7 @@ class CommonClient {
   // deadlock). We solve both problems by holding only weak pointers to the
   // completion queue in the operations scheduled on it. In order to do it, we
   // need to hold one instance by a shared pointer.
-  std::shared_ptr<CompletionQueue> refresh_cq_;
+  std::shared_ptr<google::cloud::internal::CompletionQueueImpl> refresh_cq_;
   std::shared_ptr<bigtable_internal::ConnectionRefreshState> refresh_state_;
 };
 

--- a/google/cloud/bigtable/internal/connection_refresh_state.h
+++ b/google/cloud/bigtable/internal/connection_refresh_state.h
@@ -33,8 +33,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class OutstandingTimers
     : public std::enable_shared_from_this<OutstandingTimers> {
  public:
-  explicit OutstandingTimers(std::shared_ptr<CompletionQueue> const& cq)
-      : weak_cq_(cq) {}
+  explicit OutstandingTimers(
+      std::shared_ptr<internal::CompletionQueueImpl> const& cq_impl)
+      : weak_cq_impl_(cq_impl) {}
   // Register a timer. It will automatically deregister on completion.
   void RegisterTimer(future<void> fut);
   // Cancel all currently registered timers and all which will be registered in
@@ -51,7 +52,8 @@ class OutstandingTimers
   // Object of this class is owned by timers continuations, which means it
   // cannot have an owning reference to the `CompletionQueue` because  it would
   // otherwise create a risk of a deadlock on the completion queue destruction.
-  std::weak_ptr<CompletionQueue> weak_cq_;  // GUARDED_BY(mu_)
+  std::weak_ptr<internal::CompletionQueueImpl>
+      weak_cq_impl_;  // GUARDED_BY(mu_)
 };
 
 /**
@@ -63,7 +65,7 @@ class OutstandingTimers
 class ConnectionRefreshState {
  public:
   explicit ConnectionRefreshState(
-      std::shared_ptr<CompletionQueue> const& cq,
+      std::shared_ptr<internal::CompletionQueueImpl> const& cq_impl,
       std::chrono::milliseconds min_conn_refresh_period,
       std::chrono::milliseconds max_conn_refresh_period);
   std::chrono::milliseconds RandomizedRefreshDelay();
@@ -82,7 +84,7 @@ class ConnectionRefreshState {
  * Schedule a chain of timers to refresh the connection.
  */
 void ScheduleChannelRefresh(
-    std::shared_ptr<CompletionQueue> const& cq,
+    std::shared_ptr<internal::CompletionQueueImpl> const& cq,
     std::shared_ptr<ConnectionRefreshState> const& state,
     std::shared_ptr<grpc::Channel> const& channel);
 

--- a/google/cloud/bigtable/internal/connection_refresh_state_test.cc
+++ b/google/cloud/bigtable/internal/connection_refresh_state_test.cc
@@ -39,12 +39,12 @@ TEST_F(OutstandingTimersTest, Trivial) {
   // With MSVC 2019 (19.28.29334) the value from make_shared<>
   // must be captured.
   auto unused = std::make_shared<OutstandingTimers>(
-      std::make_shared<CompletionQueue>(cq_));
+      internal::GetCompletionQueueImpl(cq_));
 }
 
 TEST_F(OutstandingTimersTest, TimerFinishes) {
   auto registry = std::make_shared<OutstandingTimers>(
-      std::make_shared<CompletionQueue>(cq_));
+      internal::GetCompletionQueueImpl(cq_));
   promise<void> continuation_promise;
   auto t = cq_.MakeRelativeTimer(std::chrono::milliseconds(2))
                .then([&](TimerFuture fut) {
@@ -61,7 +61,7 @@ TEST_F(OutstandingTimersTest, TimerFinishes) {
 
 TEST_F(OutstandingTimersTest, TimerIsCancelled) {
   auto registry = std::make_shared<OutstandingTimers>(
-      std::make_shared<CompletionQueue>(cq_));
+      internal::GetCompletionQueueImpl(cq_));
   promise<void> continuation_promise;
   auto t =
       cq_.MakeRelativeTimer(std::chrono::hours(10)).then([&](TimerFuture fut) {
@@ -77,7 +77,7 @@ TEST_F(OutstandingTimersTest, TimerIsCancelled) {
 
 TEST_F(OutstandingTimersTest, TimerOutlivesRegistry) {
   auto registry = std::make_shared<OutstandingTimers>(
-      std::make_shared<CompletionQueue>(cq_));
+      internal::GetCompletionQueueImpl(cq_));
   promise<void> continuation_promise;
   auto t = cq_.MakeRelativeTimer(std::chrono::milliseconds(10))
                .then([&](TimerFuture fut) {
@@ -92,7 +92,7 @@ TEST_F(OutstandingTimersTest, TimerOutlivesRegistry) {
 
 TEST_F(OutstandingTimersTest, TimerRegisteredAfterCancelAllGetCancelled) {
   auto registry = std::make_shared<OutstandingTimers>(
-      std::make_shared<CompletionQueue>(cq_));
+      internal::GetCompletionQueueImpl(cq_));
   promise<void> continuation_promise;
   auto t =
       cq_.MakeRelativeTimer(std::chrono::hours(10)).then([&](TimerFuture fut) {
@@ -108,15 +108,13 @@ TEST_F(OutstandingTimersTest, TimerRegisteredAfterCancelAllGetCancelled) {
 
 TEST(ConnectionRefreshState, Enabled) {
   using ms = std::chrono::milliseconds;
-  ConnectionRefreshState state(std::make_shared<CompletionQueue>(), ms(0),
-                               ms(1000));
+  ConnectionRefreshState state(nullptr, ms(0), ms(1000));
   EXPECT_TRUE(state.enabled());
 }
 
 TEST(ConnectionRefreshState, Disabled) {
   using ms = std::chrono::milliseconds;
-  ConnectionRefreshState state(std::make_shared<CompletionQueue>(), ms(0),
-                               ms(0));
+  ConnectionRefreshState state(nullptr, ms(0), ms(0));
   EXPECT_FALSE(state.enabled());
 }
 


### PR DESCRIPTION
Fixes #9712 

This is mostly a refactor. Update the channel refresh API to accept a `shared_ptr<internal::CompletionQueueImpl>` instead of a `shared_ptr<CompletionQueue>`.

Now, we will not back out of the channel refresh loop too early, because the background threads hold onto the CQ object for the lifetime of the stub.

Add a regression test for this behavior that fails at HEAD.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9718)
<!-- Reviewable:end -->
