### PR TITLE
feat(dataproc): mark the dataproc services as location dependent

### DIFF
--- a/generator/generator_config.textproto
+++ b/generator/generator_config.textproto
@@ -409,6 +409,7 @@ service {
   product_path: "google/cloud/dataproc"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -417,6 +418,7 @@ service {
   product_path: "google/cloud/dataproc"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -425,6 +427,7 @@ service {
   product_path: "google/cloud/dataproc"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -432,6 +435,7 @@ service {
   product_path: "google/cloud/dataproc"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 service {
@@ -439,6 +443,7 @@ service {
   product_path: "google/cloud/dataproc"
   initial_copyright_year: "2022"
   retryable_status_codes: ["kUnavailable"]
+  endpoint_location_style: LOCATION_DEPENDENT_COMPAT
 }
 
 # Data Loss Prevention

--- a/google/cloud/dataproc/README.md
+++ b/google/cloud/dataproc/README.md
@@ -48,20 +48,14 @@ int main(int argc, char* argv[]) try {
     std::cerr << "Usage: " << argv[0] << " project-id region\n";
     return 1;
   }
-
-  namespace gc = ::google::cloud;
-  namespace dataproc = ::google::cloud::dataproc;
-
   std::string const project_id = argv[1];
   std::string const region = argv[2];
 
-  gc::Options options;
-  if (region != "global") {
-    options.set<gc::EndpointOption>(region + "-dataproc.googleapis.com:443");
-  }
+  namespace dataproc = ::google::cloud::dataproc;
 
   auto client = dataproc::ClusterControllerClient(
-      dataproc::MakeClusterControllerConnection(options));
+      dataproc::MakeClusterControllerConnection(region == "global" ? ""
+                                                                   : region));
 
   for (auto c : client.ListClusters(project_id, region)) {
     if (!c) throw std::runtime_error(c.status().message());

--- a/google/cloud/dataproc/autoscaling_policy_connection.cc
+++ b/google/cloud/dataproc/autoscaling_policy_connection.cc
@@ -68,19 +68,26 @@ Status AutoscalingPolicyServiceConnection::DeleteAutoscalingPolicy(
 }
 
 std::shared_ptr<AutoscalingPolicyServiceConnection>
-MakeAutoscalingPolicyServiceConnection(Options options) {
+MakeAutoscalingPolicyServiceConnection(std::string const& location,
+                                       Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  AutoscalingPolicyServicePolicyOptionList>(
       options, __func__);
   options = dataproc_internal::AutoscalingPolicyServiceDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dataproc_internal::CreateDefaultAutoscalingPolicyServiceStub(
       background->cq(), options);
   return std::make_shared<
       dataproc_internal::AutoscalingPolicyServiceConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<AutoscalingPolicyServiceConnection>
+MakeAutoscalingPolicyServiceConnection(Options options) {
+  return MakeAutoscalingPolicyServiceConnection(std::string{},
+                                                std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/autoscaling_policy_connection.h
+++ b/google/cloud/dataproc/autoscaling_policy_connection.h
@@ -28,6 +28,7 @@
 #include "google/cloud/stream_range.h"
 #include "google/cloud/version.h"
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -109,8 +110,20 @@ class AutoscalingPolicyServiceConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `AutoscalingPolicyServiceConnection`
  * created by this function.
+ */
+std::shared_ptr<AutoscalingPolicyServiceConnection>
+MakeAutoscalingPolicyServiceConnection(std::string const& location,
+                                       Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<AutoscalingPolicyServiceConnection>
 MakeAutoscalingPolicyServiceConnection(Options options = {});

--- a/google/cloud/dataproc/batch_controller_connection.cc
+++ b/google/cloud/dataproc/batch_controller_connection.cc
@@ -63,18 +63,23 @@ Status BatchControllerConnection::DeleteBatch(
 }
 
 std::shared_ptr<BatchControllerConnection> MakeBatchControllerConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  BatchControllerPolicyOptionList>(options,
                                                                   __func__);
-  options =
-      dataproc_internal::BatchControllerDefaultOptions(std::move(options));
+  options = dataproc_internal::BatchControllerDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dataproc_internal::CreateDefaultBatchControllerStub(
       background->cq(), options);
   return std::make_shared<dataproc_internal::BatchControllerConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<BatchControllerConnection> MakeBatchControllerConnection(
+    Options options) {
+  return MakeBatchControllerConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/batch_controller_connection.h
+++ b/google/cloud/dataproc/batch_controller_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -99,8 +100,19 @@ class BatchControllerConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `BatchControllerConnection` created
  * by this function.
+ */
+std::shared_ptr<BatchControllerConnection> MakeBatchControllerConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<BatchControllerConnection> MakeBatchControllerConnection(
     Options options = {});

--- a/google/cloud/dataproc/cluster_controller_connection.cc
+++ b/google/cloud/dataproc/cluster_controller_connection.cc
@@ -98,18 +98,23 @@ ClusterControllerConnection::DiagnoseCluster(
 }
 
 std::shared_ptr<ClusterControllerConnection> MakeClusterControllerConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  ClusterControllerPolicyOptionList>(options,
                                                                     __func__);
-  options =
-      dataproc_internal::ClusterControllerDefaultOptions(std::move(options));
+  options = dataproc_internal::ClusterControllerDefaultOptions(
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dataproc_internal::CreateDefaultClusterControllerStub(
       background->cq(), options);
   return std::make_shared<dataproc_internal::ClusterControllerConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<ClusterControllerConnection> MakeClusterControllerConnection(
+    Options options) {
+  return MakeClusterControllerConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/cluster_controller_connection.h
+++ b/google/cloud/dataproc/cluster_controller_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -115,8 +116,19 @@ class ClusterControllerConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `ClusterControllerConnection` created
  * by this function.
+ */
+std::shared_ptr<ClusterControllerConnection> MakeClusterControllerConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<ClusterControllerConnection> MakeClusterControllerConnection(
     Options options = {});

--- a/google/cloud/dataproc/doc/main.dox
+++ b/google/cloud/dataproc/doc/main.dox
@@ -46,23 +46,23 @@ which should give you a taste of the Cloud Dataproc API C++ client library API.
 <!-- inject-endpoint-env-vars-start -->
 
 - `GOOGLE_CLOUD_CPP_AUTOSCALING_POLICY_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dataproc.googleapis.com")
   used by `MakeAutoscalingPolicyServiceConnection()`.
 
 - `GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dataproc.googleapis.com")
   used by `MakeBatchControllerConnection()`.
 
 - `GOOGLE_CLOUD_CPP_CLUSTER_CONTROLLER_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dataproc.googleapis.com")
   used by `MakeClusterControllerConnection()`.
 
 - `GOOGLE_CLOUD_CPP_JOB_CONTROLLER_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dataproc.googleapis.com")
   used by `MakeJobControllerConnection()`.
 
 - `GOOGLE_CLOUD_CPP_WORKFLOW_TEMPLATE_SERVICE_ENDPOINT=...` overrides the
-  `EndpointOption` (which defaults to "dataproc.googleapis.com")
+  `EndpointOption` (which defaults to "<location>-dataproc.googleapis.com")
   used by `MakeWorkflowTemplateServiceConnection()`.
 
 <!-- inject-endpoint-env-vars-end -->

--- a/google/cloud/dataproc/internal/autoscaling_policy_option_defaults.cc
+++ b/google/cloud/dataproc/internal/autoscaling_policy_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dataproc/internal/autoscaling_policy_option_defaults.h"
 #include "google/cloud/dataproc/autoscaling_policy_connection.h"
 #include "google/cloud/dataproc/autoscaling_policy_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,12 +33,14 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options AutoscalingPolicyServiceDefaultOptions(Options options) {
+Options AutoscalingPolicyServiceDefaultOptions(std::string const& location,
+                                               Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options),
       "GOOGLE_CLOUD_CPP_AUTOSCALING_POLICY_SERVICE_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_AUTOSCALING_POLICY_SERVICE_AUTHORITY",
-      "dataproc.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dataproc.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dataproc::AutoscalingPolicyServiceRetryPolicyOption>()) {

--- a/google/cloud/dataproc/internal/autoscaling_policy_option_defaults.h
+++ b/google/cloud/dataproc/internal/autoscaling_policy_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dataproc_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options AutoscalingPolicyServiceDefaultOptions(Options options);
+Options AutoscalingPolicyServiceDefaultOptions(std::string const& location,
+                                               Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dataproc_internal

--- a/google/cloud/dataproc/internal/batch_controller_option_defaults.cc
+++ b/google/cloud/dataproc/internal/batch_controller_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dataproc/internal/batch_controller_option_defaults.h"
 #include "google/cloud/dataproc/batch_controller_connection.h"
 #include "google/cloud/dataproc/batch_controller_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options BatchControllerDefaultOptions(Options options) {
+Options BatchControllerDefaultOptions(std::string const& location,
+                                      Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_AUTHORITY", "dataproc.googleapis.com");
+      "GOOGLE_CLOUD_CPP_BATCH_CONTROLLER_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dataproc.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dataproc::BatchControllerRetryPolicyOption>()) {

--- a/google/cloud/dataproc/internal/batch_controller_option_defaults.h
+++ b/google/cloud/dataproc/internal/batch_controller_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dataproc_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options BatchControllerDefaultOptions(Options options);
+Options BatchControllerDefaultOptions(std::string const& location,
+                                      Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dataproc_internal

--- a/google/cloud/dataproc/internal/cluster_controller_option_defaults.cc
+++ b/google/cloud/dataproc/internal/cluster_controller_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dataproc/internal/cluster_controller_option_defaults.h"
 #include "google/cloud/dataproc/cluster_controller_connection.h"
 #include "google/cloud/dataproc/cluster_controller_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options ClusterControllerDefaultOptions(Options options) {
+Options ClusterControllerDefaultOptions(std::string const& location,
+                                        Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_CLUSTER_CONTROLLER_ENDPOINT", "",
       "GOOGLE_CLOUD_CPP_CLUSTER_CONTROLLER_AUTHORITY",
-      "dataproc.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dataproc.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dataproc::ClusterControllerRetryPolicyOption>()) {

--- a/google/cloud/dataproc/internal/cluster_controller_option_defaults.h
+++ b/google/cloud/dataproc/internal/cluster_controller_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dataproc_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options ClusterControllerDefaultOptions(Options options);
+Options ClusterControllerDefaultOptions(std::string const& location,
+                                        Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dataproc_internal

--- a/google/cloud/dataproc/internal/job_controller_option_defaults.cc
+++ b/google/cloud/dataproc/internal/job_controller_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dataproc/internal/job_controller_option_defaults.h"
 #include "google/cloud/dataproc/job_controller_connection.h"
 #include "google/cloud/dataproc/job_controller_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,10 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options JobControllerDefaultOptions(Options options) {
+Options JobControllerDefaultOptions(std::string const& location,
+                                    Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_JOB_CONTROLLER_ENDPOINT", "",
-      "GOOGLE_CLOUD_CPP_JOB_CONTROLLER_AUTHORITY", "dataproc.googleapis.com");
+      "GOOGLE_CLOUD_CPP_JOB_CONTROLLER_AUTHORITY",
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dataproc.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dataproc::JobControllerRetryPolicyOption>()) {

--- a/google/cloud/dataproc/internal/job_controller_option_defaults.h
+++ b/google/cloud/dataproc/internal/job_controller_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dataproc_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options JobControllerDefaultOptions(Options options);
+Options JobControllerDefaultOptions(std::string const& location,
+                                    Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dataproc_internal

--- a/google/cloud/dataproc/internal/workflow_template_option_defaults.cc
+++ b/google/cloud/dataproc/internal/workflow_template_option_defaults.cc
@@ -19,6 +19,7 @@
 #include "google/cloud/dataproc/internal/workflow_template_option_defaults.h"
 #include "google/cloud/dataproc/workflow_template_connection.h"
 #include "google/cloud/dataproc/workflow_template_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/populate_common_options.h"
 #include "google/cloud/internal/populate_grpc_options.h"
 #include <memory>
@@ -32,11 +33,13 @@ namespace {
 auto constexpr kBackoffScaling = 2.0;
 }  // namespace
 
-Options WorkflowTemplateServiceDefaultOptions(Options options) {
+Options WorkflowTemplateServiceDefaultOptions(std::string const& location,
+                                              Options options) {
   options = google::cloud::internal::PopulateCommonOptions(
       std::move(options), "GOOGLE_CLOUD_CPP_WORKFLOW_TEMPLATE_SERVICE_ENDPOINT",
       "", "GOOGLE_CLOUD_CPP_WORKFLOW_TEMPLATE_SERVICE_AUTHORITY",
-      "dataproc.googleapis.com");
+      absl::StrCat(location, location.empty() ? "" : "-",
+                   "dataproc.googleapis.com"));
   options =
       google::cloud::internal::PopulateGrpcOptions(std::move(options), "");
   if (!options.has<dataproc::WorkflowTemplateServiceRetryPolicyOption>()) {

--- a/google/cloud/dataproc/internal/workflow_template_option_defaults.h
+++ b/google/cloud/dataproc/internal/workflow_template_option_defaults.h
@@ -21,13 +21,15 @@
 
 #include "google/cloud/options.h"
 #include "google/cloud/version.h"
+#include <string>
 
 namespace google {
 namespace cloud {
 namespace dataproc_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-Options WorkflowTemplateServiceDefaultOptions(Options options);
+Options WorkflowTemplateServiceDefaultOptions(std::string const& location,
+                                              Options options);
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace dataproc_internal

--- a/google/cloud/dataproc/job_controller_connection.cc
+++ b/google/cloud/dataproc/job_controller_connection.cc
@@ -76,17 +76,23 @@ Status JobControllerConnection::DeleteJob(
 }
 
 std::shared_ptr<JobControllerConnection> MakeJobControllerConnection(
-    Options options) {
+    std::string const& location, Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  JobControllerPolicyOptionList>(options,
                                                                 __func__);
-  options = dataproc_internal::JobControllerDefaultOptions(std::move(options));
+  options = dataproc_internal::JobControllerDefaultOptions(location,
+                                                           std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dataproc_internal::CreateDefaultJobControllerStub(
       background->cq(), options);
   return std::make_shared<dataproc_internal::JobControllerConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<JobControllerConnection> MakeJobControllerConnection(
+    Options options) {
+  return MakeJobControllerConnection(std::string{}, std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/job_controller_connection.h
+++ b/google/cloud/dataproc/job_controller_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -108,8 +109,19 @@ class JobControllerConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `JobControllerConnection` created by
  * this function.
+ */
+std::shared_ptr<JobControllerConnection> MakeJobControllerConnection(
+    std::string const& location, Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<JobControllerConnection> MakeJobControllerConnection(
     Options options = {});

--- a/google/cloud/dataproc/quickstart/quickstart.cc
+++ b/google/cloud/dataproc/quickstart/quickstart.cc
@@ -22,20 +22,14 @@ int main(int argc, char* argv[]) try {
     std::cerr << "Usage: " << argv[0] << " project-id region\n";
     return 1;
   }
-
-  namespace gc = ::google::cloud;
-  namespace dataproc = ::google::cloud::dataproc;
-
   std::string const project_id = argv[1];
   std::string const region = argv[2];
 
-  gc::Options options;
-  if (region != "global") {
-    options.set<gc::EndpointOption>(region + "-dataproc.googleapis.com:443");
-  }
+  namespace dataproc = ::google::cloud::dataproc;
 
   auto client = dataproc::ClusterControllerClient(
-      dataproc::MakeClusterControllerConnection(options));
+      dataproc::MakeClusterControllerConnection(region == "global" ? ""
+                                                                   : region));
 
   for (auto c : client.ListClusters(project_id, region)) {
     if (!c) throw std::runtime_error(c.status().message());

--- a/google/cloud/dataproc/workflow_template_connection.cc
+++ b/google/cloud/dataproc/workflow_template_connection.cc
@@ -85,19 +85,26 @@ Status WorkflowTemplateServiceConnection::DeleteWorkflowTemplate(
 }
 
 std::shared_ptr<WorkflowTemplateServiceConnection>
-MakeWorkflowTemplateServiceConnection(Options options) {
+MakeWorkflowTemplateServiceConnection(std::string const& location,
+                                      Options options) {
   internal::CheckExpectedOptions<CommonOptionList, GrpcOptionList,
                                  UnifiedCredentialsOptionList,
                                  WorkflowTemplateServicePolicyOptionList>(
       options, __func__);
   options = dataproc_internal::WorkflowTemplateServiceDefaultOptions(
-      std::move(options));
+      location, std::move(options));
   auto background = internal::MakeBackgroundThreadsFactory(options)();
   auto stub = dataproc_internal::CreateDefaultWorkflowTemplateServiceStub(
       background->cq(), options);
   return std::make_shared<
       dataproc_internal::WorkflowTemplateServiceConnectionImpl>(
       std::move(background), std::move(stub), std::move(options));
+}
+
+std::shared_ptr<WorkflowTemplateServiceConnection>
+MakeWorkflowTemplateServiceConnection(Options options) {
+  return MakeWorkflowTemplateServiceConnection(std::string{},
+                                               std::move(options));
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/dataproc/workflow_template_connection.h
+++ b/google/cloud/dataproc/workflow_template_connection.h
@@ -31,6 +31,7 @@
 #include "google/cloud/version.h"
 #include <google/longrunning/operations.grpc.pb.h>
 #include <memory>
+#include <string>
 
 namespace google {
 namespace cloud {
@@ -121,8 +122,20 @@ class WorkflowTemplateServiceConnection {
  * @note Unexpected options will be ignored. To log unexpected options instead,
  *     set `GOOGLE_CLOUD_CPP_ENABLE_CLOG=yes` in the environment.
  *
+ * @param location Sets the prefix for the default `EndpointOption` value.
  * @param options (optional) Configure the `WorkflowTemplateServiceConnection`
  * created by this function.
+ */
+std::shared_ptr<WorkflowTemplateServiceConnection>
+MakeWorkflowTemplateServiceConnection(std::string const& location,
+                                      Options options = {});
+
+/**
+ * A backwards-compatible version of the previous factory function.  Unless
+ * the service also offers a global endpoint, the default value of the
+ * `EndpointOption` may be useless, in which case it must be overridden.
+ *
+ * @deprecated Please use the `location` overload instead.
  */
 std::shared_ptr<WorkflowTemplateServiceConnection>
 MakeWorkflowTemplateServiceConnection(Options options = {});


### PR DESCRIPTION
There will now be an additional `Make<Service>Connection()` overload
that takes a `location` parameter, which is used to build the default
`EndpointOption` value (see #9625).

Update the quickstart to use the new `MakeClusterControllerConnection()`
overload.

Fixes #8239.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9722)
<!-- Reviewable:end -->
