### PR TITLE
impl(oauth2): allow for optional signing account in SignBlob

### DIFF
--- a/google/cloud/internal/oauth2_credentials.cc
+++ b/google/cloud/internal/oauth2_credentials.cc
@@ -20,7 +20,7 @@ namespace oauth2_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 StatusOr<std::vector<std::uint8_t>> Credentials::SignBlob(
-    std::string const&, std::string const&) const {
+    absl::optional<std::string> const&, std::string const&) const {
   return Status(StatusCode::kUnimplemented,
                 "The current credentials cannot sign blobs locally");
 }

--- a/google/cloud/internal/oauth2_credentials.h
+++ b/google/cloud/internal/oauth2_credentials.h
@@ -61,7 +61,7 @@ class Credentials {
    * mismatch.
    */
   virtual StatusOr<std::vector<std::uint8_t>> SignBlob(
-      std::string const& signing_service_account,
+      absl::optional<std::string> const& signing_service_account,
       std::string const& string_to_sign) const;
 
   /// Return the account's email associated with these credentials, if any.

--- a/google/cloud/internal/oauth2_service_account_credentials.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials.cc
@@ -225,11 +225,13 @@ ServiceAccountCredentials::AuthorizationHeader() {
 }
 
 StatusOr<std::vector<std::uint8_t>> ServiceAccountCredentials::SignBlob(
-    std::string const& signing_account, std::string const& blob) const {
-  if (signing_account != info_.client_email) {
-    return Status(
-        StatusCode::kInvalidArgument,
-        "The current_credentials cannot sign blobs for " + signing_account);
+    absl::optional<std::string> const& signing_account,
+    std::string const& blob) const {
+  if (signing_account.has_value() &&
+      signing_account.value() != info_.client_email) {
+    return Status(StatusCode::kInvalidArgument,
+                  "The current_credentials cannot sign blobs for " +
+                      signing_account.value());
   }
   return internal::SignUsingSha256(blob, info_.private_key);
 }

--- a/google/cloud/internal/oauth2_service_account_credentials.h
+++ b/google/cloud/internal/oauth2_service_account_credentials.h
@@ -228,7 +228,7 @@ class ServiceAccountCredentials : public oauth2_internal::Credentials {
    *     does not match the email for the credential's account.
    */
   StatusOr<std::vector<std::uint8_t>> SignBlob(
-      std::string const& signing_account,
+      absl::optional<std::string> const& signing_account,
       std::string const& blob) const override;
 
   std::string AccountEmail() const override { return info_.client_email; }


### PR DESCRIPTION
This is necessary in order to be consistent with the current `storage::oauth2::SignBlob` functionality.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9724)
<!-- Reviewable:end -->
