### PR TITLE
test(spanner): cater to the service vagaries on nested JSON

### DIFF
--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -432,17 +432,17 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 // Verify maximum JSON nesting.
 TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
   // The default value of the backend spanner_json_max_nesting_level flag.
-  int const k_spanner_json_max_nesting_level = 80;
+  int const spanner_json_max_nesting_level = 80;
 
-  // Nested arrays that exceed `k_spanner_json_max_nesting_level` by one.
+  // Nested arrays that exceed `spanner_json_max_nesting_level` by one.
   std::string bad_json;
-  for (int i = 0; i != k_spanner_json_max_nesting_level + 1; ++i)
+  for (int i = 0; i != spanner_json_max_nesting_level + 1; ++i)
     bad_json.append(1, '[');
   bad_json.append("null");
-  for (int i = 0; i != k_spanner_json_max_nesting_level + 1; ++i)
+  for (int i = 0; i != spanner_json_max_nesting_level + 1; ++i)
     bad_json.append(1, ']');
 
-  // Nested arrays that match `k_spanner_json_max_nesting_level`.
+  // Nested arrays that match `spanner_json_max_nesting_level`.
   std::string good_json = bad_json.substr(1, bad_json.size() - 2);
 
   std::vector<Json> const good_data = {Json(good_json)};

--- a/google/cloud/spanner/integration_tests/data_types_integration_test.cc
+++ b/google/cloud/spanner/integration_tests/data_types_integration_test.cc
@@ -431,8 +431,8 @@ TEST_F(DataTypeIntegrationTest, InsertAndQueryWithStruct) {
 
 // Verify maximum JSON nesting.
 TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
-  // The default value of the backend max-nesting-level flag.
-  int const k_spanner_json_max_nesting_level = 90;
+  // The default value of the backend spanner_json_max_nesting_level flag.
+  int const k_spanner_json_max_nesting_level = 80;
 
   // Nested arrays that exceed `k_spanner_json_max_nesting_level` by one.
   std::string bad_json;
@@ -456,11 +456,21 @@ TEST_F(DataTypeIntegrationTest, JsonMaxNesting) {
     // The emulator has no such limitation, so it tries to re-insert.
     EXPECT_THAT(result, StatusIs(StatusCode::kAlreadyExists));
   } else {
+#if 1
+    // NOTE: The service is currently (August 2022) in a state where there
+    // is no workable "spanner_json_max_nesting_level".  It accepts 80, but
+    // crashes on some yet-to-be discovered value in [82..90].  81 results
+    // in ALREADY_EXISTS.  We really want to get out of the "JsonMaxNesting"
+    // business!
+    EXPECT_THAT(result, StatusIs(StatusCode::kAlreadyExists,
+                                 HasSubstr("already exists")));
+#else
     // NOTE: The backend is currently dropping a more specific "Max nesting
-    // of 90 had been exceeded [INVALID_ARGUMENT]" error, so expect this
+    // of 80 had been exceeded [INVALID_ARGUMENT]" error, so expect this
     // expectation to change when that problem is fixed.
     EXPECT_THAT(result, StatusIs(StatusCode::kFailedPrecondition,
                                  HasSubstr("Expected JSON")));
+#endif
   }
 }
 


### PR DESCRIPTION
Reduce the "spanner_json_max_nesting_level" from 90 to 80, now that
the service is crashing on nesting depths somewhere in [82..90].
It appears that 80 will be the new documented limit.

And that means we temporarily expect `kAlreadyExists` when trying to
re-add a value with a nesting depth of 81.

See #7212, #8327, and #8689 for previous action in this area.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9727)
<!-- Reviewable:end -->
