### PR TITLE
doc: leave a reference to the mdformat configuration file

### DIFF
--- a/ci/cloudbuild/builds/checkers.sh
+++ b/ci/cloudbuild/builds/checkers.sh
@@ -193,10 +193,11 @@ time {
 
 printf "%-50s" "Running markdown formatter:" >&2
 time {
+  # See `.mdformat.toml` for the configuration parameters.
   git ls-files -z | grep -zE '(\.md)$' | xargs -P "$(nproc)" -n 1 -0 mdformat
 }
 
-printf "%-50s" "Running doxygen landing page updates:" >&2
+printf "%-50s" "Running doxygen landing-page updates:" >&2
 time {
   # Update the service's endpoint environment variables.
   for dox in google/cloud/*/doc/main.dox; do


### PR DESCRIPTION
Mention the `.mdformat.toml` file in the "checkers" build script.
We need the configuration file to stop `mdformat` from searching
up outside the source tree, so we might as well use it to set
the configuration, instead of using command-line options.  This
breadcrumb will reinforce that convention.

Also add some hyphenation to a nearby message while I'm here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9733)
<!-- Reviewable:end -->
