### PR TITLE
cleanup: avoid copying `Status` from `StatusOr<>`

### DIFF
--- a/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h
+++ b/google/cloud/pubsublite/internal/resumable_async_streaming_read_write_rpc.h
@@ -501,7 +501,7 @@ class ResumableAsyncStreamingReadWriteRpcImpl
                     std::shared_ptr<RetryPolicy> retry_policy,
                     std::shared_ptr<BackoffPolicy> backoff_policy) {
     if (!start_initialize_response.ok()) {
-      AttemptRetry(std::move(start_initialize_response.status()), retry_policy,
+      AttemptRetry(std::move(start_initialize_response).status(), retry_policy,
                    backoff_policy);
       return;
     }

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -642,7 +642,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> RestClient::ReadObjectXml(
   }
 
   auto response = storage_rest_client_->Get(std::move(builder).BuildRequest());
-  if (!response.ok()) return std::move(response.status());
+  if (!response.ok()) return std::move(response).status();
 
   return std::unique_ptr<ObjectReadSource>(
       new RestObjectReadSource(*std::move(response)));


### PR DESCRIPTION
The right incantation to move a `Status` from a `StatusOr<>` is
`std::move(x).status()`, not `std::move(x.status())`. Hopefully my
search-fu was good enough to find all of them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9734)
<!-- Reviewable:end -->
