### PR TITLE
doc(storage): update broken docs link

### DIFF
--- a/google/cloud/storage/doc/storage-main.dox
+++ b/google/cloud/storage/doc/storage-main.dox
@@ -201,7 +201,7 @@ good places to continue learning about the library.
 [DeleteObject]: @ref google::cloud::storage::Client::DeleteObject()
 
 
-[gcs-quickstart]: https://cloud.google.com/storage/docs/quickstarts 'GCS Quickstarts'
+[gcs-quickstart]: https://cloud.google.com/storage/docs/introduction#quickstarts 'GCS Quickstarts'
 [resource-link]: https://console.cloud.google.com/cloud-resource-manager 'Console Resource Manager'
 [billing-link]: https://cloud.google.com/billing/docs/how-to/modify-project 'How to: Modify Project'
 [concepts-link]: https://cloud.google.com/storage/docs/concepts 'GCS Concepts'

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -22,7 +22,7 @@ experience as a C++ developer and that you have a working C++ toolchain
 
 To run the quickstart examples you will need a working Google Cloud Platform
 (GCP) project and an existing bucket.
-The [GCS quickstarts](https://cloud.google.com/storage/docs/quickstarts) cover
+The [GCS quickstarts](https://cloud.google.com/storage/docs/introduction#quickstarts) cover
 the necessary steps in detail. Make a note of the GCP project id and the bucket
 name as you will need them below.
 


### PR DESCRIPTION
Change https://cloud.google.com/storage/docs/quickstarts to https://cloud.google.com/storage/docs/introduction#quickstarts as per https://critique.corp.google.com/cl/470022707

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9738)
<!-- Reviewable:end -->
