### PR TITLE
test(storage): more consistent benchmark output and options

### DIFF
--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -217,20 +217,12 @@ void PrintOptions(std::ostream& os, std::string const& prefix,
               .has<google::cloud::storage::internal::TargetApiVersionOption>();
   }
 }
+
 // Format a timestamp
 std::string FormatTimestamp(std::chrono::system_clock::time_point tp) {
   auto constexpr kFormat = "%E4Y-%m-%dT%H:%M:%E*SZ";
   auto const t = absl::FromChrono(tp);
   return absl::FormatTime(kFormat, t, absl::UTCTimeZone());
-}
-
-std::string Hostname() {
-  static char const* const kHostname = [] {
-    static char buffer[HOST_NAME_MAX + 1];
-    gethostname(buffer, sizeof(buffer));
-    return buffer;
-  }();
-  return kHostname;
 }
 
 absl::optional<std::string> GetLabel(std::vector<std::string> const& labels,
@@ -307,7 +299,6 @@ std::string AddDefaultLabels(std::string const& labels) {
       components.push_back(d.prefix + *contents);
     }
   }
-  components.push_back("hostname:" + Hostname());
   return absl::StrJoin(components, ",");
 }
 

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/benchmarks/bounded_queue.h"
 #include "google/cloud/storage/options.h"
-#include "google/cloud/trace/trace_client.h"
 #include "google/cloud/grpc_options.h"
 #include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/absl_str_join_quiet.h"
@@ -29,7 +28,6 @@
 #include "absl/time/time.h"
 #include <future>
 #include <sstream>
-#include <stdexcept>
 
 namespace google {
 namespace cloud {

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -15,9 +15,17 @@
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
 #include "google/cloud/storage/benchmarks/bounded_queue.h"
 #include "google/cloud/storage/options.h"
+#include "google/cloud/trace/trace_client.h"
 #include "google/cloud/grpc_options.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
+#include "google/cloud/internal/absl_str_join_quiet.h"
+#include "google/cloud/internal/compute_engine_util.h"
+#include "google/cloud/internal/curl_options.h"
+#include "google/cloud/internal/rest_client.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/options.h"
+#include "absl/strings/str_split.h"
+#include "absl/strings/strip.h"
 #include "absl/time/time.h"
 #include <future>
 #include <sstream>
@@ -216,6 +224,93 @@ std::string FormatTimestamp(std::chrono::system_clock::time_point tp) {
   auto constexpr kFormat = "%E4Y-%m-%dT%H:%M:%E*SZ";
   auto const t = absl::FromChrono(tp);
   return absl::FormatTime(kFormat, t, absl::UTCTimeZone());
+}
+
+std::string Hostname() {
+  static char const* const kHostname = [] {
+    static char buffer[HOST_NAME_MAX + 1];
+    gethostname(buffer, sizeof(buffer));
+    return buffer;
+  }();
+  return kHostname;
+}
+
+absl::optional<std::string> GetLabel(std::vector<std::string> const& labels,
+                                     std::string const& prefix) {
+  for (auto const& label : labels) {
+    if (absl::StartsWith(label, prefix)) {
+      return std::string{absl::StripPrefix(label, prefix)};
+    }
+  }
+  return absl::nullopt;
+}
+
+absl::optional<std::string> GetLabel(std::string const& labels,
+                                     std::string const& prefix) {
+  return GetLabel(absl::StrSplit(labels, ','), prefix);
+}
+
+absl::optional<std::string> Zone(std::string const& labels) {
+  return GetLabel(labels, "zone:");
+}
+
+absl::optional<std::string> Job(std::string const& labels) {
+  return GetLabel(labels, "job:");
+}
+
+absl::optional<std::string> Task(std::string const& labels) {
+  return GetLabel(labels, "task:");
+}
+
+using ::google::cloud::rest_internal::ReadAll;
+using ::google::cloud::rest_internal::RestClient;
+using ::google::cloud::rest_internal::RestRequest;
+
+absl::optional<std::string> GetMetadata(RestClient& metadata_server,
+                                        std::string const& path) {
+  RestRequest request(path);
+  request.AddHeader("Metadata-Flavor", "Google");
+  auto response_status = metadata_server.Get(request);
+  if (!response_status) return absl::nullopt;
+  auto response = *std::move(response_status);
+  auto const status_code = response->StatusCode();
+  auto contents = ReadAll(std::move(*response).ExtractPayload());
+  if (status_code != 200) return absl::nullopt;
+  if (!contents) return absl::nullopt;
+  // A lot of metadata attributes have the full resource name (e.e.,
+  // projects/.../zones/..), we just want the last portion.
+  std::vector<absl::string_view> split = absl::StrSplit(*contents, '/');
+  return std::string{split.back()};
+}
+
+std::string AddDefaultLabels(std::string const& labels) {
+  using google::cloud::rest_internal::ConnectionPoolSizeOption;
+  auto metadata_server = google::cloud::rest_internal::MakePooledRestClient(
+      absl::StrCat("http", "://",
+                   google::cloud::internal::GceMetadataHostname()),
+      google::cloud::Options{}.set<ConnectionPoolSizeOption>(4));
+  struct {
+    std::string prefix;
+    std::string path;
+  } defaults[] = {
+      {"zone:", "computeMetadata/v1/instance/zone"},
+      {"machine-type:", "computeMetadata/v1/instance/machine-type"},
+      {"instance-name:", "computeMetadata/v1/instance/name"},
+      {"instance-id:", "computeMetadata/v1/instance/id"},
+      {"project-id:", "computeMetadata/v1/project/project-id"},
+      {"project-number:", "computeMetadata/v1/project/numeric-project-id"},
+  };
+  std::vector<std::string> components =
+      absl::StrSplit(labels, ',', absl::SkipWhitespace());
+  for (auto const& d : defaults) {
+    if (!GetLabel(components, d.prefix).has_value()) {
+      auto contents = GetMetadata(*metadata_server, d.path);
+      if (!contents.has_value()) continue;
+      components.push_back(d.prefix + *contents);
+    }
+  }
+  components.push_back("hostname:" + Hostname());
+  return absl::StrJoin(components, ",");
 }
 
 }  // namespace storage_benchmarks

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -134,7 +134,6 @@ inline std::string CurrentTime() {
   return FormatTimestamp(std::chrono::system_clock::now());
 }
 
-std::string Hostname();
 absl::optional<std::string> GetLabel(std::string const& labels,
                                      std::string const& prefix);
 absl::optional<std::string> Zone(std::string const& labels);

--- a/google/cloud/storage/benchmarks/benchmark_utils.h
+++ b/google/cloud/storage/benchmarks/benchmark_utils.h
@@ -129,6 +129,19 @@ void PrintOptions(std::ostream& os, std::string const& prefix,
 // Format a timestamp
 std::string FormatTimestamp(std::chrono::system_clock::time_point tp);
 
+// The current time, formatted
+inline std::string CurrentTime() {
+  return FormatTimestamp(std::chrono::system_clock::now());
+}
+
+std::string Hostname();
+absl::optional<std::string> GetLabel(std::string const& labels,
+                                     std::string const& prefix);
+absl::optional<std::string> Zone(std::string const& labels);
+absl::optional<std::string> Job(std::string const& labels);
+absl::optional<std::string> Task(std::string const& labels);
+std::string AddDefaultLabels(std::string const& labels);
+
 }  // namespace storage_benchmarks
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/benchmarks/throughput_experiment.cc
+++ b/google/cloud/storage/benchmarks/throughput_experiment.cc
@@ -98,10 +98,10 @@ class ResumableUpload : public ThroughputExperiment {
                           ? std::to_string(writer.metadata()->generation())
                           : std::string{};
 
-    return ThroughputResult{ExperimentLibrary::kCppClient,
+    return ThroughputResult{start,
+                            ExperimentLibrary::kCppClient,
                             transport_,
                             kOpWrite,
-                            start,
                             config.object_size,
                             /*transfer_offset=*/0,
                             config.object_size,
@@ -116,8 +116,7 @@ class ResumableUpload : public ThroughputExperiment {
                             object_name,
                             std::move(generation),
                             std::move(upload_id),
-                            ExtractRetryCount(writer.headers()),
-                            /*notes=*/{}};
+                            ExtractRetryCount(writer.headers())};
   }
 
  private:
@@ -166,10 +165,10 @@ class SimpleUpload : public ThroughputExperiment {
     auto generation = object_metadata
                           ? std::to_string(object_metadata->generation())
                           : std::string{};
-    return ThroughputResult{ExperimentLibrary::kCppClient,
+    return ThroughputResult{start,
+                            ExperimentLibrary::kCppClient,
                             transport_,
                             kOpInsert,
-                            start,
                             config.object_size,
                             /*transfer_offset=*/0,
                             config.object_size,
@@ -184,8 +183,7 @@ class SimpleUpload : public ThroughputExperiment {
                             object_name,
                             std::move(generation),
                             "[upload-id-N/A]",
-                            "[retry-count-unknown]",
-                            /*notes=*/{}};
+                            "[retry-count-unknown]"};
   }
 
  private:
@@ -234,10 +232,10 @@ class DownloadObject : public ThroughputExperiment {
       transfer_size += reader.gcount();
     }
     auto const usage = timer.Sample();
-    return ThroughputResult{ExperimentLibrary::kCppClient,
+    return ThroughputResult{start,
+                            ExperimentLibrary::kCppClient,
                             transport_,
                             config.op,
-                            start,
                             config.object_size,
                             offset,
                             transfer_size,
@@ -252,8 +250,7 @@ class DownloadObject : public ThroughputExperiment {
                             object_name,
                             std::to_string(reader.generation().value_or(-1)),
                             "[upload-id-N/A]",
-                            ExtractRetryCount(reader.headers()),
-                            /*notes=*/{}};
+                            ExtractRetryCount(reader.headers())};
   }
 
  private:
@@ -339,10 +336,10 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
     curl_easy_cleanup(hnd);
     curl_slist_free_all(slist1);
     auto const usage = timer.Sample();
-    return ThroughputResult{ExperimentLibrary::kRaw,
+    return ThroughputResult{start,
+                            ExperimentLibrary::kRaw,
                             ExperimentTransport::kXml,
                             config.op,
-                            start,
                             config.object_size,
                             /*transfer_offset=*/0,
                             config.object_size,
@@ -357,8 +354,7 @@ class DownloadObjectLibcurl : public ThroughputExperiment {
                             object_name,
                             "[generation-N/A]",
                             "[upload-id-N/A]",
-                            "[retry-count-N/A]",
-                            /*notes=*/{}};
+                            "[retry-count-N/A]"};
   }
 
  private:
@@ -416,10 +412,10 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
         ::google::cloud::MakeStatusFromRpcError(stream->Finish());
     auto const usage = timer.Sample();
 
-    return ThroughputResult{ExperimentLibrary::kRaw,
+    return ThroughputResult{start,
+                            ExperimentLibrary::kRaw,
                             transport_,
                             config.op,
-                            start,
                             config.object_size,
                             /*transfer_offset=*/0,
                             bytes_received,
@@ -434,8 +430,7 @@ class DownloadObjectRawGrpc : public ThroughputExperiment {
                             object_name,
                             generation,
                             "[upload-id-N/A]",
-                            "[retry-count-N/A]",
-                            /*notes=*/{}};
+                            "[retry-count-N/A]"};
   }
 
  private:

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -234,6 +234,8 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        [&wants_description](std::string const&) { wants_description = true; }},
       {"--project-id", "use the given project id for the benchmark",
        [&options](std::string const& val) { options.project_id = val; }},
+      {"--labels", "user-defined labels to tag the results",
+       [&options](std::string const& val) { options.labels = val; }},
       {"--region", "use the given region for the benchmark",
        [&options](std::string const& val) { options.region = val; }},
       {"--bucket-prefix", "use this prefix when creating the bucket",

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -27,6 +27,7 @@ namespace storage_benchmarks {
 
 struct ThroughputOptions {
   std::string project_id;
+  std::string labels;
   std::string region;
   std::string bucket_prefix = "cloud-cpp-testing-bm";
   std::chrono::seconds duration =

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -74,6 +74,7 @@ TEST(ThroughputOptions, Basic) {
       "--grpc-background-threads=16",
       "--enable-retry-loop=false",
       "--rest-pool-size=123",
+      "--labels=job:foo,task:bar",
   });
   ASSERT_STATUS_OK(options);
   EXPECT_EQ("test-project", options->project_id);
@@ -125,6 +126,7 @@ TEST(ThroughputOptions, Basic) {
             options->grpc_options.get<GrpcBackgroundThreadPoolSizeOption>());
   EXPECT_TRUE(options->client_options.has<gcs::RetryPolicyOption>());
   EXPECT_EQ(123, options->client_options.get<gcs::ConnectionPoolSizeOption>());
+  EXPECT_EQ("job:foo,task:bar", options->labels);
 }
 
 TEST(ThroughputOptions, Description) {

--- a/google/cloud/storage/benchmarks/throughput_result.cc
+++ b/google/cloud/storage/benchmarks/throughput_result.cc
@@ -14,6 +14,7 @@
 
 #include "google/cloud/storage/benchmarks/throughput_result.h"
 #include "google/cloud/storage/benchmarks/benchmark_utils.h"
+#include "google/cloud/storage/benchmarks/throughput_options.h"
 #include <sstream>
 #include <string>
 
@@ -32,13 +33,15 @@ std::string CleanupCsv(std::string v) {
 
 }  // namespace
 
-void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
+void PrintAsCsv(std::ostream& os, ThroughputOptions const& options,
+                ThroughputResult const& r) {
   auto const start = FormatTimestamp(r.start);
 
-  os << ToString(r.library)                    // clang-format hack
+  os << start                                  // clang-format hack
+     << ',' << CleanupCsv(options.labels)      //
+     << ',' << ToString(r.library)             //
      << ',' << ToString(r.transport)           //
      << ',' << ToString(r.op)                  //
-     << ',' << start                           //
      << ',' << r.object_size                   //
      << ',' << r.transfer_offset               //
      << ',' << r.transfer_size                 //
@@ -53,17 +56,16 @@ void PrintAsCsv(std::ostream& os, ThroughputResult const& r) {
      << ',' << CleanupCsv(r.generation)        //
      << ',' << CleanupCsv(r.upload_id)         //
      << ',' << CleanupCsv(r.retry_count)       //
-     << ',' << CleanupCsv(r.notes)             //
      << ',' << r.status.code()                 //
      << ',' << CleanupCsv(r.status.message())  //
      << '\n';
 }
 
 void PrintThroughputResultHeader(std::ostream& os) {
-  os << "Library,Transport,Op,Start,ObjectSize,TransferOffset,TransferSize"
-     << ",AppBufferSize,Crc32cEnabled,MD5Enabled"
+  os << "Start,Labels,Library,Transport,Op,ObjectSize,TransferOffset"
+     << ",TransferSize,AppBufferSize,Crc32cEnabled,MD5Enabled"
      << ",ElapsedTimeUs,CpuTimeUs,Peer,BucketName,ObjectName,Generation"
-     << ",UploadId,RetryCount,Notes,StatusCode,Status\n";
+     << ",UploadId,RetryCount,StatusCode,Status\n";
 }
 
 char const* ToString(OpType op) {

--- a/google/cloud/storage/benchmarks/throughput_result.h
+++ b/google/cloud/storage/benchmarks/throughput_result.h
@@ -22,6 +22,7 @@
 namespace google {
 namespace cloud {
 namespace storage_benchmarks {
+struct ThroughputOptions;
 
 /// The operation used for the experiment
 enum OpType {
@@ -57,14 +58,14 @@ enum OpType {
  * etc.) as well as its results: status, CPU time, and elapsed time.
  */
 struct ThroughputResult {
+  /// The start time for this result.
+  std::chrono::system_clock::time_point start;
   /// The library used in this experiment
   ExperimentLibrary library;
   /// The transport used in this experiment
   ExperimentTransport transport;
   /// The type of operation in this experiment.
   OpType op;
-  /// The start time for this result.
-  std::chrono::system_clock::time_point start;
   /// The total size of the object involved in this experiment. Currently also
   /// represents the number of bytes transferred.
   std::int64_t object_size;
@@ -100,12 +101,11 @@ struct ThroughputResult {
   std::string upload_id;
   /// Retry Count
   std::string retry_count;
-  /// Additional notes
-  std::string notes;
 };
 
 /// Print @p r as a CSV line.
-void PrintAsCsv(std::ostream& os, ThroughputResult const& r);
+void PrintAsCsv(std::ostream& os, ThroughputOptions const& options,
+                ThroughputResult const& r);
 
 /// Print the field names produced by `PrintAsCsv()`
 void PrintThroughputResultHeader(std::ostream& os);


### PR DESCRIPTION
Now all benchmarks support `--labels`, which makes it easier to
concatenate and then analyze the results from multiple tests. The test
also capture GCE metadata by default, this is useful for analysis too.
I also changed the output from different benchmarks to start with the
timestamp of each experiment and then the labels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9748)
<!-- Reviewable:end -->
