### PR TITLE
refactor: make HTTP logs safer and more readable

### DIFF
--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -280,7 +280,7 @@ std::string DebugSendHeader(char const* data, std::size_t size) {
       trailer = payload.substr(nl_pos);
       body = payload.substr(bearer_pos, nl_pos - bearer_pos);
     }
-    auto marker = body.size() > limit ? "...<truncated>..." : "";
+    auto const* marker = body.size() > limit ? "...<truncated>..." : "";
     body = absl::ClippedSubstr(std::move(body), 0, limit);
     return absl::StrCat(">> curl(Send Header): ", prefix, body, marker,
                         trailer);

--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/curl_wrappers.h"
+#include "google/cloud/internal/absl_str_cat_quiet.h"
 #include "google/cloud/internal/curl_options.h"
 #include "google/cloud/internal/throw_delegate.h"
 #include "google/cloud/log.h"
@@ -168,6 +169,17 @@ class CurlInitializer {
   CurlInitializer() { curl_global_init(CURL_GLOBAL_ALL); }
   ~CurlInitializer() { curl_global_cleanup(); }
 };
+
+auto constexpr kMaxDebugLength = 128;
+
+std::string CleanupDebugData(char const* data, std::size_t size) {
+  auto const n = std::min<std::size_t>(size, kMaxDebugLength);
+  auto text = std::string{data, n};
+  std::transform(text.begin(), text.end(), text.begin(),
+                 [](auto c) { return std::isprint(c) ? c : '.'; });
+  return text;
+}
+
 }  // namespace
 
 std::string CurlSslLibraryId() {
@@ -243,26 +255,59 @@ std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,
   return size;
 }
 
+std::string DebugInfo(char const* data, std::size_t size) {
+  return absl::StrCat("== curl(Info): ", absl::string_view{data, size});
+}
+
+std::string DebugRecvHeader(char const* data, std::size_t size) {
+  return absl::StrCat("<< curl(Recv Header): ", absl::string_view{data, size});
+}
+
+std::string DebugSendHeader(char const* data, std::size_t size) {
+  auto header = absl::string_view{data, size};
+  auto const match = absl::string_view{": Bearer "};
+  auto const limit = match.size() + 32;
+  auto const bearer_pos = header.find(match);
+  if (bearer_pos != std::string::npos) {
+    auto const nl_pos = header.find('\n', bearer_pos);
+    auto const n = std::min(limit, nl_pos - bearer_pos);
+    return absl::StrCat(">> curl(Send Header): ", header.substr(0, bearer_pos),
+                        header.substr(bearer_pos, n), "...<truncated>...",
+                        header.substr(nl_pos), "\n");
+  }
+  return absl::StrCat(">> curl(Send Header): ", header);
+}
+
+std::string DebugInData(char const* data, std::size_t size) {
+  return absl::StrCat("<< curl(Recv Data): size=", size,
+                      " data=", CleanupDebugData(data, size), "\n");
+}
+
+std::string DebugOutData(char const* data, std::size_t size) {
+  return absl::StrCat(">> curl(Send Data): size=", size,
+                      " data=", CleanupDebugData(data, size), "\n");
+}
+
 void CurlInitializeOnce(Options const& options) {
   static CurlInitializer curl_initializer;
   static bool const kInitialized = [&options]() {
     // The Google Cloud Storage C++ client library depends on libcurl, which
-    // depends on many different SSL libraries, depending on the library the
-    // library needs to take action to be thread-safe. More details can be
-    // found here:
+    // can use different SSL libraries. Depending on the SSL implementation,
+    // we need to take action to be thread-safe. More details can be found here:
     //
     //     https://curl.haxx.se/libcurl/c/threadsafe.html
     //
     InitializeSslLocking(options.get<EnableCurlSslLockingOption>());
 
-    // libcurl recommends turning on CURLOPT_NOSIGNAL for multi-threaded
-    // applications: "Note that setting CURLOPT_NOSIGNAL to 0L will not work in
-    // a threaded situation as there will be race where libcurl risks restoring
-    // the former signal handler while another thread should still ignore it."
+    // libcurl recommends turning on `CURLOPT_NOSIGNAL` for threaded
+    // applications: "Note that setting `CURLOPT_NOSIGNAL` to 0L will not work
+    // in a threaded situation as there will be race where libcurl risks
+    // restoring the former signal handler while another thread should still
+    // ignore it."
     //
-    // libcurl further recommends that we setup our own signal handler for
-    // SIGPIPE when using multiple threads: "When CURLOPT_NOSIGNAL is set to
-    // 1L, your application needs to deal with the risk of a SIGPIPE (that at
+    // libcurl further recommends that we set up our own signal handler for
+    // SIGPIPE when using multiple threads: "When `CURLOPT_NOSIGNAL` is set to
+    // 1L, your application needs to deal with the risk of a `SIGPIPE` (that at
     // least the OpenSSL backend can trigger)".
     //
     //     https://curl.haxx.se/libcurl/c/threadsafe.html

--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -170,10 +170,10 @@ class CurlInitializer {
   ~CurlInitializer() { curl_global_cleanup(); }
 };
 
-auto constexpr kMaxDebugLength = 128;
+std::size_t constexpr kMaxDebugLength = 128;
 
 std::string CleanupDebugData(char const* data, std::size_t size) {
-  auto const n = std::min<std::size_t>(size, kMaxDebugLength);
+  auto const n = (std::min)(size, kMaxDebugLength);
   auto text = std::string{data, n};
   std::transform(text.begin(), text.end(), text.begin(),
                  [](auto c) { return std::isprint(c) ? c : '.'; });
@@ -271,9 +271,10 @@ std::string DebugSendHeader(char const* data, std::size_t size) {
   if (bearer_pos != std::string::npos) {
     auto const nl_pos = header.find('\n', bearer_pos);
     auto const n = (std::min)(limit, nl_pos - bearer_pos);
-    return absl::StrCat(">> curl(Send Header): ", header.substr(0, bearer_pos),
-                        header.substr(bearer_pos, n), "...<truncated>...",
-                        header.substr(nl_pos), "\n");
+    return absl::StrCat(
+        ">> curl(Send Header): ", header.substr(0, bearer_pos + n),
+        n == limit ? "...<truncated>..." : "",
+        nl_pos == std::string::npos ? "" : header.substr(nl_pos));
   }
   return absl::StrCat(">> curl(Send Header): ", header);
 }

--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -270,7 +270,7 @@ std::string DebugSendHeader(char const* data, std::size_t size) {
   auto const bearer_pos = header.find(match);
   if (bearer_pos != std::string::npos) {
     auto const nl_pos = header.find('\n', bearer_pos);
-    auto const n = std::min(limit, nl_pos - bearer_pos);
+    auto const n = (std::min)(limit, nl_pos - bearer_pos);
     return absl::StrCat(">> curl(Send Header): ", header.substr(0, bearer_pos),
                         header.substr(bearer_pos, n), "...<truncated>...",
                         header.substr(nl_pos), "\n");

--- a/google/cloud/internal/curl_wrappers.h
+++ b/google/cloud/internal/curl_wrappers.h
@@ -50,6 +50,12 @@ using CurlReceivedHeaders = std::multimap<std::string, std::string>;
 std::size_t CurlAppendHeaderData(CurlReceivedHeaders& received_headers,
                                  char const* data, std::size_t size);
 
+std::string DebugInfo(char const* data, std::size_t size);
+std::string DebugRecvHeader(char const* data, std::size_t size);
+std::string DebugSendHeader(char const* data, std::size_t size);
+std::string DebugInData(char const* data, std::size_t size);
+std::string DebugOutData(char const* data, std::size_t size);
+
 using CurlShare = std::unique_ptr<CURLSH, decltype(&curl_share_cleanup)>;
 
 /// Returns true if the SSL locking callbacks are installed.

--- a/google/cloud/internal/curl_wrappers_test.cc
+++ b/google/cloud/internal/curl_wrappers_test.cc
@@ -102,7 +102,6 @@ authorization: Bearer 01234567890123456789012345678912
 header2: value2
 )"""},
 
-
       {R"""(header1: long-no-nl
 authorization: Bearer 012345678901234567890123456789123456)""",
        R"""(>> curl(Send Header): header1: long-no-nl

--- a/google/cloud/internal/curl_wrappers_test.cc
+++ b/google/cloud/internal/curl_wrappers_test.cc
@@ -51,27 +51,76 @@ TEST(CurlWrappers, DebugSendHeader) {
     std::string input;
     std::string expected;
   } cases[] = {
-      {R"""(header1: v1)""", R"""(>> curl(Send Header): header1: v1)"""},
-      {R"""(header1: value1
-header2: value2)""",
-       R"""(>> curl(Send Header): header1: value1
-header2: value2)"""},
-      {R"""(header1: value1
-authorization: Bearer 1234567890
-header2: value2)""",
-       R"""(>> curl(Send Header): header1: value1
-authorization: Bearer 1234567890
-header2: value2)"""},
-      {R"""(header1: value1
-authorization: Bearer a1234567890.b1234567890.c1234567890.d1234567890
-header2: value2)""",
-       R"""(>> curl(Send Header): header1: value1
-authorization: Bearer a1234567890.b1234567890.c1234567...<truncated>...
-header2: value2)"""},
-      {R"""(header1: value1
-authorization: Bearer a1234567890.b1234567890.c1234567890.d1234567890)""",
-       R"""(>> curl(Send Header): header1: value1
-authorization: Bearer a1234567890.b1234567890.c1234567...<truncated>...)"""},
+      {R"""(header1: no-marker-no-nl)""",
+       R"""(>> curl(Send Header): header1: no-marker-no-nl)"""},
+      {R"""(header1: no-marker-w-nl
+)""",
+       R"""(>> curl(Send Header): header1: no-marker-w-nl
+)"""},
+      {R"""(header1: no-marker-w-nl-and-data
+header2: value2
+)""",
+       R"""(>> curl(Send Header): header1: no-marker-w-nl-and-data
+header2: value2
+)"""},
+
+      {R"""(header1: short-no-nl
+authorization: Bearer 012345678901234567890123456789)""",
+       R"""(>> curl(Send Header): header1: short-no-nl
+authorization: Bearer 012345678901234567890123456789)"""},
+      {R"""(header1: short-w-nl
+authorization: Bearer 012345678901234567890123456789
+)""",
+       R"""(>> curl(Send Header): header1: short-w-nl
+authorization: Bearer 012345678901234567890123456789
+)"""},
+      {R"""(header1: short-w-nl-and-data
+authorization: Bearer 012345678901234567890123456789
+header2: value2
+)""",
+       R"""(>> curl(Send Header): header1: short-w-nl-and-data
+authorization: Bearer 012345678901234567890123456789
+header2: value2
+)"""},
+
+      {R"""(header1: exact-no-nl
+authorization: Bearer 01234567890123456789012345678912)""",
+       R"""(>> curl(Send Header): header1: exact-no-nl
+authorization: Bearer 01234567890123456789012345678912)"""},
+      {R"""(header1: exact-w-nl
+authorization: Bearer 01234567890123456789012345678912
+)""",
+       R"""(>> curl(Send Header): header1: exact-w-nl
+authorization: Bearer 01234567890123456789012345678912
+)"""},
+      {R"""(header1: exact-w-nl-and-data
+authorization: Bearer 01234567890123456789012345678912
+header2: value2
+)""",
+       R"""(>> curl(Send Header): header1: exact-w-nl-and-data
+authorization: Bearer 01234567890123456789012345678912
+header2: value2
+)"""},
+
+
+      {R"""(header1: long-no-nl
+authorization: Bearer 012345678901234567890123456789123456)""",
+       R"""(>> curl(Send Header): header1: long-no-nl
+authorization: Bearer 01234567890123456789012345678912...<truncated>...)"""},
+      {R"""(header1: long-w-nl
+authorization: Bearer 012345678901234567890123456789123456
+)""",
+       R"""(>> curl(Send Header): header1: long-w-nl
+authorization: Bearer 01234567890123456789012345678912...<truncated>...
+)"""},
+      {R"""(header1: long-w-nl-and-data
+authorization: Bearer 012345678901234567890123456789123456
+header2: value2
+)""",
+       R"""(>> curl(Send Header): header1: long-w-nl-and-data
+authorization: Bearer 01234567890123456789012345678912...<truncated>...
+header2: value2
+)"""},
   };
 
   for (auto const& test : cases) {

--- a/google/cloud/internal/curl_wrappers_test.cc
+++ b/google/cloud/internal/curl_wrappers_test.cc
@@ -46,6 +46,40 @@ TEST(CurlWrappers, VersionToCurlCode) {
   }
 }
 
+TEST(CurlWrappers, DebugSendHeader) {
+  struct TestCasse {
+    std::string input;
+    std::string expected;
+  } cases[] = {
+      {R"""(header1: v1)""", R"""(>> curl(Send Header): header1: v1)"""},
+      {R"""(header1: value1
+header2: value2)""",
+       R"""(>> curl(Send Header): header1: value1
+header2: value2)"""},
+      {R"""(header1: value1
+authorization: Bearer 1234567890
+header2: value2)""",
+       R"""(>> curl(Send Header): header1: value1
+authorization: Bearer 1234567890
+header2: value2)"""},
+      {R"""(header1: value1
+authorization: Bearer a1234567890.b1234567890.c1234567890.d1234567890
+header2: value2)""",
+       R"""(>> curl(Send Header): header1: value1
+authorization: Bearer a1234567890.b1234567890.c1234567...<truncated>...
+header2: value2)"""},
+      {R"""(header1: value1
+authorization: Bearer a1234567890.b1234567890.c1234567890.d1234567890)""",
+       R"""(>> curl(Send Header): header1: value1
+authorization: Bearer a1234567890.b1234567890.c1234567...<truncated>...)"""},
+  };
+
+  for (auto const& test : cases) {
+    EXPECT_EQ(test.expected,
+              DebugSendHeader(test.input.data(), test.input.size()));
+  }
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/storage/internal/curl_handle.cc
+++ b/google/cloud/storage/internal/curl_handle.cc
@@ -30,44 +30,38 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 namespace {
 
-using ::google::cloud::storage::internal::BinaryDataAsDebugString;
-
-std::size_t const kMaxDataDebugSize = 48;
+using ::google::cloud::rest_internal::DebugInData;
+using ::google::cloud::rest_internal::DebugInfo;
+using ::google::cloud::rest_internal::DebugOutData;
+using ::google::cloud::rest_internal::DebugRecvHeader;
+using ::google::cloud::rest_internal::DebugSendHeader;
 
 extern "C" int CurlHandleDebugCallback(CURL*, curl_infotype type, char* data,
                                        std::size_t size, void* userptr) {
   auto* debug_info = reinterpret_cast<CurlHandle::DebugInfo*>(userptr);
   switch (type) {
     case CURLINFO_TEXT:
-      debug_info->buffer += "== curl(Info): " + std::string(data, size);
+      debug_info->buffer += DebugInfo(data, size);
       break;
     case CURLINFO_HEADER_IN:
-      debug_info->buffer += "<< curl(Recv Header): " + std::string(data, size);
+      debug_info->buffer += DebugRecvHeader(data, size);
       break;
     case CURLINFO_HEADER_OUT:
-      debug_info->buffer += ">> curl(Send Header): " + std::string(data, size);
+      debug_info->buffer += DebugSendHeader(data, size);
       break;
     case CURLINFO_DATA_IN:
       ++debug_info->recv_count;
       if (size == 0) {
         ++debug_info->recv_zero_count;
-      } else {
-        debug_info->buffer += ">> curl(Recv Data): size=";
-        debug_info->buffer += std::to_string(size) + "\n";
-        debug_info->buffer +=
-            BinaryDataAsDebugString(data, size, kMaxDataDebugSize);
       }
+      debug_info->buffer += DebugInData(data, size);
       break;
     case CURLINFO_DATA_OUT:
       ++debug_info->send_count;
       if (size == 0) {
         ++debug_info->send_zero_count;
-      } else {
-        debug_info->buffer += ">> curl(Send Data): size=";
-        debug_info->buffer += std::to_string(size) + "\n";
-        debug_info->buffer +=
-            BinaryDataAsDebugString(data, size, kMaxDataDebugSize);
       }
+      debug_info->buffer += DebugOutData(data, size);
       break;
     case CURLINFO_SSL_DATA_IN:
     case CURLINFO_SSL_DATA_OUT:


### PR DESCRIPTION
Shorten some excessively long messages, simplify the output format, and
truncate bearer tokens in the logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9758)
<!-- Reviewable:end -->
