### PR TITLE
cleanup(storage): remove some uses of `CurlClient`

### DIFF
--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -74,8 +74,8 @@ TEST(GrpcPluginTest, UnsetConfigCreatesCurl) {
   auto const* const retry =
       dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
   ASSERT_THAT(retry, NotNull());
-  auto const* const curl = dynamic_cast<RestClient*>(retry->client().get());
-  ASSERT_THAT(curl, NotNull());
+  auto const* const rest = dynamic_cast<RestClient*>(retry->client().get());
+  ASSERT_THAT(rest, NotNull());
 }
 
 TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
@@ -88,8 +88,8 @@ TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
   auto const* const retry =
       dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
   ASSERT_THAT(retry, NotNull());
-  auto const* const curl = dynamic_cast<RestClient*>(retry->client().get());
-  ASSERT_THAT(curl, NotNull());
+  auto const* const rest = dynamic_cast<RestClient*>(retry->client().get());
+  ASSERT_THAT(rest, NotNull());
 }
 
 TEST(GrpcPluginTest, MediaConfigCreatesHybrid) {

--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/grpc_plugin.h"
-#include "google/cloud/storage/internal/curl_client.h"
 #include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/hybrid_client.h"
+#include "google/cloud/storage/internal/rest_client.h"
 #include "google/cloud/storage/internal/retry_client.h"
 #include "google/cloud/testing_util/scoped_environment.h"
 #include <gmock/gmock.h>
@@ -27,18 +27,15 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::storage::internal::ClientImplDetails;
-using ::google::cloud::storage::internal::CurlClient;
 using ::google::cloud::storage::internal::GrpcClient;
 using ::google::cloud::storage::internal::HybridClient;
+using ::google::cloud::storage::internal::RestClient;
 using ::google::cloud::storage::internal::RetryClient;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::IsNull;
 using ::testing::NotNull;
 
 TEST(GrpcPluginTest, MetadataConfigCreatesGrpc) {
-  // Explicitly disable the RestClient, which may be enabled by our CI builds.
-  auto rest =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP", "yes");
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
@@ -54,9 +51,6 @@ TEST(GrpcPluginTest, MetadataConfigCreatesGrpc) {
 }
 
 TEST(GrpcPluginTest, EnvironmentOverrides) {
-  // Explicitly disable the RestClient, which may be enabled by our CI builds.
-  auto rest =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP", "yes");
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
@@ -71,9 +65,6 @@ TEST(GrpcPluginTest, EnvironmentOverrides) {
 }
 
 TEST(GrpcPluginTest, UnsetConfigCreatesCurl) {
-  // Explicitly disable the RestClient, which may be enabled by our CI builds.
-  auto rest =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP", "yes");
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
@@ -83,14 +74,11 @@ TEST(GrpcPluginTest, UnsetConfigCreatesCurl) {
   auto const* const retry =
       dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
   ASSERT_THAT(retry, NotNull());
-  auto const* const curl = dynamic_cast<CurlClient*>(retry->client().get());
+  auto const* const curl = dynamic_cast<RestClient*>(retry->client().get());
   ASSERT_THAT(curl, NotNull());
 }
 
 TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
-  // Explicitly disable the RestClient, which may be enabled by our CI builds.
-  auto rest =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP", "yes");
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);
@@ -100,14 +88,11 @@ TEST(GrpcPluginTest, NoneConfigCreatesCurl) {
   auto const* const retry =
       dynamic_cast<RetryClient*>(ClientImplDetails::GetRawClient(client).get());
   ASSERT_THAT(retry, NotNull());
-  auto const* const curl = dynamic_cast<CurlClient*>(retry->client().get());
+  auto const* const curl = dynamic_cast<RestClient*>(retry->client().get());
   ASSERT_THAT(curl, NotNull());
 }
 
 TEST(GrpcPluginTest, MediaConfigCreatesHybrid) {
-  // Explicitly disable the RestClient, which may be enabled by our CI builds.
-  auto rest =
-      ScopedEnvironment("GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP", "yes");
   // Explicitly disable logging, which may be enabled by our CI builds.
   auto logging =
       ScopedEnvironment("CLOUD_STORAGE_ENABLE_TRACING", absl::nullopt);

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -29,63 +29,63 @@ std::shared_ptr<RawClient> HybridClient::Create(Options const& options) {
 
 HybridClient::HybridClient(Options const& options)
     : grpc_(GrpcClient::Create(DefaultOptionsGrpc(options))),
-      curl_(RestClient::Create(DefaultOptionsWithCredentials(options))) {}
+      rest_(RestClient::Create(DefaultOptionsWithCredentials(options))) {}
 
 ClientOptions const& HybridClient::client_options() const {
-  return curl_->client_options();
+  return rest_->client_options();
 }
 
-Options HybridClient::options() const { return curl_->options(); }
+Options HybridClient::options() const { return rest_->options(); }
 
 StatusOr<ListBucketsResponse> HybridClient::ListBuckets(
     ListBucketsRequest const& request) {
-  return curl_->ListBuckets(request);
+  return rest_->ListBuckets(request);
 }
 
 StatusOr<BucketMetadata> HybridClient::CreateBucket(
     CreateBucketRequest const& request) {
-  return curl_->CreateBucket(request);
+  return rest_->CreateBucket(request);
 }
 
 StatusOr<BucketMetadata> HybridClient::GetBucketMetadata(
     GetBucketMetadataRequest const& request) {
-  return curl_->GetBucketMetadata(request);
+  return rest_->GetBucketMetadata(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteBucket(
     DeleteBucketRequest const& request) {
-  return curl_->DeleteBucket(request);
+  return rest_->DeleteBucket(request);
 }
 
 StatusOr<BucketMetadata> HybridClient::UpdateBucket(
     UpdateBucketRequest const& request) {
-  return curl_->UpdateBucket(request);
+  return rest_->UpdateBucket(request);
 }
 
 StatusOr<BucketMetadata> HybridClient::PatchBucket(
     PatchBucketRequest const& request) {
-  return curl_->PatchBucket(request);
+  return rest_->PatchBucket(request);
 }
 
 StatusOr<NativeIamPolicy> HybridClient::GetNativeBucketIamPolicy(
     GetBucketIamPolicyRequest const& request) {
-  return curl_->GetNativeBucketIamPolicy(request);
+  return rest_->GetNativeBucketIamPolicy(request);
 }
 
 StatusOr<NativeIamPolicy> HybridClient::SetNativeBucketIamPolicy(
     SetNativeBucketIamPolicyRequest const& request) {
-  return curl_->SetNativeBucketIamPolicy(request);
+  return rest_->SetNativeBucketIamPolicy(request);
 }
 
 StatusOr<TestBucketIamPermissionsResponse>
 HybridClient::TestBucketIamPermissions(
     TestBucketIamPermissionsRequest const& request) {
-  return curl_->TestBucketIamPermissions(request);
+  return rest_->TestBucketIamPermissions(request);
 }
 
 StatusOr<BucketMetadata> HybridClient::LockBucketRetentionPolicy(
     LockBucketRetentionPolicyRequest const& request) {
-  return curl_->LockBucketRetentionPolicy(request);
+  return rest_->LockBucketRetentionPolicy(request);
 }
 
 StatusOr<ObjectMetadata> HybridClient::InsertObjectMedia(
@@ -95,12 +95,12 @@ StatusOr<ObjectMetadata> HybridClient::InsertObjectMedia(
 
 StatusOr<ObjectMetadata> HybridClient::CopyObject(
     CopyObjectRequest const& request) {
-  return curl_->CopyObject(request);
+  return rest_->CopyObject(request);
 }
 
 StatusOr<ObjectMetadata> HybridClient::GetObjectMetadata(
     GetObjectMetadataRequest const& request) {
-  return curl_->GetObjectMetadata(request);
+  return rest_->GetObjectMetadata(request);
 }
 
 StatusOr<std::unique_ptr<ObjectReadSource>> HybridClient::ReadObject(
@@ -110,32 +110,32 @@ StatusOr<std::unique_ptr<ObjectReadSource>> HybridClient::ReadObject(
 
 StatusOr<ListObjectsResponse> HybridClient::ListObjects(
     ListObjectsRequest const& request) {
-  return curl_->ListObjects(request);
+  return rest_->ListObjects(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteObject(
     DeleteObjectRequest const& request) {
-  return curl_->DeleteObject(request);
+  return rest_->DeleteObject(request);
 }
 
 StatusOr<ObjectMetadata> HybridClient::UpdateObject(
     UpdateObjectRequest const& request) {
-  return curl_->UpdateObject(request);
+  return rest_->UpdateObject(request);
 }
 
 StatusOr<ObjectMetadata> HybridClient::PatchObject(
     PatchObjectRequest const& request) {
-  return curl_->PatchObject(request);
+  return rest_->PatchObject(request);
 }
 
 StatusOr<ObjectMetadata> HybridClient::ComposeObject(
     ComposeObjectRequest const& request) {
-  return curl_->ComposeObject(request);
+  return rest_->ComposeObject(request);
 }
 
 StatusOr<RewriteObjectResponse> HybridClient::RewriteObject(
     RewriteObjectRequest const& request) {
-  return curl_->RewriteObject(request);
+  return rest_->RewriteObject(request);
 }
 
 StatusOr<CreateResumableUploadResponse> HybridClient::CreateResumableUpload(
@@ -153,7 +153,7 @@ StatusOr<EmptyResponse> HybridClient::DeleteResumableUpload(
   if (internal::IsGrpcResumableSessionUrl(request.upload_session_url())) {
     return grpc_->DeleteResumableUpload(request);
   }
-  return curl_->DeleteResumableUpload(request);
+  return rest_->DeleteResumableUpload(request);
 }
 
 StatusOr<QueryResumableUploadResponse> HybridClient::UploadChunk(
@@ -163,147 +163,147 @@ StatusOr<QueryResumableUploadResponse> HybridClient::UploadChunk(
 
 StatusOr<ListBucketAclResponse> HybridClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
-  return curl_->ListBucketAcl(request);
+  return rest_->ListBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> HybridClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
-  return curl_->CreateBucketAcl(request);
+  return rest_->CreateBucketAcl(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
-  return curl_->DeleteBucketAcl(request);
+  return rest_->DeleteBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> HybridClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
-  return curl_->GetBucketAcl(request);
+  return rest_->GetBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> HybridClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
-  return curl_->UpdateBucketAcl(request);
+  return rest_->UpdateBucketAcl(request);
 }
 
 StatusOr<BucketAccessControl> HybridClient::PatchBucketAcl(
     PatchBucketAclRequest const& request) {
-  return curl_->PatchBucketAcl(request);
+  return rest_->PatchBucketAcl(request);
 }
 
 StatusOr<ListObjectAclResponse> HybridClient::ListObjectAcl(
     ListObjectAclRequest const& request) {
-  return curl_->ListObjectAcl(request);
+  return rest_->ListObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::CreateObjectAcl(
     CreateObjectAclRequest const& request) {
-  return curl_->CreateObjectAcl(request);
+  return rest_->CreateObjectAcl(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteObjectAcl(
     DeleteObjectAclRequest const& request) {
-  return curl_->DeleteObjectAcl(request);
+  return rest_->DeleteObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::GetObjectAcl(
     GetObjectAclRequest const& request) {
-  return curl_->GetObjectAcl(request);
+  return rest_->GetObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::UpdateObjectAcl(
     UpdateObjectAclRequest const& request) {
-  return curl_->UpdateObjectAcl(request);
+  return rest_->UpdateObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::PatchObjectAcl(
     PatchObjectAclRequest const& request) {
-  return curl_->PatchObjectAcl(request);
+  return rest_->PatchObjectAcl(request);
 }
 
 StatusOr<ListDefaultObjectAclResponse> HybridClient::ListDefaultObjectAcl(
     ListDefaultObjectAclRequest const& request) {
-  return curl_->ListDefaultObjectAcl(request);
+  return rest_->ListDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::CreateDefaultObjectAcl(
     CreateDefaultObjectAclRequest const& request) {
-  return curl_->CreateDefaultObjectAcl(request);
+  return rest_->CreateDefaultObjectAcl(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
-  return curl_->DeleteDefaultObjectAcl(request);
+  return rest_->DeleteDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
-  return curl_->GetDefaultObjectAcl(request);
+  return rest_->GetDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
-  return curl_->UpdateDefaultObjectAcl(request);
+  return rest_->UpdateDefaultObjectAcl(request);
 }
 
 StatusOr<ObjectAccessControl> HybridClient::PatchDefaultObjectAcl(
     PatchDefaultObjectAclRequest const& request) {
-  return curl_->PatchDefaultObjectAcl(request);
+  return rest_->PatchDefaultObjectAcl(request);
 }
 
 StatusOr<ServiceAccount> HybridClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
-  return curl_->GetServiceAccount(request);
+  return rest_->GetServiceAccount(request);
 }
 
 StatusOr<ListHmacKeysResponse> HybridClient::ListHmacKeys(
     ListHmacKeysRequest const& request) {
-  return curl_->ListHmacKeys(request);
+  return rest_->ListHmacKeys(request);
 }
 
 StatusOr<CreateHmacKeyResponse> HybridClient::CreateHmacKey(
     CreateHmacKeyRequest const& request) {
-  return curl_->CreateHmacKey(request);
+  return rest_->CreateHmacKey(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteHmacKey(
     DeleteHmacKeyRequest const& request) {
-  return curl_->DeleteHmacKey(request);
+  return rest_->DeleteHmacKey(request);
 }
 
 StatusOr<HmacKeyMetadata> HybridClient::GetHmacKey(
     GetHmacKeyRequest const& request) {
-  return curl_->GetHmacKey(request);
+  return rest_->GetHmacKey(request);
 }
 
 StatusOr<HmacKeyMetadata> HybridClient::UpdateHmacKey(
     UpdateHmacKeyRequest const& request) {
-  return curl_->UpdateHmacKey(request);
+  return rest_->UpdateHmacKey(request);
 }
 
 StatusOr<SignBlobResponse> HybridClient::SignBlob(
     SignBlobRequest const& request) {
-  return curl_->SignBlob(request);
+  return rest_->SignBlob(request);
 }
 
 StatusOr<ListNotificationsResponse> HybridClient::ListNotifications(
     ListNotificationsRequest const& request) {
-  return curl_->ListNotifications(request);
+  return rest_->ListNotifications(request);
 }
 
 StatusOr<NotificationMetadata> HybridClient::CreateNotification(
     CreateNotificationRequest const& request) {
-  return curl_->CreateNotification(request);
+  return rest_->CreateNotification(request);
 }
 
 StatusOr<NotificationMetadata> HybridClient::GetNotification(
     GetNotificationRequest const& request) {
-  return curl_->GetNotification(request);
+  return rest_->GetNotification(request);
 }
 
 StatusOr<EmptyResponse> HybridClient::DeleteNotification(
     DeleteNotificationRequest const& request) {
-  return curl_->DeleteNotification(request);
+  return rest_->DeleteNotification(request);
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 #include "google/cloud/storage/internal/hybrid_client.h"
+#include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/grpc_resumable_upload_session_url.h"
+#include "google/cloud/storage/internal/rest_client.h"
 
 namespace google {
 namespace cloud {
@@ -27,7 +29,7 @@ std::shared_ptr<RawClient> HybridClient::Create(Options const& options) {
 
 HybridClient::HybridClient(Options const& options)
     : grpc_(GrpcClient::Create(DefaultOptionsGrpc(options))),
-      curl_(CurlClient::Create(DefaultOptionsWithCredentials(options))) {}
+      curl_(RestClient::Create(DefaultOptionsWithCredentials(options))) {}
 
 ClientOptions const& HybridClient::client_options() const {
   return curl_->client_options();

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -15,8 +15,6 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HYBRID_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_HYBRID_CLIENT_H
 
-#include "google/cloud/storage/internal/curl_client.h"
-#include "google/cloud/storage/internal/grpc_client.h"
 #include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
 #include <string>
@@ -147,8 +145,8 @@ class HybridClient : public RawClient {
  private:
   explicit HybridClient(Options const& options);
 
-  std::shared_ptr<GrpcClient> grpc_;
-  std::shared_ptr<CurlClient> curl_;
+  std::shared_ptr<RawClient> grpc_;
+  std::shared_ptr<RawClient> curl_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/hybrid_client.h
+++ b/google/cloud/storage/internal/hybrid_client.h
@@ -146,7 +146,7 @@ class HybridClient : public RawClient {
   explicit HybridClient(Options const& options);
 
   std::shared_ptr<RawClient> grpc_;
-  std::shared_ptr<RawClient> curl_;
+  std::shared_ptr<RawClient> rest_;
 };
 
 }  // namespace internal

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -180,7 +180,9 @@ RestClient::RestClient(
       generator_(google::cloud::internal::MakeDefaultPRNG()),
       options_(std::move(options)),
       backwards_compatibility_options_(
-          MakeBackwardsCompatibleClientOptions(options_)) {}
+          MakeBackwardsCompatibleClientOptions(options_)) {
+  rest_internal::CurlInitializeOnce(options_);
+}
 
 ClientOptions const& RestClient::client_options() const {
   return backwards_compatibility_options_;

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -139,20 +139,18 @@ std::shared_ptr<RestClient> RestClient::Create(Options options) {
       RestEndpoint(options), ResolveStorageAuthority(options));
   auto iam_client = rest::MakePooledRestClient(IamEndpoint(options),
                                                ResolveIamAuthority(options));
-  auto curl_client = internal::CurlClient::Create(options);
   return Create(std::move(options), std::move(storage_client),
-                std::move(iam_client), std::move(curl_client));
+                std::move(iam_client));
 }
 
 std::shared_ptr<RestClient> RestClient::Create(
     Options options,
     std::shared_ptr<google::cloud::rest_internal::RestClient>
         storage_rest_client,
-    std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client,
-    std::shared_ptr<RawClient> curl_client) {
+    std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client) {
   return std::shared_ptr<RestClient>(
       new RestClient(std::move(storage_rest_client), std::move(iam_rest_client),
-                     std::move(curl_client), std::move(options)));
+                     std::move(options)));
 }
 
 Options RestClient::ResolveStorageAuthority(Options const& options) {
@@ -175,13 +173,18 @@ RestClient::RestClient(
     std::shared_ptr<google::cloud::rest_internal::RestClient>
         storage_rest_client,
     std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client,
-    std::shared_ptr<RawClient> curl_client, google::cloud::Options options)
+    google::cloud::Options options)
     : storage_rest_client_(std::move(storage_rest_client)),
       iam_rest_client_(std::move(iam_rest_client)),
-      curl_client_(std::move(curl_client)),
       xml_enabled_(XmlEnabled()),
       generator_(google::cloud::internal::MakeDefaultPRNG()),
-      options_(std::move(options)) {}
+      options_(std::move(options)),
+      backwards_compatibility_options_(
+          MakeBackwardsCompatibleClientOptions(options_)) {}
+
+ClientOptions const& RestClient::client_options() const {
+  return backwards_compatibility_options_;
+}
 
 Options RestClient::options() const { return options_; }
 

--- a/google/cloud/storage/internal/rest_client.h
+++ b/google/cloud/storage/internal/rest_client.h
@@ -15,9 +15,12 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_REST_CLIENT_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_REST_CLIENT_H
 
-#include "google/cloud/storage/internal/curl_client.h"
+#include "google/cloud/storage/internal/raw_client.h"
 #include "google/cloud/storage/version.h"
+#include "google/cloud/internal/random.h"
 #include "google/cloud/internal/rest_client.h"
+#include <memory>
+#include <mutex>
 #include <string>
 
 namespace google {
@@ -40,8 +43,8 @@ class RestClient : public RawClient,
       Options options,
       std::shared_ptr<google::cloud::rest_internal::RestClient>
           storage_rest_client,
-      std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client,
-      std::shared_ptr<RawClient> curl_client);
+      std::shared_ptr<google::cloud::rest_internal::RestClient>
+          iam_rest_client);
 
   static Options ResolveStorageAuthority(Options const& options);
   static Options ResolveIamAuthority(Options const& options);
@@ -51,9 +54,7 @@ class RestClient : public RawClient,
   RestClient& operator=(RestClient const& rhs) = delete;
   RestClient& operator=(RestClient&& rhs) = delete;
 
-  ClientOptions const& client_options() const override {
-    return curl_client_->client_options();
-  }
+  ClientOptions const& client_options() const override;
   Options options() const override;
 
   StatusOr<ListBucketsResponse> ListBuckets(
@@ -170,7 +171,7 @@ class RestClient : public RawClient,
       std::shared_ptr<google::cloud::rest_internal::RestClient>
           storage_rest_client,
       std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client,
-      std::shared_ptr<RawClient> curl_client, Options options);
+      Options options);
 
  private:
   StatusOr<ObjectMetadata> InsertObjectMediaMultipart(
@@ -189,11 +190,11 @@ class RestClient : public RawClient,
   std::shared_ptr<google::cloud::rest_internal::RestClient>
       storage_rest_client_;
   std::shared_ptr<google::cloud::rest_internal::RestClient> iam_rest_client_;
-  std::shared_ptr<RawClient> curl_client_;
   bool const xml_enabled_;
   std::mutex mu_;
   google::cloud::internal::DefaultPRNG generator_;  // GUARDED_BY(mu_);
   google::cloud::Options options_;
+  ClientOptions backwards_compatibility_options_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
Remove uses of `CurlClient`. One lingering in the implementation of
`RestClient` itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9759)
<!-- Reviewable:end -->
