### PR TITLE
fix(storage): no workaround needed with libc++ and MSVC

### DIFF
--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -91,7 +91,7 @@ bool EscapeAsciiChar(std::string& result, char32_t c) {
 StatusOr<std::string> PostPolicyV4EscapeUTF8(std::string const& utf8_bytes) {
   std::string result;
 
-#if (_MSC_VER >= 1900)
+#if (_MSC_VER >= 1900) && !defined(_LIBCPP_VERSION)
   // Working around missing std::codecvt_utf8<char32_t> symbols in MSVC
   // Microsoft bug number: VSO#143857
   // Context:


### PR DESCRIPTION
Thanks to @brianpl for this patch

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9768)
<!-- Reviewable:end -->
