### PR TITLE
test(spanner): create a PostgreSQL version of DatabaseIntegrationTest

### DIFF
--- a/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
+++ b/google/cloud/spanner/admin/integration_tests/database_admin_integration_test.cc
@@ -255,28 +255,6 @@ TEST_F(DatabaseAdminClientTest, DatabaseBasicCRUD) {
   }
   EXPECT_FALSE(metadata->throttled());
 
-  // Verify that a JSON column cannot be used as an index.
-  statements.clear();
-  statements.emplace_back(R"""(
-        CREATE INDEX SingersByDetail
-          ON Singers(SingerDetails)
-      )""");
-  metadata = client_.UpdateDatabaseDdl(database_.FullName(), statements).get();
-  EXPECT_THAT(metadata, StatusIs(StatusCode::kFailedPrecondition,
-                                 HasSubstr("SingersByDetail")));
-
-  // Verify that a JSON column cannot be used as a primary key.
-  statements.clear();
-  statements.emplace_back(R"""(
-        CREATE TABLE JsonKey (
-          Key JSON NOT NULL
-        ) PRIMARY KEY (Key)
-      )""");
-  metadata = client_.UpdateDatabaseDdl(database_.FullName(), statements).get();
-  EXPECT_THAT(metadata, StatusIs(StatusCode::kInvalidArgument,
-                                 AllOf(HasSubstr("Key has type JSON"),
-                                       HasSubstr("part of the primary key"))));
-
   // Verify that a new role can be created and returned.
   statements.clear();
   statements.emplace_back(R"""(

--- a/google/cloud/spanner/testing/database_integration_test.cc
+++ b/google/cloud/spanner/testing/database_integration_test.cc
@@ -19,44 +19,49 @@
 #include "google/cloud/spanner/testing/random_database_name.h"
 #include "google/cloud/internal/getenv.h"
 #include "google/cloud/testing_util/status_matchers.h"
+#include <chrono>
+#include <iostream>
 
 namespace google {
 namespace cloud {
 namespace spanner_testing {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
+namespace {
+
 using ::google::cloud::testing_util::IsOk;
 
-google::cloud::spanner::Database* DatabaseIntegrationTest::db_;
-google::cloud::internal::DefaultPRNG* DatabaseIntegrationTest::generator_;
+// How old a database must be to be considered stale.
+auto constexpr kStaleAge = std::chrono::hours(7 * 24);
+
+}  // namespace
+
+internal::DefaultPRNG* DatabaseIntegrationTest::generator_;
+spanner::Database* DatabaseIntegrationTest::db_;
+bool DatabaseIntegrationTest::emulator_;
 
 void DatabaseIntegrationTest::SetUpTestSuite() {
-  auto project_id =
-      google::cloud::internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
-  ASSERT_FALSE(project_id.empty());
-  generator_ = new google::cloud::internal::DefaultPRNG(
-      google::cloud::internal::MakeDefaultPRNG());
+  testing_util::IntegrationTest::SetUpTestSuite();
+  generator_ = new internal::DefaultPRNG(internal::MakeDefaultPRNG());
 
+  auto project_id = internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  ASSERT_FALSE(project_id.empty());
   auto instance_id = PickRandomInstance(*generator_, project_id);
   ASSERT_THAT(instance_id, IsOk());
+  auto database_id = RandomDatabaseName(*generator_);
+  db_ = new spanner::Database(project_id, *instance_id, database_id);
+  emulator_ = internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
 
   spanner_admin::DatabaseAdminClient admin_client(
       spanner_admin::MakeDatabaseAdminConnection());
-  CleanupStaleDatabases(
-      admin_client, project_id, *instance_id,
-      std::chrono::system_clock::now() - std::chrono::hours(7 * 24));
-
-  auto database_id = spanner_testing::RandomDatabaseName(*generator_);
-  db_ = new spanner::Database(project_id, *instance_id, database_id);
-
-  bool const emulator =
-      google::cloud::internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
+  CleanupStaleDatabases(admin_client, project_id, *instance_id,
+                        std::chrono::system_clock::now() - kStaleAge);
 
   std::cout << "Creating database and table " << std::flush;
   google::spanner::admin::database::v1::CreateDatabaseRequest request;
   request.set_parent(db_->instance().FullName());
   request.set_create_statement("CREATE DATABASE `" + db_->database_id() + "`");
-  if (!emulator) {
+  if (!emulator_) {
     // TODO(#5479): Awaiting emulator support for version_retention_period.
     request.add_extra_statements(  //
         "ALTER DATABASE `" + db_->database_id() + "` " +
@@ -121,10 +126,128 @@ void DatabaseIntegrationTest::TearDownTestSuite() {
       spanner_admin::MakeDatabaseAdminConnection());
   auto drop_status = admin_client.DropDatabase(db_->FullName());
   EXPECT_THAT(drop_status, IsOk());
+
+  emulator_ = false;
   delete db_;
   db_ = nullptr;
   delete generator_;
   generator_ = nullptr;
+
+  testing_util::IntegrationTest::TearDownTestSuite();
+}
+
+internal::DefaultPRNG* PgDatabaseIntegrationTest::generator_;
+spanner::Database* PgDatabaseIntegrationTest::db_;
+bool PgDatabaseIntegrationTest::emulator_;
+
+void PgDatabaseIntegrationTest::SetUpTestSuite() {
+  testing_util::IntegrationTest::SetUpTestSuite();
+  generator_ = new internal::DefaultPRNG(internal::MakeDefaultPRNG());
+
+  auto project_id = internal::GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
+  ASSERT_FALSE(project_id.empty());
+  auto instance_id = PickRandomInstance(*generator_, project_id);
+  ASSERT_THAT(instance_id, IsOk());
+  auto database_id = RandomDatabaseName(*generator_);
+  db_ = new spanner::Database(project_id, *instance_id, database_id);
+  emulator_ = internal::GetEnv("SPANNER_EMULATOR_HOST").has_value();
+
+  spanner_admin::DatabaseAdminClient admin_client(
+      spanner_admin::MakeDatabaseAdminConnection());
+  CleanupStaleDatabases(admin_client, project_id, *instance_id,
+                        std::chrono::system_clock::now() - kStaleAge);
+
+  std::cout << "Creating PostgreSQL database and table " << std::flush;
+  google::spanner::admin::database::v1::CreateDatabaseRequest request;
+  request.set_parent(db_->instance().FullName());
+  request.set_create_statement("CREATE DATABASE \"" + db_->database_id() +
+                               "\"");
+  request.set_database_dialect(
+      google::spanner::admin::database::v1::DatabaseDialect::POSTGRESQL);
+  auto database_future = admin_client.CreateDatabase(request);
+
+  int i = 0;
+  int const timeout = 600;
+  while (++i < timeout) {
+    auto status = database_future.wait_for(std::chrono::seconds(1));
+    if (status != std::future_status::timeout) break;
+    std::cout << '.' << std::flush;
+  }
+  if (i >= timeout) {
+    std::cout << "TIMEOUT\n";
+    FAIL();
+  }
+  auto database = database_future.get();
+  if (emulator_ && database.status().code() == StatusCode::kInvalidArgument) {
+    // The emulator does not support PostgreSQL syntax to quote identifiers.
+    std::cout << "INVALID-IGNORED\n";
+    return;
+  }
+  ASSERT_THAT(database, IsOk());
+
+  // DDL statements other than <CREATE DATABASE> are not allowed in database
+  // creation requests for PostgreSQL-enabled databases, so separate them into
+  // an attendant update request.
+  std::vector<std::string> statements;
+  statements.emplace_back(R"sql(
+        CREATE TABLE Singers (
+          SingerId   BIGINT NOT NULL,
+          FirstName  CHARACTER VARYING(1024),
+          LastName   CHARACTER VARYING(1024),
+          PRIMARY KEY(SingerId)
+        )
+      )sql");
+  statements.emplace_back(R"sql(
+        CREATE TABLE DataTypes (
+          Id CHARACTER VARYING(256) NOT NULL,
+          BoolValue BOOLEAN,
+          Int64Value BIGINT,
+          Float64Value DOUBLE PRECISION,
+          StringValue CHARACTER VARYING(1024),
+          BytesValue BYTEA,
+          TimestampValue TIMESTAMP WITH TIME ZONE,
+          DateValue DATE,
+          NumericValue NUMERIC,
+          ArrayBoolValue BOOLEAN[],
+          ArrayInt64Value BIGINT[],
+          ArrayFloat64Value DOUBLE PRECISION[],
+          ArrayStringValue CHARACTER VARYING(1024)[],
+          ArrayBytesValue BYTEA[],
+          ArrayTimestampValue TIMESTAMP WITH TIME ZONE[],
+          ArrayDateValue DATE[],
+          ArrayNumericValue NUMERIC[],
+          PRIMARY KEY(Id)
+        )
+      )sql");
+  auto metadata_future =
+      admin_client.UpdateDatabaseDdl(db_->FullName(), statements);
+  while (++i < timeout) {
+    auto status = metadata_future.wait_for(std::chrono::seconds(1));
+    if (status != std::future_status::timeout) break;
+    std::cout << '.' << std::flush;
+  }
+  if (i >= timeout) {
+    std::cout << "TIMEOUT\n";
+    FAIL();
+  }
+  auto metadata = metadata_future.get();
+  ASSERT_THAT(metadata, IsOk());
+  std::cout << "DONE\n";
+}
+
+void PgDatabaseIntegrationTest::TearDownTestSuite() {
+  spanner_admin::DatabaseAdminClient admin_client(
+      spanner_admin::MakeDatabaseAdminConnection());
+  auto drop_status = admin_client.DropDatabase(db_->FullName());
+  EXPECT_THAT(drop_status, IsOk());
+
+  emulator_ = false;
+  delete db_;
+  db_ = nullptr;
+  delete generator_;
+  generator_ = nullptr;
+
+  testing_util::IntegrationTest::TearDownTestSuite();
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/testing/database_integration_test.h
+++ b/google/cloud/spanner/testing/database_integration_test.h
@@ -23,22 +23,48 @@
 
 namespace google {
 namespace cloud {
-/// Helper types and functions used in Cloud Spanner C++ client library tests.
 namespace spanner_testing {
-/// An inlined, versioned namespace for the testing helpers.
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-class DatabaseIntegrationTest
-    : public ::google::cloud::testing_util::IntegrationTest {
- public:
+/**
+ * A `testing::Test` that:
+ *   - creates (for all tests in the suite) a randomly-named database,
+ *     in a randomly-chosen instance,
+ *   - populates the database with some useful tables, and
+ *   - flushes the `google::cloud::LogSink` when a test completes with
+ *     a failure (see `testing_util::IntegrationTest`).
+ */
+class DatabaseIntegrationTest : public testing_util::IntegrationTest {
+ protected:
   static void SetUpTestSuite();
   static void TearDownTestSuite();
 
-  static google::cloud::spanner::Database const& GetDatabase() { return *db_; }
+  static spanner::Database const& GetDatabase() { return *db_; }
+  static bool UsingEmulator() { return emulator_; }
 
  private:
-  static google::cloud::spanner::Database* db_;
-  static google::cloud::internal::DefaultPRNG* generator_;
+  static internal::DefaultPRNG* generator_;
+  static spanner::Database* db_;
+  static bool emulator_;
+};
+
+/**
+ * Same as `DatabaseIntegrationTest`, but creates the database using
+ * `DatabaseDialect::POSTGRESQL`, and with PostgreSQL-specific column
+ * types.
+ */
+class PgDatabaseIntegrationTest : public testing_util::IntegrationTest {
+ protected:
+  static void SetUpTestSuite();
+  static void TearDownTestSuite();
+
+  static spanner::Database const& GetDatabase() { return *db_; }
+  static bool UsingEmulator() { return emulator_; }
+
+ private:
+  static internal::DefaultPRNG* generator_;
+  static spanner::Database* db_;
+  static bool emulator_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
Add a `PgDatabaseIntegrationTest` test fixture that creates the
database using `DatabaseDialect::POSTGRESQL` and with PostgreSQL-
specific column types.  This enables the testing of types with
PG type annotation codes, like `spanner::PgNumeric`, from
`spanner/integration_tests:data_types_integration_test`.  Then,
add "WriteRead" and "WriteReadArray" tests for `PgNumeric` that
were previously missing.

Also move some (negative) checks for JSON index/key and PG NUMERIC
key support to the data-types integration test.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9769)
<!-- Reviewable:end -->
