### PR TITLE
impl(GCS+gRPC): support `UploadContentLength` option

### DIFF
--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -670,6 +670,10 @@ GrpcObjectRequestParser::ToProto(ResumableUploadRequest const& request) {
   SetPredefinedAcl(object_spec, request);
   SetGenerationConditions(object_spec, request);
   SetMetagenerationConditions(object_spec, request);
+  if (request.HasOption<UploadContentLength>()) {
+    object_spec.set_object_size(static_cast<std::int64_t>(
+        request.GetOption<UploadContentLength>().value()));
+  }
 
   resource.set_bucket("projects/_/buckets/" + request.bucket_name());
   resource.set_name(request.object_name());

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -1019,6 +1019,25 @@ TEST(GrpcObjectRequestParser, ResumableUploadRequestWithObjectMetadataFields) {
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
+TEST(GrpcObjectRequestParser, ResumableUploadRequestWithContentLength) {
+  google::storage::v2::StartResumableWriteRequest expected;
+  EXPECT_TRUE(TextFormat::ParseFromString(R"""(
+      write_object_spec: {
+          resource: {
+            name: "test-object"
+            bucket: "projects/_/buckets/test-bucket"
+          }
+          object_size: 123456
+      })""",
+                                          &expected));
+
+  ResumableUploadRequest req("test-bucket", "test-object");
+  req.set_multiple_options(UploadContentLength(123456));
+
+  auto actual = GrpcObjectRequestParser::ToProto(req).value();
+  EXPECT_THAT(actual, IsProtoEqual(expected));
+}
+
 TEST(GrpcObjectRequestParser, QueryResumableUploadRequestSimple) {
   google::storage::v2::QueryWriteStatusRequest expected;
   EXPECT_TRUE(TextFormat::ParseFromString(


### PR DESCRIPTION
Applications can use `UploadContentLength` to set the full object size for both gRPC-based uploads.  The same option has the same effect with REST.

Fixes #5032

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9778)
<!-- Reviewable:end -->
