### PR TITLE
cleanup: update the quickstarts for location-dependent services

### DIFF
--- a/google/cloud/dialogflow_cx/README.md
+++ b/google/cloud/dialogflow_cx/README.md
@@ -34,7 +34,6 @@ this library.
 
 ```cc
 #include "google/cloud/dialogflow_cx/agents_client.h"
-#include "google/cloud/common_options.h"
 #include <iostream>
 #include <stdexcept>
 
@@ -43,18 +42,12 @@ int main(int argc, char* argv[]) try {
     std::cerr << "Usage: " << argv[0] << " project-id region-id\n";
     return 1;
   }
-
   auto const project = std::string{argv[1]};
   auto const region = std::string{argv[2]};
-  namespace dialogflow_cx = ::google::cloud::dialogflow_cx;
-  namespace gc = ::google::cloud;
 
-  // For regional resources Dialogflow requires overriding the Authority option.
-  // TODO(#9626): Use the location-aware MakeAgentsConnection() instead.
-  auto options = gc::Options{}.set<gc::AuthorityOption>(
-      region + "-dialogflow.googleapis.com");
-  auto client = dialogflow_cx::AgentsClient(
-      dialogflow_cx::MakeAgentsConnection(std::move(options)));
+  namespace dialogflow_cx = ::google::cloud::dialogflow_cx;
+  auto client =
+      dialogflow_cx::AgentsClient(dialogflow_cx::MakeAgentsConnection(region));
 
   auto const location = "projects/" + project + "/locations/" + region;
   for (auto a : client.ListAgents(location)) {

--- a/google/cloud/dialogflow_cx/quickstart/quickstart.cc
+++ b/google/cloud/dialogflow_cx/quickstart/quickstart.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/dialogflow_cx/agents_client.h"
-#include "google/cloud/common_options.h"
 #include <iostream>
 #include <stdexcept>
 
@@ -22,18 +21,12 @@ int main(int argc, char* argv[]) try {
     std::cerr << "Usage: " << argv[0] << " project-id region-id\n";
     return 1;
   }
-
   auto const project = std::string{argv[1]};
   auto const region = std::string{argv[2]};
-  namespace dialogflow_cx = ::google::cloud::dialogflow_cx;
-  namespace gc = ::google::cloud;
 
-  // For regional resources Dialogflow requires overriding the Authority option.
-  // TODO(#9626): Use the location-aware MakeAgentsConnection() instead.
-  auto options = gc::Options{}.set<gc::AuthorityOption>(
-      region + "-dialogflow.googleapis.com");
-  auto client = dialogflow_cx::AgentsClient(
-      dialogflow_cx::MakeAgentsConnection(std::move(options)));
+  namespace dialogflow_cx = ::google::cloud::dialogflow_cx;
+  auto client =
+      dialogflow_cx::AgentsClient(dialogflow_cx::MakeAgentsConnection(region));
 
   auto const location = "projects/" + project + "/locations/" + region;
   for (auto a : client.ListAgents(location)) {

--- a/google/cloud/dialogflow_es/README.md
+++ b/google/cloud/dialogflow_es/README.md
@@ -46,14 +46,13 @@ int main(int argc, char* argv[]) try {
   }
 
   namespace dialogflow_es = ::google::cloud::dialogflow_es;
-  // TODO(#9626): Use the location-aware MakeAgentsConnection() instead?
   auto client =
       dialogflow_es::AgentsClient(dialogflow_es::MakeAgentsConnection());
 
   auto const project = google::cloud::Project(argv[1]);
-  for (auto r : client.SearchAgents(project.FullName())) {
-    if (!r) throw std::runtime_error(r.status().message());
-    std::cout << r->DebugString() << "\n";
+  for (auto a : client.SearchAgents(project.FullName())) {
+    if (!a) throw std::runtime_error(a.status().message());
+    std::cout << a->DebugString() << "\n";
   }
 
   return 0;

--- a/google/cloud/dialogflow_es/quickstart/quickstart.cc
+++ b/google/cloud/dialogflow_es/quickstart/quickstart.cc
@@ -24,14 +24,13 @@ int main(int argc, char* argv[]) try {
   }
 
   namespace dialogflow_es = ::google::cloud::dialogflow_es;
-  // TODO(#9626): Use the location-aware MakeAgentsConnection() instead?
   auto client =
       dialogflow_es::AgentsClient(dialogflow_es::MakeAgentsConnection());
 
   auto const project = google::cloud::Project(argv[1]);
-  for (auto r : client.SearchAgents(project.FullName())) {
-    if (!r) throw std::runtime_error(r.status().message());
-    std::cout << r->DebugString() << "\n";
+  for (auto a : client.SearchAgents(project.FullName())) {
+    if (!a) throw std::runtime_error(a.status().message());
+    std::cout << a->DebugString() << "\n";
   }
 
   return 0;

--- a/google/cloud/documentai/README.md
+++ b/google/cloud/documentai/README.md
@@ -34,7 +34,6 @@ this library.
 
 ```cc
 #include "google/cloud/documentai/document_processor_client.h"
-#include "google/cloud/common_options.h"
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
@@ -51,18 +50,12 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  namespace gc = ::google::cloud;
   namespace documentai = ::google::cloud::documentai;
-  // The Document AI service requires using an endpoint matching
-  // the processor's location.  TODO(#9626): Use the location-aware
-  // MakeDocumentProcessorServiceConnection() instead.
-  auto options = gc::Options{}.set<gc::EndpointOption>(
-      location + "-documentai.googleapis.com");
   auto client = documentai::DocumentProcessorServiceClient(
-      documentai::MakeDocumentProcessorServiceConnection(options));
+      documentai::MakeDocumentProcessorServiceConnection(location));
 
   auto const resource = std::string{"projects/"} + argv[1] + "/locations/" +
-                        argv[2] + "/processors/" + argv[3];
+                        location + "/processors/" + argv[3];
 
   google::cloud::documentai::v1::ProcessRequest req;
   req.set_name(resource);

--- a/google/cloud/documentai/quickstart/quickstart.cc
+++ b/google/cloud/documentai/quickstart/quickstart.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "google/cloud/documentai/document_processor_client.h"
-#include "google/cloud/common_options.h"
 #include <fstream>
 #include <iostream>
 #include <stdexcept>
@@ -30,18 +29,12 @@ int main(int argc, char* argv[]) try {
     return 1;
   }
 
-  namespace gc = ::google::cloud;
   namespace documentai = ::google::cloud::documentai;
-  // The Document AI service requires using an endpoint matching
-  // the processor's location.  TODO(#9626): Use the location-aware
-  // MakeDocumentProcessorServiceConnection() instead.
-  auto options = gc::Options{}.set<gc::EndpointOption>(
-      location + "-documentai.googleapis.com");
   auto client = documentai::DocumentProcessorServiceClient(
-      documentai::MakeDocumentProcessorServiceConnection(options));
+      documentai::MakeDocumentProcessorServiceConnection(location));
 
   auto const resource = std::string{"projects/"} + argv[1] + "/locations/" +
-                        argv[2] + "/processors/" + argv[3];
+                        location + "/processors/" + argv[3];
 
   google::cloud::documentai::v1::ProcessRequest req;
   req.set_name(resource);


### PR DESCRIPTION
Make use of new generator support for services with location-dependent default endpoints (see #9625).

Fixes #9626.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9780)
<!-- Reviewable:end -->
