### PR TITLE
fix(GCS+gRPC): use full projection in `GrpcClient::*Acl()`

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -737,6 +737,7 @@ StatusOr<ListBucketAclResponse> GrpcClient::ListBucketAcl(
     ListBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto get = GetBucketMetadata(get_request);
   if (!get) return std::move(get).status();
   ListBucketAclResponse response;
@@ -748,6 +749,7 @@ StatusOr<BucketAccessControl> GrpcClient::GetBucketAcl(
     GetBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto get = GetBucketMetadata(get_request);
   return FindBucketAccessControl(std::move(get), request.entity());
 }
@@ -756,6 +758,7 @@ StatusOr<BucketAccessControl> GrpcClient::CreateBucketAcl(
     CreateBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<BucketAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(), request.role());
   };
@@ -767,6 +770,7 @@ StatusOr<EmptyResponse> GrpcClient::DeleteBucketAcl(
     DeleteBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<BucketAccessControl> acl)
       -> StatusOr<std::vector<BucketAccessControl>> {
     auto i = std::remove_if(acl.begin(), acl.end(),
@@ -791,6 +795,7 @@ StatusOr<BucketAccessControl> GrpcClient::UpdateBucketAcl(
     UpdateBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<BucketAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(), request.role());
   };
@@ -802,6 +807,7 @@ StatusOr<BucketAccessControl> GrpcClient::PatchBucketAcl(
     PatchBucketAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<BucketAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(),
                      GrpcBucketAccessControlParser::Role(request.patch()));
@@ -815,6 +821,7 @@ StatusOr<ListObjectAclResponse> GrpcClient::ListObjectAcl(
   auto get_request =
       GetObjectMetadataRequest(request.bucket_name(), request.object_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto get = GetObjectMetadata(get_request);
   if (!get) return std::move(get).status();
   ListObjectAclResponse response;
@@ -827,6 +834,7 @@ StatusOr<ObjectAccessControl> GrpcClient::CreateObjectAcl(
   auto get_request =
       GetObjectMetadataRequest(request.bucket_name(), request.object_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(), request.role());
   };
@@ -839,6 +847,7 @@ StatusOr<EmptyResponse> GrpcClient::DeleteObjectAcl(
   auto get_request =
       GetObjectMetadataRequest(request.bucket_name(), request.object_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl)
       -> StatusOr<std::vector<ObjectAccessControl>> {
     auto i = std::remove_if(acl.begin(), acl.end(),
@@ -864,6 +873,7 @@ StatusOr<ObjectAccessControl> GrpcClient::GetObjectAcl(
   auto get_request =
       GetObjectMetadataRequest(request.bucket_name(), request.object_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto get = GetObjectMetadata(get_request);
   return FindObjectAccessControl(std::move(get), request.entity());
 }
@@ -873,6 +883,7 @@ StatusOr<ObjectAccessControl> GrpcClient::UpdateObjectAcl(
   auto get_request =
       GetObjectMetadataRequest(request.bucket_name(), request.object_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(), request.role());
   };
@@ -885,6 +896,7 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchObjectAcl(
   auto get_request =
       GetObjectMetadataRequest(request.bucket_name(), request.object_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(),
                      GrpcObjectAccessControlParser::Role(request.patch()));
@@ -897,6 +909,7 @@ StatusOr<ListDefaultObjectAclResponse> GrpcClient::ListDefaultObjectAcl(
     ListDefaultObjectAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto get = GetBucketMetadata(get_request);
   if (!get) return std::move(get).status();
   ListDefaultObjectAclResponse response;
@@ -908,6 +921,7 @@ StatusOr<ObjectAccessControl> GrpcClient::CreateDefaultObjectAcl(
     CreateDefaultObjectAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(), request.role());
   };
@@ -919,6 +933,7 @@ StatusOr<EmptyResponse> GrpcClient::DeleteDefaultObjectAcl(
     DeleteDefaultObjectAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl)
       -> StatusOr<std::vector<ObjectAccessControl>> {
     auto i = std::remove_if(acl.begin(), acl.end(),
@@ -943,6 +958,7 @@ StatusOr<ObjectAccessControl> GrpcClient::GetDefaultObjectAcl(
     GetDefaultObjectAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto get = GetBucketMetadata(get_request);
   if (!get) return std::move(get).status();
   return FindDefaultObjectAccessControl(std::move(get), request.entity());
@@ -952,6 +968,7 @@ StatusOr<ObjectAccessControl> GrpcClient::UpdateDefaultObjectAcl(
     UpdateDefaultObjectAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(), request.role());
   };
@@ -963,6 +980,7 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchDefaultObjectAcl(
     PatchDefaultObjectAclRequest const& request) {
   auto get_request = GetBucketMetadataRequest(request.bucket_name());
   request.ForEachOption(CopyCommonOptions(get_request));
+  get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(),
                      GrpcObjectAccessControlParser::Role(request.patch()));

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -832,7 +832,9 @@ TEST_F(GrpcClientTest, ListBucketAclFailure) {
 TEST_F(GrpcClientTest, ListBucketAclSuccess) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -882,7 +884,9 @@ TEST_F(GrpcClientTest, GetBucketAclFailure) {
 TEST_F(GrpcClientTest, GetBucketAclNotFound) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -897,7 +901,9 @@ TEST_F(GrpcClientTest, GetBucketAclNotFound) {
 TEST_F(GrpcClientTest, GetBucketAclSuccess) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -937,7 +943,9 @@ TEST_F(GrpcClientTest, CreateBucketAclFailure) {
 TEST_F(GrpcClientTest, CreateBucketAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -985,7 +993,9 @@ TEST_F(GrpcClientTest, DeleteBucketAclFailure) {
 TEST_F(GrpcClientTest, DeleteBucketAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1012,7 +1022,9 @@ TEST_F(GrpcClientTest, DeleteBucketAclPatchFails) {
 TEST_F(GrpcClientTest, DeleteBucketAclNotFound) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1050,7 +1062,9 @@ TEST_F(GrpcClientTest, UpdateBucketAclFailure) {
 TEST_F(GrpcClientTest, UpdateBucketAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1100,7 +1114,9 @@ TEST_F(GrpcClientTest, PatchBucketAclFailure) {
 TEST_F(GrpcClientTest, PatchBucketAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1150,7 +1166,9 @@ TEST_F(GrpcClientTest, ListObjectAclFailure) {
 TEST_F(GrpcClientTest, ListObjectAclSuccess) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1206,7 +1224,9 @@ TEST_F(GrpcClientTest, GetObjectAclFailure) {
 TEST_F(GrpcClientTest, GetObjectAclNotFound) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1221,7 +1241,9 @@ TEST_F(GrpcClientTest, GetObjectAclNotFound) {
 TEST_F(GrpcClientTest, GetObjectAclSuccess) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1263,7 +1285,9 @@ TEST_F(GrpcClientTest, CreateObjectAclFailure) {
 TEST_F(GrpcClientTest, CreateObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1314,7 +1338,9 @@ TEST_F(GrpcClientTest, DeleteObjectAclFailure) {
 TEST_F(GrpcClientTest, DeleteObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1343,7 +1369,9 @@ TEST_F(GrpcClientTest, DeleteObjectAclPatchFails) {
 TEST_F(GrpcClientTest, DeleteObjectAclNotFound) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1383,7 +1411,9 @@ TEST_F(GrpcClientTest, UpdateObjectAclFailure) {
 TEST_F(GrpcClientTest, UpdateObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1436,7 +1466,9 @@ TEST_F(GrpcClientTest, PatchObjectAclFailure) {
 TEST_F(GrpcClientTest, PatchObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetObject)
-      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetObjectRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Object response;
         EXPECT_TRUE(TextFormat::ParseFromString(kObjectProtoText, &response));
         return response;
@@ -1487,7 +1519,9 @@ TEST_F(GrpcClientTest, ListDefaultObjectAclFailure) {
 TEST_F(GrpcClientTest, ListDefaultObjectAclSuccess) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1538,7 +1572,9 @@ TEST_F(GrpcClientTest, GetDefaultObjectAclFailure) {
 TEST_F(GrpcClientTest, GetDefaultObjectAclNotFound) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1553,7 +1589,9 @@ TEST_F(GrpcClientTest, GetDefaultObjectAclNotFound) {
 TEST_F(GrpcClientTest, GetDefaultObjectAclSuccess) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1594,7 +1632,9 @@ TEST_F(GrpcClientTest, CreateDefaultObjectAclFailure) {
 TEST_F(GrpcClientTest, CreateDefaultObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1644,7 +1684,9 @@ TEST_F(GrpcClientTest, DeleteDefaultObjectAclFailure) {
 TEST_F(GrpcClientTest, DeleteDefaultObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1672,7 +1714,9 @@ TEST_F(GrpcClientTest, DeleteDefaultObjectAclPatchFails) {
 TEST_F(GrpcClientTest, DeleteDefaultObjectAclNotFound) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1711,7 +1755,9 @@ TEST_F(GrpcClientTest, UpdateDefaultObjectAclFailure) {
 TEST_F(GrpcClientTest, UpdateDefaultObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;
@@ -1763,7 +1809,9 @@ TEST_F(GrpcClientTest, PatchDefaultObjectAclFailure) {
 TEST_F(GrpcClientTest, PatchDefaultObjectAclPatchFails) {
   auto mock = std::make_shared<testing::MockStorageStub>();
   EXPECT_CALL(*mock, GetBucket)
-      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const&) {
+      .WillOnce([&](grpc::ClientContext&, v2::GetBucketRequest const& request) {
+        EXPECT_TRUE(request.has_read_mask());
+        EXPECT_THAT(request.read_mask().paths(), ElementsAre("*"));
         v2::Bucket response;
         EXPECT_TRUE(TextFormat::ParseFromString(kBucketProtoText, &response));
         return response;


### PR DESCRIPTION
The implementation of `GrpcClient::*Acl` needs to perform `GetBucketMetadata()` or `GetObjectMetadata()` requests to access the ACLs.  These requests must use the "full" projection, as the service does not return the ACLs for the default projection.  I also need to fix the testbench to work as the service does.

Part of the work for #5673

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9786)
<!-- Reviewable:end -->
