### PR TITLE
impl(GCS+gRPC): handle bucket names in logging field

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -424,7 +424,7 @@ BucketLifecycle GrpcBucketMetadataParser::FromProto(
 google::storage::v2::Bucket::Logging GrpcBucketMetadataParser::ToProto(
     BucketLogging const& rhs) {
   google::storage::v2::Bucket::Logging result;
-  result.set_log_bucket(rhs.log_bucket);
+  result.set_log_bucket(GrpcBucketIdToName(rhs.log_bucket));
   result.set_log_object_prefix(rhs.log_object_prefix);
   return result;
 }
@@ -432,7 +432,7 @@ google::storage::v2::Bucket::Logging GrpcBucketMetadataParser::ToProto(
 BucketLogging GrpcBucketMetadataParser::FromProto(
     google::storage::v2::Bucket::Logging const& rhs) {
   BucketLogging result;
-  result.log_bucket = rhs.log_bucket();
+  result.log_bucket = GrpcBucketNameToId(rhs.log_bucket());
   result.log_object_prefix = rhs.log_object_prefix();
   return result;
 }

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
@@ -101,7 +101,7 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
     }
     versioning { enabled: true }
     logging {
-      log_bucket: "test-log-bucket"
+      log_bucket: "projects/_/buckets/test-log-bucket"
       log_object_prefix: "test-log-object-prefix"
     }
     owner { entity: "test-entity" entity_id: "test-entity-id" }
@@ -423,7 +423,7 @@ TEST(GrpcBucketMetadataParser, BucketLifecycleRoundtrip) {
 
 TEST(GrpcBucketMetadataParser, BucketLoggingRoundtrip) {
   auto constexpr kText = R"pb(
-    log_bucket: "test-bucket-name"
+    log_bucket: "projects/_/buckets/test-bucket-name"
     log_object_prefix: "test-object-prefix/"
   )pb";
   google::storage::v2::Bucket::Logging start;

--- a/google/cloud/storage/internal/grpc_bucket_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser.cc
@@ -146,7 +146,8 @@ Status PatchLogging(Bucket& b, nlohmann::json const& l) {
   if (l.is_null()) {
     b.clear_logging();
   } else {
-    b.mutable_logging()->set_log_bucket(l.value("logBucket", ""));
+    b.mutable_logging()->set_log_bucket(
+        GrpcBucketIdToName(l.value("logBucket", "")));
     b.mutable_logging()->set_log_object_prefix(l.value("logObjectPrefix", ""));
   }
   return Status{};

--- a/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_request_parser_test.cc
@@ -115,7 +115,7 @@ TEST(GrpcBucketRequestParser, CreateBucketMetadataAllOptions) {
           default_event_based_hold: true
           labels { key: "k0" value: "v0" }
           logging {
-            log_bucket: "test-log-bucket"
+            log_bucket: "projects/_/buckets/test-log-bucket"
             log_object_prefix: "test-log-object-prefix"
           }
           versioning { enabled: true }
@@ -417,7 +417,7 @@ TEST(GrpcBucketRequestParser, PatchBucketRequestAllOptions) {
           website { main_page_suffix: "index.html" not_found_page: "404.html" }
           versioning { enabled: true }
           logging {
-            log_bucket: "test-log-bucket"
+            log_bucket: "projects/_/buckets/test-log-bucket"
             log_object_prefix: "test-log-prefix"
           }
           encryption { default_kms_key: "test-only-kms-key" }


### PR DESCRIPTION
The format of the `google.storage.v2.Bucket.Logging.log_bucket` field was undefined until recently. The decision is to use "proto" format, this implements that decision.

Motivated by #5673

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9789)
<!-- Reviewable:end -->
