### PR TITLE
fix(GCS+gRPC): correctly parse Bucket `name` field

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -21,6 +21,7 @@
 #include "google/cloud/internal/time_utils.h"
 #include "absl/algorithm/container.h"
 #include "absl/strings/match.h"
+#include "absl/strings/strip.h"
 #include "absl/time/civil_time.h"
 #include <algorithm>
 #include <cctype>
@@ -51,7 +52,7 @@ google::storage::v2::Bucket GrpcBucketMetadataParser::ToProto(
   google::storage::v2::Bucket result;
   // These are in the order of the proto fields, to make it easier to find them
   // later.
-  result.set_name(GrpcBucketIdToName(rhs.id()));
+  result.set_name(GrpcBucketIdToName(rhs.name()));
   result.set_bucket_id(rhs.id());
   result.set_etag(rhs.etag());
   result.set_project("projects/" + std::to_string(rhs.project_number()));

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser_test.cc
@@ -35,7 +35,7 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
   // Keep the proto fields in the order they show up in the proto file. It is
   // easier to add new fields and to inspect the test for missing fields
   auto constexpr kText = R"pb(
-    name: "projects/_/buckets/test-bucket-id"
+    name: "projects/_/buckets/test-bucket-name"
     bucket_id: "test-bucket-id"
     project: "projects/123456"
     metageneration: 1234567
@@ -173,7 +173,7 @@ TEST(GrpcBucketMetadataParser, BucketAllFieldsRoundtrip) {
     "timeCreated": "2019-08-07T16:22:04.123456000Z",
     "id": "test-bucket-id",
     "kind": "storage#bucket",
-    "name": "test-bucket-id",
+    "name": "test-bucket-name",
     "projectNumber": 123456,
     "metageneration": "1234567",
     "cors": [{


### PR DESCRIPTION
I thought I was being clever by reusing the `id` field. That does not work if the `id` field is filtered out.

Motivated by #5673 