### PR TITLE
refactor(storage): examples bucket prefix defined in a function

### DIFF
--- a/google/cloud/storage/examples/storage_bucket_samples.cc
+++ b/google/cloud/storage/examples/storage_bucket_samples.cc
@@ -625,7 +625,7 @@ void RunAll(std::vector<std::string> const& argv) {
   auto const create_time_limit =
       std::chrono::system_clock::now() - std::chrono::hours(48);
   std::cout << "\nRemoving stale buckets for examples" << std::endl;
-  examples::RemoveStaleBuckets(client, "cloud-cpp-testing-examples",
+  examples::RemoveStaleBuckets(client, examples::BucketPrefix(),
                                create_time_limit);
 
   std::cout << "\nRunning ListBucketsForProject() example" << std::endl;

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -32,9 +32,11 @@ bool UsingEmulator() {
       .has_value();
 }
 
+std::string BucketPrefix() { return "cloud-cpp-testing-examples"; }
+
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
-  return google::cloud::storage::testing::MakeRandomBucketName(
-      gen, "cloud-cpp-testing-examples");
+  return google::cloud::storage::testing::MakeRandomBucketName(gen,
+                                                               BucketPrefix());
 }
 
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,

--- a/google/cloud/storage/examples/storage_examples_common.h
+++ b/google/cloud/storage/examples/storage_examples_common.h
@@ -37,6 +37,7 @@ using ::google::cloud::testing_util::Usage;
 
 bool UsingEmulator();
 
+std::string BucketPrefix();
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen);
 std::string MakeRandomObjectName(google::cloud::internal::DefaultPRNG& gen,
                                  std::string const& prefix);

--- a/google/cloud/storage/examples/storage_examples_common_test.cc
+++ b/google/cloud/storage/examples/storage_examples_common_test.cc
@@ -27,9 +27,9 @@ using ::testing::StartsWith;
 TEST(StorageExamplesCommon, RandomBucket) {
   auto generator = google::cloud::internal::DefaultPRNG(std::random_device{}());
   auto const actual_1 = MakeRandomBucketName(generator);
-  EXPECT_THAT(actual_1, StartsWith("cloud-cpp-testing-examples"));
+  EXPECT_THAT(actual_1, StartsWith(BucketPrefix()));
   auto const actual_2 = MakeRandomBucketName(generator);
-  EXPECT_THAT(actual_2, StartsWith("cloud-cpp-testing-examples"));
+  EXPECT_THAT(actual_2, StartsWith(BucketPrefix()));
   EXPECT_NE(actual_1, actual_2);
 }
 


### PR DESCRIPTION
Motivated by #5673

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9797)
<!-- Reviewable:end -->
