### PR TITLE
fix(common): better defaults for curl initialization

### DIFF
--- a/google/cloud/internal/curl_wrappers.cc
+++ b/google/cloud/internal/curl_wrappers.cc
@@ -307,7 +307,10 @@ void CurlInitializeOnce(Options const& options) {
     //
     //     https://curl.haxx.se/libcurl/c/threadsafe.html
     //
-    InitializeSslLocking(options.get<EnableCurlSslLockingOption>());
+    auto const locking = options.has<EnableCurlSslLockingOption>()
+                             ? options.get<EnableCurlSslLockingOption>()
+                             : true;
+    InitializeSslLocking(locking);
 
     // libcurl recommends turning on `CURLOPT_NOSIGNAL` for threaded
     // applications: "Note that setting `CURLOPT_NOSIGNAL` to 0L will not work
@@ -322,7 +325,11 @@ void CurlInitializeOnce(Options const& options) {
     //
     //     https://curl.haxx.se/libcurl/c/threadsafe.html
     //
-    InitializeSigPipeHandler(options.get<EnableCurlSigpipeHandlerOption>());
+    auto const enable_handler =
+        options.has<EnableCurlSigpipeHandlerOption>()
+            ? options.get<EnableCurlSigpipeHandlerOption>()
+            : true;
+    InitializeSigPipeHandler(enable_handler);
     return true;
   }();
   static_cast<void>(kInitialized);

--- a/google/cloud/internal/curl_wrappers.h
+++ b/google/cloud/internal/curl_wrappers.h
@@ -61,6 +61,9 @@ using CurlShare = std::unique_ptr<CURLSH, decltype(&curl_share_cleanup)>;
 /// Returns true if the SSL locking callbacks are installed.
 bool SslLockingCallbacksInstalled();
 
+/// Return the default global options
+Options CurlInitializeOptions(Options options);
+
 /// Initializes (if needed) the SSL locking callbacks.
 void CurlInitializeOnce(Options const& options);
 

--- a/google/cloud/internal/curl_wrappers_test.cc
+++ b/google/cloud/internal/curl_wrappers_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "google/cloud/internal/curl_wrappers.h"
+#include "google/cloud/internal/curl_options.h"
 #include <gmock/gmock.h>
 
 namespace google {
@@ -126,6 +127,22 @@ header2: value2
     EXPECT_EQ(test.expected,
               DebugSendHeader(test.input.data(), test.input.size()));
   }
+}
+
+TEST(CurlWrappers, CurlInitializeOptions) {
+  auto defaults = CurlInitializeOptions({});
+  EXPECT_TRUE(defaults.get<EnableCurlSslLockingOption>());
+  EXPECT_TRUE(defaults.get<EnableCurlSigpipeHandlerOption>());
+
+  auto override1 =
+      CurlInitializeOptions(Options{}.set<EnableCurlSslLockingOption>(false));
+  EXPECT_FALSE(override1.get<EnableCurlSslLockingOption>());
+  EXPECT_TRUE(override1.get<EnableCurlSigpipeHandlerOption>());
+
+  auto override2 = CurlInitializeOptions(
+      Options{}.set<EnableCurlSigpipeHandlerOption>(false));
+  EXPECT_TRUE(override2.get<EnableCurlSslLockingOption>());
+  EXPECT_FALSE(override2.get<EnableCurlSigpipeHandlerOption>());
 }
 
 }  // namespace


### PR DESCRIPTION
By default, initialize libcurl with locking and signal handlers that work for most applications. In particular, leaving the default handler for `SIGPIPE` usually results in the application crashes when a socket is closed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9798)
<!-- Reviewable:end -->
