### PR TITLE
cleanup(GCS+gRPC): simplify workarounds for production

### DIFF
--- a/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
@@ -38,9 +38,8 @@ class GrpcHmacKeyMetadataIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(GrpcHmacKeyMetadataIntegrationTest, HmacKeyCRUD) {
-  // TODO(#5673) - restore gRPC integration tests against production, even then
-  //     generally we do not create HMAC keys in production because they are
-  //     an extremely limited resource.
+  // We do not run the REST or gRPC integration tests in production because
+  // quota is extremely restricted for this type of resource.
   if (!UsingEmulator()) GTEST_SKIP();
 
   auto const project_name = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");

--- a/google/cloud/storage/tests/grpc_notification_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_notification_integration_test.cc
@@ -41,6 +41,8 @@ class GrpcNotificationIntegrationTest
     : public google::cloud::storage::testing::StorageIntegrationTest {};
 
 TEST_F(GrpcNotificationIntegrationTest, NotificationCRUD) {
+  // TODO(#5673) - enable in production
+  if (!UsingEmulator()) GTEST_SKIP();
   auto const project_id = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
   ASSERT_THAT(project_id, Not(IsEmpty())) << "GOOGLE_CLOUD_PROJECT is not set";
   auto const topic_name = google::cloud::internal::GetEnv(

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -64,13 +64,10 @@ TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
   ASSERT_STATUS_OK(insert);
   ScheduleForDelete(*insert);
 
-  auto get = client->GetObjectMetadata(bucket_name, object_name);
+  auto get =
+      client->GetObjectMetadata(bucket_name, object_name, Projection::Full());
   ASSERT_STATUS_OK(get);
-  auto sans_acls = [](ObjectMetadata meta) {
-    meta.set_acl({});
-    return meta;
-  };
-  EXPECT_EQ(sans_acls(*insert), sans_acls(*get));
+  EXPECT_EQ(*insert, *get);
 
   std::vector<std::string> names;
   for (auto const& object : client->ListObjects(bucket_name)) {

--- a/google/cloud/storage/tests/object_integration_test.cc
+++ b/google/cloud/storage/tests/object_integration_test.cc
@@ -511,6 +511,9 @@ TEST_F(ObjectIntegrationTest, XmlReadWrite) {
 }
 
 TEST_F(ObjectIntegrationTest, AccessControlCRUD) {
+  // TODO(#5673) - enable in production.
+  if (UsingGrpc() && !UsingEmulator()) GTEST_SKIP();
+
   StatusOr<Client> client = MakeIntegrationTestClient();
   ASSERT_STATUS_OK(client);
 

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -272,15 +272,12 @@ TEST_F(ObjectResumableWriteIntegrationTest, WriteResumeFinalizedUpload) {
   EXPECT_EQ(session_id, os.resumable_session_id());
   ASSERT_STATUS_OK(os.metadata());
   ScheduleForDelete(*os.metadata());
-  // TODO(b/146890058) - gRPC does not return the object metadata.
-  if (!UsingGrpc()) {
-    ObjectMetadata meta = os.metadata().value();
-    EXPECT_EQ(object_name, meta.name());
-    EXPECT_EQ(bucket_name_, meta.bucket());
-    if (UsingEmulator()) {
-      EXPECT_TRUE(meta.has_metadata("x_emulator_upload"));
-      EXPECT_EQ("resumable", meta.metadata("x_emulator_upload"));
-    }
+  ObjectMetadata meta = os.metadata().value();
+  EXPECT_EQ(object_name, meta.name());
+  EXPECT_EQ(bucket_name_, meta.bucket());
+  if (UsingEmulator()) {
+    EXPECT_TRUE(meta.has_metadata("x_emulator_upload"));
+    EXPECT_EQ("resumable", meta.metadata("x_emulator_upload"));
   }
 }
 


### PR DESCRIPTION
When possible, remove or at least simplify the workarounds for production.  In some cases the test needs to be disabled.

Part of the work for #5673

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9799)
<!-- Reviewable:end -->
