### PR TITLE
test(storage): fix handling of optional ranges

### DIFF
--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -57,11 +57,11 @@ struct ThroughputOptions {
   std::vector<bool> enabled_crc32c = {false, true};
   std::vector<bool> enabled_md5 = {false, true};
   std::chrono::milliseconds minimum_sample_delay{};
-  std::int64_t minimum_read_offset = 0;
-  std::int64_t maximum_read_offset = 0;
+  absl::optional<std::int64_t> minimum_read_offset;
+  absl::optional<std::int64_t> maximum_read_offset;
   std::int64_t read_offset_quantum = 128 * kKiB;
-  std::int64_t minimum_read_size = 0;
-  std::int64_t maximum_read_size = 0;
+  absl::optional<std::int64_t> minimum_read_size;
+  absl::optional<std::int64_t> maximum_read_size;
   std::int64_t read_size_quantum = 128 * kKiB;
   Options client_options;
   Options rest_options;

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -326,6 +326,16 @@ TEST(ThroughputOptions, Validate) {
       "--maximum-read-offset=8",
       "--read-offset-quantum=5",
   }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-read-offset=4",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--maximum-read-offset=4",
+  }));
 
   EXPECT_FALSE(ParseThroughputOptions({
       "self-test",
@@ -340,6 +350,17 @@ TEST(ThroughputOptions, Validate) {
       "--maximum-read-size=8",
       "--read-size-quantum=5",
   }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--minimum-read-size=8",
+  }));
+  EXPECT_FALSE(ParseThroughputOptions({
+      "self-test",
+      "--region=r",
+      "--maximum-read-size=8",
+  }));
+
   EXPECT_FALSE(ParseThroughputOptions({
       "self-test",
       "--region=r",


### PR DESCRIPTION
I confused myself on how to interpret the default read and offset ranges. The intent was to *not* set a `ReadRange()` option if the command line arguments were not set. The effect was to set an empty `ReadRange()` value, which produced an unexpected `Range:` header. Fortunately, the value of the header had no effect, but really confused me.

With this change the optional parameters are represented by `absl::optional` values. Which makes it easier to treat them correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9808)
<!-- Reviewable:end -->
