### PR TITLE
ci: enable (most) GCS+gRPC integration tests

### DIFF
--- a/ci/cloudbuild/builds/gcs-grpc.sh
+++ b/ci/cloudbuild/builds/gcs-grpc.sh
@@ -30,9 +30,7 @@ excluded_rules=(
 )
 
 mapfile -t args < <(bazel::common_args)
-# Run as many of the integration tests as possible using production and gRPC:
-# "media" says to use the hybrid gRPC/REST client. For more details see
-# https://github.com/googleapis/google-cloud-cpp/issues/6268
-readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=media
+# Run as many of the integration tests as possible using production and gRPC.
+readonly GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG=metadata
 mapfile -t integration_args < <(integration::bazel_args)
 bazel test "${args[@]}" "${integration_args[@]}" -- //google/cloud/storage/... "${excluded_rules[@]}"

--- a/ci/etc/integration-tests-config.ps1
+++ b/ci/etc/integration-tests-config.ps1
@@ -44,8 +44,8 @@ $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_SERVICE_ACCOUNT="bigtable-test-iam-sa@${env:
 $env:GOOGLE_CLOUD_CPP_BIGTABLE_TEST_QUICKSTART_TABLE="quickstart"
 
 # Cloud Storage configuration parameters
-$env:GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="cloud-cpp-testing-bucket"
-$env:GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME="cloud-cpp-testing-regional"
+$env:GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="gcs-grpc-team-cloud-cpp-testing-bucket"
+$env:GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME="gcs-grpc-team-cloud-cpp-testing-regional"
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID="us-central1"
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_LOCATION="${env:GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID}"
 $env:GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT="storage-test-iam-sa@${env:GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"

--- a/ci/etc/integration-tests-config.sh
+++ b/ci/etc/integration-tests-config.sh
@@ -53,12 +53,12 @@ export GOOGLE_CLOUD_CPP_BIGTABLE_TEST_QUICKSTART_TABLE="quickstart"
 
 # Cloud Storage configuration parameters
 # An existing bucket, used in small tests that do not change the bucket metadata.
-export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="cloud-cpp-testing-bucket"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_BUCKET_NAME="gcs-grpc-team-cloud-cpp-testing-bucket"
 # A bucket with a different location and/or storage class from
 # `cloud-cpp-testing-bucket`, some requests (object copy and rewrite) succeed
 # immediately with buckets in the same location, and we want to demonstrate we
 # can handle partial success.
-export GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME="cloud-cpp-testing-regional"
+export GOOGLE_CLOUD_CPP_STORAGE_TEST_DESTINATION_BUCKET_NAME="gcs-grpc-team-cloud-cpp-testing-regional"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID="us-central1"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_LOCATION="${GOOGLE_CLOUD_CPP_STORAGE_TEST_REGION_ID}"
 export GOOGLE_CLOUD_CPP_STORAGE_TEST_SERVICE_ACCOUNT="storage-test-iam-sa@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com"

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -153,7 +153,9 @@ std::string ToString(ExperimentTransport v) {
   return "";
 }
 
-std::string RandomBucketPrefix() { return "cloud-cpp-testing-bm"; }
+std::string RandomBucketPrefix() {
+  return "gcs-grpc-team-cloud-cpp-testing-bm";
+}
 
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
   return storage::testing::MakeRandomBucketName(gen, RandomBucketPrefix());

--- a/google/cloud/storage/benchmarks/throughput_options.h
+++ b/google/cloud/storage/benchmarks/throughput_options.h
@@ -29,7 +29,7 @@ struct ThroughputOptions {
   std::string project_id;
   std::string labels;
   std::string region;
-  std::string bucket_prefix = "cloud-cpp-testing-bm";
+  std::string bucket_prefix = "gcs-grpc-team-cloud-cpp-testing-bm";
   std::chrono::seconds duration =
       std::chrono::seconds(std::chrono::minutes(15));
   int thread_count = 1;

--- a/google/cloud/storage/examples/storage_examples_common.cc
+++ b/google/cloud/storage/examples/storage_examples_common.cc
@@ -32,7 +32,9 @@ bool UsingEmulator() {
       .has_value();
 }
 
-std::string BucketPrefix() { return "cloud-cpp-testing-examples"; }
+std::string BucketPrefix() {
+  return "gcs-grpc-team-cloud-cpp-testing-examples";
+}
 
 std::string MakeRandomBucketName(google::cloud::internal::DefaultPRNG& gen) {
   return google::cloud::storage::testing::MakeRandomBucketName(gen,

--- a/google/cloud/storage/testing/storage_integration_test.cc
+++ b/google/cloud/storage/testing/storage_integration_test.cc
@@ -146,7 +146,7 @@ std::unique_ptr<RetryPolicy> StorageIntegrationTest::TestRetryPolicy() {
 }
 
 std::string StorageIntegrationTest::RandomBucketNamePrefix() {
-  return "cloud-cpp-testing";
+  return "gcs-grpc-team-cloud-cpp-testing";
 }
 
 std::string StorageIntegrationTest::MakeRandomBucketName() {

--- a/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
@@ -48,8 +48,6 @@ class GrpcBucketMetadataIntegrationTest
 TEST_F(GrpcBucketMetadataIntegrationTest, ObjectMetadataCRUD) {
   ScopedEnvironment grpc_config("GOOGLE_CLOUD_CPP_STORAGE_GRPC_CONFIG",
                                 "metadata");
-  // TODO(#5673) - restore gRPC integration tests against production
-  if (!UsingEmulator()) GTEST_SKIP();
 
   auto const project_name = GetEnv("GOOGLE_CLOUD_PROJECT").value_or("");
   ASSERT_THAT(project_name, Not(IsEmpty()))


### PR DESCRIPTION
There are several tests still disabled, but we have specific bugs to track them. Most of them are just waiting for changes to roll out in production.

Fixes #5673.  Or at least, the remaining work is all tracked my smaller bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9809)
<!-- Reviewable:end -->
