### PR TITLE
feat(storage): release `*StallMinimumThroughputOption`

### DIFF
--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options.cc
@@ -144,7 +144,7 @@ ParseAggregateDownloadThroughputOptions(std::vector<std::string> const& argv,
        " is aborted if the average transfer rate is below this limit for"
        " the period set via `storage::DownloadStallTimeoutOption`.",
        [&options](std::string const& val) {
-         options.client_options.set<gcs_ex::DownloadStallMinimumRateOption>(
+         options.client_options.set<gcs::DownloadStallMinimumRateOption>(
              static_cast<std::uint32_t>(ParseBufferSize(val)));
        }},
       {"--grpc-background-threads",

--- a/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_download_throughput_options_test.cc
@@ -70,9 +70,8 @@ TEST(AggregateDownloadThroughputOptions, Basic) {
             options->client_options.get<EndpointOption>());
   EXPECT_EQ(std::chrono::seconds(10),
             options->client_options.get<gcs::DownloadStallTimeoutOption>());
-  EXPECT_EQ(
-      100 * kKiB,
-      options->client_options.get<gcs_ex::DownloadStallMinimumRateOption>());
+  EXPECT_EQ(100 * kKiB,
+            options->client_options.get<gcs::DownloadStallMinimumRateOption>());
   EXPECT_EQ(4,
             options->client_options.get<GrpcBackgroundThreadPoolSizeOption>());
   EXPECT_EQ(123, options->client_options.get<gcs::ConnectionPoolSizeOption>());

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options.cc
@@ -157,7 +157,7 @@ ParseAggregateUploadThroughputOptions(std::vector<std::string> const& argv,
        " is aborted if the average transfer rate is below this limit for"
        " the period set via `storage::TransferStallTimeoutOption`.",
        [&options](std::string const& val) {
-         options.client_options.set<gcs_ex::TransferStallMinimumRateOption>(
+         options.client_options.set<gcs::TransferStallMinimumRateOption>(
              static_cast<std::uint32_t>(ParseBufferSize(val)));
        }},
       {"--grpc-background-threads",

--- a/google/cloud/storage/benchmarks/aggregate_upload_throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/aggregate_upload_throughput_options_test.cc
@@ -72,9 +72,8 @@ TEST(AggregateUploadThroughputOptions, Basic) {
             options->client_options.get<EndpointOption>());
   EXPECT_EQ(std::chrono::seconds(10),
             options->client_options.get<gcs::TransferStallTimeoutOption>());
-  EXPECT_EQ(
-      100 * kKiB,
-      options->client_options.get<gcs_ex::TransferStallMinimumRateOption>());
+  EXPECT_EQ(100 * kKiB,
+            options->client_options.get<gcs::TransferStallMinimumRateOption>());
   EXPECT_EQ(4,
             options->client_options.get<GrpcBackgroundThreadPoolSizeOption>());
   EXPECT_EQ(123, options->client_options.get<gcs::ConnectionPoolSizeOption>());

--- a/google/cloud/storage/benchmarks/benchmark_utils.cc
+++ b/google/cloud/storage/benchmarks/benchmark_utils.cc
@@ -34,7 +34,6 @@ namespace cloud {
 namespace storage_benchmarks {
 
 namespace gcs = ::google::cloud::storage;
-namespace gcs_ex = ::google::cloud::storage_experimental;
 
 void DeleteAllObjects(google::cloud::storage::Client client,
                       std::string const& bucket_name, int thread_count) {
@@ -197,20 +196,20 @@ void PrintOptions(std::ostream& os, std::string const& prefix,
        << absl::FormatDuration(
               absl::FromChrono(options.get<gcs::TransferStallTimeoutOption>()));
   }
-  if (options.has<gcs_ex::TransferStallMinimumRateOption>()) {
+  if (options.has<gcs::TransferStallMinimumRateOption>()) {
     os << "\n# " << prefix << " Transfer Stall Minimum Rate: "
        << testing_util::FormatSize(
-              options.get<gcs_ex::TransferStallMinimumRateOption>());
+              options.get<gcs::TransferStallMinimumRateOption>());
   }
   if (options.has<gcs::DownloadStallTimeoutOption>()) {
     os << "\n# " << prefix << " Download Stall Timeout: "
        << absl::FormatDuration(
               absl::FromChrono(options.get<gcs::DownloadStallTimeoutOption>()));
   }
-  if (options.has<gcs_ex::DownloadStallMinimumRateOption>()) {
+  if (options.has<gcs::DownloadStallMinimumRateOption>()) {
     os << "\n# " << prefix << " Download Stall Minimum Rate: "
        << testing_util::FormatSize(
-              options.get<gcs_ex::DownloadStallMinimumRateOption>());
+              options.get<gcs::DownloadStallMinimumRateOption>());
   }
 
   if (options.has<google::cloud::storage::internal::TargetApiVersionOption>()) {

--- a/google/cloud/storage/benchmarks/throughput_options.cc
+++ b/google/cloud/storage/benchmarks/throughput_options.cc
@@ -25,7 +25,6 @@ namespace storage_benchmarks {
 namespace {
 
 namespace gcs = ::google::cloud::storage;
-namespace gcs_ex = ::google::cloud::storage_experimental;
 
 Status ValidateQuantizedRange(std::string const& name,
                               absl::optional<std::int64_t> minimum,
@@ -368,7 +367,7 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        " is aborted if the average transfer rate is below this limit for"
        " the period set via `storage::TransferStallTimeoutOption`.",
        [&options](std::string const& val) {
-         options.client_options.set<gcs_ex::TransferStallMinimumRateOption>(
+         options.client_options.set<gcs::TransferStallMinimumRateOption>(
              static_cast<std::uint32_t>(ParseBufferSize(val)));
        }},
       {"--download-stall-timeout",
@@ -385,7 +384,7 @@ google::cloud::StatusOr<ThroughputOptions> ParseThroughputOptions(
        " is aborted if the average transfer rate is below this limit for"
        " the period set via `storage::DownloadStallTimeoutOption`.",
        [&options](std::string const& val) {
-         options.client_options.set<gcs_ex::DownloadStallMinimumRateOption>(
+         options.client_options.set<gcs::DownloadStallMinimumRateOption>(
              static_cast<std::uint32_t>(ParseBufferSize(val)));
        }},
       {"--minimum-sample-delay",

--- a/google/cloud/storage/benchmarks/throughput_options_test.cc
+++ b/google/cloud/storage/benchmarks/throughput_options_test.cc
@@ -26,7 +26,6 @@ namespace storage_benchmarks {
 namespace {
 
 namespace gcs = ::google::cloud::storage;
-namespace gcs_ex = ::google::cloud::storage_experimental;
 using ::testing::ElementsAre;
 using ::testing::UnorderedElementsAre;
 
@@ -112,14 +111,12 @@ TEST(ThroughputOptions, Basic) {
             options->direct_path_options.get<EndpointOption>());
   EXPECT_EQ(std::chrono::seconds(86400),
             options->client_options.get<gcs::TransferStallTimeoutOption>());
-  EXPECT_EQ(
-      7 * kKiB,
-      options->client_options.get<gcs_ex::TransferStallMinimumRateOption>());
+  EXPECT_EQ(7 * kKiB,
+            options->client_options.get<gcs::TransferStallMinimumRateOption>());
   EXPECT_EQ(std::chrono::seconds(86401),
             options->client_options.get<gcs::DownloadStallTimeoutOption>());
-  EXPECT_EQ(
-      9 * kKiB,
-      options->client_options.get<gcs_ex::DownloadStallMinimumRateOption>());
+  EXPECT_EQ(9 * kKiB,
+            options->client_options.get<gcs::DownloadStallMinimumRateOption>());
   EXPECT_EQ("vN",
             options->rest_options.get<gcs::internal::TargetApiVersionOption>());
   EXPECT_EQ(16,

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -187,8 +187,8 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
           .set<MaximumCurlSocketSendSizeOption>(0)
           .set<TransferStallTimeoutOption>(std::chrono::seconds(
               GOOGLE_CLOUD_CPP_STORAGE_DEFAULT_DOWNLOAD_STALL_TIMEOUT))
-          .set<storage_experimental::TransferStallMinimumRateOption>(1)
-          .set<storage_experimental::DownloadStallMinimumRateOption>(1)
+          .set<TransferStallMinimumRateOption>(1)
+          .set<DownloadStallMinimumRateOption>(1)
           .set<RetryPolicyOption>(
               LimitedTimeRetryPolicy(
                   STORAGE_CLIENT_DEFAULT_MAXIMUM_RETRY_PERIOD)
@@ -246,11 +246,11 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
           .set<rest::DownloadStallTimeoutOption>(
               o.get<DownloadStallTimeoutOption>())
           .set<rest::DownloadStallMinimumRateOption>(
-              o.get<storage_experimental::DownloadStallMinimumRateOption>())
+              o.get<DownloadStallMinimumRateOption>())
           .set<rest::TransferStallTimeoutOption>(
               o.get<TransferStallTimeoutOption>())
           .set<rest::TransferStallMinimumRateOption>(
-              o.get<storage_experimental::TransferStallMinimumRateOption>())
+              o.get<TransferStallMinimumRateOption>())
           .set<rest::MaximumCurlSocketRecvSizeOption>(
               o.get<MaximumCurlSocketRecvSizeOption>())
           .set<rest::MaximumCurlSocketSendSizeOption>(

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -325,8 +325,7 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_EQ("test-project-id", opts.get<ProjectIdOption>());
   EXPECT_LT(0, opts.get<ConnectionPoolSizeOption>());
   EXPECT_LT(0, opts.get<DownloadBufferSizeOption>());
-  EXPECT_LT(0,
-            opts.get<storage_experimental::DownloadStallMinimumRateOption>());
+  EXPECT_LT(0, opts.get<DownloadStallMinimumRateOption>());
   EXPECT_LT(0, opts.get<UploadBufferSizeOption>());
   EXPECT_LT(0, opts.get<MaximumSimpleUploadSizeOption>());
   EXPECT_TRUE(opts.has<EnableCurlSslLockingOption>());
@@ -334,8 +333,7 @@ TEST_F(ClientOptionsTest, MakeOptionsFromDefault) {
   EXPECT_EQ(0, opts.get<MaximumCurlSocketSendSizeOption>());
   EXPECT_EQ(0, opts.get<MaximumCurlSocketRecvSizeOption>());
   EXPECT_LT(0, opts.get<TransferStallTimeoutOption>().count());
-  EXPECT_LT(0,
-            opts.get<storage_experimental::TransferStallMinimumRateOption>());
+  EXPECT_LT(0, opts.get<TransferStallMinimumRateOption>());
   EXPECT_THAT(opts.get<CARootsFilePathOption>(), IsEmpty());
 }
 
@@ -364,19 +362,19 @@ TEST_F(ClientOptionsTest, DefaultOptions) {
   EXPECT_EQ(0, o.get<MaximumCurlSocketRecvSizeOption>());
   EXPECT_EQ(0, o.get<MaximumCurlSocketSendSizeOption>());
   EXPECT_LT(std::chrono::seconds(0), o.get<TransferStallTimeoutOption>());
-  EXPECT_LT(0, o.get<storage_experimental::TransferStallMinimumRateOption>());
+  EXPECT_LT(0, o.get<TransferStallMinimumRateOption>());
   EXPECT_LT(std::chrono::seconds(0), o.get<DownloadStallTimeoutOption>());
-  EXPECT_LT(0, o.get<storage_experimental::DownloadStallMinimumRateOption>());
+  EXPECT_LT(0, o.get<DownloadStallMinimumRateOption>());
 
   namespace rest = ::google::cloud::rest_internal;
   EXPECT_EQ(o.get<rest::DownloadStallTimeoutOption>(),
             o.get<DownloadStallTimeoutOption>());
   EXPECT_EQ(o.get<rest::DownloadStallMinimumRateOption>(),
-            o.get<storage_experimental::DownloadStallMinimumRateOption>());
+            o.get<DownloadStallMinimumRateOption>());
   EXPECT_EQ(o.get<rest::TransferStallTimeoutOption>(),
             o.get<TransferStallTimeoutOption>());
   EXPECT_EQ(o.get<rest::TransferStallMinimumRateOption>(),
-            o.get<storage_experimental::TransferStallMinimumRateOption>());
+            o.get<TransferStallMinimumRateOption>());
   EXPECT_EQ(o.get<rest::MaximumCurlSocketRecvSizeOption>(),
             o.get<MaximumCurlSocketRecvSizeOption>());
   EXPECT_EQ(o.get<rest::MaximumCurlSocketSendSizeOption>(),

--- a/google/cloud/storage/internal/curl_request_builder.cc
+++ b/google/cloud/storage/internal/curl_request_builder.cc
@@ -97,11 +97,9 @@ CurlRequestBuilder& CurlRequestBuilder::ApplyClientOptions(
   http_version_ =
       std::move(options.get<storage_experimental::HttpVersionOption>());
   transfer_stall_timeout_ = options.get<TransferStallTimeoutOption>();
-  transfer_stall_minimum_rate_ =
-      options.get<storage_experimental::TransferStallMinimumRateOption>();
+  transfer_stall_minimum_rate_ = options.get<TransferStallMinimumRateOption>();
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
-  download_stall_minimum_rate_ =
-      options.get<storage_experimental::DownloadStallMinimumRateOption>();
+  download_stall_minimum_rate_ = options.get<DownloadStallMinimumRateOption>();
   return *this;
 }
 

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -373,7 +373,7 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
   auto const& current = google::cloud::internal::CurrentOptions();
   auto timeout = ScaleStallTimeout(
       current.get<TransferStallTimeoutOption>(),
-      current.get<storage_experimental::TransferStallMinimumRateOption>(),
+      current.get<TransferStallMinimumRateOption>(),
       google::storage::v2::ServiceConstants::MAX_WRITE_CHUNK_BYTES);
   auto create_watchdog = [cq = background_->cq(), timeout]() mutable {
     if (timeout == std::chrono::seconds(0)) {
@@ -637,7 +637,7 @@ StatusOr<QueryResumableUploadResponse> GrpcClient::UploadChunk(
   auto const& current = google::cloud::internal::CurrentOptions();
   auto const timeout = ScaleStallTimeout(
       current.get<TransferStallTimeoutOption>(),
-      current.get<storage_experimental::TransferStallMinimumRateOption>(),
+      current.get<TransferStallMinimumRateOption>(),
       google::storage::v2::ServiceConstants::MAX_WRITE_CHUNK_BYTES);
 
   auto create_watchdog = [cq = background_->cq(), timeout]() mutable {

--- a/google/cloud/storage/options.h
+++ b/google/cloud/storage/options.h
@@ -50,26 +50,6 @@ struct HttpVersionOption {
   using Type = std::string;
 };
 
-/**
- * The minimum accepted bytes/second transfer rate.
- *
- * If the average rate is below this value for the `TransferStallTimeoutOption`
- * then the transfer is aborted.
- */
-struct TransferStallMinimumRateOption {
-  using Type = std::int32_t;
-};
-
-/**
- * The minimum accepted bytes/second download rate.
- *
- * If the average rate is below this value for the `DownloadStallTimeoutOption`
- * then the download is aborted.
- */
-struct DownloadStallMinimumRateOption {
-  using Type = std::int32_t;
-};
-
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage_experimental
 
@@ -254,6 +234,16 @@ struct TransferStallTimeoutOption {
 };
 
 /**
+ * The minimum accepted bytes/second transfer rate.
+ *
+ * If the average rate is below this value for the `TransferStallTimeoutOption`
+ * then the transfer is aborted.
+ */
+struct TransferStallMinimumRateOption {
+  using Type = std::int32_t;
+};
+
+/**
  * Sets the download stall timeout.
  *
  * If a download *stalls*, i.e., no bytes are received for a significant period,
@@ -269,6 +259,16 @@ struct TransferStallTimeoutOption {
  */
 struct DownloadStallTimeoutOption {
   using Type = std::chrono::seconds;
+};
+
+/**
+ * The minimum accepted bytes/second download rate.
+ *
+ * If the average rate is below this value for the `DownloadStallTimeoutOption`
+ * then the download is aborted.
+ */
+struct DownloadStallMinimumRateOption {
+  using Type = std::int32_t;
 };
 
 /// Set the retry policy for a GCS client.


### PR DESCRIPTION
These options have proven useful. Time to move them out of `storage_experimental`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9813)
<!-- Reviewable:end -->
