### PR TITLE
docs: update support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,14 +397,14 @@ int main(int argc, char* argv[]) {
 ## Support
 
 - This project follows Google's [Foundational C++ Support Policy][support-policy],
-  which is best understood as the [Foundational C++ Support Matrix][support-matrix].
-  - Language Version (>= C++14)
+  which is summarized in the [Foundational C++ Support Matrix][support-matrix].
+  - Language Version (>= C++14).
   - Operating Systems: Windows, macOS, and Linux.
   - Build Systems: Bazel (>= 4.0)[^bazel-version-note], CMake (>= 3.10).
-  - Compilers: GCC (>= 7.3), Clang (>= 6.0), MSVC (>= 2017), Apple Clang (>= 12)
-- This project uses dependencies described in [doc/packaging.md](https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md)
-- This project works with or without exceptions enabled
-- This project cuts [monthly releases](https://github.com/googleapis/google-cloud-cpp/releases) with detailed release notes
+  - Compilers: GCC (>= 7.3), Clang (>= 6.0), MSVC (>= 2017), Apple Clang (>= 12).
+- This project uses dependencies described in [doc/packaging.md](https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md).
+- This project works with or without exceptions enabled.
+- This project cuts [monthly releases](https://github.com/googleapis/google-cloud-cpp/releases) with detailed release notes.
 
 ## Public API and API Breaking Changes
 

--- a/README.md
+++ b/README.md
@@ -396,16 +396,19 @@ int main(int argc, char* argv[]) {
 
 ## Support
 
-- This project supports Windows, macOS, Linux
-- This project supports C++14 (and higher) compilers (we test with GCC >= 7.3,
-  Clang >= 6.0, and MSVC >= 2017)
-- This project supports Bazel (>= 4.0) and CMake (>= 3.5) builds. See the
-  [Quickstart examples](https://github.com/googleapis/google-cloud-cpp#quickstart)
+- This project follows Google's [Foundational C++ Support Policy][support-policy],
+  which is best understood as the [Foundational C++ Support Matrix][support-matrix].
+  - Language Version (>= C++14)
+  - Operating Systems: Windows, macOS, and Linux.
+  - Build Systems: Bazel (>= 4.0)[^1], CMake (>= 3.10).
+  - Compilers: GCC (>= 7.3), Clang (>= 6.0), MSVC (>= 2017), Apple Clang (>= 12)
 - This project uses dependencies described in [doc/packaging.md](https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md)
 - This project works with or without exceptions enabled
 - This project cuts [monthly releases](https://github.com/googleapis/google-cloud-cpp/releases) with detailed release notes
 
 ## Public API and API Breaking Changes
+
+This project follows Google's [OSS Library Breaking Change Policy][breaking-change-policy].
 
 In general, we avoid making backwards incompatible changes to our C++ APIs (see
 below for the definition of "API"). Sometimes such changes yield benefits to
@@ -570,6 +573,7 @@ Apache 2.0; see [`LICENSE`](/LICENSE) for details.
     may need a more recent version of Bazel. Consult the
     [Bazel Install Guide](https://bazel.build/install) for details.
 
+[breaking-change-policy]: https://opensource.google/documentation/policies/library-breaking-change
 [changelog]: /CHANGELOG.md
 [codecov-link]: https://codecov.io/gh/googleapis/google-cloud-cpp
 [codecov-shield]: https://codecov.io/gh/googleapis/google-cloud-cpp/branch/main/graph/badge.svg
@@ -589,3 +593,5 @@ Apache 2.0; see [`LICENSE`](/LICENSE) for details.
 [kokoro-windows-bazel-shield]: https://storage.googleapis.com/cloud-cpp-kokoro-status/kokoro-windows-bazel.svg
 [kokoro-windows-cmake-link]: https://storage.googleapis.com/cloud-cpp-kokoro-status/kokoro-windows-cmake-link.html
 [kokoro-windows-cmake-shield]: https://storage.googleapis.com/cloud-cpp-kokoro-status/kokoro-windows-cmake.svg
+[support-matrix]: https://github.com/google/oss-policies-info/blob/main/foundational-cxx-support-matrix.md
+[support-policy]: https://opensource.google/documentation/policies/cplusplus-support

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ bazel build //...
 
 ### Building with CMake
 
-This library requires CMake >= 3.5. If you are planning to install the libraries
+This library requires CMake >= 3.10. If you are planning to install the libraries
 please consult the [packaging guide](/doc/packaging.md), these instructions will
 **NOT** produce artifacts that you can put in `/usr/local`, or share with your
 colleagues.
@@ -400,7 +400,7 @@ int main(int argc, char* argv[]) {
   which is best understood as the [Foundational C++ Support Matrix][support-matrix].
   - Language Version (>= C++14)
   - Operating Systems: Windows, macOS, and Linux.
-  - Build Systems: Bazel (>= 4.0)[^1], CMake (>= 3.10).
+  - Build Systems: Bazel (>= 4.0)[^bazel-version-note], CMake (>= 3.10).
   - Compilers: GCC (>= 7.3), Clang (>= 6.0), MSVC (>= 2017), Apple Clang (>= 12)
 - This project uses dependencies described in [doc/packaging.md](https://github.com/googleapis/google-cloud-cpp/blob/main/doc/packaging.md)
 - This project works with or without exceptions enabled


### PR DESCRIPTION
Update the support policy and breaking change policy to point to the Google Open Source docs.

Part of me thinks we should not be in the business of writing down the minimum versions of these things. But then the other part of me thinks that the information that customers want to know should be available without clicking links (and searchable too).

Maybe we should add `<!-- inject-support-matrix -->` tags and have a script that copies the table from the `oss-policies-info` repo and writes it into our README....

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9815)
<!-- Reviewable:end -->
