### PR TITLE
ci: deflake googleapis downloads from GitHub

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -86,6 +86,7 @@ def google_cloud_cpp_deps():
             name = "com_google_googleapis",
             urls = [
                 "https://github.com/googleapis/googleapis/archive/343f52cd370556819da24df078308f3f709ff24b.tar.gz",
+                "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/343f52cd370556819da24df078308f3f709ff24b.tar.gz",
             ],
             strip_prefix = "googleapis-343f52cd370556819da24df078308f3f709ff24b",
             sha256 = "7248822e4d4cf4dbb4a4bc8e4eab9fc098f1be34453d7839a3f04e0a1a150ba0",

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -18,6 +18,7 @@ include(GoogleapisConfig)
 
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
     "https://github.com/googleapis/googleapis/archive/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
+    "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
 )
 
 set(EXTERNAL_GOOGLEAPIS_SOURCE

--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -24,6 +24,7 @@ DOWNLOAD="$(mktemp)"
 curl -sSL "https://github.com/${REPO}/archive/${COMMIT}.tar.gz" -o "${DOWNLOAD}"
 gsutil -q cp "${DOWNLOAD}" "gs://cloud-cpp-community-archive/com_google_googleapis/${COMMIT}.tar.gz"
 SHA256=$(sha256sum "${DOWNLOAD}" | sed "s/ .*//")
+rm -f "${DOWNLOAD}"
 
 # Update the Bazel dependency.
 sed -i -f - bazel/google_cloud_cpp_deps.bzl <<EOT


### PR DESCRIPTION
Use GCS as a backup source for the tarball. I changed the script that updates the googleapis SHA to populate this backup at the same time.

Fixes #8102

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9819)
<!-- Reviewable:end -->
