### PR TITLE
impl(generator): GA or experimental scaffolding

### DIFF
--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -100,7 +100,7 @@ index ab033dde9..3753287d8 100644
 Create your first commit with purely hand-crafted changes
 
 ```shell
-git checkout -b feat-${library}-generate-library # Don't forget
+git checkout -b feat-${library}-generate-library
 git commit -m"feat(${library}): generate library" external/ generator/
 ```
 
@@ -124,6 +124,9 @@ bazel run \
   --config_file="${PWD}/generator/generator_config.textproto" \
   --scaffold="google/cloud/${library}"
 ```
+
+To generate a library that is initially experimental, add an
+`--experimental_scaffold` flag.
 
 ## Fix formatting of existing libraries and the generated code
 
@@ -158,11 +161,30 @@ dependencies for more complex libraries.
 
 ## Update the root files
 
-Manually edit the top level `BUILD.bazel` to include the new target as an
-experimental library. Take note of when the library was generated.
+Manually edit the top level `BUILD.bazel` to include the new target.
 
 <details>
 <summary>Expand for an example</summary>
+
+If you are generating a GA library, add it to `GA_LIBRARIES`.
+
+```diff
+diff --git a/BUILD.bazel b/BUILD.bazel
+index 2c08e2a73..3a61351d2 100644
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -52,6 +52,7 @@ GA_LIBRARIES = [
+     "automl",
+     "billing",
+     "binaryauthorization",
++    "bms",
+     "channel",
+     "cloudbuild",
+     "composer",
+```
+
+Otherwise, if you are generating an experimental library, add it to
+`EXPERIMENTAL_LIBRARIES` and take note of when the library was generated.
 
 ```diff
 diff --git a/BUILD.bazel b/BUILD.bazel
@@ -255,7 +277,7 @@ index c4ce00489..1858b48dc 100755
 
 ```shell
 git commit -m"Manually update READMEs, quickstart, and top-level stuff" \
-   "google/cloud/${library}" BUILD.bazel CHANGELOG.md ci
+   "google/cloud/${library}" BUILD.bazel CHANGELOG.md ci README.md
 ```
 
 [retryable-status-codes]: https://github.com/googleapis/googleapis/blob/0fea253787a4f2769b97b0ed3a8f5b28ef17ffa7/google/cloud/secretmanager/v1/secretmanager_grpc_service_config.json#L77-L80

--- a/doc/contributor/howto-guide-adding-generated-libraries.md
+++ b/doc/contributor/howto-guide-adding-generated-libraries.md
@@ -219,6 +219,15 @@ arguments in the CI builds.
 
 - `google/cloud/${library}/CMakeLists.txt`
 
+The scaffold generator does not know the current version of `google-cloud-cpp`.
+We can copy it from a library that should be up-to-date.
+
+```sh
+sed -i '/workspace(/q' google/cloud/${library}/quickstart/WORKSPACE.bazel
+sed '1,/workspace(/d' google/cloud/accessapproval/quickstart/WORKSPACE.bazel \
+    >> google/cloud/${library}/quickstart/WORKSPACE.bazel
+```
+
 ## Update the README files
 
 The following files probably need some light copy-editing to read less like they

--- a/doc/contributor/howto-guide-declare-a-library-ga.md
+++ b/doc/contributor/howto-guide-declare-a-library-ga.md
@@ -81,7 +81,8 @@ Change the comments stating that the library is experimental to state that the
 library is GA, and that `google-cloud-cpp` does not follow semantic versioning.
 
 ```shell
-for lib in "${ga[@]}"; do sed -i 's;^This library is \*\*experimental.*;While this library is **GA**, please note Google Cloud C++ client libraries do **not** follow [Semantic Versioning](https://semver.org/).;' google/cloud/${lib}/doc/main.dox; done
+for lib in "${ga[@]}"; do sed -i '/^This library is \*\*experimental/,+1d' google/cloud/${lib}/doc/main.dox; done
+for lib in "${ga[@]}"; do sed -i 's/^Please note that the Google Cloud C/While this library is **GA**, please note that the Google Cloud C/' google/cloud/${lib}/doc/main.dox; done
 ```
 
 ### `google/cloud/${library}/CMakeLists.txt`:

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -82,8 +82,8 @@ std::map<std::string, std::string> ScaffoldVars(
   vars["copyright_year"] = service.initial_copyright_year();
   vars["library"] = library;
   vars["site_root"] = SiteRoot(service);
-  vars["prefix"] = experimental ? "experimental-" : "";
-  vars["suffix"] = experimental ? " (Experimental)" : "";
+  vars["library_prefix"] = experimental ? "experimental-" : "";
+  vars["doxygen_version_suffix"] = experimental ? " (Experimental)" : "";
   vars["construction"] = experimental ? "\n:construction:\n" : "";
   vars["status"] =
       experimental ? "This library is **experimental**. Its APIs are subject "
@@ -327,7 +327,7 @@ void GenerateCMakeLists(std::ostream& os,
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "$title$ C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the $title$")
-set(DOXYGEN_PROJECT_NUMBER "$${PROJECT_VERSION}$suffix$")
+set(DOXYGEN_PROJECT_NUMBER "$${PROJECT_VERSION}$doxygen_version_suffix$")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "$library$_internal" "$library$_testing"
                             "examples")
 set(DOXYGEN_EXAMPLE_PATH $${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -376,13 +376,13 @@ target_link_libraries(
 google_cloud_cpp_add_common_options(google_cloud_cpp_$library$)
 set_target_properties(
     google_cloud_cpp_$library$
-    PROPERTIES EXPORT_NAME google-cloud-cpp::$prefix$$library$
+    PROPERTIES EXPORT_NAME google-cloud-cpp::$library_prefix$$library$
                VERSION "$${PROJECT_VERSION}"
                SOVERSION "$${PROJECT_VERSION_MAJOR}")
 target_compile_options(google_cloud_cpp_$library$
                        PUBLIC $${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-add_library(google-cloud-cpp::$prefix$$library$ ALIAS google_cloud_cpp_$library$)
+add_library(google-cloud-cpp::$library_prefix$$library$ ALIAS google_cloud_cpp_$library$)
 
 # Create a header-only library for the mocks. We use a CMake `INTERFACE` library
 # for these, a regular library would not work on macOS (where the library needs
@@ -400,11 +400,11 @@ add_library(google_cloud_cpp_$library$_mocks INTERFACE)
 target_sources(google_cloud_cpp_$library$_mocks INTERFACE $${mock_files})
 target_link_libraries(
     google_cloud_cpp_$library$_mocks
-    INTERFACE google-cloud-cpp::$prefix$$library$ GTest::gmock_main
+    INTERFACE google-cloud-cpp::$library_prefix$$library$ GTest::gmock_main
               GTest::gmock GTest::gtest)
 set_target_properties(
     google_cloud_cpp_$library$_mocks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::$prefix$$library$_mocks)
+    PROPERTIES EXPORT_NAME google-cloud-cpp::$library_prefix$$library$_mocks)
 target_include_directories(
     google_cloud_cpp_$library$_mocks
     INTERFACE $$<BUILD_INTERFACE:$${PROJECT_SOURCE_DIR}>
@@ -417,7 +417,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_executable($library$_quickstart "quickstart/quickstart.cc")
     target_link_libraries($library$_quickstart
-                          PRIVATE google-cloud-cpp::$prefix$$library$)
+                          PRIVATE google-cloud-cpp::$library_prefix$$library$)
     google_cloud_cpp_add_common_options($library$_quickstart)
     add_test(
         NAME $library$_quickstart
@@ -863,7 +863,7 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::$prefix$$library$)
+target_link_libraries(quickstart google-cloud-cpp::$library_prefix$$library$)
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');
@@ -1002,7 +1002,7 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:$prefix$$library$",
+        "@com_github_googleapis_google_cloud_cpp//:$library_prefix$$library$",
     ],
 )
 )""";

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -49,7 +49,8 @@ std::string SiteRoot(
 
 std::map<std::string, std::string> ScaffoldVars(
     std::string const& googleapis_path,
-    google::cloud::cpp::generator::ServiceConfiguration const& service) {
+    google::cloud::cpp::generator::ServiceConfiguration const& service,
+    bool experimental) {
   auto const api_index_path = googleapis_path + "/" + kApiIndexFilename;
   auto status = google::cloud::internal::status(api_index_path);
   if (!exists(status)) {
@@ -81,6 +82,13 @@ std::map<std::string, std::string> ScaffoldVars(
   vars["copyright_year"] = service.initial_copyright_year();
   vars["library"] = library;
   vars["site_root"] = SiteRoot(service);
+  vars["prefix"] = experimental ? "experimental-" : "";
+  vars["suffix"] = experimental ? " (Experimental)" : "";
+  vars["construction"] = experimental ? "\n:construction:\n" : "";
+  vars["status"] =
+      experimental ? "This library is **experimental**. Its APIs are subject "
+                     "to change without notice.\n\nPlease,"
+                   : "While this library is **GA**, please";
 
   return vars;
 }
@@ -95,7 +103,8 @@ void MakeDirectory(std::string const& path) {
 
 void GenerateScaffold(
     std::string const& googleapis_path, std::string const& output_path,
-    google::cloud::cpp::generator::ServiceConfiguration const& service) {
+    google::cloud::cpp::generator::ServiceConfiguration const& service,
+    bool experimental) {
   using Generator = std::function<void(
       std::ostream&, std::map<std::string, std::string> const&)>;
   struct Destination {
@@ -116,7 +125,7 @@ void GenerateScaffold(
       {"quickstart/.bazelrc", GenerateQuickstartBazelrc},
   };
 
-  auto const vars = ScaffoldVars(googleapis_path, service);
+  auto const vars = ScaffoldVars(googleapis_path, service, experimental);
   MakeDirectory(output_path + "/");
   auto const destination = output_path + "/" + service.product_path() + "/";
   MakeDirectory(destination);
@@ -162,16 +171,12 @@ include("$${CMAKE_CURRENT_LIST_DIR}/google_cloud_cpp_$library$-targets.cmake")
 void GenerateReadme(std::ostream& os,
                     std::map<std::string, std::string> const& variables) {
   auto constexpr kText = R"""(# $title$ C++ Client Library
-
-:construction:
-
+$construction$
 This directory contains an idiomatic C++ client library for the
 [$title$][cloud-service-docs], a service to $description$
 
-This library is **experimental**. Its APIs are subject to change without notice.
-
-Please note that the Google Cloud C++ client libraries do **not** follow
-[Semantic Versioning](https://semver.org/).
+$status$ note that the Google Cloud C++ client
+libraries do **not** follow [Semantic Versioning](https://semver.org/).
 
 ## Supported Platforms
 
@@ -322,7 +327,7 @@ void GenerateCMakeLists(std::ostream& os,
 include(GoogleapisConfig)
 set(DOXYGEN_PROJECT_NAME "$title$ C++ Client")
 set(DOXYGEN_PROJECT_BRIEF "A C++ Client Library for the $title$")
-set(DOXYGEN_PROJECT_NUMBER "$${PROJECT_VERSION} (Experimental)")
+set(DOXYGEN_PROJECT_NUMBER "$${PROJECT_VERSION}$suffix$")
 set(DOXYGEN_EXCLUDE_SYMBOLS "internal" "$library$_internal" "$library$_testing"
                             "examples")
 set(DOXYGEN_EXAMPLE_PATH $${CMAKE_CURRENT_SOURCE_DIR}/quickstart)
@@ -371,13 +376,13 @@ target_link_libraries(
 google_cloud_cpp_add_common_options(google_cloud_cpp_$library$)
 set_target_properties(
     google_cloud_cpp_$library$
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-$library$
+    PROPERTIES EXPORT_NAME google-cloud-cpp::$prefix$$library$
                VERSION "$${PROJECT_VERSION}"
                SOVERSION "$${PROJECT_VERSION_MAJOR}")
 target_compile_options(google_cloud_cpp_$library$
                        PUBLIC $${GOOGLE_CLOUD_CPP_EXCEPTIONS_FLAG})
 
-add_library(google-cloud-cpp::experimental-$library$ ALIAS google_cloud_cpp_$library$)
+add_library(google-cloud-cpp::$prefix$$library$ ALIAS google_cloud_cpp_$library$)
 
 # Create a header-only library for the mocks. We use a CMake `INTERFACE` library
 # for these, a regular library would not work on macOS (where the library needs
@@ -395,11 +400,11 @@ add_library(google_cloud_cpp_$library$_mocks INTERFACE)
 target_sources(google_cloud_cpp_$library$_mocks INTERFACE $${mock_files})
 target_link_libraries(
     google_cloud_cpp_$library$_mocks
-    INTERFACE google-cloud-cpp::experimental-$library$ GTest::gmock_main
+    INTERFACE google-cloud-cpp::$prefix$$library$ GTest::gmock_main
               GTest::gmock GTest::gtest)
 set_target_properties(
     google_cloud_cpp_$library$_mocks
-    PROPERTIES EXPORT_NAME google-cloud-cpp::experimental-$library$_mocks)
+    PROPERTIES EXPORT_NAME google-cloud-cpp::$prefix$$library$_mocks)
 target_include_directories(
     google_cloud_cpp_$library$_mocks
     INTERFACE $$<BUILD_INTERFACE:$${PROJECT_SOURCE_DIR}>
@@ -412,7 +417,7 @@ include(CTest)
 if (BUILD_TESTING)
     add_executable($library$_quickstart "quickstart/quickstart.cc")
     target_link_libraries($library$_quickstart
-                          PRIVATE google-cloud-cpp::experimental-$library$)
+                          PRIVATE google-cloud-cpp::$prefix$$library$)
     google_cloud_cpp_add_common_options($library$_quickstart)
     add_test(
         NAME $library$_quickstart
@@ -502,7 +507,8 @@ void GenerateDoxygenMainPage(
 An idiomatic C++ client library for the [$title$][cloud-service-docs], a service
 to $description$
 
-This library is **experimental**. Its APIs are subject to change without notice.
+$status$ note that the Google Cloud C++ client libraries do **not** follow
+[Semantic Versioning](https://semver.org/).
 
 This library requires a C++14 compiler. It is supported (and tested) on multiple
 Linux distributions, as well as Windows and macOS. The [README][github-readme]
@@ -857,7 +863,7 @@ endif ()
 
 # Define your targets.
 add_executable(quickstart quickstart.cc)
-target_link_libraries(quickstart google-cloud-cpp::experimental-$library$)
+target_link_libraries(quickstart google-cloud-cpp::$prefix$$library$)
 )""";
   google::protobuf::io::OstreamOutputStream output(&os);
   google::protobuf::io::Printer printer(&output, '$');
@@ -940,9 +946,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
     name = "com_github_googleapis_google_cloud_cpp",
-    sha256 = "a7e51bfffb95a377094b2ae7e3b9f715a68ed931c48992c7273b2fae989c029c",
-    strip_prefix = "google-cloud-cpp-1.36.0",
-    url = "https://github.com/googleapis/google-cloud-cpp/archive/v1.36.0.tar.gz",
+    sha256 = "e8d904bbff788a26aa9cd67d6c0725f9798448fcf73ab809ec2d7b80f89a1dc5",
+    strip_prefix = "google-cloud-cpp-2.2.0",
+    url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.2.0.tar.gz",
 )
 
 # Load indirect dependencies due to
@@ -996,7 +1002,7 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-$library$",
+        "@com_github_googleapis_google_cloud_cpp//:$prefix$$library$",
     ],
 )
 )""";

--- a/generator/internal/scaffold_generator.h
+++ b/generator/internal/scaffold_generator.h
@@ -40,13 +40,15 @@ std::string LibraryName(
 
 std::map<std::string, std::string> ScaffoldVars(
     std::string const& googleapis_path,
-    google::cloud::cpp::generator::ServiceConfiguration const& service);
+    google::cloud::cpp::generator::ServiceConfiguration const& service,
+    bool experimental);
 
 void MakeDirectory(std::string const& path);
 
 void GenerateScaffold(
     std::string const& googleapis_path, std::string const& output_path,
-    google::cloud::cpp::generator::ServiceConfiguration const& service);
+    google::cloud::cpp::generator::ServiceConfiguration const& service,
+    bool experimental);
 
 void GenerateCmakeConfigIn(std::ostream& os,
                            std::map<std::string, std::string> const& variables);

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -119,17 +119,33 @@ TEST_F(ScaffoldGenerator, LibraryName) {
 }
 
 TEST_F(ScaffoldGenerator, Vars) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const ga = ScaffoldVars(path(), service(), false);
   EXPECT_THAT(
-      vars, AllOf(Contains(Pair("title", "Test Only API")),
-                  Contains(Pair("description",
-                                "Provides a placeholder to write this test.")),
-                  Contains(Pair("library", "test")),
-                  Contains(Pair("copyright_year", "2034"))));
+      ga, AllOf(Contains(Pair("title", "Test Only API")),
+                Contains(Pair("description",
+                              "Provides a placeholder to write this test.")),
+                Contains(Pair("library", "test")),
+                Contains(Pair("copyright_year", "2034")),
+                Contains(Pair("prefix", "")), Contains(Pair("suffix", "")),
+                Contains(Pair("construction", "")),
+                Contains(Pair("status", HasSubstr("**GA**")))));
+
+  auto const experimental = ScaffoldVars(path(), service(), true);
+  EXPECT_THAT(
+      experimental,
+      AllOf(Contains(Pair("title", "Test Only API")),
+            Contains(Pair("description",
+                          "Provides a placeholder to write this test.")),
+            Contains(Pair("library", "test")),
+            Contains(Pair("copyright_year", "2034")),
+            Contains(Pair("prefix", "experimental-")),
+            Contains(Pair("suffix", " (Experimental)")),
+            Contains(Pair("construction", "\n:construction:\n")),
+            Contains(Pair("status", HasSubstr("**experimental**")))));
 }
 
 TEST_F(ScaffoldGenerator, CmakeConfigIn) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateCmakeConfigIn(os, vars);
   auto const actual = std::move(os).str();
@@ -142,7 +158,7 @@ TEST_F(ScaffoldGenerator, CmakeConfigIn) {
 }
 
 TEST_F(ScaffoldGenerator, Readme) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateReadme(os, vars);
   auto const actual = std::move(os).str();
@@ -151,10 +167,13 @@ TEST_F(ScaffoldGenerator, Readme) {
 [doxygen-link]: https://googleapis.dev/cpp/google-cloud-test/latest/
 [source-link]: https://github.com/googleapis/google-cloud-cpp/tree/main/google/cloud/test
 )"""));
+  EXPECT_THAT(actual, Not(HasSubstr("$construction$")));
+  EXPECT_THAT(actual, HasSubstr("**GA**"));
+  EXPECT_THAT(actual, Not(HasSubstr("$status$")));
 }
 
 TEST_F(ScaffoldGenerator, Build) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateBuild(os, vars);
   auto const actual = std::move(os).str();
@@ -168,12 +187,14 @@ TEST_F(ScaffoldGenerator, Build) {
 }
 
 TEST_F(ScaffoldGenerator, CMakeLists) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateCMakeLists(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$prefix$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$suffix$")));
   EXPECT_THAT(actual, HasSubstr(R"""(include(CompileProtos)
 google_cloud_cpp_load_protolist(
     proto_list
@@ -195,7 +216,7 @@ target_link_libraries(google_cloud_cpp_test_protos PUBLIC ${proto_deps})
 }
 
 TEST_F(ScaffoldGenerator, DoxygenMainPage) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateDoxygenMainPage(os, vars);
   auto const actual = std::move(os).str();
@@ -206,10 +227,12 @@ to Provides a placeholder to write this test.
   EXPECT_THAT(actual, HasSubstr(R"""(
 [cloud-service-docs]: https://cloud.google.com/test
 )"""));
+  EXPECT_THAT(actual, Not(HasSubstr("$status$")));
+  EXPECT_THAT(actual, HasSubstr("**GA**"));
 }
 
 TEST_F(ScaffoldGenerator, QuickstartReadme) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartReadme(os, vars);
   auto const actual = std::move(os).str();
@@ -220,7 +243,7 @@ TEST_F(ScaffoldGenerator, QuickstartReadme) {
 }
 
 TEST_F(ScaffoldGenerator, QuickstartSkeleton) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartSkeleton(os, vars);
   auto const actual = std::move(os).str();
@@ -229,16 +252,17 @@ TEST_F(ScaffoldGenerator, QuickstartSkeleton) {
 }
 
 TEST_F(ScaffoldGenerator, QuickstartCMake) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartCMake(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$prefix$")));
 }
 
 TEST_F(ScaffoldGenerator, QuickstartMakefile) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartMakefile(os, vars);
   auto const actual = std::move(os).str();
@@ -248,7 +272,7 @@ TEST_F(ScaffoldGenerator, QuickstartMakefile) {
 }
 
 TEST_F(ScaffoldGenerator, QuickstartWorkspace) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartWorkspace(os, vars);
   auto const actual = std::move(os).str();
@@ -257,16 +281,17 @@ TEST_F(ScaffoldGenerator, QuickstartWorkspace) {
 }
 
 TEST_F(ScaffoldGenerator, QuickstartBuild) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartBuild(os, vars);
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$prefix$")));
 }
 
 TEST_F(ScaffoldGenerator, QuickstartBazelrc) {
-  auto const vars = ScaffoldVars(path(), service());
+  auto const vars = ScaffoldVars(path(), service(), false);
   std::ostringstream os;
   GenerateQuickstartBazelrc(os, vars);
   auto const actual = std::move(os).str();

--- a/generator/internal/scaffold_generator_test.cc
+++ b/generator/internal/scaffold_generator_test.cc
@@ -126,7 +126,8 @@ TEST_F(ScaffoldGenerator, Vars) {
                               "Provides a placeholder to write this test.")),
                 Contains(Pair("library", "test")),
                 Contains(Pair("copyright_year", "2034")),
-                Contains(Pair("prefix", "")), Contains(Pair("suffix", "")),
+                Contains(Pair("library_prefix", "")),
+                Contains(Pair("doxygen_version_suffix", "")),
                 Contains(Pair("construction", "")),
                 Contains(Pair("status", HasSubstr("**GA**")))));
 
@@ -138,8 +139,8 @@ TEST_F(ScaffoldGenerator, Vars) {
                           "Provides a placeholder to write this test.")),
             Contains(Pair("library", "test")),
             Contains(Pair("copyright_year", "2034")),
-            Contains(Pair("prefix", "experimental-")),
-            Contains(Pair("suffix", " (Experimental)")),
+            Contains(Pair("library_prefix", "experimental-")),
+            Contains(Pair("doxygen_version_suffix", " (Experimental)")),
             Contains(Pair("construction", "\n:construction:\n")),
             Contains(Pair("status", HasSubstr("**experimental**")))));
 }
@@ -193,8 +194,8 @@ TEST_F(ScaffoldGenerator, CMakeLists) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$prefix$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$suffix$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$library_prefix$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$doxygen_version_suffix$")));
   EXPECT_THAT(actual, HasSubstr(R"""(include(CompileProtos)
 google_cloud_cpp_load_protolist(
     proto_list
@@ -258,7 +259,7 @@ TEST_F(ScaffoldGenerator, QuickstartCMake) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$prefix$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$library_prefix$")));
 }
 
 TEST_F(ScaffoldGenerator, QuickstartMakefile) {
@@ -287,7 +288,7 @@ TEST_F(ScaffoldGenerator, QuickstartBuild) {
   auto const actual = std::move(os).str();
   EXPECT_THAT(actual, HasSubstr("2034"));
   EXPECT_THAT(actual, Not(HasSubstr("$copyright_year$")));
-  EXPECT_THAT(actual, Not(HasSubstr("$prefix$")));
+  EXPECT_THAT(actual, Not(HasSubstr("$library_prefix$")));
 }
 
 TEST_F(ScaffoldGenerator, QuickstartBazelrc) {

--- a/generator/standalone_main.cc
+++ b/generator/standalone_main.cc
@@ -40,6 +40,8 @@ ABSL_FLAG(std::string, output_path, ".",
           "Path to root dir where code is emitted.");
 ABSL_FLAG(std::string, scaffold, "",
           "Generate the library support files for the given directory.");
+ABSL_FLAG(bool, experimental_scaffold, false,
+          "Generate experimental library support files.");
 ABSL_FLAG(bool, update_ci, true, "Update the CI support files.");
 
 namespace {
@@ -172,6 +174,7 @@ int main(int argc, char** argv) {
   auto config_file = absl::GetFlag(FLAGS_config_file);
   auto output_path = absl::GetFlag(FLAGS_output_path);
   auto scaffold = absl::GetFlag(FLAGS_scaffold);
+  auto experimental_scaffold = absl::GetFlag(FLAGS_experimental_scaffold);
 
   GCP_LOG(INFO) << "proto_path = " << proto_path << "\n";
   GCP_LOG(INFO) << "googleapis_path = " << googleapis_path << "\n";
@@ -193,8 +196,8 @@ int main(int argc, char** argv) {
   std::vector<std::future<google::cloud::Status>> tasks;
   for (auto const& service : config->service()) {
     if (service.product_path() == scaffold) {
-      google::cloud::generator_internal::GenerateScaffold(googleapis_path,
-                                                          output_path, service);
+      google::cloud::generator_internal::GenerateScaffold(
+          googleapis_path, output_path, service, experimental_scaffold);
     }
     std::vector<std::string> args;
     // empty arg prevents first real arg from being ignored.


### PR DESCRIPTION
The generator can now generate GA or experimental scaffolding. GA is the default.

Update the generation instructions accordingly.

Make the GA/experimental + semver notes in the README and doxygen conform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9824)
<!-- Reviewable:end -->
