### PR TITLE
test(common): do not depend on test run order

### DIFF
--- a/google/cloud/internal/oauth2_service_account_credentials_test.cc
+++ b/google/cloud/internal/oauth2_service_account_credentials_test.cc
@@ -273,6 +273,7 @@ TEST(ServiceAccountCredentialsTest,
   auto const expected_header =
       nlohmann::json{{"alg", "RS256"}, {"typ", "JWT"}, {"kid", kPrivateKeyId}};
 
+  FakeClock::reset_clock(kFixedJwtTimestamp);
   auto const iat = static_cast<std::intmax_t>(kFixedJwtTimestamp);
   auto const exp = iat + 3600;
   auto const expected_payload = nlohmann::json{
@@ -339,6 +340,7 @@ TEST(ServiceAccountCredentialsTest,
   auto const expected_header =
       nlohmann::json{{"alg", "RS256"}, {"typ", "JWT"}, {"kid", kPrivateKeyId}};
 
+  FakeClock::reset_clock(kFixedJwtTimestamp);
   auto const iat = static_cast<std::intmax_t>(kFixedJwtTimestamp);
   auto const exp = iat + 3600;
   auto const expected_payload = nlohmann::json{
@@ -783,7 +785,7 @@ TEST(ServiceAccountCredentialsTest, AssertionComponentsFromInfo) {
   auto info = ParseServiceAccountCredentials(MakeTestContents(), "test");
   ASSERT_STATUS_OK(info);
   auto const clock_value_1 = 10000;
-  FakeClock::now_value_ = clock_value_1;
+  FakeClock::reset_clock(clock_value_1);
   auto components = AssertionComponentsFromInfo(*info, FakeClock::now());
 
   auto header = nlohmann::json::parse(components.first);


### PR DESCRIPTION
One of the tests did not initialize the `FakeClock` and thus could fail if the previous test left it in an unexpected state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9828)
<!-- Reviewable:end -->
