### PR TITLE
impl(GCS+gRPC): tweak gRPC channel configuration

### DIFF
--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -34,14 +34,16 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
     google::cloud::internal::GrpcAuthenticationStrategy& auth,
     Options const& options, int channel_id) {
   auto args = internal::MakeChannelArguments(options);
-  // Use a local subchannel pool to avoid contention in gRPC
+  // Use a local subchannel pool to avoid contention in gRPC.
   args.SetInt(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL, 1);
-  // Use separate sockets for each channel, this is redundant since we also set
+  // Use separate sockets for each channel. This is redundant since we also set
   // `GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL`, but it is harmless.
   args.SetInt(GRPC_ARG_CHANNEL_ID, channel_id);
 
-  // Disable queries see b/243676671, this is harmless as we do not use any
-  // load balancer that requires server queries.
+  // Disable queries. GCS+gRPC does not use a load-balancer (such as `grpclb`)
+  // that requires server queries. Disabling the server queries is, therefore,
+  // harmless. Furthermore, it avoids triggering any latent bugs in the code
+  // to send and/or receive those queries.
   args.SetInt(GRPC_ARG_DNS_ENABLE_SRV_QUERIES, 0);
 
   // Effectively disable keepalive messages.

--- a/google/cloud/storage/internal/storage_stub_factory.cc
+++ b/google/cloud/storage/internal/storage_stub_factory.cc
@@ -34,8 +34,27 @@ std::shared_ptr<grpc::Channel> CreateGrpcChannel(
     google::cloud::internal::GrpcAuthenticationStrategy& auth,
     Options const& options, int channel_id) {
   auto args = internal::MakeChannelArguments(options);
-  args.SetInt("grpc.channel_id", channel_id);
-  args.SetInt("grpc.use_local_subchannel_pool", 1);
+  // Use a local subchannel pool to avoid contention in gRPC
+  args.SetInt(GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL, 1);
+  // Use separate sockets for each channel, this is redundant since we also set
+  // `GRPC_ARG_USE_LOCAL_SUBCHANNEL_POOL`, but it is harmless.
+  args.SetInt(GRPC_ARG_CHANNEL_ID, channel_id);
+
+  // Disable queries see b/243676671, this is harmless as we do not use any
+  // load balancer that requires server queries.
+  args.SetInt(GRPC_ARG_DNS_ENABLE_SRV_QUERIES, 0);
+
+  // Effectively disable keepalive messages.
+  auto constexpr kDisableKeepaliveTime =
+      std::chrono::milliseconds(std::chrono::hours(24));
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIME_MS,
+              static_cast<int>(kDisableKeepaliveTime.count()));
+  // Make gRPC set the TCP_USER_TIMEOUT socket option to a value that detects
+  // broken servers more quickly.
+  auto constexpr kKeepaliveTimeout =
+      std::chrono::milliseconds(std::chrono::seconds(60));
+  args.SetInt(GRPC_ARG_KEEPALIVE_TIMEOUT_MS,
+              static_cast<int>(kKeepaliveTimeout.count()));
   return auth.CreateChannel(options.get<EndpointOption>(), std::move(args));
 }
 


### PR DESCRIPTION
Follow a number of recommendations from the gRPC team.  They all make sense to me. Turning off `GRPC_DNS_ENABLE_SRV_QUERIES` is useful in that it disables code that we do not use, and thus avoids any potential bugs.

The `KEEPALIVE` settings are less obvious.  They should help gRPC detect broken connections sooner than it would otherwise.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9832)
<!-- Reviewable:end -->
