### PR TITLE
cleanup(GCS+gRPC): remove `struct GrpcOwnerParser`

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -87,7 +87,7 @@ google::storage::v2::Bucket GrpcBucketMetadataParser::ToProto(
   }
   if (rhs.has_logging()) *result.mutable_logging() = ToProto(rhs.logging());
   if (rhs.has_owner()) {
-    *result.mutable_owner() = GrpcOwnerParser::ToProto(rhs.owner());
+    *result.mutable_owner() = storage_internal::ToProto(rhs.owner());
   }
   if (rhs.has_encryption()) {
     *result.mutable_encryption() = ToProto(rhs.encryption());
@@ -144,7 +144,7 @@ BucketMetadata GrpcBucketMetadataParser::FromProto(
   metadata.metageneration_ = rhs.metageneration();
   metadata.name_ = GrpcBucketNameToId(rhs.name());
   if (rhs.has_owner()) {
-    metadata.owner_ = GrpcOwnerParser::FromProto(rhs.owner());
+    metadata.owner_ = storage_internal::FromProto(rhs.owner());
   }
 
   // The protos use `projects/{project}` format, but the field may be absent or

--- a/google/cloud/storage/internal/grpc_object_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser.cc
@@ -111,7 +111,7 @@ ObjectMetadata GrpcObjectMetadataParser::FromProto(
 
   metadata.metageneration_ = object.metageneration();
   if (object.has_owner()) {
-    metadata.owner_ = GrpcOwnerParser::FromProto(*object.mutable_owner());
+    metadata.owner_ = storage_internal::FromProto(*object.mutable_owner());
   }
   metadata.storage_class_ = std::move(*object.mutable_storage_class());
   if (object.has_create_time()) {

--- a/google/cloud/storage/internal/grpc_owner_parser.cc
+++ b/google/cloud/storage/internal/grpc_owner_parser.cc
@@ -16,26 +16,24 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-google::storage::v2::Owner GrpcOwnerParser::ToProto(Owner rhs) {
+google::storage::v2::Owner ToProto(storage::Owner rhs) {
   google::storage::v2::Owner result;
   *result.mutable_entity() = std::move(rhs.entity);
   *result.mutable_entity_id() = std::move(rhs.entity_id);
   return result;
 }
 
-Owner GrpcOwnerParser::FromProto(google::storage::v2::Owner rhs) {
-  Owner result;
+storage::Owner FromProto(google::storage::v2::Owner rhs) {
+  storage::Owner result;
   result.entity = std::move(*rhs.mutable_entity());
   result.entity_id = std::move(*rhs.mutable_entity_id());
   return result;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_owner_parser.h
+++ b/google/cloud/storage/internal/grpc_owner_parser.h
@@ -21,18 +21,14 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-struct GrpcOwnerParser {
-  static google::storage::v2::Owner ToProto(Owner);
-  static Owner FromProto(google::storage::v2::Owner);
-};
+google::storage::v2::Owner ToProto(storage::Owner);
+storage::Owner FromProto(google::storage::v2::Owner);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_owner_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_owner_parser_test.cc
@@ -19,9 +19,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -32,16 +31,15 @@ TEST(GrpcClientFromProto, OwnerRoundtrip) {
   )pb";
   google::storage::v2::Owner start;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(kText, &start));
-  auto const expected = Owner{"test-entity", "test-entity-id"};
-  auto const middle = GrpcOwnerParser::FromProto(start);
+  auto const expected = storage::Owner{"test-entity", "test-entity-id"};
+  auto const middle = FromProto(start);
   EXPECT_EQ(middle, expected);
-  auto const end = GrpcOwnerParser::ToProto(middle);
+  auto const end = ToProto(middle);
   EXPECT_THAT(end, IsProtoEqual(start));
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
The struct was just serving as a namespace. This also starts the move of the GCS+gRPC implementation details to the `storage_internal` namespace.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9837)
<!-- Reviewable:end -->
