### PR TITLE
chore: renovate is too noisy for pip

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,6 +36,10 @@
     {
       "matchPackageNames": ["com_google_protobuf", "com_google_absl"],
       "versioning": "loose"
+    },
+    {
+      "matchManagers": ["Pip_requirements"],
+      "schedule": ["before 12pm on Tuesday"]
     }
   ],
   "ignoreDeps": [


### PR DESCRIPTION
We have very specific versions in our pip requirement files. There are lots of them, and several of them receive too many updates. Reducing update frequency to weekly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9844)
<!-- Reviewable:end -->
