### PR TITLE
ci: placeholders to change default MSVC version (#9829)

### DIFF
--- a/ci/kokoro/windows/bazel-debug-2019-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-debug-2019-presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2019"
+}

--- a/ci/kokoro/windows/bazel-debug-2019.cfg
+++ b/ci/kokoro/windows/bazel-debug-2019.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2019"
+}

--- a/ci/kokoro/windows/bazel-release-2019-presubmit.cfg
+++ b/ci/kokoro/windows/bazel-release-2019-presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2019"
+}

--- a/ci/kokoro/windows/bazel-release-2019.cfg
+++ b/ci/kokoro/windows/bazel-release-2019.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+env_vars {
+    key: "MSVC_VERSION"
+    value: "2019"
+}


### PR DESCRIPTION
This change just creates placeholder Kokoro configuration files. In a separate change I will remove the `bazel*.cfg` files without an explicit MSVC version. Then I will switch the default to 2022.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9850)
<!-- Reviewable:end -->
