### PR TITLE
ci: GCB triggers are branch-specific

### DIFF
--- a/ci/cloudbuild/trigger.sh
+++ b/ci/cloudbuild/trigger.sh
@@ -50,7 +50,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\\d+\\..*)$
+    branch: ^main$
 name: ${name}-ci
 substitutions:
   _BUILD_NAME: ${name}
@@ -69,7 +69,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\\d+\\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: ${name}-pr
 substitutions:

--- a/ci/cloudbuild/triggers/asan-ci.yaml
+++ b/ci/cloudbuild/triggers/asan-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: asan-ci
 substitutions:
   _BUILD_NAME: asan

--- a/ci/cloudbuild/triggers/asan-pr.yaml
+++ b/ci/cloudbuild/triggers/asan-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: asan-pr
 substitutions:

--- a/ci/cloudbuild/triggers/bazel-oldest-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-oldest-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: bazel-oldest-ci
 substitutions:
   _BUILD_NAME: bazel-oldest

--- a/ci/cloudbuild/triggers/bazel-oldest-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-oldest-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: bazel-oldest-pr
 substitutions:

--- a/ci/cloudbuild/triggers/bazel-targets-ci.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: bazel-targets-ci
 substitutions:
   _BUILD_NAME: bazel-targets

--- a/ci/cloudbuild/triggers/bazel-targets-pr.yaml
+++ b/ci/cloudbuild/triggers/bazel-targets-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: bazel-targets-pr
 substitutions:

--- a/ci/cloudbuild/triggers/check-api-ci.yaml
+++ b/ci/cloudbuild/triggers/check-api-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: check-api-ci
 substitutions:
   _BUILD_NAME: check-api

--- a/ci/cloudbuild/triggers/check-api-pr.yaml
+++ b/ci/cloudbuild/triggers/check-api-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: check-api-pr
 substitutions:

--- a/ci/cloudbuild/triggers/checkers-ci.yaml
+++ b/ci/cloudbuild/triggers/checkers-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: checkers-ci
 substitutions:
   _BUILD_NAME: checkers

--- a/ci/cloudbuild/triggers/checkers-pr.yaml
+++ b/ci/cloudbuild/triggers/checkers-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: checkers-pr
 substitutions:

--- a/ci/cloudbuild/triggers/clang-60-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-60-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: clang-60-ci
 substitutions:
   _BUILD_NAME: clang-60

--- a/ci/cloudbuild/triggers/clang-60-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-60-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: clang-60-pr
 substitutions:

--- a/ci/cloudbuild/triggers/clang-tidy-ci.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: clang-tidy-ci
 substitutions:
   _BUILD_NAME: clang-tidy

--- a/ci/cloudbuild/triggers/clang-tidy-pr.yaml
+++ b/ci/cloudbuild/triggers/clang-tidy-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: clang-tidy-pr
 substitutions:

--- a/ci/cloudbuild/triggers/cmake-gcs-rest-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcs-rest-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: cmake-gcs-rest-ci
 substitutions:
   _BUILD_NAME: cmake-gcs-rest

--- a/ci/cloudbuild/triggers/cmake-gcs-rest-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-gcs-rest-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: cmake-gcs-rest-pr
 substitutions:

--- a/ci/cloudbuild/triggers/cmake-install-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: cmake-install-ci
 substitutions:
   _BUILD_NAME: cmake-install

--- a/ci/cloudbuild/triggers/cmake-install-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-install-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: cmake-install-pr
 substitutions:

--- a/ci/cloudbuild/triggers/cmake-oldest-deps-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-oldest-deps-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: cmake-oldest-deps-ci
 substitutions:
   _BUILD_NAME: cmake-oldest-deps

--- a/ci/cloudbuild/triggers/cmake-oldest-deps-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-oldest-deps-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: cmake-oldest-deps-pr
 substitutions:

--- a/ci/cloudbuild/triggers/cmake-single-feature-ci.yaml
+++ b/ci/cloudbuild/triggers/cmake-single-feature-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: cmake-single-feature-ci
 substitutions:
   _BUILD_NAME: cmake-single-feature

--- a/ci/cloudbuild/triggers/cmake-single-feature-pr.yaml
+++ b/ci/cloudbuild/triggers/cmake-single-feature-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: cmake-single-feature-pr
 substitutions:

--- a/ci/cloudbuild/triggers/coverage-ci.yaml
+++ b/ci/cloudbuild/triggers/coverage-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: coverage-ci
 substitutions:
   _BUILD_NAME: coverage

--- a/ci/cloudbuild/triggers/coverage-pr.yaml
+++ b/ci/cloudbuild/triggers/coverage-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: coverage-pr
 substitutions:

--- a/ci/cloudbuild/triggers/cxx14-ci.yaml
+++ b/ci/cloudbuild/triggers/cxx14-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: cxx14-ci
 substitutions:
   _BUILD_NAME: cxx14

--- a/ci/cloudbuild/triggers/cxx14-pr.yaml
+++ b/ci/cloudbuild/triggers/cxx14-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: cxx14-pr
 substitutions:

--- a/ci/cloudbuild/triggers/cxx20-ci.yaml
+++ b/ci/cloudbuild/triggers/cxx20-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: cxx20-ci
 substitutions:
   _BUILD_NAME: cxx20

--- a/ci/cloudbuild/triggers/cxx20-pr.yaml
+++ b/ci/cloudbuild/triggers/cxx20-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: cxx20-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-alpine-stable-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-alpine-stable-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-alpine-stable-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-alpine-stable-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-alpine-stable-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-alpine-stable-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-centos-7-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-centos-7-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-centos-7-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-centos-7-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-centos-7-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-centos-7-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-debian-bullseye-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-debian-bullseye-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-debian-bullseye-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-debian-bullseye-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-debian-bullseye-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-debian-bullseye-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-debian-buster-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-debian-buster-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-debian-buster-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-debian-buster-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-debian-buster-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-debian-buster-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-fedora-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-fedora-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-fedora-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-fedora-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-fedora-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-fedora-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-opensuse-leap-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-opensuse-leap-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-opensuse-leap-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-opensuse-leap-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-opensuse-leap-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-opensuse-leap-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-rockylinux-8-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-rockylinux-8-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-rockylinux-8-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-rockylinux-8-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-rockylinux-8-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-rockylinux-8-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-ubuntu-bionic-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-ubuntu-bionic-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-ubuntu-bionic-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-ubuntu-bionic-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-ubuntu-bionic-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-ubuntu-bionic-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-ubuntu-focal-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-ubuntu-focal-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-ubuntu-focal-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-ubuntu-focal-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-ubuntu-focal-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-ubuntu-focal-pr
 substitutions:

--- a/ci/cloudbuild/triggers/demo-ubuntu-jammy-ci.yaml
+++ b/ci/cloudbuild/triggers/demo-ubuntu-jammy-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: demo-ubuntu-jammy-ci
 substitutions:
   _BUILD_NAME: demo-install

--- a/ci/cloudbuild/triggers/demo-ubuntu-jammy-pr.yaml
+++ b/ci/cloudbuild/triggers/demo-ubuntu-jammy-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: demo-ubuntu-jammy-pr
 substitutions:

--- a/ci/cloudbuild/triggers/gcc-7.3-ci.yaml
+++ b/ci/cloudbuild/triggers/gcc-7.3-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: gcc-7-3-ci
 substitutions:
   _BUILD_NAME: gcc-7.3

--- a/ci/cloudbuild/triggers/gcc-7.3-pr.yaml
+++ b/ci/cloudbuild/triggers/gcc-7.3-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: gcc-7-3-pr
 substitutions:

--- a/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: gcs-grpc-ci
 substitutions:
   _BUILD_NAME: gcs-grpc

--- a/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
+++ b/ci/cloudbuild/triggers/gcs-grpc-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: gcs-grpc-pr
 substitutions:

--- a/ci/cloudbuild/triggers/generate-libraries-ci.yaml
+++ b/ci/cloudbuild/triggers/generate-libraries-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: generate-libraries-ci
 substitutions:
   _BUILD_NAME: generate-libraries

--- a/ci/cloudbuild/triggers/generate-libraries-pr.yaml
+++ b/ci/cloudbuild/triggers/generate-libraries-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: generate-libraries-pr
 substitutions:

--- a/ci/cloudbuild/triggers/integration-production-ci.yaml
+++ b/ci/cloudbuild/triggers/integration-production-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: integration-production-ci
 substitutions:
   _BUILD_NAME: integration-production

--- a/ci/cloudbuild/triggers/integration-production-pr.yaml
+++ b/ci/cloudbuild/triggers/integration-production-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: integration-production-pr
 substitutions:

--- a/ci/cloudbuild/triggers/libcxx-ci.yaml
+++ b/ci/cloudbuild/triggers/libcxx-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: libcxx-ci
 substitutions:
   _BUILD_NAME: libcxx

--- a/ci/cloudbuild/triggers/libcxx-pr.yaml
+++ b/ci/cloudbuild/triggers/libcxx-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: libcxx-pr
 substitutions:

--- a/ci/cloudbuild/triggers/log-linker-pr.yaml
+++ b/ci/cloudbuild/triggers/log-linker-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: log-linker-pr
 substitutions:

--- a/ci/cloudbuild/triggers/msan-ci.yaml
+++ b/ci/cloudbuild/triggers/msan-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: msan-ci
 substitutions:
   _BUILD_NAME: msan

--- a/ci/cloudbuild/triggers/msan-pr.yaml
+++ b/ci/cloudbuild/triggers/msan-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: msan-pr
 substitutions:

--- a/ci/cloudbuild/triggers/noex-ci.yaml
+++ b/ci/cloudbuild/triggers/noex-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: noex-ci
 substitutions:
   _BUILD_NAME: noex

--- a/ci/cloudbuild/triggers/noex-pr.yaml
+++ b/ci/cloudbuild/triggers/noex-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: noex-pr
 substitutions:

--- a/ci/cloudbuild/triggers/publish-docs-ci.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: publish-docs-ci
 substitutions:
   _BUILD_NAME: publish-docs

--- a/ci/cloudbuild/triggers/publish-docs-pr.yaml
+++ b/ci/cloudbuild/triggers/publish-docs-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: publish-docs-pr
 substitutions:

--- a/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: quickstart-bazel-ci
 substitutions:
   _BUILD_NAME: quickstart-bazel

--- a/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-bazel-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: quickstart-bazel-pr
 substitutions:

--- a/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: quickstart-cmake-ci
 substitutions:
   _BUILD_NAME: quickstart-cmake

--- a/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-cmake-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: quickstart-cmake-pr
 substitutions:

--- a/ci/cloudbuild/triggers/quickstart-production-ci.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: quickstart-production-ci
 substitutions:
   _BUILD_NAME: quickstart-production

--- a/ci/cloudbuild/triggers/quickstart-production-pr.yaml
+++ b/ci/cloudbuild/triggers/quickstart-production-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: quickstart-production-pr
 substitutions:

--- a/ci/cloudbuild/triggers/shared-ci.yaml
+++ b/ci/cloudbuild/triggers/shared-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: shared-ci
 substitutions:
   _BUILD_NAME: shared

--- a/ci/cloudbuild/triggers/shared-pr.yaml
+++ b/ci/cloudbuild/triggers/shared-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: shared-pr
 substitutions:

--- a/ci/cloudbuild/triggers/tsan-ci.yaml
+++ b/ci/cloudbuild/triggers/tsan-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: tsan-ci
 substitutions:
   _BUILD_NAME: tsan

--- a/ci/cloudbuild/triggers/tsan-pr.yaml
+++ b/ci/cloudbuild/triggers/tsan-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: tsan-pr
 substitutions:

--- a/ci/cloudbuild/triggers/ubsan-ci.yaml
+++ b/ci/cloudbuild/triggers/ubsan-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: ubsan-ci
 substitutions:
   _BUILD_NAME: ubsan

--- a/ci/cloudbuild/triggers/ubsan-pr.yaml
+++ b/ci/cloudbuild/triggers/ubsan-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: ubsan-pr
 substitutions:

--- a/ci/cloudbuild/triggers/xsan-ci.yaml
+++ b/ci/cloudbuild/triggers/xsan-ci.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   push:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
 name: xsan-ci
 substitutions:
   _BUILD_NAME: xsan

--- a/ci/cloudbuild/triggers/xsan-pr.yaml
+++ b/ci/cloudbuild/triggers/xsan-pr.yaml
@@ -3,7 +3,7 @@ github:
   name: google-cloud-cpp
   owner: googleapis
   pullRequest:
-    branch: ^(master|main|v\d+\..*)$
+    branch: ^main$
     commentControl: COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY
 name: xsan-pr
 substitutions:


### PR DESCRIPTION
Made the GCB triggers specific to the `main` branch. When we need builds in a branch (for LTS and/or patch releases), we will use the `convert-to-branch-triggers.sh` script to create separate triggers that apply to this branch. I will update the release documentation in a future PR.

Part of the work for #9854

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9857)
<!-- Reviewable:end -->
