### PR TITLE
test: make the TerminateHandler tests order independent

### DIFF
--- a/google/cloud/terminate_handler.h
+++ b/google/cloud/terminate_handler.h
@@ -63,7 +63,6 @@ TerminateHandler GetTerminateHandler();
  * @param msg Details about the error.
  *
  * This function should never return.
- *
  */
 [[noreturn]] void Terminate(char const* msg);
 


### PR DESCRIPTION
Restore the original `TerminateHandler` at the end of each test so that
`TerminateHandler.UnsetTerminates` does not need to be run first.

Part of #9831.

And while we're here, avoid a namespace-scope `std::string`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9858)
<!-- Reviewable:end -->
