### PR TITLE
test: enable googletest shuffling

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -33,6 +33,11 @@ build:macos --cxxopt=-std=c++14
 # the project separately.
 build --experimental_convenience_symlinks=ignore
 
+# Inject ${GTEST_SHUFFLE} and ${GTEST_RANDOM_SEED} into the test environment
+# if they are set in the enclosing environment. This allows for running tests
+# in a random order to help expose undesirable interdependencies.
+test --test_env=GTEST_SHUFFLE --test_env=GTEST_RANDOM_SEED
+
 # Clang Sanitizers, use with (for example):
 #
 # --client_env=CXX=clang++ --client_env=CC=clang --config asan

--- a/ci/lib/init.sh
+++ b/ci/lib/init.sh
@@ -71,3 +71,7 @@ fi
 MODULE_SEARCH_PATH=(
   "${PROJECT_ROOT}"
 )
+
+# Run tests in a random order to help expose undesirable interdependencies.
+# Set GTEST_RANDOM_SEED=<SEED> to reproduce a previous order.
+export GTEST_SHUFFLE=1


### PR DESCRIPTION
Run tests in a random order to help expose undesirable interdependencies.

Fixes #9831.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9865)
<!-- Reviewable:end -->
