### PR TITLE
ci: new script to create branch triggers

### DIFF
--- a/ci/cloudbuild/convert-to-branch-triggers.sh
+++ b/ci/cloudbuild/convert-to-branch-triggers.sh
@@ -26,7 +26,6 @@ source "$(dirname "$0")/../lib/init.sh"
 source module ci/lib/io.sh
 
 function print_usage() {
-  # Extracts the usage from the file comment starting at line 17.
   cat <<_EOM_
 Usage: ${PROGRAM_NAME} [options]
   Options:
@@ -68,7 +67,6 @@ function parent() {
     expr "${CLOSEST[1]}" : 'refs/heads/\(.*\)'
   fi
 }
-export -f parent
 
 # Use getopt to parse and normalize all the args.
 PARSED="$(getopt -a \

--- a/ci/cloudbuild/convert-to-branch-triggers.sh
+++ b/ci/cloudbuild/convert-to-branch-triggers.sh
@@ -94,7 +94,9 @@ while true; do
   esac
 done
 
-BRANCH="$(parent)"
+if [[ -z "${BRANCH}" ]]; then
+  BRANCH="$(parent)"
+fi
 
 git ls-files -z -- ci/cloudbuild/triggers/*.yaml |
   xargs -P "$(nproc)" -n 10 -0 bash -c "convert_triggers \"${BRANCH}\" \"\$@\""

--- a/ci/cloudbuild/convert-to-branch-triggers.sh
+++ b/ci/cloudbuild/convert-to-branch-triggers.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script restores the GCB (Google Cloud Build) triggers for a branch.
+# This is useful when creating patch releases (including for LTS branches),
+# where the CI matrix may have changed since the branch was created, and
+# therefore the existing branches may not apply.
+#
+
+set -euo pipefail
+
+source "$(dirname "$0")/../lib/init.sh"
+source module ci/lib/io.sh
+
+function print_usage() {
+  # Extracts the usage from the file comment starting at line 17.
+  cat <<_EOM_
+Usage: ${PROGRAM_NAME} [options]
+  Options:
+    -h|--help          Print this help message
+    --branch=<name>    Use name instead of the current branch
+_EOM_
+}
+
+function convert_triggers() {
+  local branch="$1"
+  local name_prefix="${branch//./-}"
+  shift
+  for file in "$@"; do
+    sed -i \
+      -e "s/^name: /name: ${name_prefix}-/" \
+      -e "s/branch: .*/branch: ${branch}/" "${file}"
+  done
+}
+export -f convert_triggers
+
+# Use getopt to parse and normalize all the args.
+PARSED="$(getopt -a \
+  --options="h" \
+  --longoptions="help,branch:" \
+  --name="${PROGRAM_NAME}" \
+  -- "$@")"
+eval set -- "${PARSED}"
+
+BRANCH=""
+while true; do
+  case "$1" in
+    -h | --help)
+      print_usage
+      exit 0
+      ;;
+    --branch)
+      BRANCH="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+  esac
+done
+
+if [[ -z "${BRANCH}" ]]; then
+  BRANCH="$(git branch --show-current)"
+  if [[ ! "${BRANCH}" =~ ^v[1-9]([0-9]*)?\.[0-9]+\.x$ ]]; then
+    # This is not a release branch, find the parent branch.
+    BRANCH="$(git show-branch |
+      sed -n '/\*/ s/].*//' |
+      grep -v "$(git rev-parse --abbrev-ref HEAD)" |
+      sed '1,1 s/^.*\[//')"
+  fi
+fi
+
+git ls-files -z -- ci/cloudbuild/triggers/*.yaml |
+  xargs -P "$(nproc)" -n 10 -0 bash -c "convert_triggers \"${BRANCH}\" \"\$@\""

--- a/ci/cloudbuild/convert-to-branch-triggers.sh
+++ b/ci/cloudbuild/convert-to-branch-triggers.sh
@@ -94,13 +94,7 @@ while true; do
   esac
 done
 
-if [[ -z "${BRANCH}" ]]; then
-  BRANCH="$(git branch --show-current)"
-  if [[ ! "${BRANCH}" =~ ^v[1-9]([0-9]*)?\.[0-9]+\.x$ ]]; then
-    # This is not a release branch, find the parent branch.
-    BRANCH="$(parent)"
-  fi
-fi
+BRANCH="$(parent)"
 
 git ls-files -z -- ci/cloudbuild/triggers/*.yaml |
   xargs -P "$(nproc)" -n 10 -0 bash -c "convert_triggers \"${BRANCH}\" \"\$@\""

--- a/release/README.md
+++ b/release/README.md
@@ -177,9 +177,11 @@ In your development fork:
     ```shell
     git commit -m"Updated GCB triggers" ci
     ```
-- Run `ci/cloudbuild/build.sh -t check-api-pr` to update both the API
-  baselines and `google/cloud/internal/version_info.h`. And then commit the
-  changes:
+- Update the API baselines and `google/cloud/internal/version_info.h`:
+  ```shell
+  ci/cloudbuild/build.sh -t check-api-pr
+  ```
+- Commit the changes:
   ```shell
   git commit -m"Update API/ABI baseline" ci
   ```


### PR DESCRIPTION
To support the LTS branch and to create patch releases, we need GCB triggers for that specific branch. This adds a script to create such triggers.

Update the notes on how to create patch releases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9866)
<!-- Reviewable:end -->
