### PR TITLE
refactor(GCS+gRPC): `Notification` helpers to `storage_internal`

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1062,37 +1062,37 @@ StatusOr<SignBlobResponse> GrpcClient::SignBlob(
 
 StatusOr<ListNotificationsResponse> GrpcClient::ListNotifications(
     ListNotificationsRequest const& request) {
-  auto proto = ToProto(request);
+  auto proto = storage_internal::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->ListNotifications(context, proto);
   if (!response) return std::move(response).status();
-  return FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<NotificationMetadata> GrpcClient::CreateNotification(
     CreateNotificationRequest const& request) {
-  auto proto = ToProto(request);
+  auto proto = storage_internal::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->CreateNotification(context, proto);
   if (!response) return std::move(response).status();
-  return FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<NotificationMetadata> GrpcClient::GetNotification(
     GetNotificationRequest const& request) {
-  auto proto = ToProto(request);
+  auto proto = storage_internal::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->GetNotification(context, proto);
   if (!response) return std::move(response).status();
-  return FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<EmptyResponse> GrpcClient::DeleteNotification(
     DeleteNotificationRequest const& request) {
-  auto proto = ToProto(request);
+  auto proto = storage_internal::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->DeleteNotification(context, proto);

--- a/google/cloud/storage/internal/grpc_notification_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_notification_metadata_parser.cc
@@ -19,15 +19,15 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-NotificationMetadata FromProto(google::storage::v2::Notification const& rhs) {
+storage::NotificationMetadata FromProto(
+    google::storage::v2::Notification const& rhs) {
   std::vector<absl::string_view> components = absl::StrSplit(rhs.name(), '/');
   auto id = components.empty() ? std::string{} : std::string{components.back()};
 
-  NotificationMetadata result(std::move(id), rhs.etag());
+  storage::NotificationMetadata result(std::move(id), rhs.etag());
   absl::string_view topic = rhs.topic();
   absl::ConsumePrefix(&topic, "//pubsub.googleapis.com/");
   result.set_topic(std::string{topic});
@@ -42,7 +42,8 @@ NotificationMetadata FromProto(google::storage::v2::Notification const& rhs) {
   return result;
 }
 
-google::storage::v2::Notification ToProto(NotificationMetadata const& rhs) {
+google::storage::v2::Notification ToProto(
+    storage::NotificationMetadata const& rhs) {
   google::storage::v2::Notification result;
   result.set_topic("//pubsub.googleapis.com/" + rhs.topic());
   result.set_etag(rhs.etag());
@@ -57,16 +58,15 @@ google::storage::v2::Notification ToProto(NotificationMetadata const& rhs) {
   return result;
 }
 
-google::storage::v2::Notification ToProto(NotificationMetadata const& rhs,
-                                          std::string const& bucket_name) {
+google::storage::v2::Notification ToProto(
+    storage::NotificationMetadata const& rhs, std::string const& bucket_name) {
   auto result = ToProto(rhs);
-  result.set_name(GrpcBucketIdToName(bucket_name) + "/notificationConfigs/" +
-                  rhs.id());
+  result.set_name(storage::internal::GrpcBucketIdToName(bucket_name) +
+                  "/notificationConfigs/" + rhs.id());
   return result;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_notification_metadata_parser.h
+++ b/google/cloud/storage/internal/grpc_notification_metadata_parser.h
@@ -21,18 +21,18 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-NotificationMetadata FromProto(google::storage::v2::Notification const& rhs);
-google::storage::v2::Notification ToProto(NotificationMetadata const& rhs);
-google::storage::v2::Notification ToProto(NotificationMetadata const& rhs,
-                                          std::string const& bucket_name);
+storage::NotificationMetadata FromProto(
+    google::storage::v2::Notification const& rhs);
+google::storage::v2::Notification ToProto(
+    storage::NotificationMetadata const& rhs);
+google::storage::v2::Notification ToProto(
+    storage::NotificationMetadata const& rhs, std::string const& bucket_name);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_notification_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_notification_metadata_parser_test.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 namespace storage_proto = ::google::storage::v2;
@@ -66,8 +65,7 @@ TEST(GrpcNotificationMetadataParser, Roundtrip) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_notification_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_notification_request_parser.cc
@@ -18,52 +18,50 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 google::storage::v2::DeleteNotificationRequest ToProto(
-    DeleteNotificationRequest const& rhs) {
+    storage::internal::DeleteNotificationRequest const& rhs) {
   google::storage::v2::DeleteNotificationRequest request;
-  request.set_name(GrpcBucketIdToName(rhs.bucket_name()) +
+  request.set_name(storage::internal::GrpcBucketIdToName(rhs.bucket_name()) +
                    "/notificationConfigs/" + rhs.notification_id());
   return request;
 }
 
 google::storage::v2::GetNotificationRequest ToProto(
-    GetNotificationRequest const& rhs) {
+    storage::internal::GetNotificationRequest const& rhs) {
   google::storage::v2::GetNotificationRequest request;
-  request.set_name(GrpcBucketIdToName(rhs.bucket_name()) +
+  request.set_name(storage::internal::GrpcBucketIdToName(rhs.bucket_name()) +
                    "/notificationConfigs/" + rhs.notification_id());
   return request;
 }
 
 google::storage::v2::CreateNotificationRequest ToProto(
-    CreateNotificationRequest const& rhs) {
+    storage::internal::CreateNotificationRequest const& rhs) {
   google::storage::v2::CreateNotificationRequest request;
-  request.set_parent(GrpcBucketIdToName(rhs.bucket_name()));
-  *request.mutable_notification() = ToProto(rhs.metadata());
+  request.set_parent(storage::internal::GrpcBucketIdToName(rhs.bucket_name()));
+  *request.mutable_notification() = storage_internal::ToProto(rhs.metadata());
   return request;
 }
 
 google::storage::v2::ListNotificationsRequest ToProto(
-    ListNotificationsRequest const& rhs) {
+    storage::internal::ListNotificationsRequest const& rhs) {
   google::storage::v2::ListNotificationsRequest request;
-  request.set_parent(GrpcBucketIdToName(rhs.bucket_name()));
+  request.set_parent(storage::internal::GrpcBucketIdToName(rhs.bucket_name()));
   return request;
 }
 
-ListNotificationsResponse FromProto(
+storage::internal::ListNotificationsResponse FromProto(
     google::storage::v2::ListNotificationsResponse const& rhs) {
-  ListNotificationsResponse response;
+  storage::internal::ListNotificationsResponse response;
   for (auto const& i : rhs.notifications()) {
-    response.items.push_back(FromProto(i));
+    response.items.push_back(storage_internal::FromProto(i));
   }
   return response;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_notification_request_parser.h
+++ b/google/cloud/storage/internal/grpc_notification_request_parser.h
@@ -21,24 +21,22 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 google::storage::v2::DeleteNotificationRequest ToProto(
-    DeleteNotificationRequest const& rhs);
+    storage::internal::DeleteNotificationRequest const& rhs);
 google::storage::v2::GetNotificationRequest ToProto(
-    GetNotificationRequest const& rhs);
+    storage::internal::GetNotificationRequest const& rhs);
 google::storage::v2::CreateNotificationRequest ToProto(
-    CreateNotificationRequest const& rhs);
+    storage::internal::CreateNotificationRequest const& rhs);
 google::storage::v2::ListNotificationsRequest ToProto(
-    ListNotificationsRequest const& rhs);
-ListNotificationsResponse FromProto(
+    storage::internal::ListNotificationsRequest const& rhs);
+storage::internal::ListNotificationsResponse FromProto(
     google::storage::v2::ListNotificationsResponse const& rhs);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_notification_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_notification_request_parser_test.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 namespace v2 = ::google::storage::v2;
@@ -37,7 +36,8 @@ TEST(GrpcNotificationRequestParser, DeleteNotification) {
       )pb",
       &expected));
 
-  DeleteNotificationRequest req("test-bucket-name", "test-notification-id");
+  storage::internal::DeleteNotificationRequest req("test-bucket-name",
+                                                   "test-notification-id");
 
   auto const actual = ToProto(req);
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -51,7 +51,8 @@ TEST(GrpcNotificationRequestParser, GetNotification) {
       )pb",
       &expected));
 
-  GetNotificationRequest req("test-bucket-name", "test-notification-id");
+  storage::internal::GetNotificationRequest req("test-bucket-name",
+                                                "test-notification-id");
 
   auto const actual = ToProto(req);
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -74,9 +75,9 @@ TEST(GrpcNotificationRequestParser, CreateNotification) {
       )pb",
       &expected));
 
-  CreateNotificationRequest req(
+  storage::internal::CreateNotificationRequest req(
       "test-bucket-name",
-      NotificationMetadata()
+      storage::NotificationMetadata()
           .set_topic("projects/test-topic-project/topics/test-topic-id")
           .append_event_type("OBJECT_DELETE")
           .append_event_type("OBJECT_ARCHIVE")
@@ -84,7 +85,7 @@ TEST(GrpcNotificationRequestParser, CreateNotification) {
           .upsert_custom_attributes("test-key-1", "test-value-1")
           .set_object_name_prefix("test-object-name-prefix/")
           .set_payload_format("JSON_API_V1"));
-  req.set_multiple_options(UserProject("test-user-project"));
+  req.set_multiple_options(storage::UserProject("test-user-project"));
 
   auto const actual = ToProto(req);
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -98,7 +99,7 @@ TEST(GrpcNotificationRequestParser, ListNotifications) {
       )pb",
       &expected));
 
-  ListNotificationsRequest req("test-bucket-name");
+  storage::internal::ListNotificationsRequest req("test-bucket-name");
 
   auto const actual = ToProto(req);
   EXPECT_THAT(actual, IsProtoEqual(expected));
@@ -132,7 +133,7 @@ TEST(GrpcNotificationRequestParser, ListNotificationsResponse) {
   EXPECT_THAT(
       actual.items,
       ElementsAre(
-          NotificationMetadata("test-id-1", "test-etag-1")
+          storage::NotificationMetadata("test-id-1", "test-etag-1")
               .set_topic("projects/test-topic-project/topics/test-topic-id-1")
               .append_event_type("OBJECT_DELETE")
               .append_event_type("OBJECT_ARCHIVE")
@@ -140,14 +141,13 @@ TEST(GrpcNotificationRequestParser, ListNotificationsResponse) {
               .upsert_custom_attributes("test-key-1", "test-value-1")
               .set_object_name_prefix("test-object-name-prefix/")
               .set_payload_format("JSON_API_V1"),
-          NotificationMetadata("test-id-2", "test-etag-2")
+          storage::NotificationMetadata("test-id-2", "test-etag-2")
               .set_topic("projects/test-topic-project/topics/test-topic-id-2")
               .set_payload_format("JSON_API_V1")));
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Part of the work for #8929.

But mostly a small PR to make sure my Kokoro configuration changes did not break anything.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9867)
<!-- Reviewable:end -->
