### PR TITLE
test(spanner): remove "too many stale" checks

### DIFF
--- a/google/cloud/spanner/testing/cleanup_stale_instances.cc
+++ b/google/cloud/spanner/testing/cleanup_stale_instances.cc
@@ -74,10 +74,6 @@ Status CleanupStaleInstances(Project const& project) {
       }
     }
   }
-  // Let it fail if we have too many leaks.
-  if (instances.size() > 20) {
-    return Status(StatusCode::kInternal, "Too many stale instances");
-  }
 
   // We ignore failures here.
   spanner_admin::DatabaseAdminClient database_admin_client(
@@ -124,10 +120,6 @@ Status CleanupStaleInstanceConfigs(Project const& project) {
         configs.push_back(name);
       }
     }
-  }
-  // Let it fail if we have too many leaks.
-  if (configs.size() > 20) {
-    return Status(StatusCode::kInternal, "Too many stale instance configs");
   }
 
   // We ignore failures here.


### PR DESCRIPTION
These have never caught any problems, and, even if they did, the remedy would probably just be to remove the stales objects anyway.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9875)
<!-- Reviewable:end -->
