### PR TITLE
ci: use custom vcpkg triplets for Windows+CMake

### DIFF
--- a/ci/kokoro/windows/build-32.bat
+++ b/ci/kokoro/windows/build-32.bat
@@ -28,6 +28,7 @@ if "%KOKORO_JOB_POOL%" == "yoshi-cpp-win" (
 ) else (
   call "%ProgramFiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%\BuildTools\VC\Auxiliary\Build\vcvars32.bat"
   set "BAZEL_VC=%ProgramFiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%\BuildTools\VC"
+  set "VCPKG_OVERLAY_TRIPLETS=%cd%\ci\kokoro\windows\triplets"
 )
 
 REM The remaining of the build script is implemented in PowerShell.

--- a/ci/kokoro/windows/build.bat
+++ b/ci/kokoro/windows/build.bat
@@ -28,6 +28,7 @@ if "%KOKORO_JOB_POOL%" == "yoshi-cpp-win" (
 ) else (
   call "%ProgramFiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
   set "BAZEL_VC=%ProgramFiles(x86)%\Microsoft Visual Studio\%MSVC_VERSION%\BuildTools\VC"
+  set "VCPKG_OVERLAY_TRIPLETS=%cd%\ci\kokoro\windows\triplets"
 )
 
 REM The remaining of the build script is implemented in PowerShell.

--- a/ci/kokoro/windows/triplets/x64-windows-static.cmake
+++ b/ci/kokoro/windows/triplets/x64-windows-static.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")

--- a/ci/kokoro/windows/triplets/x64-windows-static.cmake
+++ b/ci/kokoro/windows/triplets/x64-windows-static.cmake
@@ -1,4 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")
+set(VCPKG_VISUAL_STUDIO_PATH
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools"
+)

--- a/ci/kokoro/windows/triplets/x64-windows.cmake
+++ b/ci/kokoro/windows/triplets/x64-windows.cmake
@@ -1,4 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x64)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
-set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")
+set(VCPKG_VISUAL_STUDIO_PATH
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools"
+)

--- a/ci/kokoro/windows/triplets/x64-windows.cmake
+++ b/ci/kokoro/windows/triplets/x64-windows.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")

--- a/ci/kokoro/windows/triplets/x86-windows-static.cmake
+++ b/ci/kokoro/windows/triplets/x86-windows-static.cmake
@@ -1,4 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE static)
 set(VCPKG_LIBRARY_LINKAGE static)
-set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")
+set(VCPKG_VISUAL_STUDIO_PATH
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools"
+)

--- a/ci/kokoro/windows/triplets/x86-windows-static.cmake
+++ b/ci/kokoro/windows/triplets/x86-windows-static.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_TARGET_ARCHITECTURE x86)
+set(VCPKG_CRT_LINKAGE static)
+set(VCPKG_LIBRARY_LINKAGE static)
+set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")

--- a/ci/kokoro/windows/triplets/x86-windows.cmake
+++ b/ci/kokoro/windows/triplets/x86-windows.cmake
@@ -1,0 +1,4 @@
+set(VCPKG_TARGET_ARCHITECTURE x86)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")

--- a/ci/kokoro/windows/triplets/x86-windows.cmake
+++ b/ci/kokoro/windows/triplets/x86-windows.cmake
@@ -1,4 +1,6 @@
 set(VCPKG_TARGET_ARCHITECTURE x86)
 set(VCPKG_CRT_LINKAGE dynamic)
 set(VCPKG_LIBRARY_LINKAGE dynamic)
-set(VCPKG_VISUAL_STUDIO_PATH "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools")
+set(VCPKG_VISUAL_STUDIO_PATH
+    "C:\\Program Files (x86)\\Microsoft Visual Studio\\$ENV{MSVC_VERSION}\\BuildTools"
+)


### PR DESCRIPTION
`vcpkg` uses its own algorithm to find MSVC. The documented way to change this algorithm is to create a custom triplet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9881)
<!-- Reviewable:end -->
