### PR TITLE
feat(storage): easier mocks with `BucketMetadata`

### DIFF
--- a/google/cloud/storage/bucket_metadata.cc
+++ b/google/cloud/storage/bucket_metadata.cc
@@ -140,22 +140,35 @@ std::ostream& operator<<(std::ostream& os,
 }
 
 bool operator==(BucketMetadata const& lhs, BucketMetadata const& rhs) {
-  return static_cast<internal::CommonMetadata<BucketMetadata> const&>(lhs) ==
-             rhs &&
-         lhs.acl_ == rhs.acl_ && lhs.billing_ == rhs.billing_ &&
-         lhs.cors_ == rhs.cors_ &&
-         lhs.default_event_based_hold_ == rhs.default_event_based_hold_ &&
-         lhs.default_acl_ == rhs.default_acl_ &&
-         lhs.encryption_ == rhs.encryption_ &&
-         lhs.iam_configuration_ == rhs.iam_configuration_ &&
-         lhs.project_number_ == rhs.project_number_ &&
-         lhs.lifecycle_ == rhs.lifecycle_ && lhs.location_ == rhs.location_ &&
-         lhs.location_type_ == rhs.location_type_ &&
-         lhs.logging_ == rhs.logging_ && lhs.labels_ == rhs.labels_ &&
-         lhs.retention_policy_ == rhs.retention_policy_ &&
-         lhs.rpo_ == rhs.rpo_ && lhs.versioning_ == rhs.versioning_ &&
-         lhs.website_ == rhs.website_ &&
-         lhs.custom_placement_config_ == rhs.custom_placement_config_;
+  return lhs.acl_ == rhs.acl_                                               //
+         && lhs.billing_ == rhs.billing_                                    //
+         && lhs.cors_ == rhs.cors_                                          //
+         && lhs.custom_placement_config_ == rhs.custom_placement_config_    //
+         && lhs.default_acl_ == rhs.default_acl_                            //
+         && lhs.default_event_based_hold_ == rhs.default_event_based_hold_  //
+         && lhs.encryption_ == rhs.encryption_                              //
+         && lhs.etag_ == rhs.etag_                                          //
+         && lhs.iam_configuration_ == rhs.iam_configuration_                //
+         && lhs.id_ == rhs.id_                                              //
+         && lhs.kind_ == rhs.kind_                                          //
+         && lhs.labels_ == rhs.labels_                                      //
+         && lhs.lifecycle_ == rhs.lifecycle_                                //
+         && lhs.location_ == rhs.location_                                  //
+         && lhs.location_type_ == rhs.location_type_                        //
+         && lhs.logging_ == rhs.logging_                                    //
+         && lhs.metageneration_ == rhs.metageneration_                      //
+         && lhs.name_ == rhs.name_                                          //
+         && lhs.owner_ == rhs.owner_                                        //
+         && lhs.project_number_ == rhs.project_number_                      //
+         && lhs.retention_policy_ == rhs.retention_policy_                  //
+         && lhs.rpo_ == rhs.rpo_                                            //
+         && lhs.self_link_ == rhs.self_link_                                //
+         && lhs.storage_class_ == rhs.storage_class_                        //
+         && lhs.time_created_ == rhs.time_created_                          //
+         && lhs.updated_ == rhs.updated_                                    //
+         && lhs.versioning_ == rhs.versioning_                              //
+         && lhs.website_ == rhs.website_                                    //
+      ;
 }
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs) {

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -35,8 +35,6 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
-struct BucketMetadataParser;
-struct GrpcBucketMetadataParser;
 struct GrpcBucketRequestParser;
 }  // namespace internal
 
@@ -574,7 +572,7 @@ std::ostream& operator<<(std::ostream& os,
 /**
  * Represents a Google Cloud Storage Bucket Metadata object.
  */
-class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
+class BucketMetadata {
  public:
   BucketMetadata() = default;
 
@@ -710,7 +708,12 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   ///@}
 
-  using CommonMetadata::etag;
+  std::string const& etag() const { return etag_; }
+  /// @note This is only intended for mocking.
+  BucketMetadata& set_etag(std::string v) {
+    etag_ = std::move(v);
+    return *this;
+  }
 
   /**
    * @name Get and set the IAM configuration.
@@ -743,8 +746,19 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
   ///@}
 
-  using CommonMetadata::id;
-  using CommonMetadata::kind;
+  std::string const& id() const { return id_; }
+  /// @note This is only intended for mocking
+  BucketMetadata& set_id(std::string v) {
+    id_ = std::move(v);
+    return *this;
+  }
+
+  std::string const& kind() const { return kind_; }
+  /// @note This is only intended for mocking
+  BucketMetadata& set_kind(std::string v) {
+    kind_ = std::move(v);
+    return *this;
+  }
 
   /// @name Accessors and modifiers to the `labels`.
   ///@{
@@ -819,7 +833,14 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
     return *this;
   }
 
+  /// Returns the location type (e.g. regional vs. dual region).
   std::string const& location_type() const { return location_type_; }
+
+  /// @note This is only intended for mocking.
+  BucketMetadata& set_location_type(std::string v) {
+    location_type_ = std::move(v);
+    return *this;
+  }
 
   /// @name Accessors and modifiers for logging configuration.
   ///@{
@@ -839,10 +860,15 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   ///@}
 
   /// The bucket metageneration.
-  using CommonMetadata::metageneration;
+  std::int64_t metageneration() const { return metageneration_; }
+  /// @note this is only intended for mocking.
+  BucketMetadata& set_metageneration(std::int64_t v) {
+    metageneration_ = v;
+    return *this;
+  }
 
   /// The bucket name.
-  using CommonMetadata::name;
+  std::string const& name() const { return name_; }
 
   /**
    * Changes the name.
@@ -852,17 +878,46 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
    *   some other attribute.
    */
   BucketMetadata& set_name(std::string v) {
-    CommonMetadata::set_name(std::move(v));
+    name_ = std::move(v);
     return *this;
   }
 
   /// Returns true if the bucket `owner` attribute is present.
-  using CommonMetadata::has_owner;
-  using CommonMetadata::owner;
+  bool has_owner() const { return owner_.has_value(); }
+  /**
+   * Returns the owner.
+   *
+   * It is undefined behavior to call `owner()` if `has_owner()` is false.
+   */
+  Owner const& owner() const { return *owner_; }
+
+  /// @note this is only intended for mocking.
+  BucketMetadata& set_owner(Owner v) {
+    owner_ = std::move(v);
+    return *this;
+  }
+  /// @note this is only intended for mocking.
+  BucketMetadata& reset_owner() {
+    owner_.reset();
+    return *this;
+  }
 
   std::int64_t const& project_number() const { return project_number_; }
 
-  using CommonMetadata::self_link;
+  /// @note this is only intended for mocking.
+  BucketMetadata& set_project_number(std::int64_t v) {
+    project_number_ = v;
+    return *this;
+  }
+
+  /// Returns a HTTP link to retrieve the bucket metadata.
+  std::string const& self_link() const { return self_link_; }
+
+  /// @note this is only intended for mocking.
+  BucketMetadata& set_self_link(std::string v) {
+    self_link_ = std::move(v);
+    return *this;
+  }
 
   /// @name Accessors and modifiers for retention policy configuration.
   ///@{
@@ -908,18 +963,31 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
 
   /// @name Access and modify the default storage class attribute.
   ///@{
-  using CommonMetadata::storage_class;
+  std::string const& storage_class() const { return storage_class_; }
   BucketMetadata& set_storage_class(std::string v) {
-    CommonMetadata::set_storage_class(std::move(v));
+    storage_class_ = std::move(v);
     return *this;
   }
   ///@}
 
   /// Returns the bucket creation timestamp.
-  using CommonMetadata::time_created;
+  std::chrono::system_clock::time_point time_created() const {
+    return time_created_;
+  }
+  /// @note This is only intended for mocking.
+  BucketMetadata& set_time_created(std::chrono::system_clock::time_point v) {
+    time_created_ = v;
+    return *this;
+  }
 
   /// Returns the timestamp for the last bucket metadata update.
-  using CommonMetadata::updated;
+  std::chrono::system_clock::time_point updated() const { return updated_; }
+
+  /// @note This is only intended for mocking.
+  BucketMetadata& set_updated(std::chrono::system_clock::time_point v) {
+    updated_ = v;
+    return *this;
+  }
 
   /// @name Accessors and modifiers for versioning configuration.
   ///@{
@@ -992,29 +1060,36 @@ class BucketMetadata : private internal::CommonMetadata<BucketMetadata> {
   }
 
  private:
-  friend struct internal::BucketMetadataParser;
-  friend struct internal::GrpcBucketMetadataParser;
-
   friend std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);
   // Keep the fields in alphabetical order.
   std::vector<BucketAccessControl> acl_;
   absl::optional<BucketBilling> billing_;
   std::vector<CorsEntry> cors_;
-  bool default_event_based_hold_ = false;
+  absl::optional<BucketCustomPlacementConfig> custom_placement_config_;
   std::vector<ObjectAccessControl> default_acl_;
+  bool default_event_based_hold_ = false;
   absl::optional<BucketEncryption> encryption_;
+  std::string etag_;
   absl::optional<BucketIamConfiguration> iam_configuration_;
+  std::string id_;
+  std::string kind_;
   std::map<std::string, std::string> labels_;
   absl::optional<BucketLifecycle> lifecycle_;
   std::string location_;
   std::string location_type_;
   absl::optional<BucketLogging> logging_;
+  std::int64_t metageneration_{0};
+  std::string name_;
+  absl::optional<Owner> owner_;
   std::int64_t project_number_ = 0;
   absl::optional<BucketRetentionPolicy> retention_policy_;
   std::string rpo_;
+  std::string self_link_;
+  std::string storage_class_;
+  std::chrono::system_clock::time_point time_created_;
+  std::chrono::system_clock::time_point updated_;
   absl::optional<BucketVersioning> versioning_;
   absl::optional<BucketWebsite> website_;
-  absl::optional<BucketCustomPlacementConfig> custom_placement_config_;
 };
 
 std::ostream& operator<<(std::ostream& os, BucketMetadata const& rhs);

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -709,6 +709,7 @@ class BucketMetadata {
   ///@}
 
   std::string const& etag() const { return etag_; }
+
   /// @note This is only intended for mocking.
   BucketMetadata& set_etag(std::string v) {
     etag_ = std::move(v);
@@ -746,14 +747,17 @@ class BucketMetadata {
   }
   ///@}
 
+  /// Return the bucket id.
   std::string const& id() const { return id_; }
-  /// @note This is only intended for mocking
+
+  /// @note This is only intended for mocking.
   BucketMetadata& set_id(std::string v) {
     id_ = std::move(v);
     return *this;
   }
 
   std::string const& kind() const { return kind_; }
+
   /// @note This is only intended for mocking
   BucketMetadata& set_kind(std::string v) {
     kind_ = std::move(v);
@@ -827,7 +831,10 @@ class BucketMetadata {
   }
   ///@}
 
+  /// Return the bucket location.
   std::string const& location() const { return location_; }
+
+  /// Set the bucket location. Only applicable when creating buckets.
   BucketMetadata& set_location(std::string v) {
     location_ = std::move(v);
     return *this;
@@ -861,6 +868,7 @@ class BucketMetadata {
 
   /// The bucket metageneration.
   std::int64_t metageneration() const { return metageneration_; }
+
   /// @note this is only intended for mocking.
   BucketMetadata& set_metageneration(std::int64_t v) {
     metageneration_ = v;
@@ -974,6 +982,7 @@ class BucketMetadata {
   std::chrono::system_clock::time_point time_created() const {
     return time_created_;
   }
+
   /// @note This is only intended for mocking.
   BucketMetadata& set_time_created(std::chrono::system_clock::time_point v) {
     time_created_ = v;

--- a/google/cloud/storage/internal/bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/bucket_metadata_parser.cc
@@ -197,10 +197,11 @@ std::map<std::string, std::string> ParseLabels(nlohmann::json const& json) {
 
 Status ParseOwner(BucketMetadata& meta, nlohmann::json const& json) {
   if (!json.contains("owner")) return Status{};
-  Owner o;
-  o.entity = json["owner"].value("entity", "");
-  o.entity_id = json["owner"].value("entityId", "");
-  meta.set_owner(std::move(o));
+  auto const& o = json["owner"];
+  Owner owner;
+  owner.entity = o.value("entity", "");
+  owner.entity_id = o.value("entityId", "");
+  meta.set_owner(std::move(owner));
   return Status{};
 }
 

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -115,36 +115,42 @@ BucketMetadata GrpcBucketMetadataParser::FromProto(
   // These are sorted as the fields in the BucketMetadata class, to make them
   // easier to find in the future.
   for (auto const& v : rhs.acl()) {
-    metadata.acl_.push_back(
+    metadata.mutable_acl().push_back(
         GrpcBucketAccessControlParser::FromProto(v, rhs.bucket_id()));
   }
-  if (rhs.has_billing()) metadata.billing_ = FromProto(rhs.billing());
-  metadata.default_event_based_hold_ = rhs.default_event_based_hold();
+  if (rhs.has_billing()) metadata.set_billing(FromProto(rhs.billing()));
+  metadata.set_default_event_based_hold(rhs.default_event_based_hold());
   for (auto const& v : rhs.cors()) {
-    metadata.cors_.push_back(FromProto(v));
+    metadata.mutable_cors().push_back(FromProto(v));
   }
   for (auto const& v : rhs.default_object_acl()) {
-    metadata.default_acl_.push_back(GrpcObjectAccessControlParser::FromProto(
-        v, rhs.bucket_id(), /*object_name*/ std::string{}, /*generation=*/0));
+    metadata.mutable_default_acl().push_back(
+        GrpcObjectAccessControlParser::FromProto(v, rhs.bucket_id(),
+                                                 /*object_name*/ std::string{},
+                                                 /*generation=*/0));
   }
-  if (rhs.has_encryption()) metadata.encryption_ = FromProto(rhs.encryption());
+  if (rhs.has_encryption()) {
+    metadata.set_encryption(FromProto(rhs.encryption()));
+  }
   if (rhs.has_iam_config()) {
-    metadata.iam_configuration_ = FromProto(rhs.iam_config());
+    metadata.set_iam_configuration(FromProto(rhs.iam_config()));
   }
-  metadata.etag_ = rhs.etag();
-  metadata.id_ = rhs.bucket_id();
-  metadata.kind_ = "storage#bucket";
+  metadata.set_etag(rhs.etag());
+  metadata.set_id(rhs.bucket_id());
+  metadata.set_kind("storage#bucket");
   for (auto const& kv : rhs.labels()) {
-    metadata.labels_.emplace(std::make_pair(kv.first, kv.second));
+    metadata.mutable_labels().emplace(std::make_pair(kv.first, kv.second));
   }
-  if (rhs.has_lifecycle()) metadata.lifecycle_ = FromProto(rhs.lifecycle());
-  metadata.location_ = rhs.location();
-  metadata.location_type_ = rhs.location_type();
-  if (rhs.has_logging()) metadata.logging_ = FromProto(rhs.logging());
-  metadata.metageneration_ = rhs.metageneration();
-  metadata.name_ = GrpcBucketNameToId(rhs.name());
+  if (rhs.has_lifecycle()) {
+    metadata.set_lifecycle(FromProto(rhs.lifecycle()));
+  }
+  metadata.set_location(rhs.location());
+  metadata.set_location_type(rhs.location_type());
+  if (rhs.has_logging()) metadata.set_logging(FromProto(rhs.logging()));
+  metadata.set_metageneration(rhs.metageneration());
+  metadata.set_name(GrpcBucketNameToId(rhs.name()));
   if (rhs.has_owner()) {
-    metadata.owner_ = storage_internal::FromProto(rhs.owner());
+    metadata.set_owner(storage_internal::FromProto(rhs.owner()));
   }
 
   // The protos use `projects/{project}` format, but the field may be absent or
@@ -155,27 +161,29 @@ BucketMetadata GrpcBucketMetadataParser::FromProto(
     auto s = rhs.project().substr(std::strlen("projects/"));
     char* end;
     auto number = std::strtol(s.c_str(), &end, 10);
-    if (end != nullptr && *end == '\0') metadata.project_number_ = number;
+    if (end != nullptr && *end == '\0') metadata.set_project_number(number);
   }
 
   if (rhs.has_retention_policy()) {
-    metadata.retention_policy_ = FromProto(rhs.retention_policy());
+    metadata.set_retention_policy(FromProto(rhs.retention_policy()));
   }
-  metadata.rpo_ = rhs.rpo();
-  metadata.storage_class_ = rhs.storage_class();
+  metadata.set_rpo(rhs.rpo());
+  metadata.set_storage_class(rhs.storage_class());
   if (rhs.has_create_time()) {
-    metadata.time_created_ =
-        google::cloud::internal::ToChronoTimePoint(rhs.create_time());
+    metadata.set_time_created(
+        google::cloud::internal::ToChronoTimePoint(rhs.create_time()));
   }
   if (rhs.has_update_time()) {
-    metadata.updated_ =
-        google::cloud::internal::ToChronoTimePoint(rhs.update_time());
+    metadata.set_updated(
+        google::cloud::internal::ToChronoTimePoint(rhs.update_time()));
   }
-  if (rhs.has_versioning()) metadata.versioning_ = FromProto(rhs.versioning());
-  if (rhs.has_website()) metadata.website_ = FromProto(rhs.website());
+  if (rhs.has_versioning()) {
+    metadata.set_versioning(FromProto(rhs.versioning()));
+  }
+  if (rhs.has_website()) metadata.set_website(FromProto(rhs.website()));
   if (rhs.has_custom_placement_config()) {
-    metadata.custom_placement_config_ =
-        FromProto(rhs.custom_placement_config());
+    metadata.set_custom_placement_config(
+        FromProto(rhs.custom_placement_config()));
   }
 
   return metadata;


### PR DESCRIPTION
Populating all the fields for `BucketMetadata` was somewhat difficult. The class tried to prevent applications from setting fields that only the server would set.  I thought about adding a `BucketMetadataBuilder`, but that would duplicate a lot of code without preventing anything. In addition, all the other libraries use protos that allow any field to be set, and that does not seemt to create a lot of trouble or confusion.

I also stopped using the "composition-by-private-inheritance" base because it does not save enough code.  I expect this class will go away once I make similar changes to `ObjectMetadata`.

Part of the work for #8929, I also think it will help with #7142

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9886)
<!-- Reviewable:end -->
