### PR TITLE
cleanup(spanner): throw full Status values

### DIFF
--- a/google/cloud/spanner/README.md
+++ b/google/cloud/spanner/README.md
@@ -34,9 +34,8 @@ this library.
 ```cc
 #include "google/cloud/spanner/client.h"
 #include <iostream>
-#include <stdexcept>
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[]) {
   if (argc != 4) {
     std::cerr << "Usage: " << argv[0]
               << " project-id instance-id database-id\n";
@@ -51,14 +50,14 @@ int main(int argc, char* argv[]) try {
       client.ExecuteQuery(spanner::SqlStatement("SELECT 'Hello World'"));
 
   for (auto const& row : spanner::StreamOf<std::tuple<std::string>>(rows)) {
-    if (!row) throw std::runtime_error(row.status().message());
+    if (!row) {
+      std::cerr << row.status() << "\n";
+      return 1;
+    }
     std::cout << std::get<0>(*row) << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
-  return 1;
 }
 ```
 

--- a/google/cloud/spanner/quickstart/quickstart.cc
+++ b/google/cloud/spanner/quickstart/quickstart.cc
@@ -14,9 +14,8 @@
 
 #include "google/cloud/spanner/client.h"
 #include <iostream>
-#include <stdexcept>
 
-int main(int argc, char* argv[]) try {
+int main(int argc, char* argv[]) {
   if (argc != 4) {
     std::cerr << "Usage: " << argv[0]
               << " project-id instance-id database-id\n";
@@ -31,12 +30,12 @@ int main(int argc, char* argv[]) try {
       client.ExecuteQuery(spanner::SqlStatement("SELECT 'Hello World'"));
 
   for (auto const& row : spanner::StreamOf<std::tuple<std::string>>(rows)) {
-    if (!row) throw std::runtime_error(row.status().message());
+    if (!row) {
+      std::cerr << row.status() << "\n";
+      return 1;
+    }
     std::cout << std::get<0>(*row) << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
-  return 1;
 }


### PR DESCRIPTION
Throw `google::cloud::Status` values directly in samples, instead of wrapping only their messages in a `std::runtime_error`.  And then tweak to avoid `misc-throw-by-value-catch-by-reference` clang-tidy warnings.

In the quickstart we don't really need the complications of `throw` and `catch` at all.

Part of #9016.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9892)
<!-- Reviewable:end -->
