### PR TITLE
fix(storage): decay type before testing supported-options membership

### DIFF
--- a/google/cloud/storage/parallel_upload.h
+++ b/google/cloud/storage/parallel_upload.h
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <string>
 #include <tuple>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -1015,7 +1016,7 @@ using ParallelUploadFileSupportedOptions = google::cloud::internal::TypeList<
 template <typename T>
 using SupportsParallelOption =
     google::cloud::internal::TypeListHasType<ParallelUploadFileSupportedOptions,
-                                             T>;
+                                             std::decay_t<T>>;
 
 template <typename... Provided>
 struct IsOptionSupportedWithParallelUpload


### PR DESCRIPTION
Before we check whether `ParallelUploadFileSupportedOptions` contains a given type, we should remove any reference and top-level cv qualifiers. For example, `ParallelUploadFile()` supports `UserIp const&` just like it does `UserIp`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9893)
<!-- Reviewable:end -->
