### PR TITLE
cleanup: use [[deprecated]]

### DIFF
--- a/google/cloud/internal/attributes.h
+++ b/google/cloud/internal/attributes.h
@@ -21,9 +21,6 @@
  * Marks a class, struct, enum, function, member function, or variable as
  * deprecated.
  *
- * This macro injects an attribute equivalent to C++14's `[[deprecated(msg)]]`.
- * On C++11 it uses compiler extensions to implement equivalent behavior.
- *
  * @note If you need to temporarily disable the deprecation warnings in your
  *     application, consider adding a pre-processor flag to define
  *     `GOOGLE_CLOUD_CPP_DISABLE_DEPRECATION_WARNINGS`.
@@ -36,14 +33,9 @@
 #error "Applications should not define GOOGLE_CLOUD_CPP_DEPRECATED"
 #elif GOOGLE_CLOUD_CPP_DISABLE_DEPRECATION_WARNINGS
 // Do nothing, the default definition effectively
-#elif GOOGLE_CLOUD_CPP_CPP_VERSION >= 201402L
+#else
 #define GOOGLE_CLOUD_CPP_DEPRECATED(message) [[deprecated(message)]]
-#elif defined(_MSC_VER)
-#define GOOGLE_CLOUD_CPP_DEPRECATED(message) __declspec(deprecated(message))
-#elif defined(__clang__) || defined(__GNUC__)
-#define GOOGLE_CLOUD_CPP_DEPRECATED(message) \
-  __attribute__((deprecated(message)))
-#endif  // C++ <= 11
+#endif
 
 #ifndef GOOGLE_CLOUD_CPP_DEPRECATED
 #define GOOGLE_CLOUD_CPP_DEPRECATED(message)

--- a/google/cloud/internal/attributes.h
+++ b/google/cloud/internal/attributes.h
@@ -32,13 +32,9 @@
 #if defined(GOOGLE_CLOUD_CPP_DEPRECATED)
 #error "Applications should not define GOOGLE_CLOUD_CPP_DEPRECATED"
 #elif GOOGLE_CLOUD_CPP_DISABLE_DEPRECATION_WARNINGS
-// Do nothing, the default definition effectively
+#define GOOGLE_CLOUD_CPP_DEPRECATED(message)
 #else
 #define GOOGLE_CLOUD_CPP_DEPRECATED(message) [[deprecated(message)]]
 #endif
-
-#ifndef GOOGLE_CLOUD_CPP_DEPRECATED
-#define GOOGLE_CLOUD_CPP_DEPRECATED(message)
-#endif  // GCLOUD_DEPRECATED
 
 #endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_INTERNAL_ATTRIBUTES_H


### PR DESCRIPTION
we require C++14, so simplify the deprecated macro

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9902)
<!-- Reviewable:end -->
