### PR TITLE
refactor(storage): move `ProjectTeam` to a public header

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -125,6 +125,7 @@ google_cloud_cpp_storage_hdrs = [
     "owner.h",
     "parallel_upload.h",
     "policy_document.h",
+    "project_team.h",
     "retry_policy.h",
     "service_account.h",
     "signed_url_options.h",

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -213,6 +213,7 @@ add_library(
     parallel_upload.h
     policy_document.cc
     policy_document.h
+    project_team.h
     retry_policy.h
     service_account.cc
     service_account.h

--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -15,6 +15,7 @@
 #ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_CONTROL_COMMON_H
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_INTERNAL_ACCESS_CONTROL_COMMON_H
 
+#include "google/cloud/storage/project_team.h"
 #include "google/cloud/storage/version.h"
 #include "google/cloud/status.h"
 #include "absl/types/optional.h"
@@ -27,47 +28,6 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 struct AccessControlCommonParser;
-}  // namespace internal
-
-/**
- * Represents the projectTeam field in *AccessControls.
- *
- * @see
- * https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls
- * https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls
- */
-struct ProjectTeam {
-  std::string project_number;
-  std::string team;
-};
-
-inline bool operator==(ProjectTeam const& lhs, ProjectTeam const& rhs) {
-  return std::tie(lhs.project_number, lhs.team) ==
-         std::tie(rhs.project_number, rhs.team);
-}
-
-inline bool operator<(ProjectTeam const& lhs, ProjectTeam const& rhs) {
-  return std::tie(lhs.project_number, lhs.team) <
-         std::tie(rhs.project_number, rhs.team);
-}
-
-inline bool operator!=(ProjectTeam const& lhs, ProjectTeam const& rhs) {
-  return std::rel_ops::operator!=(lhs, rhs);
-}
-
-inline bool operator>(ProjectTeam const& lhs, ProjectTeam const& rhs) {
-  return std::rel_ops::operator>(lhs, rhs);
-}
-
-inline bool operator<=(ProjectTeam const& lhs, ProjectTeam const& rhs) {
-  return std::rel_ops::operator<=(lhs, rhs);
-}
-
-inline bool operator>=(ProjectTeam const& lhs, ProjectTeam const& rhs) {
-  return std::rel_ops::operator>=(lhs, rhs);
-}
-
-namespace internal {
 struct GrpcBucketAccessControlParser;
 struct GrpcObjectAccessControlParser;
 

--- a/google/cloud/storage/project_team.h
+++ b/google/cloud/storage/project_team.h
@@ -1,0 +1,71 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_PROJECT_TEAM_H
+#define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_PROJECT_TEAM_H
+
+#include "google/cloud/storage/version.h"
+#include <string>
+#include <tuple>
+#include <utility>
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+
+/**
+ * Represents the projectTeam field in *AccessControls.
+ *
+ * @see
+ * https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls
+ * https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls
+ */
+struct ProjectTeam {
+  std::string project_number;
+  std::string team;
+};
+
+inline bool operator==(ProjectTeam const& lhs, ProjectTeam const& rhs) {
+  return std::tie(lhs.project_number, lhs.team) ==
+         std::tie(rhs.project_number, rhs.team);
+}
+
+inline bool operator<(ProjectTeam const& lhs, ProjectTeam const& rhs) {
+  return std::tie(lhs.project_number, lhs.team) <
+         std::tie(rhs.project_number, rhs.team);
+}
+
+inline bool operator!=(ProjectTeam const& lhs, ProjectTeam const& rhs) {
+  return std::rel_ops::operator!=(lhs, rhs);
+}
+
+inline bool operator>(ProjectTeam const& lhs, ProjectTeam const& rhs) {
+  return std::rel_ops::operator>(lhs, rhs);
+}
+
+inline bool operator<=(ProjectTeam const& lhs, ProjectTeam const& rhs) {
+  return std::rel_ops::operator<=(lhs, rhs);
+}
+
+inline bool operator>=(ProjectTeam const& lhs, ProjectTeam const& rhs) {
+  return std::rel_ops::operator>=(lhs, rhs);
+}
+
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google
+
+#endif  // GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_STORAGE_PROJECT_TEAM_H


### PR DESCRIPTION
Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9906)
<!-- Reviewable:end -->
