### PR TITLE
ci: enable CMake policies up to 3.24

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,15 +14,11 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 
 # Define the project name and where to report bugs.
 set(PACKAGE_BUGREPORT "https://github.com/googleapis/google-cloud-cpp/issues")
 
-# Enable support for SelectMSVCRuntime
-if (NOT (CMAKE_VERSION VERSION_LESS 3.15))
-    cmake_policy(SET CMP0091 NEW)
-endif ()
 project(
     google-cloud-cpp
     VERSION 2.3.0

--- a/ci/verify_current_targets/CMakeLists.txt
+++ b/ci/verify_current_targets/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 # ~~~
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(verify-exported-targets CXX)
 
 # We list the common libraries first because we want to load their packages

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -272,13 +272,13 @@ function (google_cloud_cpp_load_protodeps var file)
     set(targets_to_omit
         "google-cloud-cpp::cloud_orgpolicy_v1_orgpolicy_protos"
         "google-cloud-cpp::cloud_oslogin_common_common_protos"
-        "google-cloud-cpp::identity_accesscontextmanager_type_type_protos")
+        "google-cloud-cpp::identity_accesscontextmanager_type_type_protos"
+        "google-cloud-cpp::cloud_recommender_v1_recommender_protos")
     # Replace "google-cloud-cpp::$1" with "google-cloud-cpp:$2" in deps.
     set(target_substitutions
         "grafeas_v1_grafeas_protos\;grafeas_protos"
         "identity_accesscontextmanager_v1_accesscontextmanager_protos\;accesscontextmanager_protos"
         "cloud_osconfig_v1_osconfig_protos\;osconfig_protos"
-        "cloud_recommender_v1_recommender_protos\;recommender_protos"
         "devtools_source_v1_source_protos\;devtools_source_v1_source_context_protos"
     )
 

--- a/cmake/CompileProtos.cmake
+++ b/cmake/CompileProtos.cmake
@@ -272,8 +272,8 @@ function (google_cloud_cpp_load_protodeps var file)
     set(targets_to_omit
         "google-cloud-cpp::cloud_orgpolicy_v1_orgpolicy_protos"
         "google-cloud-cpp::cloud_oslogin_common_common_protos"
-        "google-cloud-cpp::identity_accesscontextmanager_type_type_protos"
-        "google-cloud-cpp::cloud_recommender_v1_recommender_protos")
+        "google-cloud-cpp::cloud_recommender_v1_recommender_protos"
+        "google-cloud-cpp::identity_accesscontextmanager_type_type_protos")
     # Replace "google-cloud-cpp::$1" with "google-cloud-cpp:$2" in deps.
     set(target_substitutions
         "grafeas_v1_grafeas_protos\;grafeas_protos"

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -849,7 +849,7 @@ void GenerateQuickstartCMake(
 # This file shows how to use the $title$ C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-$library$-quickstart CXX)
 
 find_package(google_cloud_cpp_$library$ REQUIRED)

--- a/google/cloud/accessapproval/quickstart/CMakeLists.txt
+++ b/google/cloud/accessapproval/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Access Approval API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-accessapproval-quickstart CXX)
 
 find_package(google_cloud_cpp_accessapproval REQUIRED)

--- a/google/cloud/accesscontextmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Access Context Manager API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-accesscontextmanager-quickstart CXX)
 
 find_package(google_cloud_cpp_accesscontextmanager REQUIRED)

--- a/google/cloud/apigateway/quickstart/CMakeLists.txt
+++ b/google/cloud/apigateway/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the API Gateway API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-apigateway-quickstart CXX)
 
 find_package(google_cloud_cpp_apigateway REQUIRED)

--- a/google/cloud/apigeeconnect/quickstart/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Apigee Connect API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-apigeeconnect-quickstart CXX)
 
 find_package(google_cloud_cpp_apigeeconnect REQUIRED)

--- a/google/cloud/apikeys/quickstart/CMakeLists.txt
+++ b/google/cloud/apikeys/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the API Keys API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-apikeys-quickstart CXX)
 
 find_package(google_cloud_cpp_apikeys REQUIRED)

--- a/google/cloud/appengine/quickstart/CMakeLists.txt
+++ b/google/cloud/appengine/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the App Engine Admin API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-appengine-quickstart CXX)
 
 find_package(google_cloud_cpp_appengine REQUIRED)

--- a/google/cloud/artifactregistry/quickstart/CMakeLists.txt
+++ b/google/cloud/artifactregistry/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Artifact Registry API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-artifactregistry-quickstart CXX)
 
 find_package(google_cloud_cpp_artifactregistry REQUIRED)

--- a/google/cloud/asset/quickstart/CMakeLists.txt
+++ b/google/cloud/asset/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Asset API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-asset-quickstart CXX)
 
 find_package(google_cloud_cpp_asset REQUIRED)

--- a/google/cloud/assuredworkloads/quickstart/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Assured Workloads API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-assuredworkloads-quickstart CXX)
 
 find_package(google_cloud_cpp_assuredworkloads REQUIRED)

--- a/google/cloud/automl/quickstart/CMakeLists.txt
+++ b/google/cloud/automl/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud AutoML API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-automl-quickstart CXX)
 
 find_package(google_cloud_cpp_automl REQUIRED)

--- a/google/cloud/baremetalsolution/quickstart/CMakeLists.txt
+++ b/google/cloud/baremetalsolution/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Bare Metal Solution API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-baremetalsolution-quickstart CXX)
 
 find_package(google_cloud_cpp_baremetalsolution REQUIRED)

--- a/google/cloud/batch/quickstart/CMakeLists.txt
+++ b/google/cloud/batch/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Batch API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-batch-quickstart CXX)
 
 find_package(google_cloud_cpp_batch REQUIRED)

--- a/google/cloud/beyondcorp/quickstart/CMakeLists.txt
+++ b/google/cloud/beyondcorp/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the BeyondCorp API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-beyondcorp-quickstart CXX)
 
 find_package(google_cloud_cpp_beyondcorp REQUIRED)

--- a/google/cloud/bigquery/quickstart/CMakeLists.txt
+++ b/google/cloud/bigquery/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Cloud BigQuery C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-bigquery-quickstart CXX)
 
 find_package(google_cloud_cpp_bigquery REQUIRED)

--- a/google/cloud/bigtable/quickstart/CMakeLists.txt
+++ b/google/cloud/bigtable/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Cloud Bigtable C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-bigtable-quickstart CXX)
 
 find_package(google_cloud_cpp_bigtable REQUIRED)

--- a/google/cloud/billing/quickstart/CMakeLists.txt
+++ b/google/cloud/billing/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Billing Budget API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-billing-quickstart CXX)
 
 find_package(google_cloud_cpp_billing REQUIRED)

--- a/google/cloud/binaryauthorization/quickstart/CMakeLists.txt
+++ b/google/cloud/binaryauthorization/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Binary Authorization API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-binaryauthorization-quickstart CXX)
 
 find_package(google_cloud_cpp_binaryauthorization REQUIRED)

--- a/google/cloud/channel/quickstart/CMakeLists.txt
+++ b/google/cloud/channel/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Channel API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-channel-quickstart CXX)
 
 find_package(google_cloud_cpp_channel REQUIRED)

--- a/google/cloud/cloudbuild/quickstart/CMakeLists.txt
+++ b/google/cloud/cloudbuild/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Build API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-cloudbuild-quickstart CXX)
 
 find_package(google_cloud_cpp_cloudbuild REQUIRED)

--- a/google/cloud/composer/quickstart/CMakeLists.txt
+++ b/google/cloud/composer/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Composer API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-composer-quickstart CXX)
 
 find_package(google_cloud_cpp_composer REQUIRED)

--- a/google/cloud/contactcenterinsights/quickstart/CMakeLists.txt
+++ b/google/cloud/contactcenterinsights/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Contact Center AI Insights API C++ client
 # library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-contactcenterinsights-quickstart CXX)
 
 find_package(google_cloud_cpp_contactcenterinsights REQUIRED)

--- a/google/cloud/container/quickstart/CMakeLists.txt
+++ b/google/cloud/container/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Kubernetes Engine API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-container-quickstart CXX)
 
 find_package(google_cloud_cpp_container REQUIRED)

--- a/google/cloud/containeranalysis/quickstart/CMakeLists.txt
+++ b/google/cloud/containeranalysis/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Container Analysis API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-containeranalysis-quickstart CXX)
 
 find_package(google_cloud_cpp_containeranalysis REQUIRED)

--- a/google/cloud/datacatalog/quickstart/CMakeLists.txt
+++ b/google/cloud/datacatalog/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Google Cloud Data Catalog API C++ client
 # library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-datacatalog-quickstart CXX)
 
 find_package(google_cloud_cpp_datacatalog REQUIRED)

--- a/google/cloud/datamigration/quickstart/CMakeLists.txt
+++ b/google/cloud/datamigration/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Database Migration API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-datamigration-quickstart CXX)
 
 find_package(google_cloud_cpp_datamigration REQUIRED)

--- a/google/cloud/dataplex/quickstart/CMakeLists.txt
+++ b/google/cloud/dataplex/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Dataplex API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-dataplex-quickstart CXX)
 
 find_package(google_cloud_cpp_dataplex REQUIRED)

--- a/google/cloud/dataproc/quickstart/CMakeLists.txt
+++ b/google/cloud/dataproc/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Dataproc API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-dataproc-quickstart CXX)
 
 find_package(google_cloud_cpp_dataproc REQUIRED)

--- a/google/cloud/debugger/quickstart/CMakeLists.txt
+++ b/google/cloud/debugger/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Stackdriver Debugger API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-debugger-quickstart CXX)
 
 find_package(google_cloud_cpp_debugger REQUIRED)

--- a/google/cloud/dialogflow_cx/quickstart/CMakeLists.txt
+++ b/google/cloud/dialogflow_cx/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Dialogflow API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-dialogflow_cx-quickstart CXX)
 
 find_package(google_cloud_cpp_dialogflow_cx REQUIRED)

--- a/google/cloud/dialogflow_es/quickstart/CMakeLists.txt
+++ b/google/cloud/dialogflow_es/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Dialogflow API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-dialogflow_es-quickstart CXX)
 
 find_package(google_cloud_cpp_dialogflow_es REQUIRED)

--- a/google/cloud/dlp/quickstart/CMakeLists.txt
+++ b/google/cloud/dlp/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Data Loss Prevention (DLP) API C++ client
 # library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-dlp-quickstart CXX)
 
 find_package(google_cloud_cpp_dlp REQUIRED)

--- a/google/cloud/documentai/quickstart/CMakeLists.txt
+++ b/google/cloud/documentai/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Document AI API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-documentai-quickstart CXX)
 
 find_package(google_cloud_cpp_documentai REQUIRED)

--- a/google/cloud/edgecontainer/quickstart/CMakeLists.txt
+++ b/google/cloud/edgecontainer/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Distributed Cloud Edge Container API C++ client
 # library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-edgecontainer-quickstart CXX)
 
 find_package(google_cloud_cpp_edgecontainer REQUIRED)

--- a/google/cloud/eventarc/quickstart/CMakeLists.txt
+++ b/google/cloud/eventarc/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Eventarc API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-eventarc-quickstart CXX)
 
 find_package(google_cloud_cpp_eventarc REQUIRED)

--- a/google/cloud/filestore/quickstart/CMakeLists.txt
+++ b/google/cloud/filestore/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Filestore API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-filestore-quickstart CXX)
 
 find_package(google_cloud_cpp_filestore REQUIRED)

--- a/google/cloud/functions/quickstart/CMakeLists.txt
+++ b/google/cloud/functions/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Functions API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-functions-quickstart CXX)
 
 find_package(google_cloud_cpp_functions REQUIRED)

--- a/google/cloud/gameservices/quickstart/CMakeLists.txt
+++ b/google/cloud/gameservices/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Game Services API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-gameservices-quickstart CXX)
 
 find_package(google_cloud_cpp_gameservices REQUIRED)

--- a/google/cloud/gkehub/quickstart/CMakeLists.txt
+++ b/google/cloud/gkehub/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the GKE Hub C++ client library from a larger CMake
 # project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-gkehub-quickstart CXX)
 
 find_package(google_cloud_cpp_gkehub REQUIRED)

--- a/google/cloud/iam/quickstart/CMakeLists.txt
+++ b/google/cloud/iam/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Cloud IAM C++ client library in
 # CMake-based projects.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-iam-quickstart CXX)
 
 find_package(google_cloud_cpp_iam REQUIRED)

--- a/google/cloud/iap/quickstart/CMakeLists.txt
+++ b/google/cloud/iap/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Identity-Aware Proxy API C++ client
 # library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-iap-quickstart CXX)
 
 find_package(google_cloud_cpp_iap REQUIRED)

--- a/google/cloud/ids/quickstart/CMakeLists.txt
+++ b/google/cloud/ids/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud IDS API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-ids-quickstart CXX)
 
 find_package(google_cloud_cpp_ids REQUIRED)

--- a/google/cloud/iot/quickstart/CMakeLists.txt
+++ b/google/cloud/iot/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud IoT API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-iot-quickstart CXX)
 
 find_package(google_cloud_cpp_iot REQUIRED)

--- a/google/cloud/kms/quickstart/CMakeLists.txt
+++ b/google/cloud/kms/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Key Management Service (KMS) API C++
 # client library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-kms-quickstart CXX)
 
 find_package(google_cloud_cpp_kms REQUIRED)

--- a/google/cloud/language/quickstart/CMakeLists.txt
+++ b/google/cloud/language/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Natural Language API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-language-quickstart CXX)
 
 find_package(google_cloud_cpp_language REQUIRED)

--- a/google/cloud/logging/quickstart/CMakeLists.txt
+++ b/google/cloud/logging/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Logging API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-logging-quickstart CXX)
 
 find_package(google_cloud_cpp_logging REQUIRED)

--- a/google/cloud/managedidentities/quickstart/CMakeLists.txt
+++ b/google/cloud/managedidentities/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Managed Service for Microsoft Active Directory
 # API C++ client library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-managedidentities-quickstart CXX)
 
 find_package(google_cloud_cpp_managedidentities REQUIRED)

--- a/google/cloud/memcache/quickstart/CMakeLists.txt
+++ b/google/cloud/memcache/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Memorystore for Memcached API C++ client
 # library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-memcache-quickstart CXX)
 
 find_package(google_cloud_cpp_memcache REQUIRED)

--- a/google/cloud/monitoring/quickstart/CMakeLists.txt
+++ b/google/cloud/monitoring/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Monitoring API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-monitoring-quickstart CXX)
 
 find_package(google_cloud_cpp_monitoring REQUIRED)

--- a/google/cloud/networkconnectivity/quickstart/CMakeLists.txt
+++ b/google/cloud/networkconnectivity/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Network Connectivity API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-networkconnectivity-quickstart CXX)
 
 find_package(google_cloud_cpp_networkconnectivity REQUIRED)

--- a/google/cloud/networkmanagement/quickstart/CMakeLists.txt
+++ b/google/cloud/networkmanagement/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Network Management API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-networkmanagement-quickstart CXX)
 
 find_package(google_cloud_cpp_networkmanagement REQUIRED)

--- a/google/cloud/notebooks/quickstart/CMakeLists.txt
+++ b/google/cloud/notebooks/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Notebooks API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-notebooks-quickstart CXX)
 
 find_package(google_cloud_cpp_notebooks REQUIRED)

--- a/google/cloud/optimization/quickstart/CMakeLists.txt
+++ b/google/cloud/optimization/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Optimization API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-optimization-quickstart CXX)
 
 find_package(google_cloud_cpp_optimization REQUIRED)

--- a/google/cloud/orgpolicy/quickstart/CMakeLists.txt
+++ b/google/cloud/orgpolicy/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Organization Policy API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-orgpolicy-quickstart CXX)
 
 find_package(google_cloud_cpp_orgpolicy REQUIRED)

--- a/google/cloud/osconfig/quickstart/CMakeLists.txt
+++ b/google/cloud/osconfig/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the OS Config API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-osconfig-quickstart CXX)
 
 find_package(google_cloud_cpp_osconfig REQUIRED)

--- a/google/cloud/oslogin/quickstart/CMakeLists.txt
+++ b/google/cloud/oslogin/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud OS Login API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-oslogin-quickstart CXX)
 
 find_package(google_cloud_cpp_oslogin REQUIRED)

--- a/google/cloud/policytroubleshooter/quickstart/CMakeLists.txt
+++ b/google/cloud/policytroubleshooter/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Policy Troubleshooter API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-policytroubleshooter-quickstart CXX)
 
 find_package(google_cloud_cpp_policytroubleshooter REQUIRED)

--- a/google/cloud/privateca/quickstart/CMakeLists.txt
+++ b/google/cloud/privateca/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Certificate Authority API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-privateca-quickstart CXX)
 
 find_package(google_cloud_cpp_privateca REQUIRED)

--- a/google/cloud/profiler/quickstart/CMakeLists.txt
+++ b/google/cloud/profiler/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Profiler API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-profiler-quickstart CXX)
 
 find_package(google_cloud_cpp_profiler REQUIRED)

--- a/google/cloud/pubsub/quickstart/CMakeLists.txt
+++ b/google/cloud/pubsub/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Cloud Pub/Sub C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-pubsub-quickstart CXX)
 
 find_package(google_cloud_cpp_pubsub REQUIRED)

--- a/google/cloud/pubsublite/quickstart/CMakeLists.txt
+++ b/google/cloud/pubsublite/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Pub/Sub Lite API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-pubsublite-quickstart CXX)
 
 find_package(google_cloud_cpp_pubsublite REQUIRED)

--- a/google/cloud/recommender/quickstart/CMakeLists.txt
+++ b/google/cloud/recommender/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Recommender API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-recommender-quickstart CXX)
 
 find_package(google_cloud_cpp_recommender REQUIRED)

--- a/google/cloud/redis/quickstart/CMakeLists.txt
+++ b/google/cloud/redis/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Google Cloud Memorystore for Redis API C++
 # client library from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-redis-quickstart CXX)
 
 find_package(google_cloud_cpp_redis REQUIRED)

--- a/google/cloud/resourcemanager/quickstart/CMakeLists.txt
+++ b/google/cloud/resourcemanager/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Resource Manager API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-resourcemanager-quickstart CXX)
 
 find_package(google_cloud_cpp_resourcemanager REQUIRED)

--- a/google/cloud/resourcesettings/quickstart/CMakeLists.txt
+++ b/google/cloud/resourcesettings/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Resource Settings API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-resourcesettings-quickstart CXX)
 
 find_package(google_cloud_cpp_resourcesettings REQUIRED)

--- a/google/cloud/retail/quickstart/CMakeLists.txt
+++ b/google/cloud/retail/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Retail API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-retail-quickstart CXX)
 
 find_package(google_cloud_cpp_retail REQUIRED)

--- a/google/cloud/run/quickstart/CMakeLists.txt
+++ b/google/cloud/run/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Run Admin API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-run-quickstart CXX)
 
 find_package(google_cloud_cpp_run REQUIRED)

--- a/google/cloud/scheduler/quickstart/CMakeLists.txt
+++ b/google/cloud/scheduler/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Scheduler API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-scheduler-quickstart CXX)
 
 find_package(google_cloud_cpp_scheduler REQUIRED)

--- a/google/cloud/secretmanager/quickstart/CMakeLists.txt
+++ b/google/cloud/secretmanager/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Secret Manager API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-secretmanager-quickstart CXX)
 
 find_package(google_cloud_cpp_secretmanager REQUIRED)

--- a/google/cloud/securitycenter/quickstart/CMakeLists.txt
+++ b/google/cloud/securitycenter/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Security Command Center API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-securitycenter-quickstart CXX)
 
 find_package(google_cloud_cpp_securitycenter REQUIRED)

--- a/google/cloud/servicecontrol/quickstart/CMakeLists.txt
+++ b/google/cloud/servicecontrol/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Service Control API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-servicecontrol-quickstart CXX)
 
 find_package(google_cloud_cpp_servicecontrol REQUIRED)

--- a/google/cloud/servicedirectory/quickstart/CMakeLists.txt
+++ b/google/cloud/servicedirectory/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Service Directory API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-servicedirectory-quickstart CXX)
 
 find_package(google_cloud_cpp_servicedirectory REQUIRED)

--- a/google/cloud/servicemanagement/quickstart/CMakeLists.txt
+++ b/google/cloud/servicemanagement/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Service Management API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-servicemanagement-quickstart CXX)
 
 find_package(google_cloud_cpp_servicemanagement REQUIRED)

--- a/google/cloud/serviceusage/quickstart/CMakeLists.txt
+++ b/google/cloud/serviceusage/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Service Usage API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-serviceusage-quickstart CXX)
 
 find_package(google_cloud_cpp_serviceusage REQUIRED)

--- a/google/cloud/shell/quickstart/CMakeLists.txt
+++ b/google/cloud/shell/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Shell API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-shell-quickstart CXX)
 
 find_package(google_cloud_cpp_shell REQUIRED)

--- a/google/cloud/spanner/quickstart/CMakeLists.txt
+++ b/google/cloud/spanner/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This CMake file shows how to use the Cloud Spanner C++ client from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-spanner-quickstart CXX)
 
 find_package(google_cloud_cpp_spanner REQUIRED)

--- a/google/cloud/speech/quickstart/CMakeLists.txt
+++ b/google/cloud/speech/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Speech-to-Text API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-speech-quickstart CXX)
 
 find_package(google_cloud_cpp_speech REQUIRED)

--- a/google/cloud/storage/quickstart/CMakeLists.txt
+++ b/google/cloud/storage/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # A minimal CMakeList.txt showing how to use the Google Cloud Storage C++ client
 # library in CMake-based projects.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-storage-quickstart CXX)
 
 find_package(google_cloud_cpp_storage REQUIRED)

--- a/google/cloud/storagetransfer/quickstart/CMakeLists.txt
+++ b/google/cloud/storagetransfer/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Storage Transfer API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-storagetransfer-quickstart CXX)
 
 find_package(google_cloud_cpp_storagetransfer REQUIRED)

--- a/google/cloud/talent/quickstart/CMakeLists.txt
+++ b/google/cloud/talent/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Talent Solution API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-talent-quickstart CXX)
 
 find_package(google_cloud_cpp_talent REQUIRED)

--- a/google/cloud/tasks/quickstart/CMakeLists.txt
+++ b/google/cloud/tasks/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Tasks API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-tasks-quickstart CXX)
 
 find_package(google_cloud_cpp_tasks REQUIRED)

--- a/google/cloud/texttospeech/quickstart/CMakeLists.txt
+++ b/google/cloud/texttospeech/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Text-to-Speech API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-texttospeech-quickstart CXX)
 
 find_package(google_cloud_cpp_texttospeech REQUIRED)

--- a/google/cloud/tpu/quickstart/CMakeLists.txt
+++ b/google/cloud/tpu/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud TPU API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-tpu-quickstart CXX)
 
 find_package(google_cloud_cpp_tpu REQUIRED)

--- a/google/cloud/trace/quickstart/CMakeLists.txt
+++ b/google/cloud/trace/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Stackdriver Trace API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-trace-quickstart CXX)
 
 find_package(google_cloud_cpp_trace REQUIRED)

--- a/google/cloud/translate/quickstart/CMakeLists.txt
+++ b/google/cloud/translate/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Translation API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-translate-quickstart CXX)
 
 find_package(google_cloud_cpp_translate REQUIRED)

--- a/google/cloud/video/quickstart/CMakeLists.txt
+++ b/google/cloud/video/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Transcoder API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-video-quickstart CXX)
 
 find_package(google_cloud_cpp_video REQUIRED)

--- a/google/cloud/videointelligence/quickstart/CMakeLists.txt
+++ b/google/cloud/videointelligence/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Video Intelligence API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-videointelligence-quickstart CXX)
 
 find_package(google_cloud_cpp_videointelligence REQUIRED)

--- a/google/cloud/vision/quickstart/CMakeLists.txt
+++ b/google/cloud/vision/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Cloud Vision API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-vision-quickstart CXX)
 
 find_package(google_cloud_cpp_vision REQUIRED)

--- a/google/cloud/vmmigration/quickstart/CMakeLists.txt
+++ b/google/cloud/vmmigration/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the VM Migration API C++ client library from a
 # larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-vmmigration-quickstart CXX)
 
 find_package(google_cloud_cpp_vmmigration REQUIRED)

--- a/google/cloud/vpcaccess/quickstart/CMakeLists.txt
+++ b/google/cloud/vpcaccess/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Serverless VPC Access API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-vpcaccess-quickstart CXX)
 
 find_package(google_cloud_cpp_vpcaccess REQUIRED)

--- a/google/cloud/webrisk/quickstart/CMakeLists.txt
+++ b/google/cloud/webrisk/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Web Risk API C++ client library from a larger
 # CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-webrisk-quickstart CXX)
 
 find_package(google_cloud_cpp_webrisk REQUIRED)

--- a/google/cloud/websecurityscanner/quickstart/CMakeLists.txt
+++ b/google/cloud/websecurityscanner/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Web Security Scanner API C++ client library
 # from a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-websecurityscanner-quickstart CXX)
 
 find_package(google_cloud_cpp_websecurityscanner REQUIRED)

--- a/google/cloud/workflows/quickstart/CMakeLists.txt
+++ b/google/cloud/workflows/quickstart/CMakeLists.txt
@@ -15,7 +15,7 @@
 # This file shows how to use the Workflow Executions API C++ client library from
 # a larger CMake project.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.10...3.24)
 project(google-cloud-cpp-workflows-quickstart CXX)
 
 find_package(google_cloud_cpp_workflows REQUIRED)


### PR DESCRIPTION
The main motivation is to improve the customer experience with CMake under Windows.  Until CMake 3.15 switching the MSVC runtime was a bit of a pain.  We used `cmake_minimum_required(VERSION 3.10)` which has two effects:

- It requires CMake to be >= 3.10
- It guarantees the CMake 3.10 behavior, even if you use 3.15 or 3.24

We do not want the 3.10 behavior on Windows, it requires too many steps to switch the MSVC runtime library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9912)
<!-- Reviewable:end -->
