### PR TITLE
cleanup: shorten quickstart workspace names

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -937,7 +937,7 @@ void GenerateQuickstartWorkspace(
 
 # A minimal WORKSPACE file showing how to use the $title$
 # C++ client library in Bazel-based projects.
-workspace(name = "$library$_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/accessapproval/quickstart/WORKSPACE.bazel
+++ b/google/cloud/accessapproval/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Access Approval API C++
 # client library in Bazel-based projects.
-workspace(name = "accessapproval_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/accesscontextmanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/accesscontextmanager/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Access Context Manager API
 # C++ client library in Bazel-based projects.
-workspace(name = "accesscontextmanager_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/apigateway/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apigateway/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the API Gateway API
 # C++ client library in Bazel-based projects.
-workspace(name = "apigateway_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/apigeeconnect/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apigeeconnect/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Apigee Connect API
 # C++ client library in Bazel-based projects.
-workspace(name = "apigeeconnect_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/apikeys/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apikeys/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the API Keys API
 # C++ client library in Bazel-based projects.
-workspace(name = "apikeys_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/appengine/quickstart/WORKSPACE.bazel
+++ b/google/cloud/appengine/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the App Engine Admin API
 # C++ client library in Bazel-based projects.
-workspace(name = "appengine_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/artifactregistry/quickstart/WORKSPACE.bazel
+++ b/google/cloud/artifactregistry/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Artifact Registry API
 # C++ client library in Bazel-based projects.
-workspace(name = "artifactregistry_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/asset/quickstart/WORKSPACE.bazel
+++ b/google/cloud/asset/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Asset API
 # C++ client library in Bazel-based projects.
-workspace(name = "asset_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/assuredworkloads/quickstart/WORKSPACE.bazel
+++ b/google/cloud/assuredworkloads/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Assured Workloads API C++
 # client library in Bazel-based projects.
-workspace(name = "assuredworkloads_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/automl/quickstart/WORKSPACE.bazel
+++ b/google/cloud/automl/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud AutoML API
 # C++ client library in Bazel-based projects.
-workspace(name = "automl_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/baremetalsolution/quickstart/WORKSPACE.bazel
+++ b/google/cloud/baremetalsolution/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Bare Metal Solution API
 # C++ client library in Bazel-based projects.
-workspace(name = "baremetalsolution_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/batch/quickstart/WORKSPACE.bazel
+++ b/google/cloud/batch/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Batch API
 # C++ client library in Bazel-based projects.
-workspace(name = "batch_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/beyondcorp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/beyondcorp/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the BeyondCorp API
 # C++ client library in Bazel-based projects.
-workspace(name = "beyondcorp_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/bigquery/quickstart/WORKSPACE.bazel
+++ b/google/cloud/bigquery/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud BigQuery C++
 # client library in Bazel-based projects.
-workspace(name = "bigquery_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/bigtable/quickstart/WORKSPACE.bazel
+++ b/google/cloud/bigtable/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Bigtable C++
 # client library in Bazel-based projects.
-workspace(name = "bigtable_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/billing/quickstart/WORKSPACE.bazel
+++ b/google/cloud/billing/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Billing Budget API C++
 # client library in Bazel-based projects.
-workspace(name = "billing_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/binaryauthorization/quickstart/WORKSPACE.bazel
+++ b/google/cloud/binaryauthorization/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Binary Authorization API
 # C++ client library in Bazel-based projects.
-workspace(name = "binaryauthorization_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/channel/quickstart/WORKSPACE.bazel
+++ b/google/cloud/channel/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Channel API
 # C++ client library in Bazel-based projects.
-workspace(name = "channel_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/cloudbuild/quickstart/WORKSPACE.bazel
+++ b/google/cloud/cloudbuild/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Build API
 # C++ client library in Bazel-based projects.
-workspace(name = "cloudbuild_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/composer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/composer/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Composer API
 # C++ client library in Bazel-based projects.
-workspace(name = "composer_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/contactcenterinsights/quickstart/WORKSPACE.bazel
+++ b/google/cloud/contactcenterinsights/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Contact Center AI Insights API
 # C++ client library in Bazel-based projects.
-workspace(name = "contactcenterinsights_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/container/quickstart/WORKSPACE.bazel
+++ b/google/cloud/container/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Kubernetes Engine API
 # C++ client library in Bazel-based projects.
-workspace(name = "container_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/containeranalysis/quickstart/WORKSPACE.bazel
+++ b/google/cloud/containeranalysis/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Container Analysis API
 # C++ client library in Bazel-based projects.
-workspace(name = "containeranalysis_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/datacatalog/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datacatalog/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Data Catalog API
 # C++ client library in Bazel-based projects.
-workspace(name = "datacatalog_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/datamigration/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datamigration/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Database Migration API
 # C++ client library in Bazel-based projects.
-workspace(name = "datamigration_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/dataplex/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dataplex/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Dataplex API
 # C++ client library in Bazel-based projects.
-workspace(name = "dataplex_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/dataproc/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dataproc/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Dataproc API
 # C++ client library in Bazel-based projects.
-workspace(name = "dataproc_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/debugger/quickstart/WORKSPACE.bazel
+++ b/google/cloud/debugger/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Stackdriver Debugger API
 # C++ client library in Bazel-based projects.
-workspace(name = "debugger_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/dialogflow_cx/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dialogflow_cx/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Dialogflow API
 # C++ client library in Bazel-based projects.
-workspace(name = "dialogflow_cx_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/dialogflow_es/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dialogflow_es/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Dialogflow API
 # C++ client library in Bazel-based projects.
-workspace(name = "dialogflow_es_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/dlp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dlp/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Data Loss Prevention (DLP) API
 # C++ client library in Bazel-based projects.
-workspace(name = "dlp_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/documentai/quickstart/WORKSPACE.bazel
+++ b/google/cloud/documentai/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Document AI API
 # C++ client library in Bazel-based projects.
-workspace(name = "documentai_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/edgecontainer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/edgecontainer/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Distributed Cloud Edge Container API
 # C++ client library in Bazel-based projects.
-workspace(name = "edgecontainer_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/eventarc/quickstart/WORKSPACE.bazel
+++ b/google/cloud/eventarc/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Eventarc API
 # C++ client library in Bazel-based projects.
-workspace(name = "eventarc_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/filestore/quickstart/WORKSPACE.bazel
+++ b/google/cloud/filestore/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Filestore API
 # C++ client library in Bazel-based projects.
-workspace(name = "filestore_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/functions/quickstart/WORKSPACE.bazel
+++ b/google/cloud/functions/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Functions API
 # C++ client library in Bazel-based projects.
-workspace(name = "functions_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/gameservices/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gameservices/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Game Services API
 # C++ client library in Bazel-based projects.
-workspace(name = "gameservices_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/gkehub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gkehub/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the GKE Hub
 # C++ client library in Bazel-based projects.
-workspace(name = "gkehub_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/iam/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iam/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud IAM C++ client
 # library in Bazel-based projects.
-workspace(name = "iam_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/iap/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iap/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Identity-Aware Proxy API
 # C++ client library in Bazel-based projects.
-workspace(name = "iap_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/ids/quickstart/WORKSPACE.bazel
+++ b/google/cloud/ids/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud IDS API
 # C++ client library in Bazel-based projects.
-workspace(name = "ids_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/iot/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iot/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud IoT API
 # C++ client library in Bazel-based projects.
-workspace(name = "iot_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/kms/quickstart/WORKSPACE.bazel
+++ b/google/cloud/kms/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Key Management Service (KMS) API C++
 # client library in Bazel-based projects.
-workspace(name = "kms_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/language/quickstart/WORKSPACE.bazel
+++ b/google/cloud/language/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Natural Language API
 # C++ client library in Bazel-based projects.
-workspace(name = "language_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/logging/quickstart/WORKSPACE.bazel
+++ b/google/cloud/logging/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Logging API C++
 # client library in Bazel-based projects.
-workspace(name = "logging_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/managedidentities/quickstart/WORKSPACE.bazel
+++ b/google/cloud/managedidentities/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Managed Service for Microsoft Active Directory API
 # C++ client library in Bazel-based projects.
-workspace(name = "managedidentities_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/memcache/quickstart/WORKSPACE.bazel
+++ b/google/cloud/memcache/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Memorystore for Memcached API
 # C++ client library in Bazel-based projects.
-workspace(name = "memcache_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/monitoring/quickstart/WORKSPACE.bazel
+++ b/google/cloud/monitoring/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Monitoring API
 # C++ client library in Bazel-based projects.
-workspace(name = "monitoring_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/networkconnectivity/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkconnectivity/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Network Connectivity API
 # C++ client library in Bazel-based projects.
-workspace(name = "networkconnectivity_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/networkmanagement/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkmanagement/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Network Management API
 # C++ client library in Bazel-based projects.
-workspace(name = "networkmanagement_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/notebooks/quickstart/WORKSPACE.bazel
+++ b/google/cloud/notebooks/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Notebooks API
 # C++ client library in Bazel-based projects.
-workspace(name = "notebooks_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/optimization/quickstart/WORKSPACE.bazel
+++ b/google/cloud/optimization/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Optimization API
 # C++ client library in Bazel-based projects.
-workspace(name = "optimization_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/orgpolicy/quickstart/WORKSPACE.bazel
+++ b/google/cloud/orgpolicy/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Organization Policy API
 # C++ client library in Bazel-based projects.
-workspace(name = "orgpolicy_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/osconfig/quickstart/WORKSPACE.bazel
+++ b/google/cloud/osconfig/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the OS Config API
 # C++ client library in Bazel-based projects.
-workspace(name = "osconfig_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/oslogin/quickstart/WORKSPACE.bazel
+++ b/google/cloud/oslogin/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud OS Login API
 # C++ client library in Bazel-based projects.
-workspace(name = "oslogin_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/policytroubleshooter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/policytroubleshooter/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Policy Troubleshooter API
 # C++ client library in Bazel-based projects.
-workspace(name = "policytroubleshooter_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/privateca/quickstart/WORKSPACE.bazel
+++ b/google/cloud/privateca/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Certificate Authority API
 # C++ client library in Bazel-based projects.
-workspace(name = "privateca_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/profiler/quickstart/WORKSPACE.bazel
+++ b/google/cloud/profiler/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Profiler API
 # C++ client library in Bazel-based projects.
-workspace(name = "profiler_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/pubsub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsub/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Pub/Sub C++
 # client library in Bazel-based projects.
-workspace(name = "pubsub_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/pubsublite/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsublite/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Pub/Sub Lite API C++
 # client library in Bazel-based projects.
-workspace(name = "pubsublite_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/recommender/quickstart/WORKSPACE.bazel
+++ b/google/cloud/recommender/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Recommender API
 # C++ client library in Bazel-based projects.
-workspace(name = "recommender_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/redis/quickstart/WORKSPACE.bazel
+++ b/google/cloud/redis/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Memorystore for Redis API
 # C++ client library in Bazel-based projects.
-workspace(name = "redis_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/resourcemanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/resourcemanager/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Resource Manager API
 # C++ client library in Bazel-based projects.
-workspace(name = "resourcemanager_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/resourcesettings/quickstart/WORKSPACE.bazel
+++ b/google/cloud/resourcesettings/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Resource Settings API
 # C++ client library in Bazel-based projects.
-workspace(name = "resourcesettings_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/retail/quickstart/WORKSPACE.bazel
+++ b/google/cloud/retail/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Retail API
 # C++ client library in Bazel-based projects.
-workspace(name = "retail_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/run/quickstart/WORKSPACE.bazel
+++ b/google/cloud/run/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Run Admin API
 # C++ client library in Bazel-based projects.
-workspace(name = "run_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/scheduler/quickstart/WORKSPACE.bazel
+++ b/google/cloud/scheduler/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Scheduler API C++
 # client library in Bazel-based projects.
-workspace(name = "scheduler_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/secretmanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/secretmanager/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Secret Manager API C++
 # client library in Bazel-based projects.
-workspace(name = "secretmanager_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/securitycenter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/securitycenter/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Security Command Center API
 # C++ client library in Bazel-based projects.
-workspace(name = "securitycenter_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/servicecontrol/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicecontrol/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Service Control API
 # C++ client library in Bazel-based projects.
-workspace(name = "servicecontrol_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/servicedirectory/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicedirectory/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Service Directory API
 # C++ client library in Bazel-based projects.
-workspace(name = "servicedirectory_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/servicemanagement/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicemanagement/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Service Management API
 # C++ client library in Bazel-based projects.
-workspace(name = "servicemanagement_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/serviceusage/quickstart/WORKSPACE.bazel
+++ b/google/cloud/serviceusage/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Service Usage API
 # C++ client library in Bazel-based projects.
-workspace(name = "serviceusage_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/shell/quickstart/WORKSPACE.bazel
+++ b/google/cloud/shell/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Shell API
 # C++ client library in Bazel-based projects.
-workspace(name = "shell_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/spanner/quickstart/WORKSPACE.bazel
+++ b/google/cloud/spanner/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Spanner C++
 # client library in Bazel-based projects.
-workspace(name = "spanner_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/speech/quickstart/WORKSPACE.bazel
+++ b/google/cloud/speech/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Speech-to-Text API
 # C++ client library in Bazel-based projects.
-workspace(name = "speech_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/storage/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storage/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Storage C++
 # client library in Bazel-based projects.
-workspace(name = "storage_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/storagetransfer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storagetransfer/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Storage Transfer API
 # C++ client library in Bazel-based projects.
-workspace(name = "storagetransfer_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/talent/quickstart/WORKSPACE.bazel
+++ b/google/cloud/talent/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Talent Solution API
 # C++ client library in Bazel-based projects.
-workspace(name = "talent_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/tasks/quickstart/WORKSPACE.bazel
+++ b/google/cloud/tasks/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Tasks API C++
 # client library in Bazel-based projects.
-workspace(name = "tasks_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/texttospeech/quickstart/WORKSPACE.bazel
+++ b/google/cloud/texttospeech/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Text-to-Speech API
 # C++ client library in Bazel-based projects.
-workspace(name = "texttospeech_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/tpu/quickstart/WORKSPACE.bazel
+++ b/google/cloud/tpu/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud TPU API
 # C++ client library in Bazel-based projects.
-workspace(name = "tpu_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/trace/quickstart/WORKSPACE.bazel
+++ b/google/cloud/trace/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Stackdriver Trace API
 # C++ client library in Bazel-based projects.
-workspace(name = "trace_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/translate/quickstart/WORKSPACE.bazel
+++ b/google/cloud/translate/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Translation API
 # C++ client library in Bazel-based projects.
-workspace(name = "translate_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/video/quickstart/WORKSPACE.bazel
+++ b/google/cloud/video/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Transcoder API
 # C++ client library in Bazel-based projects.
-workspace(name = "video_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/videointelligence/quickstart/WORKSPACE.bazel
+++ b/google/cloud/videointelligence/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Video Intelligence API
 # C++ client library in Bazel-based projects.
-workspace(name = "videointelligence_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/vision/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vision/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Cloud Vision API
 # C++ client library in Bazel-based projects.
-workspace(name = "vision_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/vmmigration/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vmmigration/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the VM Migration API
 # C++ client library in Bazel-based projects.
-workspace(name = "vmmigration_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/vpcaccess/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vpcaccess/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Serverless VPC Access API
 # C++ client library in Bazel-based projects.
-workspace(name = "vpcaccess_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/webrisk/quickstart/WORKSPACE.bazel
+++ b/google/cloud/webrisk/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Web Risk API C++
 # client library in Bazel-based projects.
-workspace(name = "webrisk_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/websecurityscanner/quickstart/WORKSPACE.bazel
+++ b/google/cloud/websecurityscanner/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Web Security Scanner API C++
 # client library in Bazel-based projects.
-workspace(name = "websecurityscanner_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/google/cloud/workflows/quickstart/WORKSPACE.bazel
+++ b/google/cloud/workflows/quickstart/WORKSPACE.bazel
@@ -14,7 +14,7 @@
 
 # A minimal WORKSPACE file showing how to use the Workflow Executions API C++
 # client library in Bazel-based projects.
-workspace(name = "workflows_quickstart")
+workspace(name = "qs")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")


### PR DESCRIPTION
With the longer names some of the quickstarts fail to compile on Windows.

See #9340 for context. Part of the work for #9891

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9916)
<!-- Reviewable:end -->
