### PR TITLE
test(storage): reduce runtime of ThreadIntegrationTest.Unshared

### DIFF
--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -115,7 +115,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
   // feature.
   auto const thread_count =
       (std::min)(32U, (std::max)(8U, std::thread::hardware_concurrency()));
-  auto const object_count = 100 * thread_count;
+  auto const object_count = 75 * thread_count;
   std::vector<std::string> objects(object_count);
   std::generate(objects.begin(), objects.end(),
                 [this] { return MakeRandomObjectName(); });

--- a/google/cloud/storage/tests/thread_integration_test.cc
+++ b/google/cloud/storage/tests/thread_integration_test.cc
@@ -115,7 +115,7 @@ TEST_F(ThreadIntegrationTest, Unshared) {
   // feature.
   auto const thread_count =
       (std::min)(32U, (std::max)(8U, std::thread::hardware_concurrency()));
-  auto const object_count = 75 * thread_count;
+  auto const object_count = 50 * thread_count;
   std::vector<std::string> objects(object_count);
   std::generate(objects.begin(), objects.end(),
                 [this] { return MakeRandomObjectName(); });


### PR DESCRIPTION
Lower the number of objects created/deleted in the test, which brings down the average runtime from about to 12.5m to 10m, and that reduces the possibility of exceeding the "long" timeout of 15m.

"Fixes" #9909.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9918)
<!-- Reviewable:end -->
