### PR TITLE
feat: Bazel downstream dependencies can pick repository name

### DIFF
--- a/bazel/google_cloud_cpp_deps.bzl
+++ b/bazel/google_cloud_cpp_deps.bzl
@@ -90,7 +90,7 @@ def google_cloud_cpp_deps():
             ],
             strip_prefix = "googleapis-5a9ee4d5deca8e3da550b0419ed336e22521fc8e",
             sha256 = "57ff2830ff96329e83a349757f694885c4addc2a8791120f6f7447f86daae680",
-            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:googleapis.BUILD",
+            build_file = Label("//bazel:googleapis.BUILD"),
             # Scaffolding for patching googleapis after download. For example:
             #   patches = ["googleapis.patch"]
             # NOTE: This should only be used while developing with a new
@@ -158,7 +158,7 @@ def google_cloud_cpp_deps():
             ],
             strip_prefix = "curl-7.69.1",
             sha256 = "01ae0c123dee45b01bbaef94c0bc00ed2aec89cb2ee0fd598e0d302a6b5e0a98",
-            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:curl.BUILD",
+            build_file = Label("//bazel:curl.BUILD"),
         )
 
     # We need the nlohmann_json library
@@ -169,7 +169,7 @@ def google_cloud_cpp_deps():
                 "https://github.com/nlohmann/json/releases/download/v3.11.2/include.zip",
             ],
             sha256 = "e5c7a9f49a16814be27e4ed0ee900ecd0092bfb7dbfca65b5a421b774dccaaed",
-            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:nlohmann_json.BUILD",
+            build_file = Label("//bazel:nlohmann_json.BUILD"),
         )
 
     # Load google/crc32c, a library to efficiently compute CRC32C checksums.
@@ -181,5 +181,5 @@ def google_cloud_cpp_deps():
                 "https://github.com/google/crc32c/archive/1.1.2.tar.gz",
             ],
             sha256 = "ac07840513072b7fcebda6e821068aa04889018f24e10e46181068fb214d7e56",
-            build_file = "@com_github_googleapis_google_cloud_cpp//bazel:crc32c.BUILD",
+            build_file = Label("//bazel:crc32c.BUILD"),
         )


### PR DESCRIPTION
Use `Label()` to avoid referencing the name of the repository (`@com_github_googleapis_google_cloud_cpp`) in the definition of the workspace macro.  With this change, downstream dependencies can use whatever name they want for our repository.  Currently, they have to use `@com_github_googleapis_google_cloud_cpp`.  Once we create a release, we can use this to shorten our repository name and compile more code on Windows.

Part of the work for #9340.  Tested locally with:

```
env -C google/cloud/kms/quickstart/ bazel build :quickstart
```

and

```
env -C google/cloud/kms/quickstart/ bazel build --override_repository=com_github_googleapis_google_cloud_cpp=$PWD :quickstart
```

Candidly, I copied this from the [tensorstore](https://github.com/google/tensorstore/blob/master/third_party/com_github_nlohmann_json/workspace.bzl#L30) repository.

I tried to understand the [documentation](https://bazel.build/rules/lib/Label) but at best I can guess that "The repo part of the label **(or its absence)** is interpreted in the context of the repo where this Label() call appears." means what I hope it means.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9919)
<!-- Reviewable:end -->
