### PR TITLE
ci: compile all quickstarts on Windows

### DIFF
--- a/ci/kokoro/windows/builds/quickstart-bazel.ps1
+++ b/ci/kokoro/windows/builds/quickstart-bazel.ps1
@@ -34,7 +34,23 @@ $build_flags = Get-Bazel-Build-Flags "${BuildName}"
 
 $project_root = (Get-Item -Path ".\" -Verbose).FullName
 
-$libraries=@("bigquery", "bigtable", "iam", "pubsub", "spanner", "storage")
+# Get the quickstart programs available in the previous `google-cloud-cpp` version.
+function Get-Released-Quickstarts {
+    param([string]$project_root, [string[]]$bazel_common_flags)
+
+    Push-Location "${project_root}/google/cloud/bigtable"
+    bazelisk $bazel_common_flags version | Out-Null
+    bazelisk $bazel_common_flags query --noshow_progress --noshow_loading_progress " filter(/quickstart:quickstart, kind(cc_binary, @com_github_googleapis_google_cloud_cpp//google/...))" |
+        ForEach-Object { $_.replace("@com_github_googleapis_google_cloud_cpp//google/cloud/", "").replace("/quickstart:quickstart", "") } |
+        # TODO(#8145) TODO(#9340) TODO(#8125) TODDO(#8725) - these do not compile on Windows.
+        Where-Object { -not ("asset", "beyondcorp", "channel", "storagetransfer" -contains $_) } |
+        # TODO(#9923) - compiling all quickstarts on Windows is too slow
+        Get-Random -Count 10
+    Pop-Location
+}
+
+$libraries = Get-Released-Quickstarts $project_root $common_flags
+Write-Host "`n$(Get-Date -Format o) Building the following subset of the quickstarts: [${libraries}]"
 $failures=@()
 ForEach($library in $libraries) {
     Write-Host "`n$(Get-Date -Format o) Build quickstart for ${library}"

--- a/ci/kokoro/windows/builds/quickstart-cmake.ps1
+++ b/ci/kokoro/windows/builds/quickstart-cmake.ps1
@@ -40,26 +40,67 @@ if ($missing.count -ge 1) {
     Exit 1
 }
 
+function Get-Vcpkg-Features {
+    param([string]$vcpkg_root, [string]$package)
+
+    & "${vcpkg_root}/vcpkg.exe" search "${package}" | 
+        Where-Object { $_.StartsWith("${package}[") } |
+        ForEach-Object { $_.replace("${package}[", "") -replace "].*", "" } |
+        # TODO(#8145) TODO(#9340) TODO(#8125) TODDO(#8725) - these do not compile on Windows.
+        Where-Object { -not ("asset", "beyondcorp", "channel", "storagetransfer" -contains $_) } |
+        # TODO(#9913) - these compile, but do not install on Windows.
+        Where-Object { -not ("assuredworkloads",  "dialogflow-cx", "dialogflow-es" -contains $_) } |
+        # TODO(#9914) - these depends on the `grafeas`, feature but vcpkg does not install it
+        Where-Object { -not ( "binaryauthorization", "containeranalysis" -contains $_) } |
+        # TODO(#9915) - the quickstart does not work with the version of vcpkg
+        Where-Object { -not ("assuredworkloads",  "dataproc", "documentai" -contains $_) } |
+        # These are convenience features to refactor dependencies.
+        Where-Object { -not ("googleapis", "grpc-common" -contains $_) }
+}
+
 $project_root = (Get-Item -Path ".\" -Verbose).FullName -replace "\\", "/"
 $vcpkg_root = Install-Vcpkg "${project_root}" "-qs"
 $binary_dir="cmake-out/${BuildName}"
-Build-Vcpkg-Packages $vcpkg_root @("google-cloud-cpp")
+$features = Get-Vcpkg-Features "${vcpkg_root}" "google-cloud-cpp"
+Build-Vcpkg-Packages $vcpkg_root @("google-cloud-cpp[$($features  -Join ',')]")
 
-$cmake_args=@(
-    "-G$env:GENERATOR",
-    "-S", "google/cloud/storage/quickstart",
-    "-B", "${binary_dir}/storage"
-    "-DCMAKE_TOOLCHAIN_FILE=`"${vcpkg_root}/scripts/buildsystems/vcpkg.cmake`""
-    "-DCMAKE_BUILD_TYPE=${env:CONFIG}",
-    "-DVCPKG_TARGET_TRIPLET=${env:VCPKG_TRIPLET}",
-    "-DCMAKE_C_COMPILER=cl.exe",
-    "-DCMAKE_CXX_COMPILER=cl.exe"
-)
+$failures=@()
+ForEach($feature in $features) {
+    if ($feature -eq "experimental-storage-grpc") {
+        # Skip this feature as it is not a separate library with a quickstart.
+        continue
+    }
+    $library = $feature.replace('-', '_')
+    Write-Host "`n$(Get-Date -Format o) Build quickstart for ${library}"
+    $cmake_args=@(
+        "-G$env:GENERATOR",
+        "-S", "google/cloud/${library}/quickstart",
+        "-B", "${binary_dir}/${library}"
+        "-DCMAKE_TOOLCHAIN_FILE=`"${vcpkg_root}/scripts/buildsystems/vcpkg.cmake`""
+        "-DCMAKE_BUILD_TYPE=${env:CONFIG}",
+        "-DVCPKG_TARGET_TRIPLET=${env:VCPKG_TRIPLET}",
+        "-DCMAKE_CXX_COMPILER=cl.exe"
+    )
 
-Write-Host "`n$(Get-Date -Format o) Configuring CMake with $cmake_args"
-cmake $cmake_args
+    Write-Host "$(Get-Date -Format o) Configuring CMake with $cmake_args"
+    cmake $cmake_args
+    if ($LastExitCode) {
+        Write-Host -ForegroundColor Red "CMake configuration failed with ${LastExitCode}."
+        $failures += (${library})
+        continue
+    }
+    Write-Host "$(Get-Date -Format o) Compiling $target with CMake $env:CONFIG"
+    cmake --build "${binary_dir}/${library}" --config $env:CONFIG
+    if ($LastExitCode) {
+        Write-Host -ForegroundColor Red "CMake configuration failed with ${LastExitCode}."
+        $failures += (${library})
+    }
+}
 
-Write-Host "`n$(Get-Date -Format o) Compiling $target with CMake $env:CONFIG"
-cmake --build "${binary_dir}/quickstart-storage" --config $env:CONFIG
+if ($failures.count -eq 0) {
+    Write-Host -ForegroundColor Green "`n$(Get-Date -Format o) All quickstarts built successfully"
+    Exit 0
+}
 
-Write-Host -ForegroundColor Green "`n$(Get-Date -Format o) DONE"
+Write-Host -ForegroundColor Red "`n$(Get-Date -Format o) The following quickstarts failed to build: ${failures}"
+Exit 1

--- a/ci/kokoro/windows/lib/bazel.ps1
+++ b/ci/kokoro/windows/lib/bazel.ps1
@@ -28,7 +28,7 @@ if (-not (Test-Path $bazel_root)) {
 }
 
 function Get-Bazel-Common-Flags {
-    return @("--output_user_root=${bazel_root}")
+    return @("--output_user_root=${bazel_root}", "--noshow_loading_progress")
 }
 
 function Get-Bazel-Build-Flags {

--- a/ci/kokoro/windows/lib/bazel.ps1
+++ b/ci/kokoro/windows/lib/bazel.ps1
@@ -28,7 +28,7 @@ if (-not (Test-Path $bazel_root)) {
 }
 
 function Get-Bazel-Common-Flags {
-    return @("--output_user_root=${bazel_root}", "--noshow_loading_progress")
+    return @("--output_user_root=${bazel_root}")
 }
 
 function Get-Bazel-Build-Flags {
@@ -104,7 +104,7 @@ function Fetch-Bazel-Dependencies {
     )
     ForEach($_ in (1, 2)) {
         Write-Host "$(Get-Date -Format o) Fetch dependencies [$_]"
-        bazelisk $common_flags fetch ${external} ...
+        bazelisk $common_flags fetch --noshow_loading_progress ${external} ...
         if ($LastExitCode -eq 0) {
             return
         }
@@ -112,5 +112,5 @@ function Fetch-Bazel-Dependencies {
         Start-Sleep -Seconds (60 * $_)
     }
     Write-Host "$(Get-Date -Format o) Fetch dependencies (last attempt)"
-    bazelisk $common_flags fetch ${external} ...
+    bazelisk $common_flags fetch --noshow_loading_progress ${external} ...
 }

--- a/ci/kokoro/windows/lib/vcpkg.ps1
+++ b/ci/kokoro/windows/lib/vcpkg.ps1
@@ -152,18 +152,19 @@ function Build-Vcpkg-Packages {
         ForEach($_ in (1, 2, 3)) {
             if ($_ -ne 1) { Start-Sleep -Seconds (60 * $_) }
             Write-Host "$(Get-Date -Format o) vcpkg install ${pkg} [$_]"
-            &"${vcpkg_root}/vcpkg.exe" install ${vcpkg_flags} "${pkg}"
+            &"${vcpkg_root}/vcpkg.exe" install ${vcpkg_flags} --recurse "${pkg}"
             if ($LastExitCode -eq 0) {
                 break
             }
+            $pkg_base = $pkg -replace '\[.*', ''
             Write-Host -ForegroundColor Yellow "`n`n$(Get-Date -Format o) DEBUG DEBUG DEBUG - dbg-out"
-            Get-Content "${vcpkg_root}/buildtrees/${pkg}/install-${env:VCPKG_TRIPLET}-dbg-out.log" -ErrorAction SilentlyContinue | Write-Host
+            Get-Content "${vcpkg_root}/buildtrees/${pkg_base}/install-${env:VCPKG_TRIPLET}-dbg-out.log" -ErrorAction SilentlyContinue | Write-Host
             Write-Host -ForegroundColor Yellow "`n`n$(Get-Date -Format o) DEBUG DEBUG DEBUG - dbg-err"
-            Get-Content "${vcpkg_root}/buildtrees/${pkg}/install-${env:VCPKG_TRIPLET}-dbg-err.log" -ErrorAction SilentlyContinue  Write-Host
+            Get-Content "${vcpkg_root}/buildtrees/${pkg_base}/install-${env:VCPKG_TRIPLET}-dbg-err.log" -ErrorAction SilentlyContinue | Write-Host
             Write-Host -ForegroundColor Yellow "`n`n$(Get-Date -Format o) DEBUG DEBUG DEBUG - rel-out"
-            Get-Content "${vcpkg_root}/buildtrees/${pkg}/install-${env:VCPKG_TRIPLET}-rel-out.log" -ErrorAction SilentlyContinue | Write-Host
+            Get-Content "${vcpkg_root}/buildtrees/${pkg_base}/install-${env:VCPKG_TRIPLET}-rel-out.log" -ErrorAction SilentlyContinue | Write-Host
             Write-Host -ForegroundColor Yellow "`n`n$(Get-Date -Format o) DEBUG DEBUG DEBUG - rel-err"
-            Get-Content "${vcpkg_root}/buildtrees/${pkg}/install-${env:VCPKG_TRIPLET}-rel-err.log" -ErrorAction SilentlyContinue | Write-Host
+            Get-Content "${vcpkg_root}/buildtrees/${pkg_base}/install-${env:VCPKG_TRIPLET}-rel-err.log" -ErrorAction SilentlyContinue | Write-Host
         }
         if ($LastExitCode -ne 0) {
             Write-Host -ForegroundColor Red "vcpkg install ${pkg} failed with exit code ${LastExitCode}"
@@ -172,7 +173,7 @@ function Build-Vcpkg-Packages {
     }
 
     Write-Host "`n$(Get-Date -Format o) vcpkg list"
-    &"${vcpkg_root}/vcpkg.exe" list
+    &"${vcpkg_root}/vcpkg.exe" list ${vcpkg_flags}
 }
 
 Configure-Vcpkg-Cache


### PR DESCRIPTION
For CMake: compile as many as are available with the `vcpkg` version used in the builds.

For Bazel: compile as many as are available with the `google-cloud-cpp` release used in the quickstart `WORKSPACE.bazel` files.

In both cases I created a hard-coded list of libraries that do not compile on Windows.  I could not figure out how to query the libraries that fail to compile on Windows from Bazel or CMake.

Fixes #9891 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9920)
<!-- Reviewable:end -->
