### PR TITLE
cleanup: remove references to CMP0091

### DIFF
--- a/ci/kokoro/windows/builds/quickstart-cmake.ps1
+++ b/ci/kokoro/windows/builds/quickstart-cmake.ps1
@@ -52,7 +52,6 @@ $cmake_args=@(
     "-DCMAKE_TOOLCHAIN_FILE=`"${vcpkg_root}/scripts/buildsystems/vcpkg.cmake`""
     "-DCMAKE_BUILD_TYPE=${env:CONFIG}",
     "-DVCPKG_TARGET_TRIPLET=${env:VCPKG_TRIPLET}",
-    "-DCMAKE_POLICY_DEFAULT_CMP0091=NEW",
     "-DCMAKE_C_COMPILER=cl.exe",
     "-DCMAKE_CXX_COMPILER=cl.exe"
 )

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -746,10 +746,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/accessapproval/quickstart/README.md
+++ b/google/cloud/accessapproval/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/accesscontextmanager/quickstart/README.md
+++ b/google/cloud/accesscontextmanager/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/apigateway/quickstart/README.md
+++ b/google/cloud/apigateway/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/apigeeconnect/quickstart/README.md
+++ b/google/cloud/apigeeconnect/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/apikeys/quickstart/README.md
+++ b/google/cloud/apikeys/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/appengine/quickstart/README.md
+++ b/google/cloud/appengine/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/artifactregistry/quickstart/README.md
+++ b/google/cloud/artifactregistry/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/asset/quickstart/README.md
+++ b/google/cloud/asset/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/assuredworkloads/quickstart/README.md
+++ b/google/cloud/assuredworkloads/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/automl/quickstart/README.md
+++ b/google/cloud/automl/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/baremetalsolution/quickstart/README.md
+++ b/google/cloud/baremetalsolution/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/batch/quickstart/README.md
+++ b/google/cloud/batch/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/beyondcorp/quickstart/README.md
+++ b/google/cloud/beyondcorp/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/bigquery/quickstart/README.md
+++ b/google/cloud/bigquery/quickstart/README.md
@@ -137,10 +137,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/bigtable/quickstart/README.md
+++ b/google/cloud/bigtable/quickstart/README.md
@@ -138,10 +138,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/billing/quickstart/README.md
+++ b/google/cloud/billing/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/binaryauthorization/quickstart/README.md
+++ b/google/cloud/binaryauthorization/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/channel/quickstart/README.md
+++ b/google/cloud/channel/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/cloudbuild/quickstart/README.md
+++ b/google/cloud/cloudbuild/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/composer/quickstart/README.md
+++ b/google/cloud/composer/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/contactcenterinsights/quickstart/README.md
+++ b/google/cloud/contactcenterinsights/quickstart/README.md
@@ -138,10 +138,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/container/quickstart/README.md
+++ b/google/cloud/container/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/containeranalysis/quickstart/README.md
+++ b/google/cloud/containeranalysis/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/datacatalog/quickstart/README.md
+++ b/google/cloud/datacatalog/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/datamigration/quickstart/README.md
+++ b/google/cloud/datamigration/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/dataplex/quickstart/README.md
+++ b/google/cloud/dataplex/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/dataproc/quickstart/README.md
+++ b/google/cloud/dataproc/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/debugger/quickstart/README.md
+++ b/google/cloud/debugger/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/dialogflow_cx/quickstart/README.md
+++ b/google/cloud/dialogflow_cx/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/dialogflow_es/quickstart/README.md
+++ b/google/cloud/dialogflow_es/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/dlp/quickstart/README.md
+++ b/google/cloud/dlp/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/documentai/quickstart/README.md
+++ b/google/cloud/documentai/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/edgecontainer/quickstart/README.md
+++ b/google/cloud/edgecontainer/quickstart/README.md
@@ -140,10 +140,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/eventarc/quickstart/README.md
+++ b/google/cloud/eventarc/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/filestore/quickstart/README.md
+++ b/google/cloud/filestore/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/functions/quickstart/README.md
+++ b/google/cloud/functions/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/gameservices/quickstart/README.md
+++ b/google/cloud/gameservices/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/gkehub/quickstart/README.md
+++ b/google/cloud/gkehub/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/iam/quickstart/README.md
+++ b/google/cloud/iam/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/iap/quickstart/README.md
+++ b/google/cloud/iap/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/ids/quickstart/README.md
+++ b/google/cloud/ids/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/iot/quickstart/README.md
+++ b/google/cloud/iot/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/kms/quickstart/README.md
+++ b/google/cloud/kms/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/language/quickstart/README.md
+++ b/google/cloud/language/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/logging/quickstart/README.md
+++ b/google/cloud/logging/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/managedidentities/quickstart/README.md
+++ b/google/cloud/managedidentities/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/memcache/quickstart/README.md
+++ b/google/cloud/memcache/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/monitoring/quickstart/README.md
+++ b/google/cloud/monitoring/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/networkconnectivity/quickstart/README.md
+++ b/google/cloud/networkconnectivity/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/networkmanagement/quickstart/README.md
+++ b/google/cloud/networkmanagement/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/notebooks/quickstart/README.md
+++ b/google/cloud/notebooks/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/optimization/quickstart/README.md
+++ b/google/cloud/optimization/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/orgpolicy/quickstart/README.md
+++ b/google/cloud/orgpolicy/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/osconfig/quickstart/README.md
+++ b/google/cloud/osconfig/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/oslogin/quickstart/README.md
+++ b/google/cloud/oslogin/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/policytroubleshooter/quickstart/README.md
+++ b/google/cloud/policytroubleshooter/quickstart/README.md
@@ -133,10 +133,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/privateca/quickstart/README.md
+++ b/google/cloud/privateca/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/profiler/quickstart/README.md
+++ b/google/cloud/profiler/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/pubsub/quickstart/README.md
+++ b/google/cloud/pubsub/quickstart/README.md
@@ -137,10 +137,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/pubsublite/quickstart/README.md
+++ b/google/cloud/pubsublite/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/recommender/quickstart/README.md
+++ b/google/cloud/recommender/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/redis/quickstart/README.md
+++ b/google/cloud/redis/quickstart/README.md
@@ -137,10 +137,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/resourcemanager/quickstart/README.md
+++ b/google/cloud/resourcemanager/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/resourcesettings/quickstart/README.md
+++ b/google/cloud/resourcesettings/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/retail/quickstart/README.md
+++ b/google/cloud/retail/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/run/quickstart/README.md
+++ b/google/cloud/run/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/scheduler/quickstart/README.md
+++ b/google/cloud/scheduler/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/secretmanager/quickstart/README.md
+++ b/google/cloud/secretmanager/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/securitycenter/quickstart/README.md
+++ b/google/cloud/securitycenter/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/servicecontrol/quickstart/README.md
+++ b/google/cloud/servicecontrol/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/servicedirectory/quickstart/README.md
+++ b/google/cloud/servicedirectory/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/servicemanagement/quickstart/README.md
+++ b/google/cloud/servicemanagement/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/serviceusage/quickstart/README.md
+++ b/google/cloud/serviceusage/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/shell/quickstart/README.md
+++ b/google/cloud/shell/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/spanner/quickstart/README.md
+++ b/google/cloud/spanner/quickstart/README.md
@@ -138,10 +138,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/speech/quickstart/README.md
+++ b/google/cloud/speech/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/storage/quickstart/README.md
+++ b/google/cloud/storage/quickstart/README.md
@@ -184,10 +184,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/storagetransfer/quickstart/README.md
+++ b/google/cloud/storagetransfer/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/talent/quickstart/README.md
+++ b/google/cloud/talent/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/tasks/quickstart/README.md
+++ b/google/cloud/tasks/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/texttospeech/quickstart/README.md
+++ b/google/cloud/texttospeech/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/tpu/quickstart/README.md
+++ b/google/cloud/tpu/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/trace/quickstart/README.md
+++ b/google/cloud/trace/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/translate/quickstart/README.md
+++ b/google/cloud/translate/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/video/quickstart/README.md
+++ b/google/cloud/video/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/videointelligence/quickstart/README.md
+++ b/google/cloud/videointelligence/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/vision/quickstart/README.md
+++ b/google/cloud/vision/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/vmmigration/quickstart/README.md
+++ b/google/cloud/vmmigration/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/vpcaccess/quickstart/README.md
+++ b/google/cloud/vpcaccess/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/webrisk/quickstart/README.md
+++ b/google/cloud/webrisk/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/websecurityscanner/quickstart/README.md
+++ b/google/cloud/websecurityscanner/quickstart/README.md
@@ -132,10 +132,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:

--- a/google/cloud/workflows/quickstart/README.md
+++ b/google/cloud/workflows/quickstart/README.md
@@ -136,10 +136,6 @@ bazel build --copt=-DGRPC_BAZEL_BUILD ...
 
 ### Windows
 
-To correctly configure the MSVC runtime you should change the CMake minimum
-required version to 3.15 or add `-DCMAKE_POLICY_DEFAULT_CMP0091=NEW` to the
-CMake configuration step.
-
 Bazel tends to create very long file names and paths. You may need to use a
 short directory to store the build output, such as `c:\b`, and instruct Bazel
 to use it via:


### PR DESCRIPTION
I should have removed these with the `cmake_minimum_required()` changes. I just did not remember at the time that we had these references in place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9921)
<!-- Reviewable:end -->
