### PR TITLE
fix: spurious timeouts waiting for connection

### DIFF
--- a/google/cloud/internal/async_connection_ready.h
+++ b/google/cloud/internal/async_connection_ready.h
@@ -64,6 +64,10 @@ class NotifyOnStateChange
   static future<bool> Start(std::shared_ptr<CompletionQueueImpl> cq,
                             std::shared_ptr<grpc::Channel> channel,
                             std::chrono::system_clock::time_point deadline);
+  static future<bool> Start(std::shared_ptr<CompletionQueueImpl> cq,
+                            std::shared_ptr<grpc::Channel> channel,
+                            std::chrono::system_clock::time_point deadline,
+                            int last_observed);
 
   bool Notify(bool ok) override;
   void Cancel() override {}

--- a/google/cloud/internal/async_connection_ready.h
+++ b/google/cloud/internal/async_connection_ready.h
@@ -67,7 +67,7 @@ class NotifyOnStateChange
   static future<bool> Start(std::shared_ptr<CompletionQueueImpl> cq,
                             std::shared_ptr<grpc::Channel> channel,
                             std::chrono::system_clock::time_point deadline,
-                            int last_observed);
+                            grpc_connectivity_state last_observed);
 
   bool Notify(bool ok) override;
   void Cancel() override {}


### PR DESCRIPTION
The helpers to wait for a `grpc::Channel` to be ready sometimes failed because the channel was already connected. This was harmless, as this was mostly used to continuously poll the connections.

The tests could flake under load.  Put some code to prevent this, and increase the timeouts to make it even less likely.

Fixes #9922

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9927)
<!-- Reviewable:end -->
