### PR TITLE
ci: fix directory to discover quickstarts

### DIFF
--- a/ci/kokoro/windows/builds/quickstart-bazel.ps1
+++ b/ci/kokoro/windows/builds/quickstart-bazel.ps1
@@ -38,7 +38,7 @@ $project_root = (Get-Item -Path ".\" -Verbose).FullName
 function Get-Released-Quickstarts {
     param([string]$project_root, [string[]]$bazel_common_flags)
 
-    Push-Location "${project_root}/google/cloud/bigtable"
+    Push-Location "${project_root}/google/cloud/bigtable/quickstart"
     bazelisk $bazel_common_flags version | Out-Null
     bazelisk $bazel_common_flags query --noshow_progress --noshow_loading_progress " filter(/quickstart:quickstart, kind(cc_binary, @com_github_googleapis_google_cloud_cpp//google/...))" |
         ForEach-Object { $_.replace("@com_github_googleapis_google_cloud_cpp//google/cloud/", "").replace("/quickstart:quickstart", "") } |


### PR DESCRIPTION
The intention was to discover the quickstarts available using the `google-cloud-cpp` version in the `**/quickstart/WORKSPACE.bazel` files.  To do so, we should run the bazel query in a `**/quickstart` directory.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9931)
<!-- Reviewable:end -->
