### PR TITLE
cleanup(storage): minimize friends for `*PatchBuilder`

### DIFF
--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -180,7 +180,7 @@ std::ostream& operator<<(std::ostream& os, BucketAccessControl const& rhs);
  * server, for example: while it is possible to express "change the value of the
  * entity field" with a PATCH request, the server rejects such changes.
  *
- * @see *
+ * @see
  * https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#patch
  *     for general information on PATCH requests for the Google Cloud Storage
  *     JSON API.

--- a/google/cloud/storage/bucket_access_control.h
+++ b/google/cloud/storage/bucket_access_control.h
@@ -25,10 +25,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
-struct BucketAccessControlParser;
-struct GrpcBucketAccessControlParser;
-}  // namespace internal
 
 /**
  * Wraps the bucketAccessControl resource in Google Cloud Storage.
@@ -184,7 +180,7 @@ std::ostream& operator<<(std::ostream& os, BucketAccessControl const& rhs);
  * server, for example: while it is possible to express "change the value of the
  * entity field" with a PATCH request, the server rejects such changes.
  *
- * @see
+ * @see *
  * https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance#patch
  *     for general information on PATCH requests for the Google Cloud Storage
  *     JSON API.
@@ -216,8 +212,7 @@ class BucketAccessControlPatchBuilder {
   }
 
  private:
-  friend struct internal::GrpcBucketAccessControlParser;
-
+  friend struct internal::PatchBuilderDetails;
   internal::PatchBuilder impl_;
 };
 

--- a/google/cloud/storage/bucket_metadata.h
+++ b/google/cloud/storage/bucket_metadata.h
@@ -34,9 +34,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
-struct GrpcBucketRequestParser;
-}  // namespace internal
 
 /**
  * The billing configuration for a Bucket.
@@ -1194,7 +1191,7 @@ class BucketMetadataPatchBuilder {
   BucketMetadataPatchBuilder& ResetWebsite();
 
  private:
-  friend struct internal::GrpcBucketRequestParser;
+  friend struct internal::PatchBuilderDetails;
 
   internal::PatchBuilder impl_;
   bool labels_subpatch_dirty_{false};

--- a/google/cloud/storage/google_cloud_cpp_storage.bzl
+++ b/google/cloud/storage/google_cloud_cpp_storage.bzl
@@ -191,6 +191,7 @@ google_cloud_cpp_storage_srcs = [
     "internal/object_write_streambuf.cc",
     "internal/openssl_util.cc",
     "internal/patch_builder.cc",
+    "internal/patch_builder_details.cc",
     "internal/policy_document_request.cc",
     "internal/raw_client.cc",
     "internal/rest_client.cc",

--- a/google/cloud/storage/google_cloud_cpp_storage.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage.cmake
@@ -138,6 +138,7 @@ add_library(
     internal/parameter_pack_validation.h
     internal/patch_builder.cc
     internal/patch_builder.h
+    internal/patch_builder_details.cc
     internal/patch_builder_details.h
     internal/policy_document_request.cc
     internal/policy_document_request.h

--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
@@ -66,7 +66,7 @@ BucketAccessControl GrpcBucketAccessControlParser::FromProto(
 
 std::string GrpcBucketAccessControlParser::Role(
     BucketAccessControlPatchBuilder const& patch) {
-  return PatchBuilderDetails::GetPatch(patch.impl_).value("role", "");
+  return PatchBuilderDetails::GetPatch(patch).value("role", "");
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/grpc_object_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser.cc
@@ -68,7 +68,7 @@ ObjectAccessControl GrpcObjectAccessControlParser::FromProto(
 
 std::string GrpcObjectAccessControlParser::Role(
     ObjectAccessControlPatchBuilder const& patch) {
-  return PatchBuilderDetails::GetPatch(patch.impl_).value("role", "");
+  return PatchBuilderDetails::GetPatch(patch).value("role", "");
 }
 
 }  // namespace internal

--- a/google/cloud/storage/internal/patch_builder.h
+++ b/google/cloud/storage/internal/patch_builder.h
@@ -25,6 +25,7 @@ namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
+struct PatchBuilderDetails;
 
 /**
  * Prepares a patch for the '<Resource Type>: patch' APIs in Google Cloud

--- a/google/cloud/storage/internal/patch_builder_details.cc
+++ b/google/cloud/storage/internal/patch_builder_details.cc
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "google/cloud/storage/internal/patch_builder_details.h"
+#include "google/cloud/storage/bucket_access_control.h"
+#include "google/cloud/storage/bucket_metadata.h"
+#include "google/cloud/storage/object_access_control.h"
+#include "google/cloud/storage/object_metadata.h"
+
+namespace google {
+namespace cloud {
+namespace storage {
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+namespace internal {
+
+nlohmann::json const& PatchBuilderDetails::GetPatch(
+    storage::BucketAccessControlPatchBuilder const& patch) {
+  return GetPatch(patch.impl_);
+}
+
+nlohmann::json const& PatchBuilderDetails::GetPatch(
+    storage::BucketMetadataPatchBuilder const& patch) {
+  return GetPatch(patch.impl_);
+}
+
+nlohmann::json const& PatchBuilderDetails::GetLabelsSubPatch(
+    storage::BucketMetadataPatchBuilder const& patch) {
+  static auto const* const kEmpty = [] { return new nlohmann::json({}); }();
+  if (!patch.labels_subpatch_dirty_) return *kEmpty;
+  return GetPatch(patch.labels_subpatch_);
+}
+
+nlohmann::json const& PatchBuilderDetails::GetPatch(
+    storage::ObjectAccessControlPatchBuilder const& patch) {
+  return GetPatch(patch.impl_);
+}
+
+nlohmann::json const& PatchBuilderDetails::GetPatch(
+    storage::ObjectMetadataPatchBuilder const& patch) {
+  return GetPatch(patch.impl_);
+}
+
+nlohmann::json const& PatchBuilderDetails::GetMetadataSubPatch(
+    storage::ObjectMetadataPatchBuilder const& patch) {
+  static auto const* const kEmpty = [] { return new nlohmann::json({}); }();
+  if (!patch.metadata_subpatch_dirty_) return *kEmpty;
+  return GetPatch(patch.metadata_subpatch_);
+}
+
+}  // namespace internal
+GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
+}  // namespace storage
+}  // namespace cloud
+}  // namespace google

--- a/google/cloud/storage/internal/patch_builder_details.h
+++ b/google/cloud/storage/internal/patch_builder_details.h
@@ -22,12 +22,17 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
+class BucketAccessControlPatchBuilder;
+class BucketMetadataPatchBuilder;
+class ObjectAccessControlPatchBuilder;
+class ObjectMetadataPatchBuilder;
+
 namespace internal {
 
 class PatchBuilder;
 
 /**
- * Get a JSON patch from a PatchBuilder.
+ * Get a JSON patch from a *PatchBuilder.
  *
  * The PatchBuilder class cannot expose any API returning `nlohmann::json`
  * because we do not want to expose the `nlohmann::json` in any of our public
@@ -36,6 +41,18 @@ class PatchBuilder;
  * `friend`s to achieve this.
  */
 struct PatchBuilderDetails {
+  static nlohmann::json const& GetPatch(
+      storage::BucketAccessControlPatchBuilder const& patch);
+  static nlohmann::json const& GetPatch(
+      storage::BucketMetadataPatchBuilder const& patch);
+  static nlohmann::json const& GetLabelsSubPatch(
+      storage::BucketMetadataPatchBuilder const& patch);
+  static nlohmann::json const& GetPatch(
+      storage::ObjectAccessControlPatchBuilder const& patch);
+  static nlohmann::json const& GetPatch(
+      storage::ObjectMetadataPatchBuilder const& patch);
+  static nlohmann::json const& GetMetadataSubPatch(
+      storage::ObjectMetadataPatchBuilder const& patch);
   static nlohmann::json const& GetPatch(PatchBuilder const& patch);
 };
 

--- a/google/cloud/storage/object_access_control.h
+++ b/google/cloud/storage/object_access_control.h
@@ -25,10 +25,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
-struct ObjectAccessControlParser;
-struct GrpcObjectAccessControlParser;
-}  // namespace internal
 
 /**
  * Wraps the objectAccessControl resource in Google Cloud Storage.
@@ -228,8 +224,7 @@ class ObjectAccessControlPatchBuilder {
   }
 
  private:
-  friend struct internal::GrpcObjectAccessControlParser;
-
+  friend struct internal::PatchBuilderDetails;
   internal::PatchBuilder impl_;
 };
 

--- a/google/cloud/storage/object_metadata.h
+++ b/google/cloud/storage/object_metadata.h
@@ -31,11 +31,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
-struct ObjectMetadataParser;
-struct GrpcObjectMetadataParser;
-struct GrpcObjectRequestParser;
-}  // namespace internal
 
 /// A simple representation for the customerEncryption field.
 struct CustomerEncryption {
@@ -613,7 +608,7 @@ class ObjectMetadataPatchBuilder {
   ObjectMetadataPatchBuilder& ResetCustomTime();
 
  private:
-  friend struct internal::GrpcObjectRequestParser;
+  friend struct internal::PatchBuilderDetails;
 
   internal::PatchBuilder impl_;
   bool metadata_subpatch_dirty_{false};


### PR DESCRIPTION
Use a single `friend` struct that needs to be forward declared.
The Google Style Guide frowns upon `struct` types with only static
functions. I think it is justified in this case because (a) it
simplifies all the `friend` declaratios, (b) it avoids exposing the
`nlohmann` stuff in our public headers.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9932)
<!-- Reviewable:end -->
