### PR TITLE
cleanup(GCS+gRPC): BucketAccessControl helpers

### DIFF
--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser.cc
@@ -19,12 +19,11 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-google::storage::v2::BucketAccessControl GrpcBucketAccessControlParser::ToProto(
-    BucketAccessControl const& acl) {
+google::storage::v2::BucketAccessControl ToProto(
+    storage::BucketAccessControl const& acl) {
   google::storage::v2::BucketAccessControl result;
   result.set_role(acl.role());
   result.set_id(acl.id());
@@ -41,10 +40,10 @@ google::storage::v2::BucketAccessControl GrpcBucketAccessControlParser::ToProto(
   return result;
 }
 
-BucketAccessControl GrpcBucketAccessControlParser::FromProto(
+storage::BucketAccessControl FromProto(
     google::storage::v2::BucketAccessControl acl,
     std::string const& bucket_name) {
-  BucketAccessControl result;
+  storage::BucketAccessControl result;
   result.set_kind("storage#bucketAccessControl");
   result.set_bucket(bucket_name);
   result.set_domain(std::move(*acl.mutable_domain()));
@@ -53,7 +52,7 @@ BucketAccessControl GrpcBucketAccessControlParser::FromProto(
   result.set_entity_id(std::move(*acl.mutable_entity_id()));
   result.set_id(std::move(*acl.mutable_id()));
   if (acl.has_project_team()) {
-    result.set_project_team(ProjectTeam{
+    result.set_project_team(storage::ProjectTeam{
         std::move(*acl.mutable_project_team()->mutable_project_number()),
         std::move(*acl.mutable_project_team()->mutable_team()),
     });
@@ -64,13 +63,12 @@ BucketAccessControl GrpcBucketAccessControlParser::FromProto(
   return result;
 }
 
-std::string GrpcBucketAccessControlParser::Role(
-    BucketAccessControlPatchBuilder const& patch) {
-  return PatchBuilderDetails::GetPatch(patch).value("role", "");
+std::string Role(storage::BucketAccessControlPatchBuilder const& patch) {
+  return storage::internal::PatchBuilderDetails::GetPatch(patch).value("role",
+                                                                       "");
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser.h
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser.h
@@ -21,24 +21,18 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-class BucketAccessControlPatchBuilder;
-namespace internal {
 
-struct GrpcBucketAccessControlParser {
-  static google::storage::v2::BucketAccessControl ToProto(
-      BucketAccessControl const& acl);
-  static BucketAccessControl FromProto(
-      google::storage::v2::BucketAccessControl acl,
-      std::string const& bucket_name);
+google::storage::v2::BucketAccessControl ToProto(
+    storage::BucketAccessControl const& acl);
+storage::BucketAccessControl FromProto(
+    google::storage::v2::BucketAccessControl acl,
+    std::string const& bucket_name);
+std::string Role(storage::BucketAccessControlPatchBuilder const&);
 
-  static std::string Role(BucketAccessControlPatchBuilder const&);
-};
-
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_bucket_access_control_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_bucket_access_control_parser_test.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 namespace storage_proto = ::google::storage::v2;
@@ -45,7 +44,8 @@ TEST(GrpcBucketAccessControlParser, FromProto) {
      etag: "test-etag")""",
                                                             &input));
 
-  auto const expected = BucketAccessControlParser::FromString(R"""({
+  auto const expected =
+      storage::internal::BucketAccessControlParser::FromString(R"""({
      "role": "test-role",
      "id": "test-id",
      "kind": "storage#bucketAccessControl",
@@ -62,12 +62,12 @@ TEST(GrpcBucketAccessControlParser, FromProto) {
   })""");
   ASSERT_STATUS_OK(expected);
 
-  auto actual = GrpcBucketAccessControlParser::FromProto(input, "test-bucket");
+  auto actual = FromProto(input, "test-bucket");
   EXPECT_EQ(*expected, actual);
 }
 
 TEST(GrpcBucketAccessControlParser, ToProtoSimple) {
-  auto acl = BucketAccessControlParser::FromString(R"""({
+  auto acl = storage::internal::BucketAccessControlParser::FromString(R"""({
      "role": "test-role",
      "id": "test-id",
      "kind": "storage#bucketAccessControl",
@@ -83,7 +83,7 @@ TEST(GrpcBucketAccessControlParser, ToProtoSimple) {
      "etag": "test-etag"
   })""");
   ASSERT_STATUS_OK(acl);
-  auto actual = GrpcBucketAccessControlParser::ToProto(*acl);
+  auto actual = ToProto(*acl);
 
   storage_proto::BucketAccessControl expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
@@ -104,10 +104,10 @@ TEST(GrpcBucketAccessControlParser, ToProtoSimple) {
 }
 
 TEST(GrpcBucketAccessControlParser, MinimalFields) {
-  BucketAccessControl acl;
+  storage::BucketAccessControl acl;
   acl.set_role("test-role");
   acl.set_entity("test-entity");
-  auto actual = GrpcBucketAccessControlParser::ToProto(acl);
+  auto actual = ToProto(acl);
 
   storage_proto::BucketAccessControl expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
@@ -120,13 +120,13 @@ TEST(GrpcBucketAccessControlParser, MinimalFields) {
 }
 
 TEST(GrpcBucketAccessControlParser, Role) {
-  auto const patch = BucketAccessControlPatchBuilder().set_role("test-role");
-  EXPECT_EQ("test-role", GrpcBucketAccessControlParser::Role(patch));
+  auto const patch =
+      storage::BucketAccessControlPatchBuilder().set_role("test-role");
+  EXPECT_EQ("test-role", Role(patch));
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -61,7 +61,7 @@ google::storage::v2::Bucket GrpcBucketMetadataParser::ToProto(
   result.set_storage_class(rhs.storage_class());
   result.set_rpo(rhs.rpo());
   for (auto const& v : rhs.acl()) {
-    *result.add_acl() = GrpcBucketAccessControlParser::ToProto(v);
+    *result.add_acl() = storage_internal::ToProto(v);
   }
   for (auto const& v : rhs.default_acl()) {
     *result.add_default_object_acl() =
@@ -116,7 +116,7 @@ BucketMetadata GrpcBucketMetadataParser::FromProto(
   // easier to find in the future.
   for (auto const& v : rhs.acl()) {
     metadata.mutable_acl().push_back(
-        GrpcBucketAccessControlParser::FromProto(v, rhs.bucket_id()));
+        storage_internal::FromProto(v, rhs.bucket_id()));
   }
   if (rhs.has_billing()) metadata.set_billing(FromProto(rhs.billing()));
   metadata.set_default_event_based_hold(rhs.default_event_based_hold());

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -810,7 +810,7 @@ StatusOr<BucketAccessControl> GrpcClient::PatchBucketAcl(
   get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<BucketAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(),
-                     GrpcBucketAccessControlParser::Role(request.patch()));
+                     storage_internal::Role(request.patch()));
   };
   return FindBucketAccessControl(
       ModifyBucketAccessControl(get_request, updater), request.entity());


### PR DESCRIPTION
Move the helper functions out of an empty struct and into the `storage_internal` namespace.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9937)
<!-- Reviewable:end -->
