### PR TITLE
cleanup(GCS+gRPC): `ObjectAccessControl` helpers

### DIFF
--- a/google/cloud/storage/internal/access_control_common.h
+++ b/google/cloud/storage/internal/access_control_common.h
@@ -28,8 +28,6 @@ namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 struct AccessControlCommonParser;
-struct GrpcBucketAccessControlParser;
-struct GrpcObjectAccessControlParser;
 
 /**
  * Defines common code to both `BucketAccessControl` and `ObjectAccessControl`.
@@ -93,8 +91,6 @@ class GOOGLE_CLOUD_CPP_DEPRECATED(
   std::string const& self_link() const { return self_link_; }
 
  private:
-  friend struct GrpcBucketAccessControlParser;
-  friend struct GrpcObjectAccessControlParser;
   friend struct internal::AccessControlCommonParser;
 
   std::string bucket_;

--- a/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_bucket_metadata_parser.cc
@@ -64,8 +64,7 @@ google::storage::v2::Bucket GrpcBucketMetadataParser::ToProto(
     *result.add_acl() = GrpcBucketAccessControlParser::ToProto(v);
   }
   for (auto const& v : rhs.default_acl()) {
-    *result.add_default_object_acl() =
-        GrpcObjectAccessControlParser::ToProto(v);
+    *result.add_default_object_acl() = storage_internal::ToProto(v);
   }
   if (rhs.has_lifecycle()) {
     *result.mutable_lifecycle() = ToProto(rhs.lifecycle());
@@ -125,9 +124,9 @@ BucketMetadata GrpcBucketMetadataParser::FromProto(
   }
   for (auto const& v : rhs.default_object_acl()) {
     metadata.mutable_default_acl().push_back(
-        GrpcObjectAccessControlParser::FromProto(v, rhs.bucket_id(),
-                                                 /*object_name*/ std::string{},
-                                                 /*generation=*/0));
+        storage_internal::FromProto(v, rhs.bucket_id(),
+                                    /*object_name*/ std::string{},
+                                    /*generation=*/0));
   }
   if (rhs.has_encryption()) {
     metadata.set_encryption(FromProto(rhs.encryption()));

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -899,7 +899,7 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchObjectAcl(
   get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(),
-                     GrpcObjectAccessControlParser::Role(request.patch()));
+                     storage_internal::Role(request.patch()));
   };
   return FindObjectAccessControl(
       ModifyObjectAccessControl(get_request, updater), request.entity());
@@ -983,7 +983,7 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchDefaultObjectAcl(
   get_request.set_option(Projection("full"));
   auto updater = [&request](std::vector<ObjectAccessControl> acl) {
     return UpsertAcl(std::move(acl), request.entity(),
-                     GrpcObjectAccessControlParser::Role(request.patch()));
+                     storage_internal::Role(request.patch()));
   };
   return FindDefaultObjectAccessControl(
       ModifyDefaultAccessControl(get_request, updater), request.entity());

--- a/google/cloud/storage/internal/grpc_object_access_control_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser.cc
@@ -18,12 +18,11 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-google::storage::v2::ObjectAccessControl GrpcObjectAccessControlParser::ToProto(
-    ObjectAccessControl const& acl) {
+google::storage::v2::ObjectAccessControl ToProto(
+    storage::ObjectAccessControl const& acl) {
   google::storage::v2::ObjectAccessControl result;
   result.set_role(acl.role());
   result.set_id(acl.id());
@@ -40,11 +39,11 @@ google::storage::v2::ObjectAccessControl GrpcObjectAccessControlParser::ToProto(
   return result;
 }
 
-ObjectAccessControl GrpcObjectAccessControlParser::FromProto(
+storage::ObjectAccessControl FromProto(
     google::storage::v2::ObjectAccessControl acl,
     std::string const& bucket_name, std::string const& object_name,
     std::uint64_t generation) {
-  ObjectAccessControl result;
+  storage::ObjectAccessControl result;
   result.set_kind("storage#objectAccessControl");
   result.set_bucket(bucket_name);
   result.set_object(object_name);
@@ -55,7 +54,7 @@ ObjectAccessControl GrpcObjectAccessControlParser::FromProto(
   result.set_entity_id(std::move(*acl.mutable_entity_id()));
   result.set_id(std::move(*acl.mutable_id()));
   if (acl.has_project_team()) {
-    result.set_project_team(ProjectTeam{
+    result.set_project_team(storage::ProjectTeam{
         std::move(*acl.mutable_project_team()->mutable_project_number()),
         std::move(*acl.mutable_project_team()->mutable_team()),
     });
@@ -66,13 +65,12 @@ ObjectAccessControl GrpcObjectAccessControlParser::FromProto(
   return result;
 }
 
-std::string GrpcObjectAccessControlParser::Role(
-    ObjectAccessControlPatchBuilder const& patch) {
-  return PatchBuilderDetails::GetPatch(patch).value("role", "");
+std::string Role(storage::ObjectAccessControlPatchBuilder const& patch) {
+  return storage::internal::PatchBuilderDetails::GetPatch(patch).value("role",
+                                                                       "");
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_object_access_control_parser.h
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser.h
@@ -21,25 +21,19 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-class BucketAccessControlPatchBuilder;
-namespace internal {
 
-struct GrpcObjectAccessControlParser {
-  static google::storage::v2::ObjectAccessControl ToProto(
-      ObjectAccessControl const& acl);
-  static ObjectAccessControl FromProto(
-      google::storage::v2::ObjectAccessControl acl,
-      std::string const& bucket_name, std::string const& object_name,
-      std::uint64_t generation);
+google::storage::v2::ObjectAccessControl ToProto(
+    storage::ObjectAccessControl const& acl);
+storage::ObjectAccessControl FromProto(
+    google::storage::v2::ObjectAccessControl acl,
+    std::string const& bucket_name, std::string const& object_name,
+    std::uint64_t generation);
+std::string Role(storage::ObjectAccessControlPatchBuilder const&);
 
-  static std::string Role(ObjectAccessControlPatchBuilder const&);
-};
-
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_object_access_control_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_access_control_parser_test.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 namespace storage_proto = ::google::storage::v2;
@@ -46,7 +45,8 @@ TEST(GrpcObjectAccessControlParser, FromProto) {
      )""",
                                                             &input));
 
-  auto const expected = ObjectAccessControlParser::FromString(R"""({
+  auto const expected =
+      storage::internal::ObjectAccessControlParser::FromString(R"""({
      "role": "test-role",
      "id": "test-id",
      "kind": "storage#objectAccessControl",
@@ -65,13 +65,12 @@ TEST(GrpcObjectAccessControlParser, FromProto) {
   })""");
   ASSERT_STATUS_OK(expected);
 
-  auto actual = GrpcObjectAccessControlParser::FromProto(input, "test-bucket",
-                                                         "test-object", 42);
+  auto actual = FromProto(input, "test-bucket", "test-object", 42);
   EXPECT_EQ(*expected, actual);
 }
 
 TEST(GrpcObjectAccessControlParser, ToProtoSimple) {
-  auto acl = ObjectAccessControlParser::FromString(R"""({
+  auto acl = storage::internal::ObjectAccessControlParser::FromString(R"""({
      "role": "test-role",
      "id": "test-id",
      "kind": "storage#objectAccessControl",
@@ -89,7 +88,7 @@ TEST(GrpcObjectAccessControlParser, ToProtoSimple) {
      "etag": "test-etag"
   })""");
   ASSERT_STATUS_OK(acl);
-  auto actual = GrpcObjectAccessControlParser::ToProto(*acl);
+  auto actual = ToProto(*acl);
 
   storage_proto::ObjectAccessControl expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
@@ -111,10 +110,10 @@ TEST(GrpcObjectAccessControlParser, ToProtoSimple) {
 }
 
 TEST(GrpcObjectAccessControlParser, MinimalFields) {
-  ObjectAccessControl acl;
+  storage::ObjectAccessControl acl;
   acl.set_role("test-role");
   acl.set_entity("test-entity");
-  auto actual = GrpcObjectAccessControlParser::ToProto(acl);
+  auto actual = ToProto(acl);
 
   storage_proto::ObjectAccessControl expected;
   EXPECT_TRUE(google::protobuf::TextFormat::ParseFromString(R"""(
@@ -127,8 +126,7 @@ TEST(GrpcObjectAccessControlParser, MinimalFields) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_object_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser.cc
@@ -125,9 +125,9 @@ ObjectMetadata GrpcObjectMetadataParser::FromProto(
   std::vector<ObjectAccessControl> acl;
   acl.reserve(object.acl_size());
   for (auto& item : *object.mutable_acl()) {
-    acl.push_back(GrpcObjectAccessControlParser::FromProto(
-        std::move(item), metadata.bucket(), metadata.name(),
-        metadata.generation()));
+    acl.push_back(
+        storage_internal::FromProto(std::move(item), metadata.bucket(),
+                                    metadata.name(), metadata.generation()));
   }
   metadata.set_acl(std::move(acl));
   metadata.set_cache_control(std::move(*object.mutable_cache_control()));

--- a/google/cloud/storage/internal/grpc_object_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser.cc
@@ -130,7 +130,7 @@ Status SetObjectMetadata(google::storage::v2::Object& resource,
     resource.set_cache_control(metadata.cache_control());
   }
   for (auto const& acl : metadata.acl()) {
-    *resource.add_acl() = GrpcObjectAccessControlParser::ToProto(acl);
+    *resource.add_acl() = storage_internal::ToProto(acl);
   }
   if (!metadata.content_language().empty()) {
     resource.set_content_language(metadata.content_language());
@@ -175,7 +175,7 @@ Status PatchAcl(Object& o, nlohmann::json const& p) {
     // We do not care if `o` may have been modified. It will be discarded if
     // this function (or similar functions) return a non-Okay Status.
     if (!acl) return std::move(acl).status();
-    *o.add_acl() = GrpcObjectAccessControlParser::ToProto(*acl);
+    *o.add_acl() = storage_internal::ToProto(*acl);
   }
   return Status{};
 }
@@ -223,7 +223,7 @@ GrpcObjectRequestParser::ToProto(ComposeObjectRequest const& request) {
   if (request.HasOption<WithObjectMetadata>()) {
     auto metadata = request.GetOption<WithObjectMetadata>().value();
     for (auto const& a : metadata.acl()) {
-      *destination.add_acl() = GrpcObjectAccessControlParser::ToProto(a);
+      *destination.add_acl() = storage_internal::ToProto(a);
     }
     for (auto const& kv : metadata.metadata()) {
       (*destination.mutable_metadata())[kv.first] = kv.second;
@@ -418,7 +418,7 @@ GrpcObjectRequestParser::ToProto(UpdateObjectRequest const& request) {
 
   result.mutable_update_mask()->add_paths("acl");
   for (auto const& a : request.metadata().acl()) {
-    *object.add_acl() = GrpcObjectAccessControlParser::ToProto(a);
+    *object.add_acl() = storage_internal::ToProto(a);
   }
 
   // The semantics in gRPC are to replace any metadata attributes


### PR DESCRIPTION
Move the functions to a namespace and remove the
`GrpcObjectAccessControlParser` struct.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9938)
<!-- Reviewable:end -->
