### PR TITLE
cleanup(GCS+gRPC): move `ObjectMetadata` helpers

### DIFF
--- a/google/cloud/storage/internal/async_accumulate_read_object.cc
+++ b/google/cloud/storage/internal/async_accumulate_read_object.cc
@@ -343,9 +343,7 @@ storage_experimental::AsyncReadObjectRangeResponse ToResponse(
   response.object_metadata = [&] {
     for (auto& r : accumulated.payload) {
       if (!r.has_metadata()) continue;
-      return absl::make_optional(
-          storage::internal::GrpcObjectMetadataParser::FromProto(
-              *r.mutable_metadata(), options));
+      return absl::make_optional(FromProto(*r.mutable_metadata(), options));
     }
     return absl::optional<storage::ObjectMetadata>{};
   }();

--- a/google/cloud/storage/internal/common_metadata.h
+++ b/google/cloud/storage/internal/common_metadata.h
@@ -69,8 +69,6 @@ class GOOGLE_CLOUD_CPP_DEPRECATED(
   std::chrono::system_clock::time_point updated() const { return updated_; }
 
  private:
-  friend struct GrpcBucketMetadataParser;
-  friend struct GrpcObjectMetadataParser;
   template <typename ParserDerived>
   friend struct CommonMetadataParser;
 

--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -104,13 +104,13 @@ void MaybeFinalize(google::storage::v2::WriteObjectRequest& write_request,
   options.set_last_message();
   auto const& hashes = request.full_object_hashes();
   if (!hashes.md5.empty()) {
-    auto md5 = GrpcObjectMetadataParser::MD5ToProto(hashes.md5);
+    auto md5 = storage_internal::MD5ToProto(hashes.md5);
     if (md5) {
       write_request.mutable_object_checksums()->set_md5_hash(*std::move(md5));
     }
   }
   if (!hashes.crc32c.empty()) {
-    auto crc32c = GrpcObjectMetadataParser::Crc32cToProto(hashes.crc32c);
+    auto crc32c = storage_internal::Crc32cToProto(hashes.crc32c);
     if (crc32c) {
       write_request.mutable_object_checksums()->set_crc32c(*std::move(crc32c));
     }
@@ -453,7 +453,7 @@ StatusOr<ObjectMetadata> GrpcClient::InsertObjectMedia(
 
   if (!response) return std::move(response).status();
   if (response->has_resource()) {
-    return GrpcObjectMetadataParser::FromProto(response->resource(), options());
+    return storage_internal::FromProto(response->resource(), options());
   }
   return ObjectMetadata{};
 }
@@ -470,8 +470,7 @@ StatusOr<ObjectMetadata> GrpcClient::CopyObject(
         StatusCode::kOutOfRange,
         "Object too large, use RewriteObject() instead of CopyObject()");
   }
-  return GrpcObjectMetadataParser::FromProto(response->resource(),
-                                             CurrentOptions());
+  return storage_internal::FromProto(response->resource(), CurrentOptions());
 }
 
 StatusOr<ObjectMetadata> GrpcClient::GetObjectMetadata(
@@ -481,7 +480,7 @@ StatusOr<ObjectMetadata> GrpcClient::GetObjectMetadata(
   ApplyQueryParameters(context, request);
   auto response = stub_->GetObject(context, proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
+  return storage_internal::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
@@ -551,7 +550,7 @@ StatusOr<ObjectMetadata> GrpcClient::UpdateObject(
   ApplyQueryParameters(context, request);
   auto response = stub_->UpdateObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
+  return storage_internal::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<ObjectMetadata> GrpcClient::PatchObject(
@@ -562,7 +561,7 @@ StatusOr<ObjectMetadata> GrpcClient::PatchObject(
   ApplyQueryParameters(context, request);
   auto response = stub_->UpdateObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
+  return storage_internal::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<ObjectMetadata> GrpcClient::ComposeObject(
@@ -573,7 +572,7 @@ StatusOr<ObjectMetadata> GrpcClient::ComposeObject(
   ApplyQueryParameters(context, request);
   auto response = stub_->ComposeObject(context, *proto);
   if (!response) return std::move(response).status();
-  return GrpcObjectMetadataParser::FromProto(*response, CurrentOptions());
+  return storage_internal::FromProto(*response, CurrentOptions());
 }
 
 StatusOr<RewriteObjectResponse> GrpcClient::RewriteObject(

--- a/google/cloud/storage/internal/grpc_object_metadata_parser.h
+++ b/google/cloud/storage/internal/grpc_object_metadata_parser.h
@@ -22,29 +22,25 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-struct GrpcObjectMetadataParser {
-  static StatusOr<google::storage::v2::CustomerEncryption> ToProto(
-      CustomerEncryption rhs);
-  static CustomerEncryption FromProto(
-      google::storage::v2::CustomerEncryption rhs);
+StatusOr<google::storage::v2::CustomerEncryption> ToProto(
+    storage::CustomerEncryption rhs);
+storage::CustomerEncryption FromProto(
+    google::storage::v2::CustomerEncryption rhs);
 
-  static std::string Crc32cFromProto(std::uint32_t);
-  static StatusOr<std::uint32_t> Crc32cToProto(std::string const&);
-  static std::string MD5FromProto(std::string const&);
-  static StatusOr<std::string> MD5ToProto(std::string const&);
-  static std::string ComputeMD5Hash(std::string const& payload);
+std::string Crc32cFromProto(std::uint32_t);
+StatusOr<std::uint32_t> Crc32cToProto(std::string const&);
+std::string MD5FromProto(std::string const&);
+StatusOr<std::string> MD5ToProto(std::string const&);
+std::string ComputeMD5Hash(std::string const& payload);
 
-  static ObjectMetadata FromProto(google::storage::v2::Object object,
+storage::ObjectMetadata FromProto(google::storage::v2::Object object,
                                   Options const& options);
-};
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_object_read_source.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source.cc
@@ -97,17 +97,15 @@ void GrpcObjectReadSource::HandleResponse(
   if (response.has_object_checksums()) {
     auto const& checksums = response.object_checksums();
     if (checksums.has_crc32c()) {
-      result.hashes = Merge(
-          std::move(result.hashes),
-          HashValues{
-              GrpcObjectMetadataParser::Crc32cFromProto(checksums.crc32c()),
-              {}});
+      result.hashes =
+          Merge(std::move(result.hashes),
+                HashValues{
+                    storage_internal::Crc32cFromProto(checksums.crc32c()), {}});
     }
     if (!checksums.md5_hash().empty()) {
-      result.hashes = Merge(std::move(result.hashes),
-                            HashValues{{},
-                                       GrpcObjectMetadataParser::MD5FromProto(
-                                           checksums.md5_hash())});
+      result.hashes = Merge(
+          std::move(result.hashes),
+          HashValues{{}, storage_internal::MD5FromProto(checksums.md5_hash())});
     }
   }
   if (response.has_metadata()) {

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -212,9 +212,9 @@ TEST(GrpcObjectReadSource, CaptureChecksums) {
         storage_proto::ReadObjectResponse response;
         response.mutable_checksummed_data()->set_content("The quick brown");
         response.mutable_object_checksums()->set_md5_hash(
-            GrpcObjectMetadataParser::MD5ToProto(expected_md5).value());
+            storage_internal::MD5ToProto(expected_md5).value());
         response.mutable_object_checksums()->set_crc32c(
-            GrpcObjectMetadataParser::Crc32cToProto(expected_crc32c).value());
+            storage_internal::Crc32cToProto(expected_crc32c).value());
         return response;
       })
       .WillOnce([&] {
@@ -224,9 +224,9 @@ TEST(GrpcObjectReadSource, CaptureChecksums) {
         // The headers may be included more than once in the stream,
         // `GrpcObjectReadSource` should return them only once.
         response.mutable_object_checksums()->set_md5_hash(
-            GrpcObjectMetadataParser::MD5ToProto(expected_md5).value());
+            storage_internal::MD5ToProto(expected_md5).value());
         response.mutable_object_checksums()->set_crc32c(
-            GrpcObjectMetadataParser::Crc32cToProto(expected_crc32c).value());
+            storage_internal::Crc32cToProto(expected_crc32c).value());
         return response;
       })
       .WillOnce(Return(Status{}));


### PR DESCRIPTION
Remove the `GrpcObjectMetadataParser` struct, move its functions (they were all static) to the `storage_internal` namespace.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9941)
<!-- Reviewable:end -->
