### PR TITLE
feat(storage): easier mocks for `HmacKeyMetadata`

### DIFF
--- a/google/cloud/storage/hmac_key_metadata.h
+++ b/google/cloud/storage/hmac_key_metadata.h
@@ -26,10 +26,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
-struct HmacKeyMetadataParser;
-struct GrpcHmacKeyMetadataParser;
-}  // namespace internal
 
 /**
  * Represents the metadata for a Google Cloud Storage HmacKeyResource.
@@ -78,9 +74,46 @@ class HmacKeyMetadata {
   static std::string state_inactive() { return "INACTIVE"; }
   static std::string state_deleted() { return "DELETED"; }
 
+  ///@{
+  /**
+   * @name Testing modifiers.
+   *
+   * The following attributes cannot be changed when updating, creating, or
+   * patching an HmacKeyMetadata resource. However, it is useful to change
+   * them in tests, e.g., when mocking the results from the C++ client library.
+   */
+  HmacKeyMetadata& set_access_id(std::string v) {
+    access_id_ = std::move(v);
+    return *this;
+  }
+  HmacKeyMetadata& set_id(std::string v) {
+    id_ = std::move(v);
+    return *this;
+  }
+
+  HmacKeyMetadata& set_kind(std::string v) {
+    kind_ = std::move(v);
+    return *this;
+  }
+  HmacKeyMetadata& set_project_id(std::string v) {
+    project_id_ = std::move(v);
+    return *this;
+  }
+  HmacKeyMetadata& set_service_account_email(std::string v) {
+    service_account_email_ = std::move(v);
+    return *this;
+  }
+  HmacKeyMetadata& set_time_created(std::chrono::system_clock::time_point v) {
+    time_created_ = v;
+    return *this;
+  }
+  HmacKeyMetadata& set_updated(std::chrono::system_clock::time_point v) {
+    updated_ = v;
+    return *this;
+  }
+  ///@}
+
  private:
-  friend struct internal::HmacKeyMetadataParser;
-  friend struct internal::GrpcHmacKeyMetadataParser;
   friend std::ostream& operator<<(std::ostream& os, HmacKeyMetadata const& rhs);
 
   // Keep the fields in alphabetical order.

--- a/google/cloud/storage/internal/grpc_hmac_key_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_hmac_key_metadata_parser.cc
@@ -26,22 +26,22 @@ namespace internal {
 HmacKeyMetadata GrpcHmacKeyMetadataParser::FromProto(
     google::storage::v2::HmacKeyMetadata const& rhs) {
   HmacKeyMetadata result;
-  result.id_ = rhs.id();
-  result.access_id_ = rhs.access_id();
+  result.set_id(rhs.id());
+  result.set_access_id(rhs.access_id());
   // The protos use `projects/{project}` format, but the field may be absent or
   // may have a project id (instead of number), so we need to do some parsing.
   // We are forgiving here. It is better to drop one field rather than dropping
   // the full message.
   absl::string_view project = rhs.project();
   absl::ConsumePrefix(&project, "projects/");
-  result.project_id_ = std::string(project);
-  result.service_account_email_ = rhs.service_account_email();
-  result.state_ = rhs.state();
-  result.time_created_ =
-      google::cloud::internal::ToChronoTimePoint(rhs.create_time());
-  result.updated_ =
-      google::cloud::internal::ToChronoTimePoint(rhs.update_time());
-  result.etag_ = rhs.etag();
+  result.set_project_id(std::string(project));
+  result.set_service_account_email(rhs.service_account_email());
+  result.set_state(rhs.state());
+  result.set_time_created(
+      google::cloud::internal::ToChronoTimePoint(rhs.create_time()));
+  result.set_updated(
+      google::cloud::internal::ToChronoTimePoint(rhs.update_time()));
+  result.set_etag(rhs.etag());
   return result;
 }
 

--- a/google/cloud/storage/internal/hmac_key_metadata_parser.cc
+++ b/google/cloud/storage/internal/hmac_key_metadata_parser.cc
@@ -26,19 +26,19 @@ StatusOr<HmacKeyMetadata> HmacKeyMetadataParser::FromJson(
     return Status(StatusCode::kInvalidArgument, __func__);
   }
   HmacKeyMetadata result{};
-  result.access_id_ = json.value("accessId", "");
-  result.etag_ = json.value("etag", "");
-  result.id_ = json.value("id", "");
-  result.kind_ = json.value("kind", "");
-  result.project_id_ = json.value("projectId", "");
-  result.service_account_email_ = json.value("serviceAccountEmail", "");
-  result.state_ = json.value("state", "");
+  result.set_access_id(json.value("accessId", ""));
+  result.set_etag(json.value("etag", ""));
+  result.set_id(json.value("id", ""));
+  result.set_kind(json.value("kind", ""));
+  result.set_project_id(json.value("projectId", ""));
+  result.set_service_account_email(json.value("serviceAccountEmail", ""));
+  result.set_state(json.value("state", ""));
   auto time_created = ParseTimestampField(json, "timeCreated");
   if (!time_created) return std::move(time_created).status();
-  result.time_created_ = *time_created;
+  result.set_time_created(*time_created);
   auto updated = ParseTimestampField(json, "updated");
   if (!updated) return std::move(updated).status();
-  result.updated_ = *updated;
+  result.set_updated(*updated);
   return result;
 }
 


### PR DESCRIPTION
Add modifiers to make mocking easier. Remove unneeded `friend` declarations after this change.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9949)
<!-- Reviewable:end -->
