### PR TITLE
cleanup(GCS+gRPC): move `ServiceAccount` helpers to namespace

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -990,12 +990,12 @@ StatusOr<ObjectAccessControl> GrpcClient::PatchDefaultObjectAcl(
 
 StatusOr<ServiceAccount> GrpcClient::GetServiceAccount(
     GetProjectServiceAccountRequest const& request) {
-  auto proto = GrpcServiceAccountParser::ToProto(request);
+  auto proto = storage_internal::ToProto(request);
   grpc::ClientContext context;
   ApplyQueryParameters(context, request);
   auto response = stub_->GetServiceAccount(context, proto);
   if (!response) return std::move(response).status();
-  return GrpcServiceAccountParser::FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<ListHmacKeysResponse> GrpcClient::ListHmacKeys(

--- a/google/cloud/storage/internal/grpc_service_account_parser.cc
+++ b/google/cloud/storage/internal/grpc_service_account_parser.cc
@@ -16,27 +16,25 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-google::storage::v2::GetServiceAccountRequest GrpcServiceAccountParser::ToProto(
-    GetProjectServiceAccountRequest const& request) {
+google::storage::v2::GetServiceAccountRequest ToProto(
+    storage::internal::GetProjectServiceAccountRequest const& request) {
   google::storage::v2::GetServiceAccountRequest proto;
   proto.set_project("projects/" + request.project_id());
   return proto;
 }
 
-ServiceAccount GrpcServiceAccountParser::FromProto(
+storage::ServiceAccount FromProto(
     google::storage::v2::ServiceAccount const& meta) {
-  ServiceAccount result;
+  storage::ServiceAccount result;
   result.set_email_address(meta.email_address());
   result.set_kind("storage#serviceAccount");
   return result;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_service_account_parser.h
+++ b/google/cloud/storage/internal/grpc_service_account_parser.h
@@ -22,20 +22,16 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-struct GrpcServiceAccountParser {
-  static google::storage::v2::GetServiceAccountRequest ToProto(
-      GetProjectServiceAccountRequest const& request);
-  static ServiceAccount FromProto(
-      google::storage::v2::ServiceAccount const& meta);
-};
+google::storage::v2::GetServiceAccountRequest ToProto(
+    storage::internal::GetProjectServiceAccountRequest const& request);
+storage::ServiceAccount FromProto(
+    google::storage::v2::ServiceAccount const& meta);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_service_account_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_service_account_parser_test.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 namespace storage_proto = ::google::storage::v2;
@@ -33,13 +32,14 @@ TEST(GrpcServiceAccountParser, FromProtoServiceAccount) {
   storage_proto::ServiceAccount response;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(email_address: "test-only@example.com")pb", &response));
-  auto const expected = ServiceAccountParser::FromString(R"""({
+  auto const expected =
+      storage::internal::ServiceAccountParser::FromString(R"""({
     "email_address": "test-only@example.com",
     "kind": "storage#serviceAccount"
   })""");
   ASSERT_STATUS_OK(expected);
 
-  auto const actual = GrpcServiceAccountParser::FromProto(response);
+  auto const actual = FromProto(response);
   EXPECT_EQ(*expected, actual);
 }
 
@@ -47,15 +47,15 @@ TEST(GrpcServiceAccountParser, ToProtoGetServiceAccount) {
   storage_proto::GetServiceAccountRequest expected;
   ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
       R"pb(project: "projects/test-only-project-id")pb", &expected));
-  GetProjectServiceAccountRequest request("test-only-project-id");
-  request.set_multiple_options(UserProject("test-only-user-project"));
-  auto const actual = GrpcServiceAccountParser::ToProto(request);
+  storage::internal::GetProjectServiceAccountRequest request(
+      "test-only-project-id");
+  request.set_multiple_options(storage::UserProject("test-only-user-project"));
+  auto const actual = ToProto(request);
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Remove the `GrpcServiceAccountParser` struct, and move all its functions (they were all `static`) to the `storage_internal` namespace.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9950)
<!-- Reviewable:end -->
