### PR TITLE
fix(spanner): remove session from pool upon "not found" refresh failure

### DIFF
--- a/google/cloud/spanner/internal/session_pool.h
+++ b/google/cloud/spanner/internal/session_pool.h
@@ -177,6 +177,9 @@ class SessionPool : public std::enable_shared_from_this<SessionPool> {
   void MaintainPoolSize();
   void RefreshExpiringSessions();
 
+  // Remove the named session from the pool (if it is present).
+  void Erase(std::string const& session_name);
+
   spanner::Database const db_;
   google::cloud::CompletionQueue cq_;
   Options const opts_;


### PR DESCRIPTION
When the "SELECT 1" session-refresh query fails with "Session not found", remove the bad session from the pool, if possible.  Previously we did nothing because (1) it shouldn't happen, and (2) we have other mechanisms in place to deal with bad sessions (which must remain).  But it is better dealt with directly if we can.

Fixes #4026.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9954)
<!-- Reviewable:end -->
