### PR TITLE
cleanup(GCS+gRPC): move `HmacKeyMetadata` helpers to namespace

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1035,7 +1035,7 @@ StatusOr<HmacKeyMetadata> GrpcClient::GetHmacKey(
   ApplyQueryParameters(context, request);
   auto response = stub_->GetHmacKey(context, proto);
   if (!response) return std::move(response).status();
-  return GrpcHmacKeyMetadataParser::FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<HmacKeyMetadata> GrpcClient::UpdateHmacKey(
@@ -1045,7 +1045,7 @@ StatusOr<HmacKeyMetadata> GrpcClient::UpdateHmacKey(
   ApplyQueryParameters(context, request);
   auto response = stub_->UpdateHmacKey(context, proto);
   if (!response) return std::move(response).status();
-  return GrpcHmacKeyMetadataParser::FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<SignBlobResponse> GrpcClient::SignBlob(

--- a/google/cloud/storage/internal/grpc_hmac_key_metadata_parser.cc
+++ b/google/cloud/storage/internal/grpc_hmac_key_metadata_parser.cc
@@ -19,13 +19,12 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-HmacKeyMetadata GrpcHmacKeyMetadataParser::FromProto(
+storage::HmacKeyMetadata FromProto(
     google::storage::v2::HmacKeyMetadata const& rhs) {
-  HmacKeyMetadata result;
+  storage::HmacKeyMetadata result;
   result.set_id(rhs.id());
   result.set_access_id(rhs.access_id());
   // The protos use `projects/{project}` format, but the field may be absent or
@@ -45,8 +44,8 @@ HmacKeyMetadata GrpcHmacKeyMetadataParser::FromProto(
   return result;
 }
 
-google::storage::v2::HmacKeyMetadata GrpcHmacKeyMetadataParser::ToProto(
-    HmacKeyMetadata const& rhs) {
+google::storage::v2::HmacKeyMetadata ToProto(
+    storage::HmacKeyMetadata const& rhs) {
   google::storage::v2::HmacKeyMetadata result;
   result.set_id(rhs.id());
   result.set_access_id(rhs.access_id());
@@ -61,8 +60,7 @@ google::storage::v2::HmacKeyMetadata GrpcHmacKeyMetadataParser::ToProto(
   return result;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_hmac_key_metadata_parser.h
+++ b/google/cloud/storage/internal/grpc_hmac_key_metadata_parser.h
@@ -22,20 +22,16 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
-struct GrpcHmacKeyMetadataParser {
-  static HmacKeyMetadata FromProto(
-      google::storage::v2::HmacKeyMetadata const& rhs);
-  static google::storage::v2::HmacKeyMetadata ToProto(
-      HmacKeyMetadata const& rhs);
-};
+storage::HmacKeyMetadata FromProto(
+    google::storage::v2::HmacKeyMetadata const& rhs);
+google::storage::v2::HmacKeyMetadata ToProto(
+    storage::HmacKeyMetadata const& rhs);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_hmac_key_metadata_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_hmac_key_metadata_parser_test.cc
@@ -21,9 +21,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 namespace storage_proto = ::google::storage::v2;
@@ -44,7 +43,7 @@ TEST(GrpcHmacKeyMetadataParser, Roundtrip) {
     etag: "test-etag")pb";
   EXPECT_TRUE(TextFormat::ParseFromString(kProtoText, &input));
 
-  auto const actual = GrpcHmacKeyMetadataParser::FromProto(input);
+  auto const actual = FromProto(input);
   EXPECT_EQ(actual.id(), "test-id");
   EXPECT_EQ(actual.access_id(), "test-access-id");
   EXPECT_EQ(actual.state(), "INACTIVE");
@@ -54,13 +53,12 @@ TEST(GrpcHmacKeyMetadataParser, Roundtrip) {
   //     date --rfc-3339=seconds --date=@1652186096  # Update
   EXPECT_EQ(FormatRfc3339(actual.time_created()), "2022-05-09T12:34:56.789Z");
   EXPECT_EQ(FormatRfc3339(actual.updated()), "2022-05-10T12:34:56.789Z");
-  auto const output = GrpcHmacKeyMetadataParser::ToProto(actual);
+  auto const output = ToProto(actual);
   EXPECT_THAT(output, IsProtoEqual(input));
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_hmac_key_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_hmac_key_request_parser.cc
@@ -33,7 +33,7 @@ google::storage::v2::CreateHmacKeyRequest GrpcHmacKeyRequestParser::ToProto(
 CreateHmacKeyResponse GrpcHmacKeyRequestParser::FromProto(
     google::storage::v2::CreateHmacKeyResponse const& response) {
   CreateHmacKeyResponse result;
-  result.metadata = GrpcHmacKeyMetadataParser::FromProto(response.metadata());
+  result.metadata = storage_internal::FromProto(response.metadata());
   result.secret = internal::Base64Encode(response.secret_key_bytes());
   return result;
 }
@@ -64,7 +64,7 @@ ListHmacKeysResponse GrpcHmacKeyRequestParser::FromProto(
   ListHmacKeysResponse result;
   result.next_page_token = response.next_page_token();
   for (auto const& m : response.hmac_keys()) {
-    result.items.push_back(GrpcHmacKeyMetadataParser::FromProto(m));
+    result.items.push_back(storage_internal::FromProto(m));
   }
   return result;
 }


### PR DESCRIPTION
Remove the `HmacKeyMetadataParser` struct, which only had static member functions. Move the functions to the `storage_internal` namespace.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9955)
<!-- Reviewable:end -->
