### PR TITLE
cleanup(GCS+gRPC): move `SignBlob` request helpers

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -1050,13 +1050,13 @@ StatusOr<HmacKeyMetadata> GrpcClient::UpdateHmacKey(
 
 StatusOr<SignBlobResponse> GrpcClient::SignBlob(
     SignBlobRequest const& request) {
-  auto proto = ToProto(request);
+  auto proto = storage_internal::ToProto(request);
   grpc::ClientContext context;
   // This request does not have any options that require using
   //     ApplyQueryParameters(context, request)
   auto response = iam_stub_->SignBlob(context, proto);
   if (!response) return std::move(response).status();
-  return FromProto(*response);
+  return storage_internal::FromProto(*response);
 }
 
 StatusOr<ListNotificationsResponse> GrpcClient::ListNotifications(

--- a/google/cloud/storage/internal/grpc_sign_blob_request_parser.cc
+++ b/google/cloud/storage/internal/grpc_sign_blob_request_parser.cc
@@ -17,31 +17,29 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 google::iam::credentials::v1::SignBlobRequest ToProto(
-    SignBlobRequest const& rhs) {
+    storage::internal::SignBlobRequest const& rhs) {
   google::iam::credentials::v1::SignBlobRequest request;
   request.set_name("projects/-/serviceAccounts/" + rhs.service_account());
   for (auto const& d : rhs.delegates()) request.add_delegates(d);
-  auto b64decoded = Base64Decode(rhs.base64_encoded_blob());
+  auto b64decoded = storage::internal::Base64Decode(rhs.base64_encoded_blob());
   if (!b64decoded) return request;
   request.mutable_payload()->assign(b64decoded->begin(), b64decoded->end());
   return request;
 }
 
-SignBlobResponse FromProto(
+storage::internal::SignBlobResponse FromProto(
     google::iam::credentials::v1::SignBlobResponse const& rhs) {
-  SignBlobResponse response;
+  storage::internal::SignBlobResponse response;
   response.key_id = rhs.key_id();
-  response.signed_blob = Base64Encode(rhs.signed_blob());
+  response.signed_blob = storage::internal::Base64Encode(rhs.signed_blob());
   return response;
 }
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_sign_blob_request_parser.h
+++ b/google/cloud/storage/internal/grpc_sign_blob_request_parser.h
@@ -21,18 +21,16 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 google::iam::credentials::v1::SignBlobRequest ToProto(
-    SignBlobRequest const& rhs);
-SignBlobResponse FromProto(
+    storage::internal::SignBlobRequest const& rhs);
+storage::internal::SignBlobResponse FromProto(
     google::iam::credentials::v1::SignBlobResponse const& rhs);
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_sign_blob_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_sign_blob_request_parser_test.cc
@@ -20,9 +20,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -38,11 +37,11 @@ TEST(GrpcSignBlobRequestParser, ToProto) {
       )pb",
       &expected));
 
-  auto b64encoded = Base64Encode("test-only-text-to-sign");
+  auto b64encoded = storage::internal::Base64Encode("test-only-text-to-sign");
 
-  auto request =
-      SignBlobRequest("test-only-sa", std::move(b64encoded),
-                      {"test-only-delegate-1", "test-only-delegate-2"});
+  auto request = storage::internal::SignBlobRequest(
+      "test-only-sa", std::move(b64encoded),
+      {"test-only-delegate-1", "test-only-delegate-2"});
   auto const actual = ToProto(request);
   EXPECT_THAT(actual, IsProtoEqual(expected));
 }
@@ -56,12 +55,12 @@ TEST(GrpcSignBlobRequestParser, FromProto) {
       &input));
   auto response = FromProto(input);
   EXPECT_EQ(response.key_id, "test-only-key-id");
-  EXPECT_EQ(response.signed_blob, Base64Encode("test-only-signed-blob"));
+  EXPECT_EQ(response.signed_blob,
+            storage::internal::Base64Encode("test-only-signed-blob"));
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Despite the branch name, this is only part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9962)
<!-- Reviewable:end -->
