### PR TITLE
fix(bigtable): simplify channel refresh

### DIFF
--- a/google/cloud/bigtable/internal/bigtable_channel_refresh.h
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh.h
@@ -16,7 +16,6 @@
 #define GOOGLE_CLOUD_CPP_GOOGLE_CLOUD_BIGTABLE_INTERNAL_BIGTABLE_CHANNEL_REFRESH_H
 
 #include "google/cloud/bigtable/internal/bigtable_stub.h"
-#include "google/cloud/bigtable/internal/connection_refresh_state.h"
 #include "google/cloud/bigtable/version.h"
 
 namespace google {
@@ -25,22 +24,17 @@ namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 /**
- * A container that holds the shared state of timer futures involved in
- * channel refreshing.
+ * A container responsible for channel refreshing.
  */
-class BigtableChannelRefresh : public BigtableStub {
+class BigtableChannelRefresh
+    : public BigtableStub,
+      public std::enable_shared_from_this<BigtableChannelRefresh> {
  public:
-  explicit BigtableChannelRefresh(
-      std::shared_ptr<BigtableStub> child,
-      std::shared_ptr<ConnectionRefreshState> refresh_state)
-      : child_(std::move(child)), refresh_state_(std::move(refresh_state)) {}
+  ~BigtableChannelRefresh() override = default;
 
-  ~BigtableChannelRefresh() override {
-    // Eventually the channel refresh chain will terminate after this class is
-    // destroyed. But only after the timer futures expire on the CompletionQueue
-    // performing this work. We might as well cancel those timer futures now.
-    refresh_state_->timers().CancelAll();
-  }
+  static std::shared_ptr<BigtableChannelRefresh> Create(
+      std::shared_ptr<BigtableStub> child, CompletionQueue cq,
+      std::vector<std::shared_ptr<grpc::Channel>> channels);
 
   std::unique_ptr<google::cloud::internal::StreamingReadRpc<
       google::bigtable::v2::ReadRowsResponse>>
@@ -112,8 +106,23 @@ class BigtableChannelRefresh : public BigtableStub {
       google::bigtable::v2::ReadModifyWriteRowRequest const& request) override;
 
  private:
+  explicit BigtableChannelRefresh(
+      std::shared_ptr<BigtableStub> child,
+      std::vector<std::shared_ptr<grpc::Channel>> channels)
+      : child_(std::move(child)), channels_(std::move(channels)) {}
+
+  std::weak_ptr<BigtableChannelRefresh> WeakFromThis() {
+    return shared_from_this();
+  }
+  void Refresh(std::size_t index,
+               std::weak_ptr<google::cloud::internal::CompletionQueueImpl> wcq);
+  void OnRefresh(
+      std::size_t index,
+      std::weak_ptr<google::cloud::internal::CompletionQueueImpl> wcq, bool ok);
+  void StartRefreshLoop(CompletionQueue cq);
+
   std::shared_ptr<BigtableStub> child_;
-  std::shared_ptr<ConnectionRefreshState> refresh_state_;
+  std::vector<std::shared_ptr<grpc::Channel>> channels_;
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/bigtable/internal/bigtable_channel_refresh_test.cc
+++ b/google/cloud/bigtable/internal/bigtable_channel_refresh_test.cc
@@ -27,102 +27,72 @@ namespace bigtable_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ms = std::chrono::milliseconds;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
+using ::testing::ReturnRef;
 
 auto constexpr kTestChannels = 3;
 
 TEST(BigtableChannelRefresh, Enabled) {
-  using ms = std::chrono::milliseconds;
-  using ns = std::chrono::nanoseconds;
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
+  grpc::CompletionQueue grpc_cq;
+  EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
 
-  auto mock = std::make_shared<MockCompletionQueueImpl>();
-
-  // We call `MakeRelativeTimer` once per channel when registering the refresh
-  // timers and `RunAsync` once per channel when deregistering them.
-  EXPECT_CALL(*mock, RunAsync).Times(kTestChannels);
-  EXPECT_CALL(*mock, MakeRelativeTimer)
+  // Mock the call to `NotifyOnStateChange::Start()` for each channel
+  EXPECT_CALL(*mock_cq, StartOperation)
       .Times(kTestChannels)
-      .WillRepeatedly([](std::chrono::nanoseconds duration) {
-        EXPECT_LE(ns(ms(500)).count(), duration.count());
-        EXPECT_LE(duration.count(), ns(ms(1000)).count());
-        return make_ready_future<
-            StatusOr<std::chrono::system_clock::time_point>>(
-            Status(StatusCode::kCancelled, "cancelled"));
-      });
+      .WillRepeatedly(
+          [](std::shared_ptr<internal::AsyncGrpcOperation> const& op,
+             absl::FunctionRef<void(void*)>) {
+            // False means no state change in the underlying gRPC channel. This
+            // will break the refresh loop.
+            op->Notify(false);
+          });
 
-  CompletionQueue cq(mock);
+  CompletionQueue cq(mock_cq);
   auto stub = CreateBigtableStub(
       cq, Options{}
               .set<GrpcNumChannelsOption>(kTestChannels)
-              .set<bigtable::MinConnectionRefreshOption>(ms(500))
               .set<bigtable::MaxConnectionRefreshOption>(ms(1000)));
 }
 
 TEST(BigtableChannelRefresh, Disabled) {
-  using ms = std::chrono::milliseconds;
-
-  auto mock = std::make_shared<MockCompletionQueueImpl>();
+  auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
 
   // The CQ should only do work if we have to set up the channel refresh.
-  EXPECT_CALL(*mock, RunAsync).Times(0);
-  EXPECT_CALL(*mock, MakeRelativeTimer).Times(0);
+  EXPECT_CALL(*mock_cq, StartOperation).Times(0);
 
-  CompletionQueue cq(mock);
+  CompletionQueue cq(mock_cq);
   auto stub = CreateBigtableStub(
       cq, Options{}.set<bigtable::MaxConnectionRefreshOption>(ms(0)));
 }
 
 TEST(BigtableChannelRefresh, Continuations) {
-  using ms = std::chrono::milliseconds;
-  using ns = std::chrono::nanoseconds;
-  using ::testing::ReturnRef;
-
-  promise<StatusOr<std::chrono::system_clock::time_point>> p;
-
   auto mock_cq = std::make_shared<MockCompletionQueueImpl>();
   grpc::CompletionQueue grpc_cq;
   EXPECT_CALL(*mock_cq, cq).WillRepeatedly(ReturnRef(grpc_cq));
 
   ::testing::InSequence s;
-  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
-      .WillOnce([&p](std::chrono::nanoseconds duration) {
-        EXPECT_LE(ns(ms(500)).count(), duration.count());
-        EXPECT_LE(duration.count(), ns(ms(1000)).count());
-        // This is a regression test for
-        // https://github.com/googleapis/google-cloud-cpp/issues/9712
-        //
-        // We delay returning the future until the Stub is fully constructed.
-        return p.get_future();
-      });
-  // Mock the call to `CQ::AsyncWaitConnectionReady()`
+  // Mock the call to `NotifyOnStateChange::Start()` for the single channel
   EXPECT_CALL(*mock_cq, StartOperation)
       .WillOnce([](std::shared_ptr<internal::AsyncGrpcOperation> const& op,
                    absl::FunctionRef<void(void*)>) {
-        // False means no state change in the underlying gRPC channel
+        // The state has changed. We should schedule another channel refresh.
+        op->Notify(true);
+      })
+      .WillOnce([](std::shared_ptr<internal::AsyncGrpcOperation> const& op,
+                   absl::FunctionRef<void(void*)>) {
+        // False means no state change in the underlying gRPC channel. This
+        // will break the refresh loop.
         op->Notify(false);
       });
-  // We should schedule another channel refresh.
-  EXPECT_CALL(*mock_cq, MakeRelativeTimer)
-      .WillOnce([](std::chrono::nanoseconds duration) {
-        EXPECT_LE(ns(ms(500)).count(), duration.count());
-        EXPECT_LE(duration.count(), ns(ms(1000)).count());
-        return make_ready_future<
-            StatusOr<std::chrono::system_clock::time_point>>(
-            Status(StatusCode::kCancelled, "cancelled"));
-      });
-  // Deregister the two timers we created.
-  EXPECT_CALL(*mock_cq, RunAsync).Times(2);
 
   CompletionQueue cq(mock_cq);
   auto stub = CreateBigtableStub(
       cq, Options{}
               .set<UnifiedCredentialsOption>(MakeInsecureCredentials())
               .set<GrpcNumChannelsOption>(1)
-              .set<bigtable::MinConnectionRefreshOption>(ms(500))
               .set<bigtable::MaxConnectionRefreshOption>(ms(1000)));
-
-  // Simulate the timer firing, which should trigger another round of refreshes.
-  p.set_value(make_status_or(std::chrono::system_clock::now()));
 }
 
 }  // namespace

--- a/google/cloud/bigtable/internal/bigtable_stub_factory.h
+++ b/google/cloud/bigtable/internal/bigtable_stub_factory.h
@@ -30,10 +30,6 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 using BaseBigtableStubFactory = std::function<std::shared_ptr<BigtableStub>(
     std::shared_ptr<grpc::Channel>)>;
 
-std::shared_ptr<BigtableStub> CreateBigtableStubRoundRobin(
-    Options const& options,
-    std::function<std::shared_ptr<BigtableStub>(int)> child_factory);
-
 /// Used in testing to create decorated mocks.
 std::shared_ptr<BigtableStub> CreateDecoratedStubs(
     google::cloud::CompletionQueue cq, Options const& options,


### PR DESCRIPTION
The `DataConnection` part of #5871. (I do not intend to fix this for `DataClient`).

Simplify the channel refresh logic. Stop using `bigtable::ConnectionRefreshState`.

This PR diverges from the `storage` implementation, which puts this functionality in `StorageRoundRobinStub`. Modifying `BigtableChannelRefresh` seemed like a smaller change given the current state of the library.

Eventually we would like the generator to know how to refresh channels (and generate round robin stubs). That will be easiest if the `bigtable` and `storage` implementations are in parity. I will consider refactoring at a later time.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9967)
<!-- Reviewable:end -->
