### PR TITLE
fix(common): preserve `ErrorInfo` on retry errors

### DIFF
--- a/google/cloud/internal/retry_loop_helpers.cc
+++ b/google/cloud/internal/retry_loop_helpers.cc
@@ -21,10 +21,10 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace internal {
 
 Status RetryLoopError(char const* loop_message, char const* location,
-                      Status const& last_status) {
+                      Status const& status) {
   std::ostringstream os;
-  os << loop_message << " " << location << ": " << last_status.message();
-  return Status(last_status.code(), std::move(os).str());
+  os << loop_message << " " << location << ": " << status.message();
+  return Status(status.code(), std::move(os).str(), status.error_info());
 }
 
 }  // namespace internal

--- a/google/cloud/internal/retry_loop_helpers.h
+++ b/google/cloud/internal/retry_loop_helpers.h
@@ -34,7 +34,7 @@ Status GetResultStatus(StatusOr<T> result) {
 
 /// Generate an error Status for `RetryLoop()` and `AsyncRetryLoop()`
 Status RetryLoopError(char const* loop_message, char const* location,
-                      Status const& last_status);
+                      Status const& status);
 
 }  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/internal/retry_loop_helpers_test.cc
+++ b/google/cloud/internal/retry_loop_helpers_test.cc
@@ -29,11 +29,16 @@ TEST(RetryLoopHelpersTest, IncludeErrorInfo) {
   auto const code = StatusCode::kFailedPrecondition;
   auto const message = std::string{
       "At least one of the pre-conditions you specified did not hold."};
-  auto input = Status(code, message);
+  auto const error_info = ErrorInfo("conditionNotMet", "global",
+                                    {{"locationType", "header"},
+                                     {"location", "If-Match"},
+                                     {"http_status_code", "412"}});
+  auto input = Status(code, message, error_info);
   auto actual = RetryLoopError("permanent error", "SomeFunction", input);
   EXPECT_THAT(actual, StatusIs(code, HasSubstr(message)));
   EXPECT_THAT(actual.message(), HasSubstr("permanent error"));
   EXPECT_THAT(actual.message(), HasSubstr("SomeFunction"));
+  EXPECT_EQ(actual.error_info(), error_info);
 }
 
 }  // namespace


### PR DESCRIPTION
Motivated by #9947

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9971)
<!-- Reviewable:end -->
