### PR TITLE
test(storage): check for useful `ErrorInfo`

### DIFF
--- a/google/cloud/storage/tests/error_parsing_integration_test.cc
+++ b/google/cloud/storage/tests/error_parsing_integration_test.cc
@@ -54,7 +54,7 @@ TEST_F(ErrorParsingIntegrationTest, FailureContainsErrorInfo) {
   insert = client->InsertObject(bucket_name_, object_name, LoremIpsum(),
                                 IfGenerationMatch(0));
   ASSERT_THAT(insert, Not(StatusIs(StatusCode::kOk)));
-  if (UsingEmulator()) return;
+  if (UsingEmulator() || UsingGrpc()) return;
   EXPECT_THAT(insert.status().message(),
               HasSubstr("pre-conditions you specified did not hold"));
   auto const& error_info = insert.status().error_info();

--- a/google/cloud/storage/tests/error_parsing_integration_test.cc
+++ b/google/cloud/storage/tests/error_parsing_integration_test.cc
@@ -30,6 +30,7 @@ namespace {
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::google::cloud::testing_util::StatusIs;
 using ::testing::HasSubstr;
+using ::testing::IsEmpty;
 using ::testing::Not;
 
 using ErrorParsingIntegrationTest =
@@ -56,6 +57,10 @@ TEST_F(ErrorParsingIntegrationTest, FailureContainsErrorInfo) {
   if (UsingEmulator()) return;
   EXPECT_THAT(insert.status().message(),
               HasSubstr("pre-conditions you specified did not hold"));
+  auto const& error_info = insert.status().error_info();
+  EXPECT_THAT(error_info.reason(), Not(IsEmpty()));
+  EXPECT_THAT(error_info.domain(), Not(IsEmpty()));
+  EXPECT_THAT(error_info.metadata(), Not(IsEmpty()));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
Motivated by #9947

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9974)
<!-- Reviewable:end -->
