### PR TITLE
impl(GCS+gRPC): use protos for *AccessControl updates

### DIFF
--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -187,9 +187,10 @@ class GrpcClient : public RawClient,
       Options opts);
 
  private:
-  using BucketAclUpdater =
-      std::function<StatusOr<std::vector<BucketAccessControl>>(
-          std::vector<BucketAccessControl> acl)>;
+  using BucketAccessControlList = google::protobuf::RepeatedPtrField<
+      google::storage::v2::BucketAccessControl>;
+  using BucketAclUpdater = std::function<StatusOr<BucketAccessControlList>(
+      BucketAccessControlList acl)>;
 
   // REST has RPCs that change `BucketAccessControl` resources atomically. gRPC
   // lacks such RPCs. This function hijacks the retry loop to implement an OCC
@@ -197,9 +198,10 @@ class GrpcClient : public RawClient,
   StatusOr<BucketMetadata> ModifyBucketAccessControl(
       GetBucketMetadataRequest const& request, BucketAclUpdater const& updater);
 
-  using ObjectAclUpdater =
-      std::function<StatusOr<std::vector<ObjectAccessControl>>(
-          std::vector<ObjectAccessControl> acl)>;
+  using ObjectAccessControlList = google::protobuf::RepeatedPtrField<
+      google::storage::v2::ObjectAccessControl>;
+  using ObjectAclUpdater = std::function<StatusOr<ObjectAccessControlList>(
+      ObjectAccessControlList acl)>;
 
   // REST has RPCs that change `ObjectAccessControl` resources atomically. gRPC
   // lacks such RPCs. This function hijacks the retry loop to implement an OCC
@@ -208,8 +210,8 @@ class GrpcClient : public RawClient,
       GetObjectMetadataRequest const& request, ObjectAclUpdater const& updater);
 
   using DefaultObjectAclUpdater =
-      std::function<StatusOr<std::vector<ObjectAccessControl>>(
-          std::vector<ObjectAccessControl> acl)>;
+      std::function<StatusOr<ObjectAccessControlList>(
+          ObjectAccessControlList acl)>;
 
   // REST has RPCs that change `DefaultObjectAccessControl` resources
   // atomically. gRPC lacks such RPCs. This function hijacks the retry loop to

--- a/google/cloud/storage/internal/grpc_client_test.cc
+++ b/google/cloud/storage/internal/grpc_client_test.cc
@@ -924,9 +924,10 @@ TEST_F(GrpcClientTest, CreateBucketAclFailure) {
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
         auto metadata = GetMetadata(context);
-        EXPECT_THAT(metadata, UnorderedElementsAre(
-                                  Pair("x-goog-quota-user", "test-quota-user"),
-                                  Pair("x-goog-fieldmask", "field1,field2")));
+        // The `Field()` option is ignored, as the implementation only works
+        // correctly if key fields are present.
+        EXPECT_THAT(metadata, UnorderedElementsAre(Pair("x-goog-quota-user",
+                                                        "test-quota-user")));
         EXPECT_THAT(request.name(), "projects/_/buckets/test-bucket-name");
         return PermanentError();
       });
@@ -974,9 +975,10 @@ TEST_F(GrpcClientTest, DeleteBucketAclFailure) {
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
         auto metadata = GetMetadata(context);
-        EXPECT_THAT(metadata, UnorderedElementsAre(
-                                  Pair("x-goog-quota-user", "test-quota-user"),
-                                  Pair("x-goog-fieldmask", "field1,field2")));
+        // The `Field()` option is ignored, as the implementation only works
+        // correctly if key fields are present.
+        EXPECT_THAT(metadata, UnorderedElementsAre(Pair("x-goog-quota-user",
+                                                        "test-quota-user")));
         EXPECT_THAT(request.name(), "projects/_/buckets/test-bucket-name");
         return PermanentError();
       });
@@ -1043,9 +1045,10 @@ TEST_F(GrpcClientTest, UpdateBucketAclFailure) {
       .WillOnce([this](grpc::ClientContext& context,
                        v2::GetBucketRequest const& request) {
         auto metadata = GetMetadata(context);
-        EXPECT_THAT(metadata, UnorderedElementsAre(
-                                  Pair("x-goog-quota-user", "test-quota-user"),
-                                  Pair("x-goog-fieldmask", "field1,field2")));
+        // The `Field()` option is ignored, as the implementation only works
+        // correctly if key fields are present.
+        EXPECT_THAT(metadata, UnorderedElementsAre(Pair("x-goog-quota-user",
+                                                        "test-quota-user")));
         EXPECT_THAT(request.name(), "projects/_/buckets/test-bucket-name");
         return PermanentError();
       });


### PR DESCRIPTION
An upcoming change to the GCS protos will allow us to improve the implementation of `*AccessControl` updates.  Some entities go by two different ids.  The upcoming protos will include both ids. We can then implement more accurate Get -> Modify -> Update loops for these resources.

Part of the work for #9900

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9979)
<!-- Reviewable:end -->
