### PR TITLE
cleanup: shorten most workspace names

### DIFF
--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "com_github_googleapis_google_cloud_cpp")
+workspace(name = "google_cloud_cpp")
 
 load("//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 

--- a/ci/kokoro/windows/builds/quickstart-bazel.ps1
+++ b/ci/kokoro/windows/builds/quickstart-bazel.ps1
@@ -40,8 +40,8 @@ function Get-Released-Quickstarts {
 
     Push-Location "${project_root}/google/cloud/bigtable/quickstart"
     bazelisk $bazel_common_flags version | Out-Null
-    bazelisk $bazel_common_flags query --noshow_progress --noshow_loading_progress "filter(/quickstart:quickstart$, kind(cc_binary, @com_github_googleapis_google_cloud_cpp//google/...))" |
-        ForEach-Object { $_.replace("@com_github_googleapis_google_cloud_cpp//google/cloud/", "").replace("/quickstart:quickstart", "") } |
+    bazelisk $bazel_common_flags query --noshow_progress --noshow_loading_progress "filter(/quickstart:quickstart$, kind(cc_binary, @google_cloud_cpp//google/...))" |
+        ForEach-Object { $_.replace("@google_cloud_cpp//google/cloud/", "").replace("/quickstart:quickstart", "") } |
         # TODO(#8145) TODO(#9340) TODO(#8125) TODDO(#8725) - these do not compile on Windows.
         Where-Object { -not ("asset", "beyondcorp", "channel", "storagetransfer" -contains $_) } |
         # TODO(#9923) - compiling all quickstarts on Windows is too slow

--- a/ci/verify_current_targets/BUILD.bazel
+++ b/ci/verify_current_targets/BUILD.bazel
@@ -34,6 +34,6 @@ CURRENT_TARGETS = [
         "verify_current_targets.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//" + target,
+        "@google_cloud_cpp//" + target,
     ],
 ) for target in CURRENT_TARGETS]

--- a/ci/verify_current_targets/WORKSPACE.bazel
+++ b/ci/verify_current_targets/WORKSPACE.bazel
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-workspace(name = "com_github_googleapis_google_cloud_cpp_verify_current_targets")
+workspace(name = "google_cloud_cpp_verify_current_targets")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     path = "../../",
 )
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/ci/verify_deprecated_targets/BUILD.bazel
+++ b/ci/verify_deprecated_targets/BUILD.bazel
@@ -38,6 +38,6 @@ DEPRECATED_TARGETS = [
         "verify_deprecated_targets.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//" + target,
+        "@google_cloud_cpp//" + target,
     ],
 ) for target in DEPRECATED_TARGETS]

--- a/ci/verify_deprecated_targets/WORKSPACE.bazel
+++ b/ci/verify_deprecated_targets/WORKSPACE.bazel
@@ -14,19 +14,19 @@
 
 # A minimal WORKSPACE file showing how to use the Google Cloud Bigtable C++
 # client library in Bazel-based projects.
-workspace(name = "com_github_googleapis_google_cloud_cpp_verify_deprecated_targets")
+workspace(name = "google_cloud_cpp_verify_deprecated_targets")
 
 # Add the necessary Starlark functions to fetch google-cloud-cpp.
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     path = "../../",
 )
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -941,7 +941,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "e8d904bbff788a26aa9cd67d6c0725f9798448fcf73ab809ec2d7b80f89a1dc5",
     strip_prefix = "google-cloud-cpp-2.2.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.2.0.tar.gz",
@@ -949,7 +949,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 
@@ -998,7 +998,7 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:$library_prefix$$library$",
+        "@google_cloud_cpp//:$library_prefix$$library$",
     ],
 )
 )""";

--- a/google/cloud/accessapproval/quickstart/BUILD.bazel
+++ b/google/cloud/accessapproval/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:accessapproval",
+        "@google_cloud_cpp//:accessapproval",
     ],
 )

--- a/google/cloud/accessapproval/quickstart/WORKSPACE.bazel
+++ b/google/cloud/accessapproval/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/accesscontextmanager/quickstart/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:accesscontextmanager",
+        "@google_cloud_cpp//:accesscontextmanager",
     ],
 )

--- a/google/cloud/accesscontextmanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/accesscontextmanager/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/apigateway/quickstart/BUILD.bazel
+++ b/google/cloud/apigateway/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:apigateway",
+        "@google_cloud_cpp//:apigateway",
     ],
 )

--- a/google/cloud/apigateway/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apigateway/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/apigeeconnect/quickstart/BUILD.bazel
+++ b/google/cloud/apigeeconnect/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:apigeeconnect",
+        "@google_cloud_cpp//:apigeeconnect",
     ],
 )

--- a/google/cloud/apigeeconnect/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apigeeconnect/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/apikeys/quickstart/BUILD.bazel
+++ b/google/cloud/apikeys/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-apikeys",
+        "@google_cloud_cpp//:experimental-apikeys",
     ],
 )

--- a/google/cloud/apikeys/quickstart/WORKSPACE.bazel
+++ b/google/cloud/apikeys/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/appengine/quickstart/BUILD.bazel
+++ b/google/cloud/appengine/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:appengine",
+        "@google_cloud_cpp//:appengine",
     ],
 )

--- a/google/cloud/appengine/quickstart/WORKSPACE.bazel
+++ b/google/cloud/appengine/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/artifactregistry/quickstart/BUILD.bazel
+++ b/google/cloud/artifactregistry/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:artifactregistry",
+        "@google_cloud_cpp//:artifactregistry",
     ],
 )

--- a/google/cloud/artifactregistry/quickstart/WORKSPACE.bazel
+++ b/google/cloud/artifactregistry/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/asset/quickstart/BUILD.bazel
+++ b/google/cloud/asset/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:asset",
+        "@google_cloud_cpp//:asset",
     ],
 )

--- a/google/cloud/asset/quickstart/WORKSPACE.bazel
+++ b/google/cloud/asset/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/assuredworkloads/quickstart/BUILD.bazel
+++ b/google/cloud/assuredworkloads/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:assuredworkloads",
+        "@google_cloud_cpp//:assuredworkloads",
     ],
 )

--- a/google/cloud/assuredworkloads/quickstart/WORKSPACE.bazel
+++ b/google/cloud/assuredworkloads/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/automl/quickstart/BUILD.bazel
+++ b/google/cloud/automl/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:automl",
+        "@google_cloud_cpp//:automl",
     ],
 )

--- a/google/cloud/automl/quickstart/WORKSPACE.bazel
+++ b/google/cloud/automl/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/baremetalsolution/quickstart/BUILD.bazel
+++ b/google/cloud/baremetalsolution/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:baremetalsolution",
+        "@google_cloud_cpp//:baremetalsolution",
     ],
 )

--- a/google/cloud/baremetalsolution/quickstart/WORKSPACE.bazel
+++ b/google/cloud/baremetalsolution/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/batch/quickstart/BUILD.bazel
+++ b/google/cloud/batch/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-batch",
+        "@google_cloud_cpp//:experimental-batch",
     ],
 )

--- a/google/cloud/batch/quickstart/WORKSPACE.bazel
+++ b/google/cloud/batch/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/beyondcorp/quickstart/BUILD.bazel
+++ b/google/cloud/beyondcorp/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:beyondcorp",
+        "@google_cloud_cpp//:beyondcorp",
     ],
 )

--- a/google/cloud/beyondcorp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/beyondcorp/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/bigquery/quickstart/BUILD.bazel
+++ b/google/cloud/bigquery/quickstart/BUILD.bazel
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:bigquery",
+        "@google_cloud_cpp//:bigquery",
     ],
 )

--- a/google/cloud/bigquery/quickstart/WORKSPACE.bazel
+++ b/google/cloud/bigquery/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/bigtable/quickstart/BUILD.bazel
+++ b/google/cloud/bigtable/quickstart/BUILD.bazel
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:bigtable",
+        "@google_cloud_cpp//:bigtable",
     ],
 )

--- a/google/cloud/bigtable/quickstart/WORKSPACE.bazel
+++ b/google/cloud/bigtable/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/billing/quickstart/BUILD.bazel
+++ b/google/cloud/billing/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:billing",
+        "@google_cloud_cpp//:billing",
     ],
 )

--- a/google/cloud/billing/quickstart/WORKSPACE.bazel
+++ b/google/cloud/billing/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/binaryauthorization/quickstart/BUILD.bazel
+++ b/google/cloud/binaryauthorization/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:binaryauthorization",
+        "@google_cloud_cpp//:binaryauthorization",
     ],
 )

--- a/google/cloud/binaryauthorization/quickstart/WORKSPACE.bazel
+++ b/google/cloud/binaryauthorization/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/channel/quickstart/BUILD.bazel
+++ b/google/cloud/channel/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:channel",
+        "@google_cloud_cpp//:channel",
     ],
 )

--- a/google/cloud/channel/quickstart/WORKSPACE.bazel
+++ b/google/cloud/channel/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/cloudbuild/quickstart/BUILD.bazel
+++ b/google/cloud/cloudbuild/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:cloudbuild",
+        "@google_cloud_cpp//:cloudbuild",
     ],
 )

--- a/google/cloud/cloudbuild/quickstart/WORKSPACE.bazel
+++ b/google/cloud/cloudbuild/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/composer/quickstart/BUILD.bazel
+++ b/google/cloud/composer/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:composer",
+        "@google_cloud_cpp//:composer",
     ],
 )

--- a/google/cloud/composer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/composer/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/contactcenterinsights/quickstart/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:contactcenterinsights",
+        "@google_cloud_cpp//:contactcenterinsights",
     ],
 )

--- a/google/cloud/contactcenterinsights/quickstart/WORKSPACE.bazel
+++ b/google/cloud/contactcenterinsights/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/container/quickstart/BUILD.bazel
+++ b/google/cloud/container/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:container",
+        "@google_cloud_cpp//:container",
     ],
 )

--- a/google/cloud/container/quickstart/WORKSPACE.bazel
+++ b/google/cloud/container/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/containeranalysis/quickstart/BUILD.bazel
+++ b/google/cloud/containeranalysis/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:containeranalysis",
+        "@google_cloud_cpp//:containeranalysis",
     ],
 )

--- a/google/cloud/containeranalysis/quickstart/WORKSPACE.bazel
+++ b/google/cloud/containeranalysis/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/datacatalog/quickstart/BUILD.bazel
+++ b/google/cloud/datacatalog/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:datacatalog",
+        "@google_cloud_cpp//:datacatalog",
     ],
 )

--- a/google/cloud/datacatalog/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datacatalog/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/datamigration/quickstart/BUILD.bazel
+++ b/google/cloud/datamigration/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:datamigration",
+        "@google_cloud_cpp//:datamigration",
     ],
 )

--- a/google/cloud/datamigration/quickstart/WORKSPACE.bazel
+++ b/google/cloud/datamigration/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/dataplex/quickstart/BUILD.bazel
+++ b/google/cloud/dataplex/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:dataplex",
+        "@google_cloud_cpp//:dataplex",
     ],
 )

--- a/google/cloud/dataplex/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dataplex/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/dataproc/quickstart/BUILD.bazel
+++ b/google/cloud/dataproc/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:dataproc",
+        "@google_cloud_cpp//:dataproc",
     ],
 )

--- a/google/cloud/dataproc/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dataproc/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/debugger/quickstart/BUILD.bazel
+++ b/google/cloud/debugger/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:debugger",
+        "@google_cloud_cpp//:debugger",
     ],
 )

--- a/google/cloud/debugger/quickstart/WORKSPACE.bazel
+++ b/google/cloud/debugger/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/dialogflow_cx/quickstart/BUILD.bazel
+++ b/google/cloud/dialogflow_cx/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:dialogflow_cx",
+        "@google_cloud_cpp//:dialogflow_cx",
     ],
 )

--- a/google/cloud/dialogflow_cx/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dialogflow_cx/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/dialogflow_es/quickstart/BUILD.bazel
+++ b/google/cloud/dialogflow_es/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:dialogflow_es",
+        "@google_cloud_cpp//:dialogflow_es",
     ],
 )

--- a/google/cloud/dialogflow_es/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dialogflow_es/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/dlp/quickstart/BUILD.bazel
+++ b/google/cloud/dlp/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:dlp",
+        "@google_cloud_cpp//:dlp",
     ],
 )

--- a/google/cloud/dlp/quickstart/WORKSPACE.bazel
+++ b/google/cloud/dlp/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/documentai/quickstart/BUILD.bazel
+++ b/google/cloud/documentai/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:documentai",
+        "@google_cloud_cpp//:documentai",
     ],
 )

--- a/google/cloud/documentai/quickstart/WORKSPACE.bazel
+++ b/google/cloud/documentai/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/edgecontainer/quickstart/BUILD.bazel
+++ b/google/cloud/edgecontainer/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:edgecontainer",
+        "@google_cloud_cpp//:edgecontainer",
     ],
 )

--- a/google/cloud/edgecontainer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/edgecontainer/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/eventarc/quickstart/BUILD.bazel
+++ b/google/cloud/eventarc/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:eventarc",
+        "@google_cloud_cpp//:eventarc",
     ],
 )

--- a/google/cloud/eventarc/quickstart/WORKSPACE.bazel
+++ b/google/cloud/eventarc/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/filestore/quickstart/BUILD.bazel
+++ b/google/cloud/filestore/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:filestore",
+        "@google_cloud_cpp//:filestore",
     ],
 )

--- a/google/cloud/filestore/quickstart/WORKSPACE.bazel
+++ b/google/cloud/filestore/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/functions/quickstart/BUILD.bazel
+++ b/google/cloud/functions/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:functions",
+        "@google_cloud_cpp//:functions",
     ],
 )

--- a/google/cloud/functions/quickstart/WORKSPACE.bazel
+++ b/google/cloud/functions/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/gameservices/quickstart/BUILD.bazel
+++ b/google/cloud/gameservices/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:gameservices",
+        "@google_cloud_cpp//:gameservices",
     ],
 )

--- a/google/cloud/gameservices/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gameservices/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/gkehub/quickstart/BUILD.bazel
+++ b/google/cloud/gkehub/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:gkehub",
+        "@google_cloud_cpp//:gkehub",
     ],
 )

--- a/google/cloud/gkehub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/gkehub/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/iam/quickstart/BUILD.bazel
+++ b/google/cloud/iam/quickstart/BUILD.bazel
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:iam",
+        "@google_cloud_cpp//:iam",
     ],
 )

--- a/google/cloud/iam/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iam/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/iap/quickstart/BUILD.bazel
+++ b/google/cloud/iap/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:iap",
+        "@google_cloud_cpp//:iap",
     ],
 )

--- a/google/cloud/iap/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iap/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/ids/quickstart/BUILD.bazel
+++ b/google/cloud/ids/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:ids",
+        "@google_cloud_cpp//:ids",
     ],
 )

--- a/google/cloud/ids/quickstart/WORKSPACE.bazel
+++ b/google/cloud/ids/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/iot/quickstart/BUILD.bazel
+++ b/google/cloud/iot/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:iot",
+        "@google_cloud_cpp//:iot",
     ],
 )

--- a/google/cloud/iot/quickstart/WORKSPACE.bazel
+++ b/google/cloud/iot/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/kms/quickstart/BUILD.bazel
+++ b/google/cloud/kms/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:kms",
+        "@google_cloud_cpp//:kms",
     ],
 )

--- a/google/cloud/kms/quickstart/WORKSPACE.bazel
+++ b/google/cloud/kms/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/language/quickstart/BUILD.bazel
+++ b/google/cloud/language/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:language",
+        "@google_cloud_cpp//:language",
     ],
 )

--- a/google/cloud/language/quickstart/WORKSPACE.bazel
+++ b/google/cloud/language/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/logging/quickstart/BUILD.bazel
+++ b/google/cloud/logging/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:logging",
+        "@google_cloud_cpp//:logging",
     ],
 )

--- a/google/cloud/logging/quickstart/WORKSPACE.bazel
+++ b/google/cloud/logging/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/managedidentities/quickstart/BUILD.bazel
+++ b/google/cloud/managedidentities/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:managedidentities",
+        "@google_cloud_cpp//:managedidentities",
     ],
 )

--- a/google/cloud/managedidentities/quickstart/WORKSPACE.bazel
+++ b/google/cloud/managedidentities/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/memcache/quickstart/BUILD.bazel
+++ b/google/cloud/memcache/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:memcache",
+        "@google_cloud_cpp//:memcache",
     ],
 )

--- a/google/cloud/memcache/quickstart/WORKSPACE.bazel
+++ b/google/cloud/memcache/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/monitoring/quickstart/BUILD.bazel
+++ b/google/cloud/monitoring/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:monitoring",
+        "@google_cloud_cpp//:monitoring",
     ],
 )

--- a/google/cloud/monitoring/quickstart/WORKSPACE.bazel
+++ b/google/cloud/monitoring/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/networkconnectivity/quickstart/BUILD.bazel
+++ b/google/cloud/networkconnectivity/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:networkconnectivity",
+        "@google_cloud_cpp//:networkconnectivity",
     ],
 )

--- a/google/cloud/networkconnectivity/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkconnectivity/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/networkmanagement/quickstart/BUILD.bazel
+++ b/google/cloud/networkmanagement/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:networkmanagement",
+        "@google_cloud_cpp//:networkmanagement",
     ],
 )

--- a/google/cloud/networkmanagement/quickstart/WORKSPACE.bazel
+++ b/google/cloud/networkmanagement/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/notebooks/quickstart/BUILD.bazel
+++ b/google/cloud/notebooks/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:notebooks",
+        "@google_cloud_cpp//:notebooks",
     ],
 )

--- a/google/cloud/notebooks/quickstart/WORKSPACE.bazel
+++ b/google/cloud/notebooks/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/optimization/quickstart/BUILD.bazel
+++ b/google/cloud/optimization/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:optimization",
+        "@google_cloud_cpp//:optimization",
     ],
 )

--- a/google/cloud/optimization/quickstart/WORKSPACE.bazel
+++ b/google/cloud/optimization/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/orgpolicy/quickstart/BUILD.bazel
+++ b/google/cloud/orgpolicy/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:orgpolicy",
+        "@google_cloud_cpp//:orgpolicy",
     ],
 )

--- a/google/cloud/orgpolicy/quickstart/WORKSPACE.bazel
+++ b/google/cloud/orgpolicy/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/osconfig/quickstart/BUILD.bazel
+++ b/google/cloud/osconfig/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:osconfig",
+        "@google_cloud_cpp//:osconfig",
     ],
 )

--- a/google/cloud/osconfig/quickstart/WORKSPACE.bazel
+++ b/google/cloud/osconfig/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/oslogin/quickstart/BUILD.bazel
+++ b/google/cloud/oslogin/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:oslogin",
+        "@google_cloud_cpp//:oslogin",
     ],
 )

--- a/google/cloud/oslogin/quickstart/WORKSPACE.bazel
+++ b/google/cloud/oslogin/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/policytroubleshooter/quickstart/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:policytroubleshooter",
+        "@google_cloud_cpp//:policytroubleshooter",
     ],
 )

--- a/google/cloud/policytroubleshooter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/policytroubleshooter/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/privateca/quickstart/BUILD.bazel
+++ b/google/cloud/privateca/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:privateca",
+        "@google_cloud_cpp//:privateca",
     ],
 )

--- a/google/cloud/privateca/quickstart/WORKSPACE.bazel
+++ b/google/cloud/privateca/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/profiler/quickstart/BUILD.bazel
+++ b/google/cloud/profiler/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:profiler",
+        "@google_cloud_cpp//:profiler",
     ],
 )

--- a/google/cloud/profiler/quickstart/WORKSPACE.bazel
+++ b/google/cloud/profiler/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/pubsub/quickstart/BUILD.bazel
+++ b/google/cloud/pubsub/quickstart/BUILD.bazel
@@ -22,6 +22,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:pubsub",
+        "@google_cloud_cpp//:pubsub",
     ],
 )

--- a/google/cloud/pubsub/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsub/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/pubsublite/quickstart/BUILD.bazel
+++ b/google/cloud/pubsublite/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-pubsublite",
+        "@google_cloud_cpp//:experimental-pubsublite",
     ],
 )

--- a/google/cloud/pubsublite/quickstart/WORKSPACE.bazel
+++ b/google/cloud/pubsublite/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/recommender/quickstart/BUILD.bazel
+++ b/google/cloud/recommender/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:recommender",
+        "@google_cloud_cpp//:recommender",
     ],
 )

--- a/google/cloud/recommender/quickstart/WORKSPACE.bazel
+++ b/google/cloud/recommender/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/redis/quickstart/BUILD.bazel
+++ b/google/cloud/redis/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:redis",
+        "@google_cloud_cpp//:redis",
     ],
 )

--- a/google/cloud/redis/quickstart/WORKSPACE.bazel
+++ b/google/cloud/redis/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/resourcemanager/quickstart/BUILD.bazel
+++ b/google/cloud/resourcemanager/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:resourcemanager",
+        "@google_cloud_cpp//:resourcemanager",
     ],
 )

--- a/google/cloud/resourcemanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/resourcemanager/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/resourcesettings/quickstart/BUILD.bazel
+++ b/google/cloud/resourcesettings/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:resourcesettings",
+        "@google_cloud_cpp//:resourcesettings",
     ],
 )

--- a/google/cloud/resourcesettings/quickstart/WORKSPACE.bazel
+++ b/google/cloud/resourcesettings/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/retail/quickstart/BUILD.bazel
+++ b/google/cloud/retail/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:retail",
+        "@google_cloud_cpp//:retail",
     ],
 )

--- a/google/cloud/retail/quickstart/WORKSPACE.bazel
+++ b/google/cloud/retail/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/run/quickstart/BUILD.bazel
+++ b/google/cloud/run/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:run",
+        "@google_cloud_cpp//:run",
     ],
 )

--- a/google/cloud/run/quickstart/WORKSPACE.bazel
+++ b/google/cloud/run/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/scheduler/quickstart/BUILD.bazel
+++ b/google/cloud/scheduler/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:scheduler",
+        "@google_cloud_cpp//:scheduler",
     ],
 )

--- a/google/cloud/scheduler/quickstart/WORKSPACE.bazel
+++ b/google/cloud/scheduler/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/secretmanager/quickstart/BUILD.bazel
+++ b/google/cloud/secretmanager/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:secretmanager",
+        "@google_cloud_cpp//:secretmanager",
     ],
 )

--- a/google/cloud/secretmanager/quickstart/WORKSPACE.bazel
+++ b/google/cloud/secretmanager/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/securitycenter/quickstart/BUILD.bazel
+++ b/google/cloud/securitycenter/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:securitycenter",
+        "@google_cloud_cpp//:securitycenter",
     ],
 )

--- a/google/cloud/securitycenter/quickstart/WORKSPACE.bazel
+++ b/google/cloud/securitycenter/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/servicecontrol/quickstart/BUILD.bazel
+++ b/google/cloud/servicecontrol/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:servicecontrol",
+        "@google_cloud_cpp//:servicecontrol",
     ],
 )

--- a/google/cloud/servicecontrol/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicecontrol/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/servicedirectory/quickstart/BUILD.bazel
+++ b/google/cloud/servicedirectory/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:servicedirectory",
+        "@google_cloud_cpp//:servicedirectory",
     ],
 )

--- a/google/cloud/servicedirectory/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicedirectory/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/servicemanagement/quickstart/BUILD.bazel
+++ b/google/cloud/servicemanagement/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:servicemanagement",
+        "@google_cloud_cpp//:servicemanagement",
     ],
 )

--- a/google/cloud/servicemanagement/quickstart/WORKSPACE.bazel
+++ b/google/cloud/servicemanagement/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/serviceusage/quickstart/BUILD.bazel
+++ b/google/cloud/serviceusage/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:serviceusage",
+        "@google_cloud_cpp//:serviceusage",
     ],
 )

--- a/google/cloud/serviceusage/quickstart/WORKSPACE.bazel
+++ b/google/cloud/serviceusage/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/shell/quickstart/BUILD.bazel
+++ b/google/cloud/shell/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:shell",
+        "@google_cloud_cpp//:shell",
     ],
 )

--- a/google/cloud/shell/quickstart/WORKSPACE.bazel
+++ b/google/cloud/shell/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/spanner/quickstart/BUILD.bazel
+++ b/google/cloud/spanner/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:spanner",
+        "@google_cloud_cpp//:spanner",
     ],
 )

--- a/google/cloud/spanner/quickstart/WORKSPACE.bazel
+++ b/google/cloud/spanner/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/speech/quickstart/BUILD.bazel
+++ b/google/cloud/speech/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:speech",
+        "@google_cloud_cpp//:speech",
     ],
 )

--- a/google/cloud/speech/quickstart/WORKSPACE.bazel
+++ b/google/cloud/speech/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/storage/doc/storage-grpc.dox
+++ b/google/cloud/storage/doc/storage-grpc.dox
@@ -39,8 +39,8 @@ target_link_libraries(quickstart_grpc google-cloud-cpp::experimental-storage-grp
 ```
 
 If you are using Bazel to compile your application, then you need to change
-the dependencies from `@com_github_googleapis_google_cloud_cpp//:storage`
-to `@com_github_googleapis_google_cloud_cpp//:experimental-storage-grpc`.
+the dependencies from `@google_cloud_cpp//:storage`
+to `@google_cloud_cpp//:experimental-storage-grpc`.
 For example, our `grpc/quickstart uses:
 
 ```{.py}
@@ -50,7 +50,7 @@ cc_binary(
         "quickstart_grpc.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:experimental-storage-grpc",
+        "@google_cloud_cpp//:experimental-storage-grpc",
     ],
 )
 ```

--- a/google/cloud/storagetransfer/quickstart/BUILD.bazel
+++ b/google/cloud/storagetransfer/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:storagetransfer",
+        "@google_cloud_cpp//:storagetransfer",
     ],
 )

--- a/google/cloud/storagetransfer/quickstart/WORKSPACE.bazel
+++ b/google/cloud/storagetransfer/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/talent/quickstart/BUILD.bazel
+++ b/google/cloud/talent/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:talent",
+        "@google_cloud_cpp//:talent",
     ],
 )

--- a/google/cloud/talent/quickstart/WORKSPACE.bazel
+++ b/google/cloud/talent/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/tasks/quickstart/BUILD.bazel
+++ b/google/cloud/tasks/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:tasks",
+        "@google_cloud_cpp//:tasks",
     ],
 )

--- a/google/cloud/tasks/quickstart/WORKSPACE.bazel
+++ b/google/cloud/tasks/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/texttospeech/quickstart/BUILD.bazel
+++ b/google/cloud/texttospeech/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:texttospeech",
+        "@google_cloud_cpp//:texttospeech",
     ],
 )

--- a/google/cloud/texttospeech/quickstart/WORKSPACE.bazel
+++ b/google/cloud/texttospeech/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/tpu/quickstart/BUILD.bazel
+++ b/google/cloud/tpu/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:tpu",
+        "@google_cloud_cpp//:tpu",
     ],
 )

--- a/google/cloud/tpu/quickstart/WORKSPACE.bazel
+++ b/google/cloud/tpu/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/trace/quickstart/BUILD.bazel
+++ b/google/cloud/trace/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:trace",
+        "@google_cloud_cpp//:trace",
     ],
 )

--- a/google/cloud/trace/quickstart/WORKSPACE.bazel
+++ b/google/cloud/trace/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/translate/quickstart/BUILD.bazel
+++ b/google/cloud/translate/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:translate",
+        "@google_cloud_cpp//:translate",
     ],
 )

--- a/google/cloud/translate/quickstart/WORKSPACE.bazel
+++ b/google/cloud/translate/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/video/quickstart/BUILD.bazel
+++ b/google/cloud/video/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:video",
+        "@google_cloud_cpp//:video",
     ],
 )

--- a/google/cloud/video/quickstart/WORKSPACE.bazel
+++ b/google/cloud/video/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/videointelligence/quickstart/BUILD.bazel
+++ b/google/cloud/videointelligence/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:videointelligence",
+        "@google_cloud_cpp//:videointelligence",
     ],
 )

--- a/google/cloud/videointelligence/quickstart/WORKSPACE.bazel
+++ b/google/cloud/videointelligence/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/vision/quickstart/BUILD.bazel
+++ b/google/cloud/vision/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:vision",
+        "@google_cloud_cpp//:vision",
     ],
 )

--- a/google/cloud/vision/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vision/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/vmmigration/quickstart/BUILD.bazel
+++ b/google/cloud/vmmigration/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:vmmigration",
+        "@google_cloud_cpp//:vmmigration",
     ],
 )

--- a/google/cloud/vmmigration/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vmmigration/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/vpcaccess/quickstart/BUILD.bazel
+++ b/google/cloud/vpcaccess/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:vpcaccess",
+        "@google_cloud_cpp//:vpcaccess",
     ],
 )

--- a/google/cloud/vpcaccess/quickstart/WORKSPACE.bazel
+++ b/google/cloud/vpcaccess/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/webrisk/quickstart/BUILD.bazel
+++ b/google/cloud/webrisk/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:webrisk",
+        "@google_cloud_cpp//:webrisk",
     ],
 )

--- a/google/cloud/webrisk/quickstart/WORKSPACE.bazel
+++ b/google/cloud/webrisk/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/websecurityscanner/quickstart/BUILD.bazel
+++ b/google/cloud/websecurityscanner/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:websecurityscanner",
+        "@google_cloud_cpp//:websecurityscanner",
     ],
 )

--- a/google/cloud/websecurityscanner/quickstart/WORKSPACE.bazel
+++ b/google/cloud/websecurityscanner/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 

--- a/google/cloud/workflows/quickstart/BUILD.bazel
+++ b/google/cloud/workflows/quickstart/BUILD.bazel
@@ -20,6 +20,6 @@ cc_binary(
         "quickstart.cc",
     ],
     deps = [
-        "@com_github_googleapis_google_cloud_cpp//:workflows",
+        "@google_cloud_cpp//:workflows",
     ],
 )

--- a/google/cloud/workflows/quickstart/WORKSPACE.bazel
+++ b/google/cloud/workflows/quickstart/WORKSPACE.bazel
@@ -22,7 +22,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Fetch the Google Cloud C++ libraries.
 # NOTE: Update this version and SHA256 as needed.
 http_archive(
-    name = "com_github_googleapis_google_cloud_cpp",
+    name = "google_cloud_cpp",
     sha256 = "d2c764831c63529449d9d61c0403b97555d6c6cbeaab1809bc51c51ac5c7e0f3",
     strip_prefix = "google-cloud-cpp-2.3.0",
     url = "https://github.com/googleapis/google-cloud-cpp/archive/v2.3.0.tar.gz",
@@ -30,7 +30,7 @@ http_archive(
 
 # Load indirect dependencies due to
 #     https://github.com/bazelbuild/bazel/issues/1943
-load("@com_github_googleapis_google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
+load("@google_cloud_cpp//bazel:google_cloud_cpp_deps.bzl", "google_cloud_cpp_deps")
 
 google_cloud_cpp_deps()
 


### PR DESCRIPTION
Use shorter names for the quickstart and other Bazel workspaces. This should unblock some Windows builds.  I missed one call to `Label()`, the storage workspace will need a new PR and a release cycle.

Part of the work for #9340

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9980)
<!-- Reviewable:end -->
