### PR TITLE
fix(pubsub): faster shutdowns for `Publisher`

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.h
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.h
@@ -33,6 +33,8 @@ class BatchingPublisherConnection
     : public pubsub::PublisherConnection,
       public std::enable_shared_from_this<BatchingPublisherConnection> {
  public:
+  ~BatchingPublisherConnection() override;
+
   static std::shared_ptr<BatchingPublisherConnection> Create(
       pubsub::Topic topic, Options opts, std::string ordering_key,
       std::shared_ptr<BatchSink> sink, CompletionQueue cq) {
@@ -79,6 +81,7 @@ class BatchingPublisherConnection
   google::pubsub::v1::PublishRequest pending_;
   std::size_t current_bytes_ = 0;
   std::chrono::system_clock::time_point batch_expiration_;
+  future<void> timer_;
 
   Status corked_on_status_;
 };

--- a/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection_test.cc
@@ -60,6 +60,40 @@ std::vector<std::string> MessagesData(
   return data;
 }
 
+TEST(BatchingPublisherConnectionTest, FastDestructor) {
+  auto mock = std::make_shared<pubsub_testing::MockBatchSink>();
+  pubsub::Topic const topic("test-project", "test-topic");
+
+  AsyncSequencer<void> async;
+  // This test will never get a chance to flush its message.
+  EXPECT_CALL(*mock, AsyncPublish).Times(0);
+
+  google::cloud::internal::AutomaticallyCreatedBackgroundThreads background;
+  // Make this so large that the test times out before the message hold expires.
+  // This ensures that the two messages will be sent in one batch.
+  auto constexpr kMaxHoldTime = std::chrono::hours(24);
+  auto const ordering_key = std::string{};
+  auto publisher = BatchingPublisherConnection::Create(
+      topic,
+      DefaultPublisherOptions(
+          Options{}
+              .set<pubsub::MaxBatchMessagesOption>(4)
+              .set<pubsub::MaxHoldTimeOption>(kMaxHoldTime)),
+      ordering_key, mock, background.cq());
+
+  // Publishing a message starts the batch timer.
+  auto pending = publisher->Publish(
+      {pubsub::MessageBuilder{}.SetData("test-data-0").Build()});
+
+  auto const start = std::chrono::steady_clock::now();
+  publisher.reset();
+  auto const elapsed = std::chrono::steady_clock::now() - start;
+  // Considering that the timer is configured to wait 24 hours, shutting down in
+  // 30s is good enough. It also avoids flakiness introduced by more precise
+  // measurements.
+  EXPECT_LE(elapsed, std::chrono::seconds(30));
+}
+
 TEST(BatchingPublisherConnectionTest, DefaultMakesProgress) {
   auto mock = std::make_shared<pubsub_testing::MockBatchSink>();
   pubsub::Topic const topic("test-project", "test-topic");


### PR DESCRIPTION
Cancel the timer (if any) before shutting down.  This can be a problem for applications that have very long batches (say multiple seconds or minutes).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9991)
<!-- Reviewable:end -->
