### PR TITLE
fix: download googleapis if SHA changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,35 @@ option(GOOGLE_CLOUD_CPP_USE_MAIN_FOR_REFDOC_LINKS
        "Use main as the version part for refdoc relative links" OFF)
 mark_as_advanced(GOOGLE_CLOUD_CPP_USE_MAIN_FOR_REFDOC_LINKS)
 
+set(GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL
+    ""
+    CACHE
+        STRING
+        [==[
+Override the default URL for the googleapis protos. google-cloud-cpp needs the
+proto and gRPC definitions for most Google Cloud services. By default these
+definitions are downloaded from GitHub. In some environments, this may not be
+possible. This variable can be used to use a local directory, or a local
+tarball, with the proto definitions.
+
+If you override this variable, you must ensure the proto definitions match the
+expectations in google-cloud-cpp. Using the same SHA is the recommended
+practice. Using older SHAs is **NOT** supported, and will almost certainly
+result in build problems. You may be able to use a more recent SHA of the
+protos, but do not expect that new features will become exposed via the C++
+client libraries.
+]==])
+mark_as_advanced(GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL)
+set(GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH
+    ""
+    CACHE
+        STRING
+        [==[
+Override the hash for the googleapis protos tarball. See
+GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL for details.
+]==])
+mark_as_advanced(GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH)
+
 include(CMakeDependentOption)
 
 option(GOOGLE_CLOUD_CPP_ENABLE_BIGTABLE "Enable building the Bigtable library."

--- a/cmake/GoogleapisConfig.cmake
+++ b/cmake/GoogleapisConfig.cmake
@@ -17,15 +17,21 @@
 # Give application developers a hook to configure the version and hash
 # downloaded from GitHub.
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA
-    "7b5a467b978ff2dde6cd34717ebad5728d05f2bb"
-    CACHE STRING "Configure the commit SHA (or tag) for the googleapis protos.")
-mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA)
+    ""
+    CACHE STRING "Deprecated. Use GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL")
+mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA)
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
-    "dcb6fb94ddde6d28a6414c93e880db13fb0402753bbfc94e1e16b475969a982d"
-    CACHE STRING "Configure the SHA256 checksum of the googleapis tarball.")
+    ""
+    CACHE STRING
+          "Deprecated. Use GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH")
 mark_as_advanced(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256)
 
+set(_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA
+    "7b5a467b978ff2dde6cd34717ebad5728d05f2bb")
+set(_GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256
+    "dcb6fb94ddde6d28a6414c93e880db13fb0402753bbfc94e1e16b475969a982d")
+
 set(DOXYGEN_ALIASES
-    "googleapis_link{2}=\"[\\1](https://github.com/googleapis/googleapis/blob/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\2)\""
-    "googleapis_reference_link{1}=\"https://github.com/googleapis/googleapis/blob/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\1\""
+    "googleapis_link{2}=\"[\\1](https://github.com/googleapis/googleapis/blob/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\2)\""
+    "googleapis_reference_link{1}=\"https://github.com/googleapis/googleapis/blob/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}/\\1\""
 )

--- a/doc/contributor/howto-guide-update-googleapis-sha.md
+++ b/doc/contributor/howto-guide-update-googleapis-sha.md
@@ -55,8 +55,6 @@ git add .
 
 ```shell
 bazel build //google/cloud/...
-# CMake caches the old protos, clear them before compiling
-rm -fr build-out/*/cmake-out
 ci/cloudbuild/build.sh -t cmake-install-pr
 ```
 

--- a/external/googleapis/CMakeLists.txt
+++ b/external/googleapis/CMakeLists.txt
@@ -17,9 +17,19 @@
 include(GoogleapisConfig)
 
 set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
-    "https://github.com/googleapis/googleapis/archive/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
-    "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/${GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
+    "https://github.com/googleapis/googleapis/archive/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
+    "https://storage.googleapis.com/cloud-cpp-community-archive/com_google_googleapis/${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA}.tar.gz"
 )
+set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
+    "${_GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}")
+if (GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL)
+    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL
+        ${GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL})
+endif ()
+if (GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH)
+    set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH
+        "${GOOGLE_CLOUD_CPP_OVERRIDE_GOOGLEAPIS_URL_HASH}")
+endif ()
 
 set(EXTERNAL_GOOGLEAPIS_SOURCE
     "${PROJECT_BINARY_DIR}/external/googleapis/src/googleapis_download")
@@ -110,7 +120,7 @@ externalproject_add(
     EXCLUDE_FROM_ALL ON
     PREFIX "${PROJECT_BINARY_DIR}/external/googleapis"
     URL ${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL}
-    URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256}
+    URL_HASH SHA256=${GOOGLE_CLOUD_CPP_GOOGLEAPIS_URL_HASH}
     PATCH_COMMAND
         ""
         # ~~~

--- a/external/googleapis/renovate.sh
+++ b/external/googleapis/renovate.sh
@@ -38,11 +38,11 @@ EOT
 
 # Update the CMake dependency.
 sed -i -f - cmake/GoogleapisConfig.cmake <<EOT
-  /^set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA$/ {
+  /^set(_GOOGLE_CLOUD_CPP_GOOGLEAPIS_COMMIT_SHA$/ {
     n
     s/".*"/"${COMMIT}"/
   }
-  /^set(GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256$/ {
+  /^set(_GOOGLE_CLOUD_CPP_GOOGLEAPIS_SHA256$/ {
     n
     s/".*"/"${SHA256}"/
   }


### PR DESCRIPTION
Still provide a mechanism to override the URL. This is useful when building in environments disconnected from the Internet, or when creating packages, where downloading is frowned upon.

Fixes #9993

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9994)
<!-- Reviewable:end -->
