### PR TITLE
fix(pubsub): race condition capturing batching timer

### DIFF
--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -149,7 +149,7 @@ void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
   // `weak_from_this()`.
   auto weak = std::weak_ptr<BatchingPublisherConnection>(shared_from_this());
   // Note that at this point the lock is released, so whether the timer
-  // schedules later on schedules in this thread has no effect.
+  // schedules later or schedules in this thread has no effect.
   auto timer =
       cq_.MakeDeadlineTimer(expiration)
           .then(
@@ -159,7 +159,7 @@ void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
   lk.lock();
   // Assignment without a lock is not safe, as it is not an atomic assignment.
   // If the timer already expired, there is no problem. The only place where
-  // it is used is in the destructor and a cancel request on a expired timer is
+  // it is used is in the destructor and a cancel request on an expired timer is
   // harmless.
   timer_ = std::move(timer);
 }

--- a/google/cloud/pubsub/internal/batching_publisher_connection.cc
+++ b/google/cloud/pubsub/internal/batching_publisher_connection.cc
@@ -149,16 +149,19 @@ void BatchingPublisherConnection::MaybeFlush(std::unique_lock<std::mutex> lk) {
   // `weak_from_this()`.
   auto weak = std::weak_ptr<BatchingPublisherConnection>(shared_from_this());
   // Note that at this point the lock is released, so whether the timer
-  // schedules later on schedules in this thread has no effect.  In addition,
-  // the assignment to `timer_` is safe.  It is only used from the destructor,
-  // and if the destructor and this function are running at the same time, then
-  // we had a massive problem already.
-  timer_ =
+  // schedules later on schedules in this thread has no effect.
+  auto timer =
       cq_.MakeDeadlineTimer(expiration)
           .then(
               [weak](future<StatusOr<std::chrono::system_clock::time_point>>) {
                 if (auto self = weak.lock()) self->OnTimer();
               });
+  lk.lock();
+  // Assignment without a lock is not safe, as it is not an atomic assignment.
+  // If the timer already expired, there is no problem. The only place where
+  // it is used is in the destructor and a cancel request on a expired timer is
+  // harmless.
+  timer_ = std::move(timer);
 }
 
 void BatchingPublisherConnection::OnTimer() {


### PR DESCRIPTION
Fixes #9995  Tested with:

```
CXX=clang++ CC=clang bazel test --test_filter=BatchingPublisherConnectionTest.BatchTorture --config=tsan --runs_per_test=10000 //google/cloud/pubsub:internal_batching_publisher_connection_test
INFO: Analyzed target //google/cloud/pubsub:internal_batching_publisher_connection_test (0 packages loaded, 137 targets configured).
INFO: Found 1 test target...
Target //google/cloud/pubsub:internal_batching_publisher_connection_test up-to-date:
  /usr/local/google/home/coryan/.cache/bazel/_bazel_coryan/f1b649d8eddab70da217bfe95503f270/execroot/com_github_googleapis_google_cloud_cpp/bazel-out/k8-fastbuild/bin/google/cloud/pubsub/internal_batching_publisher_connection_test
INFO: Elapsed time: 290.361s, Critical Path: 10.31s
INFO: 10001 processes: 1 internal, 10000 linux-sandbox.
INFO: Build completed successfully, 10001 total actions
//google/cloud/pubsub:internal_batching_publisher_connection_test        PASSED in 5.3s
  Stats over 10000 runs: max = 5.3s, min = 0.4s, avg = 1.8s, dev = 0.6s
```


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/9996)
<!-- Reviewable:end -->
