### PR TITLE
cleanup: bazel `*_mocks` depend on gtest

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -296,8 +296,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_$library$",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )
 )""";

--- a/google/cloud/accessapproval/BUILD.bazel
+++ b/google/cloud/accessapproval/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accessapproval",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/accesscontextmanager/BUILD.bazel
+++ b/google/cloud/accesscontextmanager/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_accesscontextmanager",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/apigateway/BUILD.bazel
+++ b/google/cloud/apigateway/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigateway",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/apigeeconnect/BUILD.bazel
+++ b/google/cloud/apigeeconnect/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apigeeconnect",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/apikeys/BUILD.bazel
+++ b/google/cloud/apikeys/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_apikeys",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/appengine/BUILD.bazel
+++ b/google/cloud/appengine/BUILD.bazel
@@ -55,7 +55,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_appengine",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/artifactregistry/BUILD.bazel
+++ b/google/cloud/artifactregistry/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_artifactregistry",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/asset/BUILD.bazel
+++ b/google/cloud/asset/BUILD.bazel
@@ -58,7 +58,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_asset",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/assuredworkloads/BUILD.bazel
+++ b/google/cloud/assuredworkloads/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_assuredworkloads",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/automl/BUILD.bazel
+++ b/google/cloud/automl/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_automl",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/baremetalsolution/BUILD.bazel
+++ b/google/cloud/baremetalsolution/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_baremetalsolution",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/batch/BUILD.bazel
+++ b/google/cloud/batch/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_batch",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/beyondcorp/BUILD.bazel
+++ b/google/cloud/beyondcorp/BUILD.bazel
@@ -62,7 +62,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_beyondcorp",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/bigquery/BUILD.bazel
+++ b/google/cloud/bigquery/BUILD.bazel
@@ -45,7 +45,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_bigquery",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/billing/BUILD.bazel
+++ b/google/cloud/billing/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_billing",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/binaryauthorization/BUILD.bazel
+++ b/google/cloud/binaryauthorization/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_binaryauthorization",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/channel/BUILD.bazel
+++ b/google/cloud/channel/BUILD.bazel
@@ -59,7 +59,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_channel",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/cloudbuild/BUILD.bazel
+++ b/google/cloud/cloudbuild/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_cloudbuild",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/composer/BUILD.bazel
+++ b/google/cloud/composer/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_composer",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/contactcenterinsights/BUILD.bazel
+++ b/google/cloud/contactcenterinsights/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_contactcenterinsights",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/container/BUILD.bazel
+++ b/google/cloud/container/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_container",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/containeranalysis/BUILD.bazel
+++ b/google/cloud/containeranalysis/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_containeranalysis",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/datacatalog/BUILD.bazel
+++ b/google/cloud/datacatalog/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datacatalog",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/datamigration/BUILD.bazel
+++ b/google/cloud/datamigration/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_datamigration",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/dataplex/BUILD.bazel
+++ b/google/cloud/dataplex/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataplex",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/dataproc/BUILD.bazel
+++ b/google/cloud/dataproc/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dataproc",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/debugger/BUILD.bazel
+++ b/google/cloud/debugger/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_debugger",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/dialogflow_cx/BUILD.bazel
+++ b/google/cloud/dialogflow_cx/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dialogflow_cx",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/dialogflow_es/BUILD.bazel
+++ b/google/cloud/dialogflow_es/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dialogflow_es",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/dlp/BUILD.bazel
+++ b/google/cloud/dlp/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_dlp",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/documentai/BUILD.bazel
+++ b/google/cloud/documentai/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_documentai",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/edgecontainer/BUILD.bazel
+++ b/google/cloud/edgecontainer/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_edgecontainer",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/eventarc/BUILD.bazel
+++ b/google/cloud/eventarc/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_eventarc",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/filestore/BUILD.bazel
+++ b/google/cloud/filestore/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_filestore",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/functions/BUILD.bazel
+++ b/google/cloud/functions/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_functions",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/gameservices/BUILD.bazel
+++ b/google/cloud/gameservices/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gameservices",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/gkehub/BUILD.bazel
+++ b/google/cloud/gkehub/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_gkehub",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/iam/BUILD.bazel
+++ b/google/cloud/iam/BUILD.bazel
@@ -43,9 +43,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iam",
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/iam/admin/v1:admin_cc_grpc",
-        "@com_google_googleapis//google/iam/credentials/v1:credentials_cc_grpc",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/iap/BUILD.bazel
+++ b/google/cloud/iap/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iap",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/ids/BUILD.bazel
+++ b/google/cloud/ids/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_ids",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/iot/BUILD.bazel
+++ b/google/cloud/iot/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_iot",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/kms/BUILD.bazel
+++ b/google/cloud/kms/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_kms",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/language/BUILD.bazel
+++ b/google/cloud/language/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_language",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/logging/BUILD.bazel
+++ b/google/cloud/logging/BUILD.bazel
@@ -39,7 +39,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_logging",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/managedidentities/BUILD.bazel
+++ b/google/cloud/managedidentities/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_managedidentities",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/memcache/BUILD.bazel
+++ b/google/cloud/memcache/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_memcache",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/monitoring/BUILD.bazel
+++ b/google/cloud/monitoring/BUILD.bazel
@@ -55,7 +55,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_monitoring",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/networkconnectivity/BUILD.bazel
+++ b/google/cloud/networkconnectivity/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkconnectivity",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/networkmanagement/BUILD.bazel
+++ b/google/cloud/networkmanagement/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_networkmanagement",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/notebooks/BUILD.bazel
+++ b/google/cloud/notebooks/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_notebooks",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/optimization/BUILD.bazel
+++ b/google/cloud/optimization/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_optimization",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/orgpolicy/BUILD.bazel
+++ b/google/cloud/orgpolicy/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_orgpolicy",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/osconfig/BUILD.bazel
+++ b/google/cloud/osconfig/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_osconfig",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/oslogin/BUILD.bazel
+++ b/google/cloud/oslogin/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_oslogin",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/policytroubleshooter/BUILD.bazel
+++ b/google/cloud/policytroubleshooter/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_policytroubleshooter",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/privateca/BUILD.bazel
+++ b/google/cloud/privateca/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_privateca",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/profiler/BUILD.bazel
+++ b/google/cloud/profiler/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_profiler",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/pubsub/BUILD.bazel
+++ b/google/cloud/pubsub/BUILD.bazel
@@ -79,9 +79,7 @@ cc_library(
     ],
     deps = [
         ":google_cloud_cpp_pubsub",
-        "//:common",
-        "//:grpc_utils",
-        "@com_google_googleapis//google/pubsub/v1:pubsub_cc_grpc",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/google/cloud/pubsublite/BUILD.bazel
+++ b/google/cloud/pubsublite/BUILD.bazel
@@ -41,8 +41,7 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_pubsublite",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )
 

--- a/google/cloud/recommender/BUILD.bazel
+++ b/google/cloud/recommender/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_recommender",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/redis/BUILD.bazel
+++ b/google/cloud/redis/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_redis",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/resourcemanager/BUILD.bazel
+++ b/google/cloud/resourcemanager/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcemanager",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/resourcesettings/BUILD.bazel
+++ b/google/cloud/resourcesettings/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_resourcesettings",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/retail/BUILD.bazel
+++ b/google/cloud/retail/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_retail",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/run/BUILD.bazel
+++ b/google/cloud/run/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_run",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/scheduler/BUILD.bazel
+++ b/google/cloud/scheduler/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_scheduler",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/secretmanager/BUILD.bazel
+++ b/google/cloud/secretmanager/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_secretmanager",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/securitycenter/BUILD.bazel
+++ b/google/cloud/securitycenter/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_securitycenter",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/servicecontrol/BUILD.bazel
+++ b/google/cloud/servicecontrol/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicecontrol",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/servicedirectory/BUILD.bazel
+++ b/google/cloud/servicedirectory/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicedirectory",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/servicemanagement/BUILD.bazel
+++ b/google/cloud/servicemanagement/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_servicemanagement",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/serviceusage/BUILD.bazel
+++ b/google/cloud/serviceusage/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_serviceusage",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/shell/BUILD.bazel
+++ b/google/cloud/shell/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_shell",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/speech/BUILD.bazel
+++ b/google/cloud/speech/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_speech",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/storagetransfer/BUILD.bazel
+++ b/google/cloud/storagetransfer/BUILD.bazel
@@ -58,7 +58,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_storagetransfer",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/talent/BUILD.bazel
+++ b/google/cloud/talent/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_talent",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/tasks/BUILD.bazel
+++ b/google/cloud/tasks/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tasks",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/texttospeech/BUILD.bazel
+++ b/google/cloud/texttospeech/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_texttospeech",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/tpu/BUILD.bazel
+++ b/google/cloud/tpu/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_tpu",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/trace/BUILD.bazel
+++ b/google/cloud/trace/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_trace",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/translate/BUILD.bazel
+++ b/google/cloud/translate/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_translate",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/video/BUILD.bazel
+++ b/google/cloud/video/BUILD.bazel
@@ -55,7 +55,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_video",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/videointelligence/BUILD.bazel
+++ b/google/cloud/videointelligence/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_videointelligence",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/vision/BUILD.bazel
+++ b/google/cloud/vision/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vision",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/vmmigration/BUILD.bazel
+++ b/google/cloud/vmmigration/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vmmigration",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/vpcaccess/BUILD.bazel
+++ b/google/cloud/vpcaccess/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_vpcaccess",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/webrisk/BUILD.bazel
+++ b/google/cloud/webrisk/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_webrisk",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/websecurityscanner/BUILD.bazel
+++ b/google/cloud/websecurityscanner/BUILD.bazel
@@ -53,7 +53,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_websecurityscanner",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )

--- a/google/cloud/workflows/BUILD.bazel
+++ b/google/cloud/workflows/BUILD.bazel
@@ -54,7 +54,6 @@ cc_library(
     visibility = ["//:__pkg__"],
     deps = [
         ":google_cloud_cpp_workflows",
-        "//:common",
-        "//:grpc_utils",
+        "@com_google_googletest//:gtest",
     ],
 )


### PR DESCRIPTION
Files in these targets `#include <gmock/gmock.h>` so I think they should take a dep on GoogleTest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10007)
<!-- Reviewable:end -->
