### PR TITLE
feat(pubsub): install pubsub_mocks pkg

### DIFF
--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -110,6 +110,8 @@ expected_dirs+=(
   ./lib64/cmake/google_cloud_cpp_googleapis
   ./lib64/cmake/google_cloud_cpp_grafeas
   ./lib64/cmake/google_cloud_cpp_grpc_utils
+  ./lib64/cmake/google_cloud_cpp_pubsub
+  ./lib64/cmake/google_cloud_cpp_pubsub_mocks
   ./lib64/cmake/google_cloud_cpp_rest_internal
   ./lib64/cmake/google_cloud_cpp_rest_protobuf_internal
   ./lib64/cmake/google_cloud_cpp_spanner

--- a/ci/cloudbuild/builds/cmake-install.sh
+++ b/ci/cloudbuild/builds/cmake-install.sh
@@ -110,7 +110,6 @@ expected_dirs+=(
   ./lib64/cmake/google_cloud_cpp_googleapis
   ./lib64/cmake/google_cloud_cpp_grafeas
   ./lib64/cmake/google_cloud_cpp_grpc_utils
-  ./lib64/cmake/google_cloud_cpp_pubsub
   ./lib64/cmake/google_cloud_cpp_pubsub_mocks
   ./lib64/cmake/google_cloud_cpp_rest_internal
   ./lib64/cmake/google_cloud_cpp_rest_protobuf_internal

--- a/ci/verify_current_targets/CMakeLists.txt
+++ b/ci/verify_current_targets/CMakeLists.txt
@@ -30,6 +30,7 @@ set(ga_libraries
     iam
     logging
     pubsub
+    pubsub_mocks
     spanner
     storage)
 

--- a/cmake/AddPkgConfig.cmake
+++ b/cmake/AddPkgConfig.cmake
@@ -35,16 +35,16 @@ macro (google_cloud_cpp_set_pkgconfig_paths)
 endmacro ()
 
 #
-# Create the pkgconfig configuration file (aka *.pc file) and the rules to
-# install it.
+# Implementation to create the pkgconfig configuration file (aka *.pc file) and
+# the rules to install it.
 #
 # * library: the name of the library, such as `storage`, or `spanner`
 # * ARGN: the names of any pkgconfig modules the generated module depends on
 #
-function (google_cloud_cpp_add_pkgconfig library name description)
+function (google_cloud_cpp_add_pkgconfig_impl library name description pc_libs)
     set(GOOGLE_CLOUD_CPP_PC_NAME "${name}")
     set(GOOGLE_CLOUD_CPP_PC_DESCRIPTION "${description}")
-    set(GOOGLE_CLOUD_CPP_PC_LIBS "-lgoogle_cloud_cpp_${library}")
+    set(GOOGLE_CLOUD_CPP_PC_LIBS "${pc_libs}")
     string(CONCAT GOOGLE_CLOUD_CPP_PC_REQUIRES ${ARGN})
     google_cloud_cpp_set_pkgconfig_paths()
 
@@ -55,4 +55,29 @@ function (google_cloud_cpp_add_pkgconfig library name description)
         FILES "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_${library}.pc"
         DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
         COMPONENT google_cloud_cpp_development)
+endfunction ()
+
+#
+# Create the pkgconfig configuration file (aka *.pc file) and the rules to
+# install it.
+#
+# * library: the name of the library, such as `storage`, or `spanner`
+# * ARGN: the names of any pkgconfig modules the generated module depends on
+#
+function (google_cloud_cpp_add_pkgconfig library name description)
+    google_cloud_cpp_add_pkgconfig_impl("${library}" "${name}" "${description}"
+                                        "-lgoogle_cloud_cpp_${library}" ${ARGN})
+endfunction ()
+
+#
+# Create the pkgconfig configuration file (aka *.pc file) and the rules to
+# install it for an interface library. These libraries only contain headers, so
+# they do not generate lib files to link against with `-l`.
+#
+# * library: the name of the library, such as `storage`, or `spanner`
+# * ARGN: the names of any pkgconfig modules the generated module depends on
+#
+function (google_cloud_cpp_add_pkgconfig_interface library name description)
+    google_cloud_cpp_add_pkgconfig_impl("${library}" "${name}" "${description}"
+                                        "" ${ARGN})
 endfunction ()

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -387,9 +387,15 @@ install(
 google_cloud_cpp_install_headers("google_cloud_cpp_pubsub"
                                  "include/google/cloud/pubsub")
 
+# Export the CMake targets to make it easy to create configuration files.
+install(
+    EXPORT pubsub_mocks-targets
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub_mocks"
+    COMPONENT google_cloud_cpp_development)
+
 install(
     TARGETS google_cloud_cpp_pubsub_mocks
-    EXPORT pubsub-targets
+    EXPORT pubsub_mocks-targets
     COMPONENT google_cloud_cpp_development)
 install(
     FILES ${google_cloud_cpp_pubsub_mocks_hdrs}
@@ -418,4 +424,25 @@ install(
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub-config-version.cmake"
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
+    COMPONENT google_cloud_cpp_development)
+
+google_cloud_cpp_add_pkgconfig(
+    pubsub_mocks "Mocks for the Google Cloud Pub/Sub C++ Client Library"
+    "Provides mock classes for the Google Cloud Pub/Sub C++ APIs."
+    "google_cloud_cpp_pubsub" " gtest")
+
+# Create and install the CMake configuration files.
+include(CMakePackageConfigHelpers)
+configure_file("config-mocks.cmake.in"
+               "google_cloud_cpp_pubsub_mocks-config.cmake" @ONLY)
+write_basic_package_version_file(
+    "google_cloud_cpp_pubsub_mocks-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY ExactVersion)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub_mocks-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/google_cloud_cpp_pubsub_mocks-config-version.cmake"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub_mocks"
     COMPONENT google_cloud_cpp_development)

--- a/google/cloud/pubsub/CMakeLists.txt
+++ b/google/cloud/pubsub/CMakeLists.txt
@@ -426,14 +426,13 @@ install(
     DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/google_cloud_cpp_pubsub"
     COMPONENT google_cloud_cpp_development)
 
-google_cloud_cpp_add_pkgconfig(
-    pubsub_mocks "Mocks for the Google Cloud Pub/Sub C++ Client Library"
-    "Provides mock classes for the Google Cloud Pub/Sub C++ APIs."
-    "google_cloud_cpp_pubsub" " gtest")
+google_cloud_cpp_add_pkgconfig_interface(
+    pubsub_mocks "Google Cloud C++ Pub/Sub Mocks"
+    "Mocks for the Google Cloud Pub/Sub C++ Client Library"
+    "google_cloud_cpp_pubsub" " gmock_main")
 
 # Create and install the CMake configuration files.
-include(CMakePackageConfigHelpers)
-configure_file("config-mocks.cmake.in"
+configure_file("mocks-config.cmake.in"
                "google_cloud_cpp_pubsub_mocks-config.cmake" @ONLY)
 write_basic_package_version_file(
     "google_cloud_cpp_pubsub_mocks-config-version.cmake"

--- a/google/cloud/pubsub/config-mocks.cmake.in
+++ b/google/cloud/pubsub/config-mocks.cmake.in
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include(CMakeFindDependencyMacro)
+find_dependency(google_cloud_cpp_pubsub)
+find_dependency(gtest)
+
+include("${CMAKE_CURRENT_LIST_DIR}/pubsub_mocks-targets.cmake")

--- a/google/cloud/pubsub/mocks-config.cmake.in
+++ b/google/cloud/pubsub/mocks-config.cmake.in
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(google_cloud_cpp_pubsub)
-find_dependency(gtest)
+find_dependency(GTest)
 
 include("${CMAKE_CURRENT_LIST_DIR}/pubsub_mocks-targets.cmake")


### PR DESCRIPTION
Part of the work for #5782

* Move `google-cloud-cpp::pubsub_mocks` out of `pubsub-targets` and into `pubsub_mocks-targets`.
  * **Is this a breaking change?**
* Add a google_cloud_cpp_pubsub_mocks pkg

I have no idea if this works. Or how to test it.

But I can (from the `demo-fedora-pr` docker shell)
```sh
docker:demo-fedora$ ls /h/google-cloud-cpp-installed/lib64/cmake/google_cloud_cpp_pubsub_mocks/
google_cloud_cpp_pubsub_mocks-config-version.cmake  pubsub_mocks-targets.cmake
google_cloud_cpp_pubsub_mocks-config.cmake

# the pubsub one has a `noconfig.cmake`... whatever that means.
```
```sh
docker:demo-fedora$ PKG_CONFIG_PATH="/h/google-cloud-cpp-installed/lib64/pkgconfig:${PKG_CONFIG_PATH:-}"
docker:demo-fedora$ pkg-config --validate google_cloud_cpp_pubsub_mocks
```

of course, `GTest` is not installed on that image, so I don't know what is being validated. /shrug

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10008)
<!-- Reviewable:end -->
