### PR TITLE
cleanup(GCS+gRPC): move to `storage_internal`

### DIFF
--- a/google/cloud/storage/internal/grpc_client.cc
+++ b/google/cloud/storage/internal/grpc_client.cc
@@ -510,7 +510,7 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
   // The default timer source is a no-op. It does not set a timer, and always
   // returns an indication that the timer expired.  The GrpcObjectReadSource
   // takes no action on expired timers.
-  GrpcObjectReadSource::TimerSource timer_source = [] {
+  storage_internal::GrpcObjectReadSource::TimerSource timer_source = [] {
     return make_ready_future(false);
   };
   auto const timeout = CurrentOptions().get<DownloadStallTimeoutOption>();
@@ -523,8 +523,8 @@ StatusOr<std::unique_ptr<ObjectReadSource>> GrpcClient::ReadObject(
   }
 
   return std::unique_ptr<ObjectReadSource>(
-      absl::make_unique<GrpcObjectReadSource>(std::move(timer_source),
-                                              std::move(stream)));
+      absl::make_unique<storage_internal::GrpcObjectReadSource>(
+          std::move(timer_source), std::move(stream)));
 }
 
 StatusOr<ListObjectsResponse> GrpcClient::ListObjects(

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::storage::testing::MockObjectMediaStream;
@@ -64,15 +63,16 @@ TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
   EXPECT_CALL(*mock_cq, MakeRelativeTimer).Times(0);
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
-      mock, Options{}
-                .set<DownloadStallTimeoutOption>(std::chrono::seconds(0))
-                .set<GrpcCompletionQueueOption>(cq));
+  auto client = storage::internal::GrpcClient::CreateMock(
+      mock,
+      Options{}
+          .set<storage::DownloadStallTimeoutOption>(std::chrono::seconds(0))
+          .set<GrpcCompletionQueueOption>(cq));
   // Normally the span is created by `storage::Client`, but we bypass that code
   // in this test.
   google::cloud::internal::OptionsSpan const span(client->options());
-  auto stream =
-      client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
+  auto stream = client->ReadObject(
+      storage::internal::ReadObjectRangeRequest("test-bucket", "test-object"));
   ASSERT_STATUS_OK(stream);
   ASSERT_THAT(stream->get(), NotNull());
   std::vector<char> unused(1024);
@@ -108,15 +108,15 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = GrpcClient::CreateMock(
+  auto client = storage::internal::GrpcClient::CreateMock(
       mock, Options{}
-                .set<DownloadStallTimeoutOption>(configured_timeout)
+                .set<storage::DownloadStallTimeoutOption>(configured_timeout)
                 .set<GrpcCompletionQueueOption>(cq));
   // Normally the span is created by `storage::Client`, but we bypass that code
   // in this test.
   google::cloud::internal::OptionsSpan const span(client->options());
-  auto stream =
-      client->ReadObject(ReadObjectRangeRequest("test-bucket", "test-object"));
+  auto stream = client->ReadObject(
+      storage::internal::ReadObjectRangeRequest("test-bucket", "test-object"));
   ASSERT_STATUS_OK(stream);
   ASSERT_THAT(stream->get(), NotNull());
   std::vector<char> unused(1024);
@@ -125,8 +125,7 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_object_read_source.h
+++ b/google/cloud/storage/internal/grpc_object_read_source.h
@@ -26,9 +26,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 /**
  * A data source for storage::ObjectReadStream using gRPC.
@@ -40,7 +39,7 @@ namespace internal {
  * storage::internal::ReadObjectStreambuf), read chunks from gRPC through this
  * class.
  */
-class GrpcObjectReadSource : public ObjectReadSource {
+class GrpcObjectReadSource : public storage::internal::ObjectReadSource {
  public:
   using StreamingRpc = ::google::cloud::internal::StreamingReadRpc<
       google::storage::v2::ReadObjectResponse>;
@@ -57,18 +56,19 @@ class GrpcObjectReadSource : public ObjectReadSource {
   bool IsOpen() const override { return static_cast<bool>(stream_); }
 
   /// Actively close a download, even if not all the data has been read.
-  StatusOr<HttpResponse> Close() override;
+  StatusOr<storage::internal::HttpResponse> Close() override;
 
   /// Read more data from the download, returning any HTTP headers and error
   /// codes.
-  StatusOr<ReadSourceResult> Read(char* buf, std::size_t n) override;
+  StatusOr<storage::internal::ReadSourceResult> Read(char* buf,
+                                                     std::size_t n) override;
 
  private:
   using BufferManager =
       absl::FunctionRef<std::pair<absl::string_view, std::size_t>(
           absl::string_view, std::size_t)>;
 
-  void HandleResponse(ReadSourceResult& result,
+  void HandleResponse(storage::internal::ReadSourceResult& result,
                       google::storage::v2::ReadObjectResponse response,
                       BufferManager buffer_manager);
 
@@ -85,9 +85,8 @@ class GrpcObjectReadSource : public ObjectReadSource {
   google::cloud::Status status_;
 };
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_object_read_source_test.cc
+++ b/google/cloud/storage/internal/grpc_object_read_source_test.cc
@@ -24,9 +24,8 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::StreamingRpcMetadata;
@@ -203,8 +202,8 @@ TEST(GrpcObjectReadSource, CaptureChecksums) {
   auto mock = absl::make_unique<MockObjectMediaStream>();
   std::string const expected_payload =
       "The quick brown fox jumps over the lazy dog";
-  auto const expected_md5 = ComputeMD5Hash(expected_payload);
-  auto const expected_crc32c = ComputeCrc32cChecksum(expected_payload);
+  auto const expected_md5 = storage::ComputeMD5Hash(expected_payload);
+  auto const expected_crc32c = storage::ComputeCrc32cChecksum(expected_payload);
 
   ::testing::InSequence sequence;
   EXPECT_CALL(*mock, Read)
@@ -371,8 +370,7 @@ TEST(GrpcObjectReadSource, StallTimeout) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google


### PR DESCRIPTION
Specifically `GrpcObjectReadSource`.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10011)
<!-- Reviewable:end -->
