### PR TITLE
cleanup(GCS+gRPC): move to `storage_internal`

### DIFF
--- a/google/cloud/storage/async_client.cc
+++ b/google/cloud/storage/async_client.cc
@@ -30,7 +30,7 @@ AsyncClient::AsyncClient(
     : background_(std::move(background)), connection_(std::move(connection)) {}
 
 AsyncClient MakeAsyncClient(Options opts) {
-  auto options = storage::internal::DefaultOptionsGrpc(std::move(opts));
+  auto options = storage_internal::DefaultOptionsGrpc(std::move(opts));
   auto background = MakeBackgroundThreadsFactory(options)();
   auto connection = storage_internal::MakeAsyncConnection(background->cq(),
                                                           std::move(options));

--- a/google/cloud/storage/grpc_plugin.cc
+++ b/google/cloud/storage/grpc_plugin.cc
@@ -30,10 +30,9 @@ google::cloud::storage::Client DefaultGrpcClient(Options opts) {
     return google::cloud::storage::Client(std::move(opts));
   }
   if (config == "metadata") {
-    opts =
-        google::cloud::storage::internal::DefaultOptionsGrpc(std::move(opts));
+    opts = google::cloud::storage_internal::DefaultOptionsGrpc(std::move(opts));
     return storage::internal::ClientImplDetails::CreateClient(
-        storage::internal::GrpcClient::Create(opts));
+        storage_internal::GrpcClient::Create(opts));
   }
   return storage::internal::ClientImplDetails::CreateClient(
       storage_internal::HybridClient::Create(opts));

--- a/google/cloud/storage/grpc_plugin_test.cc
+++ b/google/cloud/storage/grpc_plugin_test.cc
@@ -30,9 +30,9 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
 using ::google::cloud::storage::internal::ClientImplDetails;
-using ::google::cloud::storage::internal::GrpcClient;
 using ::google::cloud::storage::internal::RestClient;
 using ::google::cloud::storage::internal::RetryClient;
+using ::google::cloud::storage_internal::GrpcClient;
 using ::google::cloud::storage_internal::HybridClient;
 using ::google::cloud::testing_util::ScopedEnvironment;
 using ::testing::IsNull;

--- a/google/cloud/storage/internal/async_connection_impl.cc
+++ b/google/cloud/storage/internal/async_connection_impl.cc
@@ -122,7 +122,7 @@ future<StatusOr<std::string>> AsyncConnectionImpl::AsyncStartResumableWrite(
 
 std::shared_ptr<AsyncConnection> MakeAsyncConnection(CompletionQueue cq,
                                                      Options options) {
-  options = storage::internal::DefaultOptionsGrpc(std::move(options));
+  options = storage_internal::DefaultOptionsGrpc(std::move(options));
   auto stub = CreateStorageStub(cq, options);
   return MakeAsyncConnection(std::move(cq), std::move(stub),
                              std::move(options));

--- a/google/cloud/storage/internal/async_connection_impl_test.cc
+++ b/google/cloud/storage/internal/async_connection_impl_test.cc
@@ -52,9 +52,8 @@ auto constexpr kAuthority = "storage.googleapis.com";
 std::shared_ptr<AsyncConnection> MakeTestConnection(
     CompletionQueue cq, std::shared_ptr<storage::testing::MockStorageStub> mock,
     Options options = {}) {
-  return MakeAsyncConnection(
-      std::move(cq), std::move(mock),
-      storage::internal::DefaultOptionsGrpc(std::move(options)));
+  return MakeAsyncConnection(std::move(cq), std::move(mock),
+                             DefaultOptionsGrpc(std::move(options)));
 }
 
 TEST_F(AsyncConnectionImplTest, AsyncDeleteObject) {

--- a/google/cloud/storage/internal/grpc_client.h
+++ b/google/cloud/storage/internal/grpc_client.h
@@ -27,16 +27,9 @@
 
 namespace google {
 namespace cloud {
-
 namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 class StorageStub;
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage_internal
-
-namespace storage {
-GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 
 /**
  * The default options for gRPC.
@@ -45,7 +38,7 @@ namespace internal {
  */
 Options DefaultOptionsGrpc(Options = {});
 
-class GrpcClient : public RawClient,
+class GrpcClient : public storage::internal::RawClient,
                    public std::enable_shared_from_this<GrpcClient> {
  public:
   // Creates a new instance, assumes the options have all default values set.
@@ -67,117 +60,131 @@ class GrpcClient : public RawClient,
       google::storage::v2::WriteObjectRequest,
       google::storage::v2::WriteObjectResponse>;
 
-  ClientOptions const& client_options() const override;
+  storage::ClientOptions const& client_options() const override;
   Options options() const override;
 
-  StatusOr<ListBucketsResponse> ListBuckets(
-      ListBucketsRequest const& request) override;
-  StatusOr<BucketMetadata> CreateBucket(
-      CreateBucketRequest const& request) override;
-  StatusOr<BucketMetadata> GetBucketMetadata(
-      GetBucketMetadataRequest const& request) override;
-  StatusOr<EmptyResponse> DeleteBucket(DeleteBucketRequest const&) override;
-  StatusOr<BucketMetadata> UpdateBucket(
-      UpdateBucketRequest const& request) override;
-  StatusOr<BucketMetadata> PatchBucket(
-      PatchBucketRequest const& request) override;
-  StatusOr<NativeIamPolicy> GetNativeBucketIamPolicy(
-      GetBucketIamPolicyRequest const& request) override;
-  StatusOr<NativeIamPolicy> SetNativeBucketIamPolicy(
-      SetNativeBucketIamPolicyRequest const& request) override;
-  StatusOr<TestBucketIamPermissionsResponse> TestBucketIamPermissions(
-      TestBucketIamPermissionsRequest const& request) override;
-  StatusOr<BucketMetadata> LockBucketRetentionPolicy(
-      LockBucketRetentionPolicyRequest const& request) override;
+  StatusOr<storage::internal::ListBucketsResponse> ListBuckets(
+      storage::internal::ListBucketsRequest const& request) override;
+  StatusOr<storage::BucketMetadata> CreateBucket(
+      storage::internal::CreateBucketRequest const& request) override;
+  StatusOr<storage::BucketMetadata> GetBucketMetadata(
+      storage::internal::GetBucketMetadataRequest const& request) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteBucket(
+      storage::internal::DeleteBucketRequest const&) override;
+  StatusOr<storage::BucketMetadata> UpdateBucket(
+      storage::internal::UpdateBucketRequest const& request) override;
+  StatusOr<storage::BucketMetadata> PatchBucket(
+      storage::internal::PatchBucketRequest const& request) override;
+  StatusOr<storage::NativeIamPolicy> GetNativeBucketIamPolicy(
+      storage::internal::GetBucketIamPolicyRequest const& request) override;
+  StatusOr<storage::NativeIamPolicy> SetNativeBucketIamPolicy(
+      storage::internal::SetNativeBucketIamPolicyRequest const& request)
+      override;
+  StatusOr<storage::internal::TestBucketIamPermissionsResponse>
+  TestBucketIamPermissions(
+      storage::internal::TestBucketIamPermissionsRequest const& request)
+      override;
+  StatusOr<storage::BucketMetadata> LockBucketRetentionPolicy(
+      storage::internal::LockBucketRetentionPolicyRequest const& request)
+      override;
 
-  StatusOr<ObjectMetadata> InsertObjectMedia(
-      InsertObjectMediaRequest const& request) override;
-  StatusOr<ObjectMetadata> CopyObject(
-      CopyObjectRequest const& request) override;
-  StatusOr<ObjectMetadata> GetObjectMetadata(
-      GetObjectMetadataRequest const& request) override;
+  StatusOr<storage::ObjectMetadata> InsertObjectMedia(
+      storage::internal::InsertObjectMediaRequest const& request) override;
+  StatusOr<storage::ObjectMetadata> CopyObject(
+      storage::internal::CopyObjectRequest const& request) override;
+  StatusOr<storage::ObjectMetadata> GetObjectMetadata(
+      storage::internal::GetObjectMetadataRequest const& request) override;
 
-  StatusOr<std::unique_ptr<ObjectReadSource>> ReadObject(
-      ReadObjectRangeRequest const&) override;
+  StatusOr<std::unique_ptr<storage::internal::ObjectReadSource>> ReadObject(
+      storage::internal::ReadObjectRangeRequest const&) override;
 
-  StatusOr<ListObjectsResponse> ListObjects(ListObjectsRequest const&) override;
-  StatusOr<EmptyResponse> DeleteObject(DeleteObjectRequest const&) override;
-  StatusOr<ObjectMetadata> UpdateObject(
-      UpdateObjectRequest const& request) override;
-  StatusOr<ObjectMetadata> PatchObject(
-      PatchObjectRequest const& request) override;
-  StatusOr<ObjectMetadata> ComposeObject(
-      ComposeObjectRequest const& request) override;
-  StatusOr<RewriteObjectResponse> RewriteObject(
-      RewriteObjectRequest const&) override;
+  StatusOr<storage::internal::ListObjectsResponse> ListObjects(
+      storage::internal::ListObjectsRequest const&) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteObject(
+      storage::internal::DeleteObjectRequest const&) override;
+  StatusOr<storage::ObjectMetadata> UpdateObject(
+      storage::internal::UpdateObjectRequest const& request) override;
+  StatusOr<storage::ObjectMetadata> PatchObject(
+      storage::internal::PatchObjectRequest const& request) override;
+  StatusOr<storage::ObjectMetadata> ComposeObject(
+      storage::internal::ComposeObjectRequest const& request) override;
+  StatusOr<storage::internal::RewriteObjectResponse> RewriteObject(
+      storage::internal::RewriteObjectRequest const&) override;
 
-  StatusOr<CreateResumableUploadResponse> CreateResumableUpload(
-      ResumableUploadRequest const& request) override;
-  StatusOr<QueryResumableUploadResponse> QueryResumableUpload(
-      QueryResumableUploadRequest const& request) override;
-  StatusOr<EmptyResponse> DeleteResumableUpload(
-      DeleteResumableUploadRequest const& request) override;
-  StatusOr<QueryResumableUploadResponse> UploadChunk(
-      UploadChunkRequest const& request) override;
+  StatusOr<storage::internal::CreateResumableUploadResponse>
+  CreateResumableUpload(
+      storage::internal::ResumableUploadRequest const& request) override;
+  StatusOr<storage::internal::QueryResumableUploadResponse>
+  QueryResumableUpload(
+      storage::internal::QueryResumableUploadRequest const& request) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteResumableUpload(
+      storage::internal::DeleteResumableUploadRequest const& request) override;
+  StatusOr<storage::internal::QueryResumableUploadResponse> UploadChunk(
+      storage::internal::UploadChunkRequest const& request) override;
 
-  StatusOr<ListBucketAclResponse> ListBucketAcl(
-      ListBucketAclRequest const& request) override;
-  StatusOr<BucketAccessControl> CreateBucketAcl(
-      CreateBucketAclRequest const&) override;
-  StatusOr<EmptyResponse> DeleteBucketAcl(
-      DeleteBucketAclRequest const&) override;
-  StatusOr<BucketAccessControl> GetBucketAcl(
-      GetBucketAclRequest const&) override;
-  StatusOr<BucketAccessControl> UpdateBucketAcl(
-      UpdateBucketAclRequest const&) override;
-  StatusOr<BucketAccessControl> PatchBucketAcl(
-      PatchBucketAclRequest const&) override;
+  StatusOr<storage::internal::ListBucketAclResponse> ListBucketAcl(
+      storage::internal::ListBucketAclRequest const& request) override;
+  StatusOr<storage::BucketAccessControl> CreateBucketAcl(
+      storage::internal::CreateBucketAclRequest const&) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteBucketAcl(
+      storage::internal::DeleteBucketAclRequest const&) override;
+  StatusOr<storage::BucketAccessControl> GetBucketAcl(
+      storage::internal::GetBucketAclRequest const&) override;
+  StatusOr<storage::BucketAccessControl> UpdateBucketAcl(
+      storage::internal::UpdateBucketAclRequest const&) override;
+  StatusOr<storage::BucketAccessControl> PatchBucketAcl(
+      storage::internal::PatchBucketAclRequest const&) override;
 
-  StatusOr<ListObjectAclResponse> ListObjectAcl(
-      ListObjectAclRequest const& request) override;
-  StatusOr<ObjectAccessControl> CreateObjectAcl(
-      CreateObjectAclRequest const&) override;
-  StatusOr<EmptyResponse> DeleteObjectAcl(
-      DeleteObjectAclRequest const&) override;
-  StatusOr<ObjectAccessControl> GetObjectAcl(
-      GetObjectAclRequest const&) override;
-  StatusOr<ObjectAccessControl> UpdateObjectAcl(
-      UpdateObjectAclRequest const&) override;
-  StatusOr<ObjectAccessControl> PatchObjectAcl(
-      PatchObjectAclRequest const&) override;
+  StatusOr<storage::internal::ListObjectAclResponse> ListObjectAcl(
+      storage::internal::ListObjectAclRequest const& request) override;
+  StatusOr<storage::ObjectAccessControl> CreateObjectAcl(
+      storage::internal::CreateObjectAclRequest const&) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteObjectAcl(
+      storage::internal::DeleteObjectAclRequest const&) override;
+  StatusOr<storage::ObjectAccessControl> GetObjectAcl(
+      storage::internal::GetObjectAclRequest const&) override;
+  StatusOr<storage::ObjectAccessControl> UpdateObjectAcl(
+      storage::internal::UpdateObjectAclRequest const&) override;
+  StatusOr<storage::ObjectAccessControl> PatchObjectAcl(
+      storage::internal::PatchObjectAclRequest const&) override;
 
-  StatusOr<ListDefaultObjectAclResponse> ListDefaultObjectAcl(
-      ListDefaultObjectAclRequest const& request) override;
-  StatusOr<ObjectAccessControl> CreateDefaultObjectAcl(
-      CreateDefaultObjectAclRequest const&) override;
-  StatusOr<EmptyResponse> DeleteDefaultObjectAcl(
-      DeleteDefaultObjectAclRequest const&) override;
-  StatusOr<ObjectAccessControl> GetDefaultObjectAcl(
-      GetDefaultObjectAclRequest const&) override;
-  StatusOr<ObjectAccessControl> UpdateDefaultObjectAcl(
-      UpdateDefaultObjectAclRequest const&) override;
-  StatusOr<ObjectAccessControl> PatchDefaultObjectAcl(
-      PatchDefaultObjectAclRequest const&) override;
+  StatusOr<storage::internal::ListDefaultObjectAclResponse>
+  ListDefaultObjectAcl(
+      storage::internal::ListDefaultObjectAclRequest const& request) override;
+  StatusOr<storage::ObjectAccessControl> CreateDefaultObjectAcl(
+      storage::internal::CreateDefaultObjectAclRequest const&) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteDefaultObjectAcl(
+      storage::internal::DeleteDefaultObjectAclRequest const&) override;
+  StatusOr<storage::ObjectAccessControl> GetDefaultObjectAcl(
+      storage::internal::GetDefaultObjectAclRequest const&) override;
+  StatusOr<storage::ObjectAccessControl> UpdateDefaultObjectAcl(
+      storage::internal::UpdateDefaultObjectAclRequest const&) override;
+  StatusOr<storage::ObjectAccessControl> PatchDefaultObjectAcl(
+      storage::internal::PatchDefaultObjectAclRequest const&) override;
 
-  StatusOr<ServiceAccount> GetServiceAccount(
-      GetProjectServiceAccountRequest const&) override;
-  StatusOr<ListHmacKeysResponse> ListHmacKeys(
-      ListHmacKeysRequest const&) override;
-  StatusOr<CreateHmacKeyResponse> CreateHmacKey(
-      CreateHmacKeyRequest const&) override;
-  StatusOr<EmptyResponse> DeleteHmacKey(DeleteHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> GetHmacKey(GetHmacKeyRequest const&) override;
-  StatusOr<HmacKeyMetadata> UpdateHmacKey(UpdateHmacKeyRequest const&) override;
-  StatusOr<SignBlobResponse> SignBlob(SignBlobRequest const&) override;
+  StatusOr<storage::ServiceAccount> GetServiceAccount(
+      storage::internal::GetProjectServiceAccountRequest const&) override;
+  StatusOr<storage::internal::ListHmacKeysResponse> ListHmacKeys(
+      storage::internal::ListHmacKeysRequest const&) override;
+  StatusOr<storage::internal::CreateHmacKeyResponse> CreateHmacKey(
+      storage::internal::CreateHmacKeyRequest const&) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteHmacKey(
+      storage::internal::DeleteHmacKeyRequest const&) override;
+  StatusOr<storage::HmacKeyMetadata> GetHmacKey(
+      storage::internal::GetHmacKeyRequest const&) override;
+  StatusOr<storage::HmacKeyMetadata> UpdateHmacKey(
+      storage::internal::UpdateHmacKeyRequest const&) override;
+  StatusOr<storage::internal::SignBlobResponse> SignBlob(
+      storage::internal::SignBlobRequest const&) override;
 
-  StatusOr<ListNotificationsResponse> ListNotifications(
-      ListNotificationsRequest const&) override;
-  StatusOr<NotificationMetadata> CreateNotification(
-      CreateNotificationRequest const&) override;
-  StatusOr<NotificationMetadata> GetNotification(
-      GetNotificationRequest const&) override;
-  StatusOr<EmptyResponse> DeleteNotification(
-      DeleteNotificationRequest const&) override;
+  StatusOr<storage::internal::ListNotificationsResponse> ListNotifications(
+      storage::internal::ListNotificationsRequest const&) override;
+  StatusOr<storage::NotificationMetadata> CreateNotification(
+      storage::internal::CreateNotificationRequest const&) override;
+  StatusOr<storage::NotificationMetadata> GetNotification(
+      storage::internal::GetNotificationRequest const&) override;
+  StatusOr<storage::internal::EmptyResponse> DeleteNotification(
+      storage::internal::DeleteNotificationRequest const&) override;
 
  protected:
   explicit GrpcClient(Options opts);
@@ -188,13 +195,13 @@ class GrpcClient : public RawClient,
 
  private:
   StatusOr<google::storage::v2::Bucket> GetBucketMetadataImpl(
-      GetBucketMetadataRequest const& request);
+      storage::internal::GetBucketMetadataRequest const& request);
   StatusOr<google::storage::v2::Bucket> PatchBucketImpl(
-      PatchBucketRequest const& request);
+      storage::internal::PatchBucketRequest const& request);
   StatusOr<google::storage::v2::Object> GetObjectMetadataImpl(
-      GetObjectMetadataRequest const& request);
+      storage::internal::GetObjectMetadataRequest const& request);
   StatusOr<google::storage::v2::Object> PatchObjectImpl(
-      PatchObjectRequest const& request);
+      storage::internal::PatchObjectRequest const& request);
 
   using BucketAccessControlList = google::protobuf::RepeatedPtrField<
       google::storage::v2::BucketAccessControl>;
@@ -205,7 +212,8 @@ class GrpcClient : public RawClient,
   // lacks such RPCs. This function hijacks the retry loop to implement an OCC
   // loop to make such changes.
   StatusOr<google::storage::v2::Bucket> ModifyBucketAccessControl(
-      GetBucketMetadataRequest const& request, BucketAclUpdater const& updater);
+      storage::internal::GetBucketMetadataRequest const& request,
+      BucketAclUpdater const& updater);
 
   using ObjectAccessControlList = google::protobuf::RepeatedPtrField<
       google::storage::v2::ObjectAccessControl>;
@@ -216,7 +224,8 @@ class GrpcClient : public RawClient,
   // lacks such RPCs. This function hijacks the retry loop to implement an OCC
   // loop to make such changes.
   StatusOr<google::storage::v2::Object> ModifyObjectAccessControl(
-      GetObjectMetadataRequest const& request, ObjectAclUpdater const& updater);
+      storage::internal::GetObjectMetadataRequest const& request,
+      ObjectAclUpdater const& updater);
 
   using DefaultObjectAclUpdater =
       std::function<StatusOr<ObjectAccessControlList>(
@@ -226,19 +235,18 @@ class GrpcClient : public RawClient,
   // atomically. gRPC lacks such RPCs. This function hijacks the retry loop to
   // implement an OCC loop to make such changes.
   StatusOr<google::storage::v2::Bucket> ModifyDefaultAccessControl(
-      GetBucketMetadataRequest const& request,
+      storage::internal::GetBucketMetadataRequest const& request,
       DefaultObjectAclUpdater const& updater);
 
   Options options_;
-  ClientOptions backwards_compatibility_options_;
+  storage::ClientOptions backwards_compatibility_options_;
   std::unique_ptr<google::cloud::BackgroundThreads> background_;
   std::shared_ptr<storage_internal::StorageStub> stub_;
   std::shared_ptr<google::cloud::internal::MinimalIamCredentialsStub> iam_stub_;
 };
 
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google
 

--- a/google/cloud/storage/internal/grpc_client_failures_test.cc
+++ b/google/cloud/storage/internal/grpc_client_failures_test.cc
@@ -56,10 +56,11 @@ class GrpcClientFailuresTest
             .set<Oauth2CredentialsOption>(oauth2::CreateAnonymousCredentials())
             .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials());
     if (grpc_config == "metadata") {
-      client_ = GrpcClient::Create(DefaultOptionsGrpc(std::move(options)));
+      client_ = storage_internal::GrpcClient::Create(
+          storage_internal::DefaultOptionsGrpc(std::move(options)));
     } else {
       client_ = storage_internal::HybridClient::Create(
-          DefaultOptionsGrpc(std::move(options)));
+          storage_internal::DefaultOptionsGrpc(std::move(options)));
     }
   }
 

--- a/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
+++ b/google/cloud/storage/internal/grpc_client_insert_object_media_test.cc
@@ -25,11 +25,12 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
+using ::google::cloud::storage::TransferStallTimeoutOption;
+using ::google::cloud::storage::internal::InsertObjectMediaRequest;
 using ::google::cloud::storage::testing::MockInsertStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -164,8 +165,7 @@ TEST(GrpcClientInsertObjectMediaTest, StallTimeoutClose) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_client_read_object_test.cc
+++ b/google/cloud/storage/internal/grpc_client_read_object_test.cc
@@ -30,6 +30,7 @@ namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
+using ::google::cloud::storage::DownloadStallTimeoutOption;
 using ::google::cloud::storage::testing::MockObjectMediaStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::IsProtoEqual;
@@ -63,7 +64,7 @@ TEST(GrpcClientReadObjectTest, WithDefaultTimeout) {
   EXPECT_CALL(*mock_cq, MakeRelativeTimer).Times(0);
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = storage::internal::GrpcClient::CreateMock(
+  auto client = GrpcClient::CreateMock(
       mock,
       Options{}
           .set<storage::DownloadStallTimeoutOption>(std::chrono::seconds(0))
@@ -108,7 +109,7 @@ TEST(GrpcClientReadObjectTest, WithExplicitTimeout) {
           make_status_or(std::chrono::system_clock::now())))));
   auto cq = CompletionQueue(mock_cq);
 
-  auto client = storage::internal::GrpcClient::CreateMock(
+  auto client = GrpcClient::CreateMock(
       mock, Options{}
                 .set<storage::DownloadStallTimeoutOption>(configured_timeout)
                 .set<GrpcCompletionQueueOption>(cq));

--- a/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
+++ b/google/cloud/storage/internal/grpc_client_upload_chunk_test.cc
@@ -24,11 +24,13 @@
 
 namespace google {
 namespace cloud {
-namespace storage {
+namespace storage_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
+using ::google::cloud::storage::TransferStallTimeoutOption;
+using ::google::cloud::storage::internal::ConstBuffer;
+using ::google::cloud::storage::internal::UploadChunkRequest;
 using ::google::cloud::storage::testing::MockInsertStream;
 using ::google::cloud::storage::testing::MockStorageStub;
 using ::google::cloud::testing_util::MockCompletionQueueImpl;
@@ -152,8 +154,7 @@ TEST(GrpcClientUploadChunkTest, StallTimeoutClose) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
-}  // namespace storage
+}  // namespace storage_internal
 }  // namespace cloud
 }  // namespace google

--- a/google/cloud/storage/internal/grpc_object_request_parser_test.cc
+++ b/google/cloud/storage/internal/grpc_object_request_parser_test.cc
@@ -318,11 +318,10 @@ TEST(GrpcObjectRequestParser, ReadObjectRangeRequestReadLastZero) {
   auto const actual = ToProto(req).value();
   EXPECT_THAT(actual, IsProtoEqual(expected));
 
-  auto client = storage::internal::GrpcClient::Create(
-      storage::internal::DefaultOptionsGrpc(
-          Options{}
-              .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
-              .set<EndpointOption>("localhost:1")));
+  auto client = GrpcClient::Create(DefaultOptionsGrpc(
+      Options{}
+          .set<GrpcCredentialOption>(grpc::InsecureChannelCredentials())
+          .set<EndpointOption>("localhost:1")));
   StatusOr<std::unique_ptr<storage::internal::ObjectReadSource>> reader =
       client->ReadObject(req);
   EXPECT_THAT(reader, StatusIs(StatusCode::kOutOfRange));

--- a/google/cloud/storage/internal/hybrid_client.cc
+++ b/google/cloud/storage/internal/hybrid_client.cc
@@ -28,8 +28,7 @@ std::shared_ptr<storage::internal::RawClient> HybridClient::Create(
 }
 
 HybridClient::HybridClient(Options const& options)
-    : grpc_(storage::internal::GrpcClient::Create(
-          storage::internal::DefaultOptionsGrpc(options))),
+    : grpc_(GrpcClient::Create(DefaultOptionsGrpc(options))),
       rest_(storage::internal::RestClient::Create(
           storage::internal::DefaultOptionsWithCredentials(options))) {}
 


### PR DESCRIPTION
Specifically `GrpcClient`.

Part of the work for #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10015)
<!-- Reviewable:end -->
