### PR TITLE
cleanup: use recommended `benchmark::DoNotOptimize` overload

### DIFF
--- a/google/cloud/completion_queue_benchmark.cc
+++ b/google/cloud/completion_queue_benchmark.cc
@@ -89,7 +89,8 @@ void BM_Baseline(benchmark::State& state) {
   };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(runner(state.range(1)));
+    auto unused = runner(state.range(1));
+    benchmark::DoNotOptimize(unused);
   }
   state.SetComplexityN(state.range(1));
 }
@@ -115,7 +116,8 @@ void BM_CompletionQueueRunAsync(benchmark::State& state) {
   };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(runner(state.range(1)));
+    auto unused = runner(state.range(1));
+    benchmark::DoNotOptimize(unused);
   }
   state.SetComplexityN(state.range(1));
   cq.Shutdown();

--- a/google/cloud/options_benchmark.cc
+++ b/google/cloud/options_benchmark.cc
@@ -45,7 +45,8 @@ void BM_OptionsOneElementDefault(benchmark::State& state) {
   auto const opts = Options{}.set<StringOptionPresent>(
       "You will do foolish things, but do them with enthusiasm.");
   for (auto _ : state) {
-    benchmark::DoNotOptimize(opts.get<StringOptionDefault>());
+    auto unused = opts.get<StringOptionDefault>();
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_OptionsOneElementDefault);
@@ -54,7 +55,8 @@ void BM_OptionsOneElementPresent(benchmark::State& state) {
   auto const opts = Options{}.set<StringOptionPresent>(
       "You will do foolish things, but do them with enthusiasm.");
   for (auto _ : state) {
-    benchmark::DoNotOptimize(opts.get<StringOptionPresent>());
+    auto unused = opts.get<StringOptionPresent>();
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_OptionsOneElementPresent);

--- a/google/cloud/spanner/bytes_benchmark.cc
+++ b/google/cloud/spanner/bytes_benchmark.cc
@@ -65,7 +65,8 @@ std::string const kText = R"""(
 
 void BM_BytesCtor(benchmark::State& state) {
   for (auto _ : state) {
-    benchmark::DoNotOptimize(Bytes(kText));
+    auto unused = Bytes(kText);
+    benchmark::DoNotOptimize(unused);
   }
   state.SetBytesProcessed(state.iterations() * kText.size());
 }
@@ -74,7 +75,8 @@ BENCHMARK(BM_BytesCtor);
 void BM_BytesGet(benchmark::State& state) {
   Bytes b(kText);
   for (auto _ : state) {
-    benchmark::DoNotOptimize(b.get<std::string>());
+    auto unused = b.get<std::string>();
+    benchmark::DoNotOptimize(unused);
   }
   state.SetBytesProcessed(state.iterations() *
                           spanner_internal::BytesToBase64(b).size());

--- a/google/cloud/spanner/internal/merge_chunk_benchmark.cc
+++ b/google/cloud/spanner/internal/merge_chunk_benchmark.cc
@@ -75,7 +75,8 @@ void BM_MergeChunkStrings(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
+    auto unused = MergeChunk(value, std::move(chunk));
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_MergeChunkStrings);
@@ -86,7 +87,8 @@ void BM_MergeChunkListOfInts(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
+    auto unused = MergeChunk(value, std::move(chunk));
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_MergeChunkListOfInts);
@@ -97,7 +99,8 @@ void BM_MergeChunkListOfStrings(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
+    auto unused = MergeChunk(value, std::move(chunk));
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_MergeChunkListOfStrings);
@@ -110,7 +113,8 @@ void BM_MergeChunkListsOfListOfString(benchmark::State& state) {
   for (auto _ : state) {
     auto value = a;
     auto chunk = b;
-    benchmark::DoNotOptimize(MergeChunk(value, std::move(chunk)));
+    auto unused = MergeChunk(value, std::move(chunk));
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_MergeChunkListsOfListOfString);

--- a/google/cloud/spanner/numeric_benchmark.cc
+++ b/google/cloud/spanner/numeric_benchmark.cc
@@ -47,7 +47,8 @@ namespace {
 void BM_NumericFromStringCanonical(benchmark::State& state) {
   std::string s = "99999999999999999999999999999.999999999";
   for (auto _ : state) {
-    benchmark::DoNotOptimize(MakeNumeric(s));
+    auto unused = MakeNumeric(s);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericFromStringCanonical);
@@ -55,7 +56,8 @@ BENCHMARK(BM_NumericFromStringCanonical);
 void BM_NumericFromString(benchmark::State& state) {
   std::string s = "+9999999999999999999999999999.9999999999e1";
   for (auto _ : state) {
-    benchmark::DoNotOptimize(MakeNumeric(s));
+    auto unused = MakeNumeric(s);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericFromString);
@@ -63,7 +65,8 @@ BENCHMARK(BM_NumericFromString);
 void BM_NumericFromDouble(benchmark::State& state) {
   double d = 9.999999999999999e+28;
   for (auto _ : state) {
-    benchmark::DoNotOptimize(MakeNumeric(d));
+    auto unused = MakeNumeric(d);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericFromDouble);
@@ -71,7 +74,8 @@ BENCHMARK(BM_NumericFromDouble);
 void BM_NumericFromUnsigned(benchmark::State& state) {
   auto u = std::numeric_limits<std::uint64_t>::max();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(MakeNumeric(u));
+    auto unused = MakeNumeric(u);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericFromUnsigned);
@@ -79,7 +83,8 @@ BENCHMARK(BM_NumericFromUnsigned);
 void BM_NumericFromInteger(benchmark::State& state) {
   auto i = std::numeric_limits<std::int64_t>::min();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(MakeNumeric(i));
+    auto unused = MakeNumeric(i);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericFromInteger);
@@ -88,7 +93,8 @@ void BM_NumericToString(benchmark::State& state) {
   std::string s = "99999999999999999999999999999.999999999";
   Numeric n = MakeNumeric(s).value();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(n.ToString());
+    auto unused = n.ToString();
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericToString);
@@ -97,7 +103,8 @@ void BM_NumericToDouble(benchmark::State& state) {
   double d = 9.999999999999999e+28;
   Numeric n = MakeNumeric(d).value();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(ToDouble(n));
+    auto unused = ToDouble(n);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericToDouble);
@@ -106,7 +113,8 @@ void BM_NumericToUnsigned(benchmark::State& state) {
   auto u = std::numeric_limits<std::uint64_t>::max();
   Numeric n = MakeNumeric(u).value();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(ToInteger<std::uint64_t>(n));
+    auto unused = ToInteger<std::uint64_t>(n);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericToUnsigned);
@@ -115,7 +123,8 @@ void BM_NumericToInteger(benchmark::State& state) {
   auto i = std::numeric_limits<std::int64_t>::min();
   Numeric n = MakeNumeric(i).value();
   for (auto _ : state) {
-    benchmark::DoNotOptimize(ToInteger<std::int64_t>(n));
+    auto unused = ToInteger<std::int64_t>(n);
+    benchmark::DoNotOptimize(unused);
   }
 }
 BENCHMARK(BM_NumericToInteger);

--- a/google/cloud/spanner/row_benchmark.cc
+++ b/google/cloud/spanner/row_benchmark.cc
@@ -38,9 +38,12 @@ namespace {
 void BM_RowGetByPosition(benchmark::State& state) {
   Row row = spanner_mocks::MakeRow(1, "blah", true);
   for (auto _ : state) {
-    benchmark::DoNotOptimize(row.get(0));
-    benchmark::DoNotOptimize(row.get(1));
-    benchmark::DoNotOptimize(row.get(2));
+    auto unused_0 = row.get(0);
+    benchmark::DoNotOptimize(unused_0);
+    auto unused_1 = row.get(1);
+    benchmark::DoNotOptimize(unused_1);
+    auto unused_2 = row.get(2);
+    benchmark::DoNotOptimize(unused_2);
   }
 }
 BENCHMARK(BM_RowGetByPosition);
@@ -52,9 +55,12 @@ void BM_RowGetByColumnName(benchmark::State& state) {
       {"c", Value(true)}     //
   });
   for (auto _ : state) {
-    benchmark::DoNotOptimize(row.get("a"));
-    benchmark::DoNotOptimize(row.get("b"));
-    benchmark::DoNotOptimize(row.get("c"));
+    auto unused_a = row.get("a");
+    benchmark::DoNotOptimize(unused_a);
+    auto unused_b = row.get("b");
+    benchmark::DoNotOptimize(unused_b);
+    auto unused_c = row.get("c");
+    benchmark::DoNotOptimize(unused_c);
   }
 }
 BENCHMARK(BM_RowGetByColumnName);

--- a/google/cloud/storage/internal/generate_message_boundary_benchmark.cc
+++ b/google/cloud/storage/internal/generate_message_boundary_benchmark.cc
@@ -87,7 +87,8 @@ BENCHMARK_F(GenerateBoundaryFixture, GenerateBoundary)
   auto make_string = [this]() { return GenerateCandidate(); };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(make_string());
+    auto unused = make_string();
+    benchmark::DoNotOptimize(unused);
   }
 }
 
@@ -96,7 +97,8 @@ BENCHMARK_F(GenerateBoundaryFixture, GenerateBoundaryWithValidation)
   auto make_string = [this]() { return GenerateCandidate(); };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(GenerateMessageBoundary(message(), make_string));
+    auto unused = GenerateMessageBoundary(message(), make_string);
+    benchmark::DoNotOptimize(unused);
   }
 }
 
@@ -112,7 +114,8 @@ BENCHMARK_F(GenerateBoundaryFixture, GenerateBoundaryOld)
   };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(old(message()));
+    auto unused = old(message());
+    benchmark::DoNotOptimize(unused);
   }
 }
 
@@ -124,7 +127,8 @@ BENCHMARK_F(GenerateBoundaryFixture, WorstCase)
   };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(test(message()));
+    auto unused = test(message());
+    benchmark::DoNotOptimize(unused);
   }
 }
 
@@ -139,7 +143,8 @@ BENCHMARK_F(GenerateBoundaryFixture, BestCase)
   };
 
   for (auto _ : state) {
-    benchmark::DoNotOptimize(test(message()));
+    auto unused = test(message());
+    benchmark::DoNotOptimize(unused);
   }
 }
 


### PR DESCRIPTION
There are `T const&` and `T&` overloads of `benchmark::DoNotOptimize()`. It seems the `T const&` does not work with some compilers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10018)
<!-- Reviewable:end -->
