### PR TITLE
test(storage): make one test more hermetic

### DIFF
--- a/google/cloud/storage/tests/create_client_integration_test.cc
+++ b/google/cloud/storage/tests/create_client_integration_test.cc
@@ -71,10 +71,14 @@ TEST_F(CreateClientIntegrationTest, DefaultWorks) {
 }
 
 TEST_F(CreateClientIntegrationTest, SettingPolicies) {
-  auto credentials = oauth2::GoogleDefaultCredentials();
-  ASSERT_THAT(credentials, IsOk());
+  auto credentials = oauth2::CreateAnonymousCredentials();
+  if (!UsingEmulator()) {
+    auto c = oauth2::GoogleDefaultCredentials();
+    ASSERT_THAT(c, IsOk());
+    credentials = *std::move(c);
+  }
   auto client =
-      Client(ClientOptions(*credentials),
+      Client(ClientOptions(std::move(credentials)),
              LimitedErrorCountRetryPolicy(/*maximum_failures=*/5),
              ExponentialBackoffPolicy(/*initial_delay=*/std::chrono::seconds(1),
                                       /*maximum_delay=*/std::chrono::minutes(5),


### PR DESCRIPTION
Even though `create_client_integration_test.cc` is an integration test, there is no reason to use the default credentials with the emulator. The default credentials typically try to use the GCE metadata service, which may not exist in some CI environments. Or may take a long time to fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10019)
<!-- Reviewable:end -->
