### PR TITLE
test(spanner): only use alpha-numerics in random name suffixes

### DIFF
--- a/google/cloud/spanner/testing/random_backup_name.cc
+++ b/google/cloud/spanner/testing/random_backup_name.cc
@@ -21,15 +21,14 @@ GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
 std::string RandomBackupName(google::cloud::internal::DefaultPRNG& generator) {
   // A backup ID must be between 2 and 60 characters, fitting the regular
-  // expression `[a-z][a-z0-9_]*[a-z0-9]`
+  // expression `[a-z][a-z0-9_]*[a-z0-9]`. We omit underscores from the
+  // generated suffix to aid readability.
   std::size_t const max_size = 60;
   std::string const prefix = "backup-";
-  auto size = static_cast<int>(max_size - 1 - prefix.size());
+  auto const suffix_size = static_cast<int>(max_size - prefix.size());
   return prefix +
          google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789_") +
-         google::cloud::internal::Sample(
-             generator, 1, "abcdefghijlkmnopqrstuvwxyz0123456789");
+             generator, suffix_size, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/testing/random_database_name.cc
+++ b/google/cloud/spanner/testing/random_database_name.cc
@@ -31,15 +31,14 @@ std::string RandomDatabasePrefix(std::chrono::system_clock::time_point tp) {
 std::string RandomDatabaseName(google::cloud::internal::DefaultPRNG& generator,
                                std::chrono::system_clock::time_point tp) {
   // A database ID must be between 2 and 30 characters, fitting the regular
-  // expression `[a-z][a-z0-9_-]*[a-z0-9]`
+  // expression `[a-z][a-z0-9_-]*[a-z0-9]`. We omit underscores and hyphens
+  // from the generated suffix to aid readability.
   std::size_t const max_size = 30;
   auto const prefix = RandomDatabasePrefix(tp);
-  auto size = static_cast<int>(max_size - 1 - prefix.size());
+  auto const suffix_size = static_cast<int>(max_size - prefix.size());
   return prefix +
          google::cloud::internal::Sample(
-             generator, size, "abcdefghijlkmnopqrstuvwxyz0123456789_-") +
-         google::cloud::internal::Sample(
-             generator, 1, "abcdefghijlkmnopqrstuvwxyz0123456789");
+             generator, suffix_size, "abcdefghijlkmnopqrstuvwxyz0123456789");
 }
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END

--- a/google/cloud/spanner/testing/random_instance_name.cc
+++ b/google/cloud/spanner/testing/random_instance_name.cc
@@ -29,18 +29,17 @@ std::string RandomId(std::string prefix, std::size_t max_size,
   prefix.push_back('-');
   prefix.append(internal::FormatUtcDate(now));
   prefix.push_back('-');
-  auto size = static_cast<int>(max_size - 1 - prefix.size());
-  return prefix +
-         internal::Sample(generator, size,
-                          "abcdefghijlkmnopqrstuvwxyz0123456789-") +
-         internal::Sample(generator, 1, "abcdefghijlkmnopqrstuvwxyz");
+  auto const suffix_size = static_cast<int>(max_size - prefix.size());
+  return prefix + internal::Sample(generator, suffix_size,
+                                   "abcdefghijlkmnopqrstuvwxyz0123456789");
 }
 
 }  // namespace
 
 std::string RandomInstanceName(internal::DefaultPRNG& generator) {
   // An instance ID must be between 2 and 64 characters, matching the
-  // regular expression `[a-z][-a-z0-9]*[a-z0-9]`.
+  // regular expression `[a-z][-a-z0-9]*[a-z0-9]`.  We omit hyphens from
+  // the generated suffix to aid readability.
   return RandomId("temporary-instance", 64, generator);
 }
 
@@ -48,6 +47,7 @@ std::string RandomInstanceConfigName(internal::DefaultPRNG& generator) {
   // An instance-config ID must be between 2 and 64 characters, matching the
   // regular expression `custom-[-a-z0-9]*[a-z0-9]`. The `custom-` prefix
   // is required to avoid name conflicts with Google-managed configurations.
+  // We omit hyphens from the generated suffix to aid readability.
   return RandomId("custom-temporary-config", 64, generator);
 }
 


### PR DESCRIPTION
While it is allowable to use hyphens and/or underscores in the suffixes we generate for random database, backup, and instance{,config} names, they just make the prefixes less discernible at a glance.  So, omit them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10020)
<!-- Reviewable:end -->
