### PR TITLE
cleanup(GCS+gRPC): keep library sources sorted

### DIFF
--- a/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
+++ b/google/cloud/storage/google_cloud_cpp_storage_grpc.cmake
@@ -25,7 +25,7 @@ if (NOT GOOGLE_CLOUD_CPP_STORAGE_ENABLE_GRPC)
         PROPERTIES EXPORT_NAME "google-cloud-cpp::experimental-storage-grpc")
 else ()
     add_library(
-        google_cloud_cpp_storage_grpc
+        google_cloud_cpp_storage_grpc # cmake-format: sort
         async_client.cc
         async_client.h
         async_object_responses.h


### PR DESCRIPTION
They were sorted already, so this is probably redundant. At least, it makes the CMake file consistent with other similar files and minimizes confusion.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10025)
<!-- Reviewable:end -->
