### PR TITLE
cleanup(GCS+gRPC): move out of `storage::internal`

### DIFF
--- a/google/cloud/storage/tests/grpc_bucket_acl_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_acl_integration_test.cc
@@ -25,7 +25,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -146,7 +145,6 @@ TEST_F(GrpcBucketAclIntegrationTest, AclCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_bucket_metadata_integration_test.cc
@@ -25,7 +25,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -138,7 +137,6 @@ TEST_F(GrpcBucketMetadataIntegrationTest, ObjectMetadataCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_default_object_acl_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_default_object_acl_integration_test.cc
@@ -25,7 +25,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -150,7 +149,6 @@ TEST_F(GrpcDefaultObjectAclIntegrationTest, AclCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_hmac_key_integration_test.cc
@@ -22,7 +22,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -100,7 +99,6 @@ TEST_F(GrpcHmacKeyMetadataIntegrationTest, HmacKeyCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_integration_test.cc
@@ -26,7 +26,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -248,7 +247,6 @@ INSTANTIATE_TEST_SUITE_P(GrpcIntegrationMediaTest, GrpcIntegrationTest,
 #endif  // GOOGLE_CLOUD_CPP_STORAGE_HAVE_GRPC
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_notification_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_notification_integration_test.cc
@@ -22,7 +22,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -89,7 +88,6 @@ TEST_F(GrpcNotificationIntegrationTest, NotificationCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_object_acl_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_acl_integration_test.cc
@@ -25,7 +25,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -154,7 +153,6 @@ TEST_F(GrpcObjectAclIntegrationTest, AclCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_object_media_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_media_integration_test.cc
@@ -24,7 +24,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -64,7 +63,6 @@ TEST_F(GrpcObjectMediaIntegrationTest, CancelResumableUpload) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_object_metadata_integration_test.cc
@@ -24,7 +24,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -118,7 +117,6 @@ TEST_F(GrpcObjectMetadataIntegrationTest, ObjectMetadataCRUD) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud

--- a/google/cloud/storage/tests/grpc_service_account_integration_test.cc
+++ b/google/cloud/storage/tests/grpc_service_account_integration_test.cc
@@ -23,7 +23,6 @@ namespace google {
 namespace cloud {
 namespace storage {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace internal {
 namespace {
 
 using ::google::cloud::internal::GetEnv;
@@ -49,7 +48,6 @@ TEST_F(GrpcServiceAccountIntegrationTest, GetServiceAccount) {
 }
 
 }  // namespace
-}  // namespace internal
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace storage
 }  // namespace cloud


### PR DESCRIPTION
The integration tests do not need to be in the `storage::internal` namespace.

Fixes #8929

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10026)
<!-- Reviewable:end -->
