### PR TITLE
cleanup(storage): clang tidy optimization nits

### DIFF
--- a/google/cloud/storage/internal/policy_document_request.cc
+++ b/google/cloud/storage/internal/policy_document_request.cc
@@ -221,9 +221,11 @@ std::string PolicyDocumentV4Request::Credentials() const {
 std::vector<PolicyDocumentCondition> PolicyDocumentV4Request::GetAllConditions()
     const {
   std::vector<PolicyDocumentCondition> conditions;
-  for (auto const& field : extension_fields_) {
-    conditions.push_back(PolicyDocumentCondition({field.first, field.second}));
-  }
+  conditions.reserve(extension_fields_.size());
+  std::transform(extension_fields_.begin(), extension_fields_.end(),
+                 std::back_inserter(conditions), [](auto const& f) {
+                   return PolicyDocumentCondition({f.first, f.second});
+                 });
   std::sort(conditions.begin(), conditions.end());
   auto const& document = policy_document();
   std::copy(document.conditions.begin(), document.conditions.end(),


### PR DESCRIPTION
`clang-tidy` wants us to pre-allocate vectors before a loop full of `push_back()` or `emplace_back()`.  I agree, and I think we should express these things as `std::transform()` calls.