### PR TITLE
cleanup(spanner): fix future clang-tidy warnings

### DIFF
--- a/google/cloud/spanner/numeric.cc
+++ b/google/cloud/spanner/numeric.cc
@@ -141,7 +141,7 @@ StatusOr<std::string> MakeDecimalRep(std::string s, bool const has_nan,
   char const* e = p + s.size();
 
   // Consume any sign part.
-  auto sign_part = absl::string_view(p, 0);
+  auto sign_part = absl::string_view{};
   if (p != e && (*p == '+' || *p == '-')) {
     sign_part = absl::string_view(p++, 1);
   }
@@ -152,7 +152,7 @@ StatusOr<std::string> MakeDecimalRep(std::string s, bool const has_nan,
   auto int_part = absl::string_view(ip, p - ip);
 
   // Consume any fractional part.
-  auto frac_part = absl::string_view(p, 0);
+  auto frac_part = absl::string_view{};
   if (p != e && *p == '.') {
     char const* fp = p++;
     for (; p != e && IsDigit(*p); ++p) continue;


### PR DESCRIPTION
`clang-tidy` says that `std::string(ptr, 0)` is bug prone. Same thing for `std::string_view` and `absl::string_view`.  We could silence the warning with `NOLINT`, but I think a default constructor captures the intent better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10029)
<!-- Reviewable:end -->
