### PR TITLE
fix(rest): add response error payload to Status message

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -655,7 +655,8 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
   if (curl_closed_) {
     OnTransferDone();
     status = google::cloud::rest_internal::AsStatus(
-        static_cast<HttpStatusCode>(http_code_), {});
+        static_cast<HttpStatusCode>(http_code_),
+        std::string(spill_.data(), spill_offset_));
     TRACE_STATE() << ", status=" << status << ", http code=" << http_code_
                   << "\n";
 

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -106,7 +106,7 @@ class CurlImpl {
 
   // Cleanup the CURL handles, leaving them ready for reuse.
   void CleanupHandles();
-  // Copy any available data from the spill buffer to `buffer_`
+  // Copy any available data from the spill buffer to `remaining_buffer_`
   std::size_t DrainSpillBuffer();
   // Use libcurl to perform at least part of the request.
   StatusOr<int> PerformWork();
@@ -161,8 +161,10 @@ class CurlImpl {
   // Track when status and headers from the response are received.
   bool all_headers_received_ = false;
 
-  // Track the usage of the buffer provided to Read.
-  absl::Span<char> buffer_;
+  // Track the usage of the output Span provided to Read. As bytes are read from
+  // the connection to the user provided buffer, this variable is overwritten to
+  // represent the remaining space in the user provided buffer.
+  absl::Span<char> remaining_buffer_;
 
   // libcurl(1) will never pass a block larger than CURL_MAX_WRITE_SIZE to
   // `WriteCallback()`:

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -312,7 +312,8 @@ TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
       AnyOf(Eq(StatusCode::kFailedPrecondition), Eq(StatusCode::kAborted)))
       << " status=" << os.metadata().status();
 
-  if (UsingEmulator() && os.metadata().status().code() == StatusCode::kFailedPrecondition) {
+  if (UsingEmulator() &&
+      os.metadata().status().code() == StatusCode::kFailedPrecondition) {
     auto constexpr kErrorMessage =
         R"""(Permanent error UploadChunk: {"error":{"code":412,"message":"{\"error\": {\"errors\": [{\"domain\": \"global\", \"message\": \"ifGenerationMatch validation failed. Expected = 0 vs Actual =)""";
     EXPECT_THAT(os.metadata().status().message(), HasSubstr(kErrorMessage));

--- a/google/cloud/storage/tests/object_resumable_write_integration_test.cc
+++ b/google/cloud/storage/tests/object_resumable_write_integration_test.cc
@@ -324,9 +324,11 @@ TEST_F(ObjectResumableWriteIntegrationTest, StreamingWriteFailure) {
     auto constexpr kProdErrorMessage =
         R"""(Permanent error UploadChunk: At least one of the pre-conditions you specified did not hold.)""";
     EXPECT_THAT(os.metadata().status().message(), HasSubstr(kProdErrorMessage));
-    EXPECT_THAT(os.metadata().status().error_info().domain(), Eq("global"));
-    EXPECT_THAT(os.metadata().status().error_info().reason(),
-                Eq("conditionNotMet"));
+    if (!UsingGrpc()) {
+      EXPECT_THAT(os.metadata().status().error_info().domain(), Eq("global"));
+      EXPECT_THAT(os.metadata().status().error_info().reason(),
+                  Eq("conditionNotMet"));
+    }
   }
 
   auto status = client->DeleteObject(bucket_name_, object_name);


### PR DESCRIPTION
The response payload was read into the spill buffer, but was not being included in creation of the Status value.

Using `testing_util::ScopedEnvironment env("GOOGLE_CLOUD_CPP_STORAGE_USE_LEGACY_HTTP", "yes");` on the StreamingWriteFailure test, I modified the checks in the tests to verify the error message the legacy implementation provided. The current implementation with the Rest Library now satisfies those same additional checks.

fixes #9947

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10046)
<!-- Reviewable:end -->
