### PR TITLE
impl(pubsub): add `Publish()` to stub and decorators

### DIFF
--- a/google/cloud/pubsub/internal/publisher_auth.cc
+++ b/google/cloud/pubsub/internal/publisher_auth.cc
@@ -104,6 +104,14 @@ PublisherAuth::AsyncPublish(google::cloud::CompletionQueue& cq,
       });
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherAuth::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  auto status = auth_->ConfigureContext(context);
+  if (!status.ok()) return status;
+  return child_->Publish(context, request);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/publisher_auth.h
+++ b/google/cloud/pubsub/internal/publisher_auth.h
@@ -71,6 +71,10 @@ class PublisherAuth : public PublisherStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::PublishRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
  private:
   std::shared_ptr<google::cloud::internal::GrpcAuthenticationStrategy> auth_;
   std::shared_ptr<PublisherStub> child_;

--- a/google/cloud/pubsub/internal/publisher_logging.cc
+++ b/google/cloud/pubsub/internal/publisher_logging.cc
@@ -126,6 +126,17 @@ PublisherLogging::AsyncPublish(
       cq, std::move(context), request, __func__, tracing_options_);
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherLogging::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  return LogWrapper(
+      [this](grpc::ClientContext& context,
+             google::pubsub::v1::PublishRequest const& request) {
+        return child_->Publish(context, request);
+      },
+      context, request, __func__, tracing_options_);
+}
+
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal
 }  // namespace cloud

--- a/google/cloud/pubsub/internal/publisher_logging.h
+++ b/google/cloud/pubsub/internal/publisher_logging.h
@@ -71,6 +71,10 @@ class PublisherLogging : public PublisherStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::PublishRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
  private:
   std::shared_ptr<PublisherStub> child_;
   TracingOptions tracing_options_;

--- a/google/cloud/pubsub/internal/publisher_logging_test.cc
+++ b/google/cloud/pubsub/internal/publisher_logging_test.cc
@@ -178,6 +178,21 @@ TEST_F(PublisherLoggingTest, AsyncPublish) {
       Contains(AllOf(HasSubstr("AsyncPublish"), HasSubstr("test-topic-name"))));
 }
 
+TEST_F(PublisherLoggingTest, Publish) {
+  auto mock = std::make_shared<pubsub_testing::MockPublisherStub>();
+  EXPECT_CALL(*mock, Publish)
+      .WillOnce(Return(make_status_or(google::pubsub::v1::PublishResponse{})));
+  PublisherLogging stub(mock, TracingOptions{}.SetOptions("single_line_mode"));
+  grpc::ClientContext context;
+  google::pubsub::v1::PublishRequest request;
+  request.set_topic("test-topic-name");
+  auto status = stub.Publish(context, request);
+  EXPECT_STATUS_OK(status);
+  EXPECT_THAT(
+      log_.ExtractLines(),
+      Contains(AllOf(HasSubstr("Publish"), HasSubstr("test-topic-name"))));
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/publisher_metadata.cc
+++ b/google/cloud/pubsub/internal/publisher_metadata.cc
@@ -91,6 +91,13 @@ PublisherMetadata::AsyncPublish(
   return child_->AsyncPublish(cq, std::move(context), request);
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherMetadata::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  SetMetadata(context, "topic=" + request.topic());
+  return child_->Publish(context, request);
+}
+
 void PublisherMetadata::SetMetadata(grpc::ClientContext& context,
                                     std::string const& request_params) {
   context.AddMetadata("x-goog-request-params", request_params);

--- a/google/cloud/pubsub/internal/publisher_metadata.h
+++ b/google/cloud/pubsub/internal/publisher_metadata.h
@@ -69,6 +69,10 @@ class PublisherMetadata : public PublisherStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::PublishRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
  private:
   void SetMetadata(grpc::ClientContext& context,
                    std::string const& request_params);

--- a/google/cloud/pubsub/internal/publisher_round_robin.cc
+++ b/google/cloud/pubsub/internal/publisher_round_robin.cc
@@ -78,6 +78,12 @@ PublisherRoundRobin::AsyncPublish(
   return Child()->AsyncPublish(cq, std::move(context), request);
 }
 
+StatusOr<google::pubsub::v1::PublishResponse> PublisherRoundRobin::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  return Child()->Publish(context, request);
+}
+
 std::shared_ptr<PublisherStub> PublisherRoundRobin::Child() {
   std::lock_guard<std::mutex> lk(mu_);
   auto child = children_[current_];

--- a/google/cloud/pubsub/internal/publisher_round_robin.h
+++ b/google/cloud/pubsub/internal/publisher_round_robin.h
@@ -71,6 +71,10 @@ class PublisherRoundRobin : public PublisherStub {
       std::unique_ptr<grpc::ClientContext> context,
       google::pubsub::v1::PublishRequest const& request) override;
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
  private:
   std::shared_ptr<PublisherStub> Child();
 

--- a/google/cloud/pubsub/internal/publisher_round_robin_test.cc
+++ b/google/cloud/pubsub/internal/publisher_round_robin_test.cc
@@ -227,6 +227,26 @@ TEST(PublisherRoundRobinTest, AsyncPublish) {
   }
 }
 
+TEST(PublisherRoundRobinTest, Publish) {
+  auto mocks = MakeMocks();
+  InSequence sequence;
+  for (int i = 0; i != kRepeats; ++i) {
+    for (auto& m : mocks) {
+      EXPECT_CALL(*m, Publish)
+          .WillOnce(
+              Return(make_status_or(google::pubsub::v1::PublishResponse{})));
+    }
+  }
+  PublisherRoundRobin stub(AsPlainStubs(mocks));
+  for (size_t i = 0; i != kRepeats * mocks.size(); ++i) {
+    grpc::ClientContext context;
+    google::pubsub::v1::PublishRequest request;
+    request.set_topic("test-topic-name");
+    auto status = stub.Publish(context, request);
+    EXPECT_STATUS_OK(status);
+  }
+}
+
 }  // namespace
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace pubsub_internal

--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -119,6 +119,15 @@ class DefaultPublisherStub : public PublisherStub {
         request, std::move(context));
   }
 
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& context,
+      google::pubsub::v1::PublishRequest const& request) override {
+    google::pubsub::v1::PublishResponse response;
+    auto status = grpc_stub_->Publish(&context, request, &response);
+    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+    return response;
+  }
+
  private:
   std::unique_ptr<google::pubsub::v1::Publisher::StubInterface> grpc_stub_;
 };

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -88,6 +88,11 @@ class PublisherStub {
       google::cloud::CompletionQueue& cq,
       std::unique_ptr<grpc::ClientContext> client_context,
       google::pubsub::v1::PublishRequest const& request) = 0;
+
+  /// Publish a batch of messages.
+  virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::PublishRequest const& request) = 0;
 };
 
 /**

--- a/google/cloud/pubsub/testing/mock_publisher_stub.h
+++ b/google/cloud/pubsub/testing/mock_publisher_stub.h
@@ -79,6 +79,10 @@ class MockPublisherStub : public pubsub_internal::PublisherStub {
                std::unique_ptr<grpc::ClientContext>,
                google::pubsub::v1::PublishRequest const&),
               (override));
+
+  MOCK_METHOD(StatusOr<google::pubsub::v1::PublishResponse>, Publish,
+              (grpc::ClientContext&, google::pubsub::v1::PublishRequest const&),
+              (override));
 };
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END


### PR DESCRIPTION
This is the blocking version of `AsyncPublish()`, I will use it to implement a simpler API for applications that do not need high-performance publishers.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10047)
<!-- Reviewable:end -->
