### PR TITLE
fix(rest): return complete payloads for errors

### DIFF
--- a/google/cloud/internal/curl_impl.cc
+++ b/google/cloud/internal/curl_impl.cc
@@ -181,7 +181,6 @@ void CurlImpl::ApplyOptions(Options const& options) {
   transfer_stall_minimum_rate_ = options.get<TransferStallMinimumRateOption>();
   download_stall_timeout_ = options.get<DownloadStallTimeoutOption>();
   transfer_stall_minimum_rate_ = options.get<DownloadStallMinimumRateOption>();
-  ignored_http_error_codes_ = options.get<IgnoredHttpErrorCodes>();
 }
 
 CurlImpl::CurlImpl(CurlHandle handle,
@@ -654,16 +653,7 @@ StatusOr<std::size_t> CurlImpl::ReadImpl(absl::Span<char> output) {
 
   if (curl_closed_) {
     OnTransferDone();
-    status = google::cloud::rest_internal::AsStatus(
-        static_cast<HttpStatusCode>(http_code_), {});
-    TRACE_STATE() << ", status=" << status << ", http code=" << http_code_
-                  << "\n";
-
-    if (status.ok() ||
-        internal::Contains(ignored_http_error_codes_, http_code_)) {
-      return bytes_read;
-    }
-    return status;
+    return bytes_read;
   }
   TRACE_STATE() << ", http code=" << http_code_ << "\n";
   received_headers_.emplace(":curl-peer", handle_.GetPeer());

--- a/google/cloud/internal/curl_impl.h
+++ b/google/cloud/internal/curl_impl.h
@@ -132,7 +132,6 @@ class CurlImpl {
   std::uint32_t download_stall_minimum_rate_ = 1;
   std::string http_version_;
   std::int32_t http_code_;
-  std::set<std::int32_t> ignored_http_error_codes_;
 
   // Explicitly closing the handle happens in two steps.
   // 1. This class needs to notify libcurl that the transfer is terminated by

--- a/google/cloud/internal/curl_rest_client_integration_test.cc
+++ b/google/cloud/internal/curl_rest_client_integration_test.cc
@@ -28,7 +28,6 @@ namespace rest_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 namespace {
 
-using ::google::cloud::testing_util::IsOk;
 using ::testing::Contains;
 using ::testing::Eq;
 using ::testing::HasSubstr;
@@ -146,31 +145,6 @@ TEST_F(RestClientIntegrationTest, Get) {
   auto body = ReadAll(std::move(payload));
   EXPECT_STATUS_OK(body);
   EXPECT_GT(body->size(), 0);
-}
-
-TEST_F(RestClientIntegrationTest, GetWithIgnoredErrorCode) {
-  options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
-  auto client =
-      MakeDefaultRestClient(url_, Options{}.set<IgnoredHttpErrorCodes>({308}));
-  RestRequest request;
-  request.SetPath("status/308");
-  auto response_status = RetryRestRequest([&] { return client->Get(request); });
-  ASSERT_STATUS_OK(response_status);
-  auto response = std::move(response_status.value());
-  EXPECT_THAT(response->StatusCode(), Eq(HttpStatusCode::kResumeIncomplete));
-  EXPECT_GT(response->Headers().size(), 0);
-  std::unique_ptr<HttpPayload> payload = std::move(*response).ExtractPayload();
-  auto body = ReadAll(std::move(payload));
-  EXPECT_STATUS_OK(body);
-}
-
-TEST_F(RestClientIntegrationTest, GetWithNonIgnoredErrorCode) {
-  options_.set<UnifiedCredentialsOption>(MakeInsecureCredentials());
-  auto client = MakeDefaultRestClient(url_, {});
-  RestRequest request;
-  request.SetPath("status/308");
-  auto response_status = RetryRestRequest([&] { return client->Get(request); });
-  EXPECT_THAT(response_status, Not(IsOk()));
 }
 
 TEST_F(RestClientIntegrationTest, Delete) {

--- a/google/cloud/internal/rest_options.h
+++ b/google/cloud/internal/rest_options.h
@@ -95,20 +95,10 @@ struct DownloadStallMinimumRateOption {
   using Type = std::int32_t;
 };
 
-/**
- * Some services appropriate Http error codes for their own use. If any such
- * error codes need to be treated as non-failures, this option can indicate
- * which codes.
- */
-struct IgnoredHttpErrorCodes {
-  using Type = std::set<std::int32_t>;
-};
-
 /// The complete list of options accepted by `CurlRestClient`
 using RestOptionList = ::google::cloud::OptionList<
     UserIpOption, TransferStallTimeoutOption, TransferStallMinimumRateOption,
-    DownloadStallTimeoutOption, DownloadStallMinimumRateOption,
-    IgnoredHttpErrorCodes>;
+    DownloadStallTimeoutOption, DownloadStallMinimumRateOption>;
 
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_END
 }  // namespace rest_internal

--- a/google/cloud/internal/rest_response.cc
+++ b/google/cloud/internal/rest_response.cc
@@ -49,7 +49,7 @@ StatusCode MapHttpCodeToStatus3xx(std::int32_t code) {
     //   is a success status.
     //
     // This level of complexity / detail is something that the caller should
-    // handle, that is what `IgnoredHttpErrorCodes` are for.
+    // handle.
     return StatusCode::kFailedPrecondition;
   }
   if (code == HttpStatusCode::kNotModified) {

--- a/google/cloud/storage/client_options.cc
+++ b/google/cloud/storage/client_options.cc
@@ -241,32 +241,25 @@ Options DefaultOptions(std::shared_ptr<oauth2::Credentials> credentials,
   // use the low-level initialization code in
   // google/cloud/internal/curl_wrappers.cc, these are always needed.
   namespace rest = ::google::cloud::rest_internal;
-  auto rest_defaults =
-      Options{}
-          .set<rest::DownloadStallTimeoutOption>(
-              o.get<DownloadStallTimeoutOption>())
-          .set<rest::DownloadStallMinimumRateOption>(
-              o.get<DownloadStallMinimumRateOption>())
-          .set<rest::TransferStallTimeoutOption>(
-              o.get<TransferStallTimeoutOption>())
-          .set<rest::TransferStallMinimumRateOption>(
-              o.get<TransferStallMinimumRateOption>())
-          .set<rest::MaximumCurlSocketRecvSizeOption>(
-              o.get<MaximumCurlSocketRecvSizeOption>())
-          .set<rest::MaximumCurlSocketSendSizeOption>(
-              o.get<MaximumCurlSocketSendSizeOption>())
-          .set<rest::ConnectionPoolSizeOption>(
-              o.get<ConnectionPoolSizeOption>())
-          .set<rest::EnableCurlSslLockingOption>(
-              o.get<EnableCurlSslLockingOption>())
-          .set<rest::EnableCurlSigpipeHandlerOption>(
-              o.get<EnableCurlSigpipeHandlerOption>())
-          // This prevents the RestClient from treating these codes as errors.
-          // Instead, it will allow them to propagate back to the calling code
-          // where it can determine if they are indeed errors or not.
-          .set<rest::IgnoredHttpErrorCodes>(
-              {rest::HttpStatusCode::kResumeIncomplete,
-               rest::HttpStatusCode::kClientClosedRequest});
+  auto rest_defaults = Options{}
+                           .set<rest::DownloadStallTimeoutOption>(
+                               o.get<DownloadStallTimeoutOption>())
+                           .set<rest::DownloadStallMinimumRateOption>(
+                               o.get<DownloadStallMinimumRateOption>())
+                           .set<rest::TransferStallTimeoutOption>(
+                               o.get<TransferStallTimeoutOption>())
+                           .set<rest::TransferStallMinimumRateOption>(
+                               o.get<TransferStallMinimumRateOption>())
+                           .set<rest::MaximumCurlSocketRecvSizeOption>(
+                               o.get<MaximumCurlSocketRecvSizeOption>())
+                           .set<rest::MaximumCurlSocketSendSizeOption>(
+                               o.get<MaximumCurlSocketSendSizeOption>())
+                           .set<rest::ConnectionPoolSizeOption>(
+                               o.get<ConnectionPoolSizeOption>())
+                           .set<rest::EnableCurlSslLockingOption>(
+                               o.get<EnableCurlSslLockingOption>())
+                           .set<rest::EnableCurlSigpipeHandlerOption>(
+                               o.get<EnableCurlSigpipeHandlerOption>());
 
   // These two are not always present, but if they are, and only if they are, we
   // need to map their value to the corresponding option in `rest_internal::`.

--- a/google/cloud/storage/client_options_test.cc
+++ b/google/cloud/storage/client_options_test.cc
@@ -386,10 +386,6 @@ TEST_F(ClientOptionsTest, DefaultOptions) {
   EXPECT_EQ(o.get<rest::EnableCurlSigpipeHandlerOption>(),
             o.get<EnableCurlSigpipeHandlerOption>());
 
-  EXPECT_THAT(o.get<rest::IgnoredHttpErrorCodes>(),
-              UnorderedElementsAre(rest::kResumeIncomplete,
-                                   rest::kClientClosedRequest));
-
   EXPECT_FALSE(o.has<rest::HttpVersionOption>());
   EXPECT_FALSE(o.has<rest::CAPathOption>());
 }

--- a/google/cloud/storage/internal/rest_client.cc
+++ b/google/cloud/storage/internal/rest_client.cc
@@ -634,7 +634,9 @@ StatusOr<std::unique_ptr<ObjectReadSource>> RestClient::ReadObjectXml(
 
   auto response = storage_rest_client_->Get(std::move(builder).BuildRequest());
   if (!response.ok()) return std::move(response).status();
-
+  if (IsHttpError((*response)->StatusCode())) {
+    return rest::AsStatus(std::move(**response));
+  }
   return std::unique_ptr<ObjectReadSource>(
       new RestObjectReadSource(*std::move(response)));
 }
@@ -667,6 +669,9 @@ StatusOr<std::unique_ptr<ObjectReadSource>> RestClient::ReadObject(
 
   auto response = storage_rest_client_->Get(std::move(builder).BuildRequest());
   if (!response.ok()) return response.status();
+  if (IsHttpError((*response)->StatusCode())) {
+    return rest::AsStatus(std::move(**response));
+  }
 
   return std::unique_ptr<ObjectReadSource>(
       new RestObjectReadSource(*std::move(response)));


### PR DESCRIPTION
We need the full payload when returning completing a `HttpRequest` with a non-OK status code. The payload may contain a full ErrorInfo, and we want the application to have access to those.

`rest_internal::CurlImpl` was converting the HTTP status code unless it was in a list of values ignored. Then `storage::RestClient` used a per-method predicate to convert some values to errors.  It seems simpler to *never* convert an HTTP status code to a `Status` in the `CurlImpl` layer. After all, an HTTP request that completes with a status code was able to send and receive the call.

Fixes #9947 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10051)
<!-- Reviewable:end -->
