### PR TITLE
cleanup: stop throwing/catching standard exceptions in quickstarts

### DIFF
--- a/generator/internal/scaffold_generator.cc
+++ b/generator/internal/scaffold_generator.cc
@@ -796,7 +796,6 @@ void GenerateQuickstartSkeleton(
 #include "google/cloud/$library$/ EDIT HERE .h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -810,13 +809,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto r : client.List/*EDIT HERE*/(project.FullName())) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 )""";

--- a/google/cloud/accessapproval/README.md
+++ b/google/cloud/accessapproval/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/accessapproval/access_approval_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
       accessapproval::MakeAccessApprovalConnection());
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.ListApprovalRequests(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/accessapproval/quickstart/quickstart.cc
+++ b/google/cloud/accessapproval/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/accessapproval/access_approval_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
       accessapproval::MakeAccessApprovalConnection());
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.ListApprovalRequests(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/accesscontextmanager/CMakeLists.txt
+++ b/google/cloud/accesscontextmanager/CMakeLists.txt
@@ -123,7 +123,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         accesscontextmanager_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in ListAccessLevels:")
+                   "Permanent error in.*ListAccessLevels:")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/accesscontextmanager/README.md
+++ b/google/cloud/accesscontextmanager/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/accesscontextmanager/access_context_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string("accessPolicies/") + argv[1];
   for (auto r : client.ListAccessLevels(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/accesscontextmanager/quickstart/quickstart.cc
+++ b/google/cloud/accesscontextmanager/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/accesscontextmanager/access_context_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string("accessPolicies/") + argv[1];
   for (auto r : client.ListAccessLevels(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/apigateway/README.md
+++ b/google/cloud/apigateway/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/apigateway/api_gateway_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListGateways(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/apigateway/quickstart/quickstart.cc
+++ b/google/cloud/apigateway/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/apigateway/api_gateway_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListGateways(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/apigeeconnect/CMakeLists.txt
+++ b/google/cloud/apigeeconnect/CMakeLists.txt
@@ -121,7 +121,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         apigeeconnect_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in ListConnections:")
+                   "Permanent error in.*ListConnections:")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/apigeeconnect/README.md
+++ b/google/cloud/apigeeconnect/README.md
@@ -41,7 +41,6 @@ this library.
 ```cc
 #include "google/cloud/apigeeconnect/connection_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -56,13 +55,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/endpoints/" + argv[2];
   for (auto r : client.ListConnections(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/apigeeconnect/quickstart/quickstart.cc
+++ b/google/cloud/apigeeconnect/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/apigeeconnect/connection_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/endpoints/" + argv[2];
   for (auto r : client.ListConnections(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/apikeys/README.md
+++ b/google/cloud/apikeys/README.md
@@ -38,7 +38,6 @@ this library.
 ```cc
 #include "google/cloud/apikeys/api_keys_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
   for (auto r : client.ListKeys(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/apikeys/quickstart/quickstart.cc
+++ b/google/cloud/apikeys/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/apikeys/api_keys_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
   for (auto r : client.ListKeys(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/appengine/README.md
+++ b/google/cloud/appengine/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/appengine/services_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
   ::google::appengine::v1::ListServicesRequest request;
   request.set_parent(std::string{"apps/"} + argv[1]);
   for (auto r : client.ListServices(request)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/appengine/quickstart/quickstart.cc
+++ b/google/cloud/appengine/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/appengine/services_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
   ::google::appengine::v1::ListServicesRequest request;
   request.set_parent(std::string{"apps/"} + argv[1]);
   for (auto r : client.ListServices(request)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/artifactregistry/README.md
+++ b/google/cloud/artifactregistry/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/artifactregistry/artifact_registry_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListRepositories(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/artifactregistry/quickstart/quickstart.cc
+++ b/google/cloud/artifactregistry/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/artifactregistry/artifact_registry_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListRepositories(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/asset/README.md
+++ b/google/cloud/asset/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/asset/asset_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -52,13 +51,13 @@ int main(int argc, char* argv[]) try {
   request.set_parent(project.FullName());
   request.add_asset_types("storage.googleapis.com/Bucket");
   for (auto a : client.ListAssets(request)) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/asset/quickstart/quickstart.cc
+++ b/google/cloud/asset/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/asset/asset_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -31,12 +30,12 @@ int main(int argc, char* argv[]) try {
   request.set_parent(project.FullName());
   request.add_asset_types("storage.googleapis.com/Bucket");
   for (auto a : client.ListAssets(request)) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/assuredworkloads/CMakeLists.txt
+++ b/google/cloud/assuredworkloads/CMakeLists.txt
@@ -124,7 +124,7 @@ if (BUILD_TESTING)
         PROPERTIES
             LABELS "integration-test;quickstart" ENVIRONMENT
             GOOGLE_CLOUD_CPP_USER_PROJECT=$ENV{GOOGLE_CLOUD_CPP_USER_PROJECT}
-            PASS_REGULAR_EXPRESSION "Permanent error in ListWorkloads:")
+            PASS_REGULAR_EXPRESSION "Permanent error in.*ListWorkloads:")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/assuredworkloads/README.md
+++ b/google/cloud/assuredworkloads/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/assuredworkloads/assured_workloads_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
       std::string("organizations/") + argv[1] + "/locations/" + argv[2];
 
   for (auto w : client.ListWorkloads(parent)) {
-    if (!w) throw std::runtime_error(w.status().message());
+    if (!w) throw std::move(w).status();
     std::cout << w->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/assuredworkloads/quickstart/quickstart.cc
+++ b/google/cloud/assuredworkloads/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/assuredworkloads/assured_workloads_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
       std::string("organizations/") + argv[1] + "/locations/" + argv[2];
 
   for (auto w : client.ListWorkloads(parent)) {
-    if (!w) throw std::runtime_error(w.status().message());
+    if (!w) throw std::move(w).status();
     std::cout << w->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/automl/README.md
+++ b/google/cloud/automl/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/automl/auto_ml_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto m : client.ListModels(parent)) {
-    if (!m) throw std::runtime_error(m.status().message());
+    if (!m) throw std::move(m).status();
     std::cout << m->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/automl/quickstart/quickstart.cc
+++ b/google/cloud/automl/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/automl/auto_ml_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto m : client.ListModels(parent)) {
-    if (!m) throw std::runtime_error(m.status().message());
+    if (!m) throw std::move(m).status();
     std::cout << m->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/baremetalsolution/README.md
+++ b/google/cloud/baremetalsolution/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/baremetalsolution/bare_metal_solution_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListInstances(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/baremetalsolution/quickstart/quickstart.cc
+++ b/google/cloud/baremetalsolution/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/baremetalsolution/bare_metal_solution_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListInstances(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/batch/README.md
+++ b/google/cloud/batch/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/batch/batch_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
   auto const location =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListJobs(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/batch/quickstart/quickstart.cc
+++ b/google/cloud/batch/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/batch/batch_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
   auto const location =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListJobs(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/beyondcorp/README.md
+++ b/google/cloud/beyondcorp/README.md
@@ -36,7 +36,6 @@ this library.
 ```cc
 #include "google/cloud/beyondcorp/app_connectors_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListAppConnectors(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/beyondcorp/quickstart/quickstart.cc
+++ b/google/cloud/beyondcorp/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/beyondcorp/app_connectors_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListAppConnectors(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/bigquery/README.md
+++ b/google/cloud/bigquery/README.md
@@ -32,7 +32,6 @@ this library.
 ```cc
 #include "google/cloud/bigquery/bigquery_read_client.h"
 #include <iostream>
-#include <stdexcept>
 
 namespace {
 void ProcessRowsInAvroFormat(
@@ -68,7 +67,7 @@ int main(int argc, char* argv[]) try {
   read_session.set_table(table_name);
   auto session =
       client.CreateReadSession(project_name, read_session, kMaxReadStreams);
-  if (!session) throw std::runtime_error(session.status().message());
+  if (!session) throw std::move(session).status();
 
   // Read rows from the ReadSession.
   constexpr int kRowOffset = 0;
@@ -84,8 +83,8 @@ int main(int argc, char* argv[]) try {
 
   std::cout << num_rows << " rows read from table: " << table_name << "\n";
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/bigquery/quickstart/quickstart.cc
+++ b/google/cloud/bigquery/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 //! [START bigquerystorage_quickstart]
 #include "google/cloud/bigquery/bigquery_read_client.h"
 #include <iostream>
-#include <stdexcept>
 
 namespace {
 void ProcessRowsInAvroFormat(
@@ -51,7 +50,7 @@ int main(int argc, char* argv[]) try {
   read_session.set_table(table_name);
   auto session =
       client.CreateReadSession(project_name, read_session, kMaxReadStreams);
-  if (!session) throw std::runtime_error(session.status().message());
+  if (!session) throw std::move(session).status();
 
   // Read rows from the ReadSession.
   constexpr int kRowOffset = 0;
@@ -67,8 +66,8 @@ int main(int argc, char* argv[]) try {
 
   std::cout << num_rows << " rows read from table: " << table_name << "\n";
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 //! [END bigquerystorage_quickstart]

--- a/google/cloud/bigtable/README.md
+++ b/google/cloud/bigtable/README.md
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "Getting a single row by row key:" << std::flush;
   google::cloud::StatusOr<std::pair<bool, cbt::Row>> result =
       table.ReadRow(row_key, cbt::Filter::FamilyRegex(column_family));
-  if (!result) throw std::runtime_error(result.status().message());
+  if (!result) throw std::move(result).status();
   if (!result->first) {
     std::cout << "Cannot find row " << row_key << " in the table: " << table_id
               << "\n";
@@ -72,8 +72,8 @@ int main(int argc, char* argv[]) try {
             << '"' << cell.value() << '"' << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/bigtable/quickstart/quickstart.cc
+++ b/google/cloud/bigtable/quickstart/quickstart.cc
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "Getting a single row by row key:" << std::flush;
   google::cloud::StatusOr<std::pair<bool, cbt::Row>> result =
       table.ReadRow(row_key, cbt::Filter::FamilyRegex(column_family));
-  if (!result) throw std::runtime_error(result.status().message());
+  if (!result) throw std::move(result).status();
   if (!result->first) {
     std::cout << "Cannot find row " << row_key << " in the table: " << table_id
               << "\n";
@@ -53,8 +53,8 @@ int main(int argc, char* argv[]) try {
             << '"' << cell.value() << '"' << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard C++ exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 // [END bigtable_quickstart]

--- a/google/cloud/billing/README.md
+++ b/google/cloud/billing/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/billing/cloud_billing_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 1) {
@@ -47,13 +46,13 @@ int main(int argc, char* argv[]) try {
       billing::CloudBillingClient(billing::MakeCloudBillingConnection());
 
   for (auto a : client.ListBillingAccounts()) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/billing/quickstart/quickstart.cc
+++ b/google/cloud/billing/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/billing/cloud_billing_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 1) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
       billing::CloudBillingClient(billing::MakeCloudBillingConnection());
 
   for (auto a : client.ListBillingAccounts()) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/binaryauthorization/README.md
+++ b/google/cloud/binaryauthorization/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/binaryauthorization/binauthz_management_service_v1_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.ListAttestors(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/binaryauthorization/quickstart/quickstart.cc
+++ b/google/cloud/binaryauthorization/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/binaryauthorization/binauthz_management_service_v1_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.ListAttestors(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/certificatemanager/README.md
+++ b/google/cloud/certificatemanager/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/certificatemanager/certificate_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -55,9 +54,6 @@ int main(int argc, char* argv[]) try {
   return 0;
 } catch (google::cloud::Status const& status) {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
   return 1;
 }
 ```

--- a/google/cloud/certificatemanager/quickstart/quickstart.cc
+++ b/google/cloud/certificatemanager/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/certificatemanager/certificate_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -35,8 +34,5 @@ int main(int argc, char* argv[]) try {
   return 0;
 } catch (google::cloud::Status const& status) {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
   return 1;
 }

--- a/google/cloud/channel/README.md
+++ b/google/cloud/channel/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/channel/cloud_channel_client.h"
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[]) try {
@@ -52,13 +51,13 @@ int main(int argc, char* argv[]) try {
   auto request = google::cloud::channel::v1::ListProductsRequest{};
   request.set_account(std::string("accounts/") + argv[1]);
   for (auto r : client.ListProducts(std::move(request))) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/channel/quickstart/quickstart.cc
+++ b/google/cloud/channel/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/channel/cloud_channel_client.h"
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[]) try {
@@ -31,12 +30,12 @@ int main(int argc, char* argv[]) try {
   auto request = google::cloud::channel::v1::ListProductsRequest{};
   request.set_account(std::string("accounts/") + argv[1]);
   for (auto r : client.ListProducts(std::move(request))) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/cloudbuild/README.md
+++ b/google/cloud/cloudbuild/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/cloudbuild/cloud_build_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -47,13 +46,13 @@ int main(int argc, char* argv[]) try {
       cloudbuild::CloudBuildClient(cloudbuild::MakeCloudBuildConnection());
   auto const* filter = R"""(status="WORKING")""";  // List only running builds
   for (auto b : client.ListBuilds(argv[1], filter)) {
-    if (!b) throw std::runtime_error(b.status().message());
+    if (!b) throw std::move(b).status();
     std::cout << b->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/cloudbuild/quickstart/quickstart.cc
+++ b/google/cloud/cloudbuild/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/cloudbuild/cloud_build_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
       cloudbuild::CloudBuildClient(cloudbuild::MakeCloudBuildConnection());
   auto const* filter = R"""(status="WORKING")""";  // List only running builds
   for (auto b : client.ListBuilds(argv[1], filter)) {
-    if (!b) throw std::runtime_error(b.status().message());
+    if (!b) throw std::move(b).status();
     std::cout << b->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/composer/README.md
+++ b/google/cloud/composer/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/composer/environments_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto e : client.ListEnvironments(parent)) {
-    if (!e) throw std::runtime_error(e.status().message());
+    if (!e) throw std::move(e).status();
     std::cout << e->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/composer/quickstart/quickstart.cc
+++ b/google/cloud/composer/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/composer/environments_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto e : client.ListEnvironments(parent)) {
-    if (!e) throw std::runtime_error(e.status().message());
+    if (!e) throw std::move(e).status();
     std::cout << e->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/contactcenterinsights/README.md
+++ b/google/cloud/contactcenterinsights/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/contactcenterinsights/contact_center_insights_client.h"
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,7 +49,7 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto c : client.ListConversations(parent)) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
 
     using ::google::protobuf::util::TimeUtil;
     std::cout << c->name() << "\n";
@@ -59,8 +58,8 @@ int main(int argc, char* argv[]) try {
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/contactcenterinsights/quickstart/quickstart.cc
+++ b/google/cloud/contactcenterinsights/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/contactcenterinsights/contact_center_insights_client.h"
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -30,7 +29,7 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto c : client.ListConversations(parent)) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
 
     using ::google::protobuf::util::TimeUtil;
     std::cout << c->name() << "\n";
@@ -39,7 +38,7 @@ int main(int argc, char* argv[]) try {
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/container/README.md
+++ b/google/cloud/container/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/container/cluster_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,14 +48,14 @@ int main(int argc, char* argv[]) try {
   auto const location =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   auto response = client.ListClusters(location);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   for (auto const& c : response->clusters()) {
     std::cout << c.DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/container/quickstart/quickstart.cc
+++ b/google/cloud/container/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/container/cluster_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,13 +28,13 @@ int main(int argc, char* argv[]) try {
   auto const location =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   auto response = client.ListClusters(location);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   for (auto const& c : response->clusters()) {
     std::cout << c.DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/containeranalysis/README.md
+++ b/google/cloud/containeranalysis/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/containeranalysis/grafeas_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto n : client.ListNotes(project.FullName(), /*filter=*/"")) {
-    if (!n) throw std::runtime_error(n.status().message());
+    if (!n) throw std::move(n).status();
     std::cout << n->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/containeranalysis/quickstart/quickstart.cc
+++ b/google/cloud/containeranalysis/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/containeranalysis/grafeas_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto n : client.ListNotes(project.FullName(), /*filter=*/"")) {
-    if (!n) throw std::runtime_error(n.status().message());
+    if (!n) throw std::move(n).status();
     std::cout << n->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/datacatalog/README.md
+++ b/google/cloud/datacatalog/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/datacatalog/data_catalog_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListEntryGroups(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/datacatalog/quickstart/quickstart.cc
+++ b/google/cloud/datacatalog/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/datacatalog/data_catalog_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListEntryGroups(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/datamigration/README.md
+++ b/google/cloud/datamigration/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/datamigration/data_migration_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListMigrationJobs(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/datamigration/quickstart/quickstart.cc
+++ b/google/cloud/datamigration/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/datamigration/data_migration_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListMigrationJobs(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/dataplex/README.md
+++ b/google/cloud/dataplex/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/dataplex/dataplex_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListLakes(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/dataplex/quickstart/quickstart.cc
+++ b/google/cloud/dataplex/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/dataplex/dataplex_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListLakes(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/dataproc/README.md
+++ b/google/cloud/dataproc/README.md
@@ -38,7 +38,6 @@ this library.
 #include "google/cloud/dataproc/cluster_controller_client.h"
 #include "google/cloud/common_options.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -55,13 +54,13 @@ int main(int argc, char* argv[]) try {
                                                                    : region));
 
   for (auto c : client.ListClusters(project_id, region)) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->cluster_name() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/dataproc/quickstart/quickstart.cc
+++ b/google/cloud/dataproc/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/dataproc/cluster_controller_client.h"
 #include "google/cloud/common_options.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -32,12 +31,12 @@ int main(int argc, char* argv[]) try {
                                                                    : region));
 
   for (auto c : client.ListClusters(project_id, region)) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->cluster_name() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/datastream/README.md
+++ b/google/cloud/datastream/README.md
@@ -37,7 +37,6 @@ this library.
 #include "google/cloud/datastream/datastream_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -59,9 +58,6 @@ int main(int argc, char* argv[]) try {
   return 0;
 } catch (google::cloud::Status const& status) {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
   return 1;
 }
 ```

--- a/google/cloud/datastream/quickstart/quickstart.cc
+++ b/google/cloud/datastream/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/datastream/datastream_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -37,8 +36,5 @@ int main(int argc, char* argv[]) try {
   return 0;
 } catch (google::cloud::Status const& status) {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
   return 1;
 }

--- a/google/cloud/debugger/README.md
+++ b/google/cloud/debugger/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/debugger/debugger2_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -46,12 +45,12 @@ int main(int argc, char* argv[]) try {
   namespace debugger = ::google::cloud::debugger;
   auto client = debugger::Debugger2Client(debugger::MakeDebugger2Connection());
   auto response = client.ListDebuggees(argv[1], "quickstart");
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/debugger/quickstart/quickstart.cc
+++ b/google/cloud/debugger/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/debugger/debugger2_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -25,11 +24,11 @@ int main(int argc, char* argv[]) try {
   namespace debugger = ::google::cloud::debugger;
   auto client = debugger::Debugger2Client(debugger::MakeDebugger2Connection());
   auto response = client.ListDebuggees(argv[1], "quickstart");
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/deploy/README.md
+++ b/google/cloud/deploy/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/deploy/cloud_deploy_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -55,9 +54,6 @@ int main(int argc, char* argv[]) try {
   return 0;
 } catch (google::cloud::Status const& status) {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
   return 1;
 }
 ```

--- a/google/cloud/deploy/quickstart/quickstart.cc
+++ b/google/cloud/deploy/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/deploy/cloud_deploy_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -35,8 +34,5 @@ int main(int argc, char* argv[]) try {
   return 0;
 } catch (google::cloud::Status const& status) {
   std::cerr << "google::cloud::Status thrown: " << status << "\n";
-  return 1;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
   return 1;
 }

--- a/google/cloud/dialogflow_cx/README.md
+++ b/google/cloud/dialogflow_cx/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/dialogflow_cx/agents_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
 
   auto const location = "projects/" + project + "/locations/" + region;
   for (auto a : client.ListAgents(location)) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/dialogflow_cx/quickstart/quickstart.cc
+++ b/google/cloud/dialogflow_cx/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/dialogflow_cx/agents_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
 
   auto const location = "projects/" + project + "/locations/" + region;
   for (auto a : client.ListAgents(location)) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/dialogflow_es/README.md
+++ b/google/cloud/dialogflow_es/README.md
@@ -37,7 +37,6 @@ this library.
 #include "google/cloud/dialogflow_es/agents_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.SearchAgents(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/dialogflow_es/quickstart/quickstart.cc
+++ b/google/cloud/dialogflow_es/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/dialogflow_es/agents_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.SearchAgents(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/dlp/README.md
+++ b/google/cloud/dlp/README.md
@@ -36,7 +36,6 @@ this library.
 ```cc
 #include "google/cloud/dlp/dlp_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const location =
       "projects/" + std::string(argv[1]) + "/locations/" + std::string(argv[2]);
   for (auto r : client.ListStoredInfoTypes(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/dlp/quickstart/quickstart.cc
+++ b/google/cloud/dlp/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/dlp/dlp_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
   auto const location =
       "projects/" + std::string(argv[1]) + "/locations/" + std::string(argv[2]);
   for (auto r : client.ListStoredInfoTypes(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/documentai/README.md
+++ b/google/cloud/documentai/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/documentai/document_processor_client.h"
 #include <fstream>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 5) {
@@ -66,12 +65,12 @@ int main(int argc, char* argv[]) try {
   doc.set_content(std::string{std::istreambuf_iterator<char>(is), {}});
 
   auto resp = client.ProcessDocument(std::move(req));
-  if (!resp) throw std::runtime_error(resp.status().message());
+  if (!resp) throw std::move(resp).status();
   std::cout << resp->document().text() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/documentai/quickstart/quickstart.cc
+++ b/google/cloud/documentai/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/documentai/document_processor_client.h"
 #include <fstream>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 5) {
@@ -45,11 +44,11 @@ int main(int argc, char* argv[]) try {
   doc.set_content(std::string{std::istreambuf_iterator<char>(is), {}});
 
   auto resp = client.ProcessDocument(std::move(req));
-  if (!resp) throw std::runtime_error(resp.status().message());
+  if (!resp) throw std::move(resp).status();
   std::cout << resp->document().text() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/edgecontainer/README.md
+++ b/google/cloud/edgecontainer/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/edgecontainer/edge_container_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListClusters(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/edgecontainer/quickstart/quickstart.cc
+++ b/google/cloud/edgecontainer/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/edgecontainer/edge_container_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListClusters(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/eventarc/README.md
+++ b/google/cloud/eventarc/README.md
@@ -34,7 +34,6 @@ this library.
 #include "google/cloud/eventarc/eventarc_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   auto const parent = project.FullName() + "/locations/" + argv[2];
   for (auto t : client.ListTriggers(parent)) {
-    if (!t) throw std::runtime_error(t.status().message());
+    if (!t) throw std::move(t).status();
     std::cout << t->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/eventarc/quickstart/quickstart.cc
+++ b/google/cloud/eventarc/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/eventarc/eventarc_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   auto const parent = project.FullName() + "/locations/" + argv[2];
   for (auto t : client.ListTriggers(parent)) {
-    if (!t) throw std::runtime_error(t.status().message());
+    if (!t) throw std::move(t).status();
     std::cout << t->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/filestore/README.md
+++ b/google/cloud/filestore/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/filestore/cloud_filestore_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto i : client.ListInstances(parent)) {
-    if (!i) throw std::runtime_error(i.status().message());
+    if (!i) throw std::move(i).status();
     std::cout << i->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/filestore/quickstart/quickstart.cc
+++ b/google/cloud/filestore/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/filestore/cloud_filestore_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto i : client.ListInstances(parent)) {
-    if (!i) throw std::runtime_error(i.status().message());
+    if (!i) throw std::move(i).status();
     std::cout << i->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/functions/README.md
+++ b/google/cloud/functions/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/functions/cloud_functions_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -52,13 +51,13 @@ int main(int argc, char* argv[]) try {
   request.set_parent("projects/" + project_id + "/locations/-");
 
   for (auto r : client.ListFunctions(std::move(request))) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/functions/quickstart/quickstart.cc
+++ b/google/cloud/functions/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/functions/cloud_functions_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -31,12 +30,12 @@ int main(int argc, char* argv[]) try {
   request.set_parent("projects/" + project_id + "/locations/-");
 
   for (auto r : client.ListFunctions(std::move(request))) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/gameservices/README.md
+++ b/google/cloud/gameservices/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/gameservices/game_server_clusters_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 4) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const realm = "projects/" + std::string(argv[1]) + "/locations/" +
                      std::string(argv[2]) + "/realms/" + std::string(argv[3]);
   for (auto r : client.ListGameServerClusters(realm)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/gameservices/quickstart/quickstart.cc
+++ b/google/cloud/gameservices/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/gameservices/game_server_clusters_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 4) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const realm = "projects/" + std::string(argv[1]) + "/locations/" +
                      std::string(argv[2]) + "/realms/" + std::string(argv[3]);
   for (auto r : client.ListGameServerClusters(realm)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/gkehub/README.md
+++ b/google/cloud/gkehub/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/gkehub/gke_hub_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
 
   auto const location = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto r : client.ListMemberships(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/gkehub/quickstart/quickstart.cc
+++ b/google/cloud/gkehub/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/gkehub/gke_hub_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
 
   auto const location = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto r : client.ListMemberships(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/iam/README.md
+++ b/google/cloud/iam/README.md
@@ -33,7 +33,6 @@ this library.
 #include "google/cloud/iam/iam_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -47,16 +46,16 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   std::cout << "Service Accounts for project: " << project.project_id() << "\n";
   int count = 0;
-  for (auto const& sa : client.ListServiceAccounts(project.FullName())) {
-    if (!sa) throw std::runtime_error(sa.status().message());
+  for (auto sa : client.ListServiceAccounts(project.FullName())) {
+    if (!sa) throw std::move(sa).status();
     std::cout << sa->name() << "\n";
     ++count;
   }
   if (count == 0) std::cout << "No Service Accounts found.\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/iam/quickstart/quickstart.cc
+++ b/google/cloud/iam/quickstart/quickstart.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/iam/iam_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -30,16 +29,16 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   std::cout << "Service Accounts for project: " << project.project_id() << "\n";
   int count = 0;
-  for (auto const& sa : client.ListServiceAccounts(project.FullName())) {
-    if (!sa) throw std::runtime_error(sa.status().message());
+  for (auto sa : client.ListServiceAccounts(project.FullName())) {
+    if (!sa) throw std::move(sa).status();
     std::cout << sa->name() << "\n";
     ++count;
   }
   if (count == 0) std::cout << "No Service Accounts found.\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 //! [END iam_quickstart]

--- a/google/cloud/iap/README.md
+++ b/google/cloud/iap/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/iap/identity_aware_proxy_o_auth_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -51,12 +50,12 @@ int main(int argc, char* argv[]) try {
   request.set_parent(google::cloud::Project(argv[1]).FullName());
   // ListBrands is not paginated, a single response includes all the "brands".
   auto response = client.ListBrands(request);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/iap/quickstart/quickstart.cc
+++ b/google/cloud/iap/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/iap/identity_aware_proxy_o_auth_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -31,11 +30,11 @@ int main(int argc, char* argv[]) try {
   request.set_parent(google::cloud::Project(argv[1]).FullName());
   // ListBrands is not paginated, a single response includes all the "brands".
   auto response = client.ListBrands(request);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/ids/README.md
+++ b/google/cloud/ids/README.md
@@ -38,7 +38,6 @@ this library.
 ```cc
 #include "google/cloud/ids/ids_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto ep : client.ListEndpoints(parent)) {
-    if (!ep) throw std::runtime_error(ep.status().message());
+    if (!ep) throw std::move(ep).status();
     std::cout << ep->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/ids/quickstart/quickstart.cc
+++ b/google/cloud/ids/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/ids/ids_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto ep : client.ListEndpoints(parent)) {
-    if (!ep) throw std::runtime_error(ep.status().message());
+    if (!ep) throw std::move(ep).status();
     std::cout << ep->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/iot/README.md
+++ b/google/cloud/iot/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/iot/device_manager_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   auto const parent = project.FullName() + "/locations/" + argv[2];
   for (auto dr : client.ListDeviceRegistries(parent)) {
-    if (!dr) throw std::runtime_error(dr.status().message());
+    if (!dr) throw std::move(dr).status();
     std::cout << dr->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/iot/quickstart/quickstart.cc
+++ b/google/cloud/iot/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/iot/device_manager_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   auto const parent = project.FullName() + "/locations/" + argv[2];
   for (auto dr : client.ListDeviceRegistries(parent)) {
-    if (!dr) throw std::runtime_error(dr.status().message());
+    if (!dr) throw std::move(dr).status();
     std::cout << dr->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/kms/README.md
+++ b/google/cloud/kms/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/kms/key_management_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListKeyRings(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/kms/quickstart/quickstart.cc
+++ b/google/cloud/kms/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/kms/key_management_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListKeyRings(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/language/README.md
+++ b/google/cloud/language/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/language/language_client.h"
 #include <iostream>
-#include <stdexcept>
 
 auto constexpr kText = R"""(
 Four score and seven years ago our fathers brought forth on this
@@ -58,7 +57,7 @@ int main(int argc, char* argv[]) try {
   document.set_language("en-US");
 
   auto response = client.AnalyzeEntities(document);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
 
   for (auto const& entity : response->entities()) {
     if (entity.type() != language::v1::Entity::NUMBER) continue;
@@ -66,8 +65,8 @@ int main(int argc, char* argv[]) try {
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/language/quickstart/quickstart.cc
+++ b/google/cloud/language/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/language/language_client.h"
 #include <iostream>
-#include <stdexcept>
 
 auto constexpr kText = R"""(
 Four score and seven years ago our fathers brought forth on this
@@ -37,7 +36,7 @@ int main(int argc, char* argv[]) try {
   document.set_language("en-US");
 
   auto response = client.AnalyzeEntities(document);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
 
   for (auto const& entity : response->entities()) {
     if (entity.type() != language::v1::Entity::NUMBER) continue;
@@ -45,7 +44,7 @@ int main(int argc, char* argv[]) try {
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/logging/README.md
+++ b/google/cloud/logging/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/logging/logging_service_v2_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
       logging::MakeLoggingServiceV2Connection());
   auto const project = google::cloud::Project(argv[1]);
   for (auto l : client.ListLogs(project.FullName())) {
-    if (!l) throw std::runtime_error(l.status().message());
+    if (!l) throw std::move(l).status();
     std::cout << *l << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/logging/quickstart/quickstart.cc
+++ b/google/cloud/logging/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/logging/logging_service_v2_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
       logging::MakeLoggingServiceV2Connection());
   auto const project = google::cloud::Project(argv[1]);
   for (auto l : client.ListLogs(project.FullName())) {
-    if (!l) throw std::runtime_error(l.status().message());
+    if (!l) throw std::move(l).status();
     std::cout << *l << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/managedidentities/README.md
+++ b/google/cloud/managedidentities/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/managedidentities/managed_identities_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
   for (auto d : client.ListDomains(parent)) {
-    if (!d) throw std::runtime_error(d.status().message());
+    if (!d) throw std::move(d).status();
     std::cout << d->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/managedidentities/quickstart/quickstart.cc
+++ b/google/cloud/managedidentities/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/managedidentities/managed_identities_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
   for (auto d : client.ListDomains(parent)) {
-    if (!d) throw std::runtime_error(d.status().message());
+    if (!d) throw std::move(d).status();
     std::cout << d->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/memcache/README.md
+++ b/google/cloud/memcache/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/memcache/cloud_memcache_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const project_id = std::string(argv[1]);
   auto const parent = "projects/" + project_id + "/locations/-";
   for (auto r : client.ListInstances(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/memcache/quickstart/quickstart.cc
+++ b/google/cloud/memcache/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/memcache/cloud_memcache_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
   auto const project_id = std::string(argv[1]);
   auto const parent = "projects/" + project_id + "/locations/-";
   for (auto r : client.ListInstances(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/monitoring/README.md
+++ b/google/cloud/monitoring/README.md
@@ -38,7 +38,6 @@ this library.
 #include "google/cloud/monitoring/alert_policy_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -52,13 +51,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.ListAlertPolicies(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/monitoring/quickstart/quickstart.cc
+++ b/google/cloud/monitoring/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/monitoring/alert_policy_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto a : client.ListAlertPolicies(project.FullName())) {
-    if (!a) throw std::runtime_error(a.status().message());
+    if (!a) throw std::move(a).status();
     std::cout << a->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/networkconnectivity/README.md
+++ b/google/cloud/networkconnectivity/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/networkconnectivity/hub_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
   for (auto h : client.ListHubs(parent)) {
-    if (!h) throw std::runtime_error(h.status().message());
+    if (!h) throw std::move(h).status();
     std::cout << h->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/networkconnectivity/quickstart/quickstart.cc
+++ b/google/cloud/networkconnectivity/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/networkconnectivity/hub_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
   for (auto h : client.ListHubs(parent)) {
-    if (!h) throw std::runtime_error(h.status().message());
+    if (!h) throw std::move(h).status();
     std::cout << h->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/networkmanagement/README.md
+++ b/google/cloud/networkmanagement/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/networkmanagement/reachability_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
 
   for (auto t : client.ListConnectivityTests(parent)) {
-    if (!t) throw std::runtime_error(t.status().message());
+    if (!t) throw std::move(t).status();
     std::cout << t->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/networkmanagement/quickstart/quickstart.cc
+++ b/google/cloud/networkmanagement/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/networkmanagement/reachability_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/global";
 
   for (auto t : client.ListConnectivityTests(parent)) {
-    if (!t) throw std::runtime_error(t.status().message());
+    if (!t) throw std::move(t).status();
     std::cout << t->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/notebooks/README.md
+++ b/google/cloud/notebooks/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/notebooks/managed_notebook_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListRuntimes(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/notebooks/quickstart/quickstart.cc
+++ b/google/cloud/notebooks/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/notebooks/managed_notebook_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListRuntimes(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/optimization/README.md
+++ b/google/cloud/optimization/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/common_options.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -71,12 +70,12 @@ int main(int argc, char* argv[]) try {
   auto fut = client.BatchOptimizeTours(req);
   std::cout << "Request sent to the service...\n";
   auto resp = fut.get();
-  if (!resp) throw std::runtime_error(resp.status().message());
+  if (!resp) throw std::move(resp).status();
   std::cout << "Solution written to: " << destination << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/optimization/quickstart/quickstart.cc
+++ b/google/cloud/optimization/quickstart/quickstart.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/common_options.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -51,11 +50,11 @@ int main(int argc, char* argv[]) try {
   auto fut = client.BatchOptimizeTours(req);
   std::cout << "Request sent to the service...\n";
   auto resp = fut.get();
-  if (!resp) throw std::runtime_error(resp.status().message());
+  if (!resp) throw std::move(resp).status();
   std::cout << "Solution written to: " << destination << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/orgpolicy/README.md
+++ b/google/cloud/orgpolicy/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/orgpolicy/org_policy_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto p : client.ListPolicies(project.FullName())) {
-    if (!p) throw std::runtime_error(p.status().message());
+    if (!p) throw std::move(p).status();
     std::cout << p->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/orgpolicy/quickstart/quickstart.cc
+++ b/google/cloud/orgpolicy/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/orgpolicy/org_policy_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto p : client.ListPolicies(project.FullName())) {
-    if (!p) throw std::runtime_error(p.status().message());
+    if (!p) throw std::move(p).status();
     std::cout << p->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/osconfig/README.md
+++ b/google/cloud/osconfig/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/osconfig/os_config_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto p : client.ListPatchJobs(project.FullName())) {
-    if (!p) throw std::runtime_error(p.status().message());
+    if (!p) throw std::move(p).status();
     std::cout << p->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/osconfig/quickstart/quickstart.cc
+++ b/google/cloud/osconfig/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/osconfig/os_config_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto p : client.ListPatchJobs(project.FullName())) {
-    if (!p) throw std::runtime_error(p.status().message());
+    if (!p) throw std::move(p).status();
     std::cout << p->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/oslogin/CMakeLists.txt
+++ b/google/cloud/oslogin/CMakeLists.txt
@@ -115,7 +115,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         oslogin_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Permanent error in GetLoginProfile:")
+                   "Permanent error in.*GetLoginProfile:")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/oslogin/README.md
+++ b/google/cloud/oslogin/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/oslogin/os_login_client.h"
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[]) try {
@@ -49,12 +48,12 @@ int main(int argc, char* argv[]) try {
 
   auto const name = "users/" + std::string{argv[1]};
   auto lp = client.GetLoginProfile(name);
-  if (!lp) throw std::runtime_error(lp.status().message());
+  if (!lp) throw std::move(lp).status();
   std::cout << lp->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/oslogin/quickstart/quickstart.cc
+++ b/google/cloud/oslogin/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/oslogin/os_login_client.h"
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[]) try {
@@ -29,11 +28,11 @@ int main(int argc, char* argv[]) try {
 
   auto const name = "users/" + std::string{argv[1]};
   auto lp = client.GetLoginProfile(name);
-  if (!lp) throw std::runtime_error(lp.status().message());
+  if (!lp) throw std::move(lp).status();
   std::cout << lp->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/policytroubleshooter/README.md
+++ b/google/cloud/policytroubleshooter/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/policytroubleshooter/iam_checker_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 4) {
@@ -54,12 +53,12 @@ int main(int argc, char* argv[]) try {
   access_tuple.set_full_resource_name(argv[2]);
   access_tuple.set_permission(argv[3]);
   auto const response = client.TroubleshootIamPolicy(request);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/policytroubleshooter/quickstart/quickstart.cc
+++ b/google/cloud/policytroubleshooter/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/policytroubleshooter/iam_checker_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 4) {
@@ -33,11 +32,11 @@ int main(int argc, char* argv[]) try {
   access_tuple.set_full_resource_name(argv[2]);
   access_tuple.set_permission(argv[3]);
   auto const response = client.TroubleshootIamPolicy(request);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/privateca/README.md
+++ b/google/cloud/privateca/README.md
@@ -36,7 +36,6 @@ this library.
 ```cc
 #include "google/cloud/privateca/certificate_authority_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
   auto const ca_pool =
       "projects/" + std::string(argv[1]) + "/locations/" + std::string(argv[2]);
   for (auto r : client.ListCaPools(ca_pool)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/privateca/quickstart/quickstart.cc
+++ b/google/cloud/privateca/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/privateca/certificate_authority_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const ca_pool =
       "projects/" + std::string(argv[1]) + "/locations/" + std::string(argv[2]);
   for (auto r : client.ListCaPools(ca_pool)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/profiler/README.md
+++ b/google/cloud/profiler/README.md
@@ -40,7 +40,6 @@ this library.
 #include "google/cloud/profiler/profiler_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -60,12 +59,12 @@ int main(int argc, char* argv[]) try {
   deployment.set_target("quickstart");
 
   auto profile = client.CreateProfile(req);
-  if (!profile) throw std::runtime_error(profile.status().message());
+  if (!profile) throw std::move(profile).status();
   std::cout << profile->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/profiler/quickstart/quickstart.cc
+++ b/google/cloud/profiler/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/profiler/profiler_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -35,11 +34,11 @@ int main(int argc, char* argv[]) try {
   deployment.set_target("quickstart");
 
   auto profile = client.CreateProfile(req);
-  if (!profile) throw std::runtime_error(profile.status().message());
+  if (!profile) throw std::move(profile).status();
   std::cout << profile->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/pubsub/README.md
+++ b/google/cloud/pubsub/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/pubsub/publisher.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -53,12 +52,12 @@ int main(int argc, char* argv[]) try {
       publisher
           .Publish(pubsub::MessageBuilder{}.SetData("Hello World!").Build())
           .get();
-  if (!id) throw std::runtime_error(id.status().message());
+  if (!id) throw std::move(id).status();
   std::cout << "Hello World published with id=" << *id << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/pubsub/quickstart/quickstart.cc
+++ b/google/cloud/pubsub/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 //! [START pubsub_quickstart_publisher]
 #include "google/cloud/pubsub/publisher.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -34,12 +33,12 @@ int main(int argc, char* argv[]) try {
       publisher
           .Publish(pubsub::MessageBuilder{}.SetData("Hello World!").Build())
           .get();
-  if (!id) throw std::runtime_error(id.status().message());
+  if (!id) throw std::move(id).status();
   std::cout << "Hello World published with id=" << *id << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 //! [END pubsub_quickstart_publisher]

--- a/google/cloud/pubsublite/README.md
+++ b/google/cloud/pubsublite/README.md
@@ -41,7 +41,6 @@ this library.
 #include "google/cloud/pubsublite/endpoint.h"
 #include "google/cloud/common_options.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -53,7 +52,7 @@ int main(int argc, char* argv[]) try {
   namespace pubsublite = ::google::cloud::pubsublite;
   auto const zone_id = std::string{argv[2]};
   auto endpoint = pubsublite::EndpointFromZone(zone_id);
-  if (!endpoint) throw std::runtime_error(endpoint.status().message());
+  if (!endpoint) throw std::move(endpoint).status();
   auto client =
       pubsublite::AdminServiceClient(pubsublite::MakeAdminServiceConnection(
           gc::Options{}
@@ -61,13 +60,14 @@ int main(int argc, char* argv[]) try {
               .set<gc::AuthorityOption>(*endpoint)));
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + zone_id;
-  for (auto const& topic : client.ListTopics(parent)) {
-    std::cout << topic.value().DebugString() << "\n";
+  for (auto topic : client.ListTopics(parent)) {
+    if (!topic) throw std::move(topic).status();
+    std::cout << topic->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/recommender/README.md
+++ b/google/cloud/recommender/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/recommender/recommender_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
       std::string("projects/") + argv[1] + "/locations/" + argv[2] +
       "/recommenders/google.compute.instance.MachineTypeRecommender";
   for (auto r : client.ListRecommendations(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/recommender/quickstart/quickstart.cc
+++ b/google/cloud/recommender/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/recommender/recommender_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -31,12 +30,12 @@ int main(int argc, char* argv[]) try {
       std::string("projects/") + argv[1] + "/locations/" + argv[2] +
       "/recommenders/google.compute.instance.MachineTypeRecommender";
   for (auto r : client.ListRecommendations(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/redis/README.md
+++ b/google/cloud/redis/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/redis/cloud_redis_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const project_id = std::string(argv[1]);
   auto const parent = "projects/" + project_id + "/locations/-";
   for (auto r : client.ListInstances(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/redis/quickstart/quickstart.cc
+++ b/google/cloud/redis/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/redis/cloud_redis_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const project_id = std::string(argv[1]);
   auto const parent = "projects/" + project_id + "/locations/-";
   for (auto r : client.ListInstances(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/resourcemanager/README.md
+++ b/google/cloud/resourcemanager/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/resourcemanager/projects_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -47,13 +46,13 @@ int main(int argc, char* argv[]) try {
       resourcemanager::MakeProjectsConnection());
 
   for (auto p : client.ListProjects("folders/" + std::string(argv[1]))) {
-    if (!p) throw std::runtime_error(p.status().message());
+    if (!p) throw std::move(p).status();
     std::cout << p->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/resourcemanager/quickstart/quickstart.cc
+++ b/google/cloud/resourcemanager/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/resourcemanager/projects_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
       resourcemanager::MakeProjectsConnection());
 
   for (auto p : client.ListProjects("folders/" + std::string(argv[1]))) {
-    if (!p) throw std::runtime_error(p.status().message());
+    if (!p) throw std::move(p).status();
     std::cout << p->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/resourcesettings/README.md
+++ b/google/cloud/resourcesettings/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/resourcesettings/resource_settings_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto r : client.ListSettings(project.FullName())) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/resourcesettings/quickstart/quickstart.cc
+++ b/google/cloud/resourcesettings/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/resourcesettings/resource_settings_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto r : client.ListSettings(project.FullName())) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/retail/README.md
+++ b/google/cloud/retail/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/retail/catalog_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -51,13 +50,13 @@ int main(int argc, char* argv[]) try {
   auto const location =
       "projects/" + std::string(argv[1]) + "/locations/global";
   for (auto r : client.ListCatalogs(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/retail/quickstart/quickstart.cc
+++ b/google/cloud/retail/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/retail/catalog_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
   auto const location =
       "projects/" + std::string(argv[1]) + "/locations/global";
   for (auto r : client.ListCatalogs(location)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/run/README.md
+++ b/google/cloud/run/README.md
@@ -39,7 +39,6 @@ this library.
 ```cc
 #include "google/cloud/run/services_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -53,13 +52,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListServices(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/run/quickstart/quickstart.cc
+++ b/google/cloud/run/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/run/services_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListServices(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/scheduler/README.md
+++ b/google/cloud/scheduler/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/scheduler/cloud_scheduler_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto j : client.ListJobs(parent)) {
-    if (!j) throw std::runtime_error(j.status().message());
+    if (!j) throw std::move(j).status();
     std::cout << j->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/scheduler/quickstart/quickstart.cc
+++ b/google/cloud/scheduler/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/scheduler/cloud_scheduler_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto j : client.ListJobs(parent)) {
-    if (!j) throw std::runtime_error(j.status().message());
+    if (!j) throw std::move(j).status();
     std::cout << j->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/secretmanager/README.md
+++ b/google/cloud/secretmanager/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/secretmanager/secret_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,14 @@ int main(int argc, char* argv[]) try {
       secretmanager::MakeSecretManagerServiceConnection());
 
   auto const parent = std::string("projects/") + argv[1];
-  for (auto const& secret : client.ListSecrets(parent)) {
-    std::cout << secret.value().DebugString() << "\n";
+  for (auto secret : client.ListSecrets(parent)) {
+    if (!secret) throw std::move(secret).status();
+    std::cout << secret->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/secretmanager/quickstart/quickstart.cc
+++ b/google/cloud/secretmanager/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/secretmanager/secret_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,13 @@ int main(int argc, char* argv[]) try {
       secretmanager::MakeSecretManagerServiceConnection());
 
   auto const parent = std::string("projects/") + argv[1];
-  for (auto const& secret : client.ListSecrets(parent)) {
-    std::cout << secret.value().DebugString() << "\n";
+  for (auto secret : client.ListSecrets(parent)) {
+    if (!secret) throw std::move(secret).status();
+    std::cout << secret->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/securitycenter/README.md
+++ b/google/cloud/securitycenter/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/securitycenter/security_center_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto c : client.ListSources(project.FullName())) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/securitycenter/quickstart/quickstart.cc
+++ b/google/cloud/securitycenter/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/securitycenter/security_center_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto c : client.ListSources(project.FullName())) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/servicecontrol/CMakeLists.txt
+++ b/google/cloud/servicecontrol/CMakeLists.txt
@@ -119,7 +119,7 @@ if (BUILD_TESTING)
     set_tests_properties(
         servicecontrol_quickstart
         PROPERTIES LABELS "integration-test;quickstart" PASS_REGULAR_EXPRESSION
-                   "Error in non-idempotent operation Check:")
+                   "Error in non-idempotent.*operation Check:")
 endif ()
 
 # Get the destination directories based on the GNU recommendations.

--- a/google/cloud/servicecontrol/README.md
+++ b/google/cloud/servicecontrol/README.md
@@ -37,7 +37,6 @@ this library.
 #include "google/cloud/project.h"
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -64,12 +63,12 @@ int main(int argc, char* argv[]) try {
   }();
 
   auto response = client.Check(request);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/servicecontrol/quickstart/quickstart.cc
+++ b/google/cloud/servicecontrol/quickstart/quickstart.cc
@@ -16,7 +16,6 @@
 #include "google/cloud/project.h"
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -43,11 +42,11 @@ int main(int argc, char* argv[]) try {
   }();
 
   auto response = client.Check(request);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/servicedirectory/README.md
+++ b/google/cloud/servicedirectory/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/servicedirectory/registration_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   auto const parent = project.FullName() + "/locations/" + argv[2];
   for (auto ns : client.ListNamespaces(parent)) {
-    if (!ns) throw std::runtime_error(ns.status().message());
+    if (!ns) throw std::move(ns).status();
     std::cout << ns->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/servicedirectory/quickstart/quickstart.cc
+++ b/google/cloud/servicedirectory/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/servicedirectory/registration_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
   auto const project = google::cloud::Project(argv[1]);
   auto const parent = project.FullName() + "/locations/" + argv[2];
   for (auto ns : client.ListNamespaces(parent)) {
-    if (!ns) throw std::runtime_error(ns.status().message());
+    if (!ns) throw std::move(ns).status();
     std::cout << ns->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/servicemanagement/README.md
+++ b/google/cloud/servicemanagement/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/servicemanagement/service_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   google::api::servicemanagement::v1::ListServicesRequest request;
   request.set_producer_project_id(argv[1]);
   for (auto s : client.ListServices(request)) {
-    if (!s) throw std::runtime_error(s.status().message());
+    if (!s) throw std::move(s).status();
     std::cout << s->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/servicemanagement/quickstart/quickstart.cc
+++ b/google/cloud/servicemanagement/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/servicemanagement/service_manager_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   google::api::servicemanagement::v1::ListServicesRequest request;
   request.set_producer_project_id(argv[1]);
   for (auto s : client.ListServices(request)) {
-    if (!s) throw std::runtime_error(s.status().message());
+    if (!s) throw std::move(s).status();
     std::cout << s->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/serviceusage/README.md
+++ b/google/cloud/serviceusage/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/serviceusage/service_usage_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -52,13 +51,13 @@ int main(int argc, char* argv[]) try {
   request.set_parent(project.FullName());
   request.set_filter("state:ENABLED");
   for (auto s : client.ListServices(request)) {
-    if (!s) throw std::runtime_error(s.status().message());
+    if (!s) throw std::move(s).status();
     std::cout << s->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/serviceusage/quickstart/quickstart.cc
+++ b/google/cloud/serviceusage/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/serviceusage/service_usage_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -32,12 +31,12 @@ int main(int argc, char* argv[]) try {
   request.set_parent(project.FullName());
   request.set_filter("state:ENABLED");
   for (auto s : client.ListServices(request)) {
-    if (!s) throw std::runtime_error(s.status().message());
+    if (!s) throw std::move(s).status();
     std::cout << s->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/shell/README.md
+++ b/google/cloud/shell/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/shell/cloud_shell_client.h"
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[]) try {
@@ -49,12 +48,12 @@ int main(int argc, char* argv[]) try {
 
   auto const name = "users/" + std::string{argv[1]} + "/environments/default";
   auto env = client.GetEnvironment(name);
-  if (!env) throw std::runtime_error(env.status().message());
+  if (!env) throw std::move(env).status();
   std::cout << env->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/shell/quickstart/quickstart.cc
+++ b/google/cloud/shell/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/shell/cloud_shell_client.h"
 #include <iostream>
-#include <stdexcept>
 #include <string>
 
 int main(int argc, char* argv[]) try {
@@ -29,11 +28,11 @@ int main(int argc, char* argv[]) try {
 
   auto const name = "users/" + std::string{argv[1]} + "/environments/default";
   auto env = client.GetEnvironment(name);
-  if (!env) throw std::runtime_error(env.status().message());
+  if (!env) throw std::move(env).status();
   std::cout << env->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/speech/README.md
+++ b/google/cloud/speech/README.md
@@ -38,7 +38,6 @@ this library.
 #include "google/cloud/speech/speech_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
@@ -58,12 +57,12 @@ int main(int argc, char* argv[]) try {
   google::cloud::speech::v1::RecognitionAudio audio;
   audio.set_uri(uri);
   auto response = client.Recognize(config, audio);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/speech/quickstart/quickstart.cc
+++ b/google/cloud/speech/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/speech/speech_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/speech/hello.wav";
@@ -35,11 +34,11 @@ int main(int argc, char* argv[]) try {
   google::cloud::speech::v1::RecognitionAudio audio;
   audio.set_uri(uri);
   auto response = client.Recognize(config, audio);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/storagetransfer/README.md
+++ b/google/cloud/storagetransfer/README.md
@@ -35,7 +35,6 @@ this library.
 ```cc
 #include "google/cloud/storagetransfer/storage_transfer_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   ::google::storagetransfer::v1::ListTransferJobsRequest request;
   request.set_filter("{\"projectId\": \"" + std::string{argv[1]} + "\"}");
   for (auto r : client.ListTransferJobs(request)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/storagetransfer/quickstart/quickstart.cc
+++ b/google/cloud/storagetransfer/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/storagetransfer/storage_transfer_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   ::google::storagetransfer::v1::ListTransferJobsRequest request;
   request.set_filter("{\"projectId\": \"" + std::string{argv[1]} + "\"}");
   for (auto r : client.ListTransferJobs(request)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/talent/README.md
+++ b/google/cloud/talent/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/talent/company_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto c : client.ListCompanies(project.FullName())) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/talent/quickstart/quickstart.cc
+++ b/google/cloud/talent/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/talent/company_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
 
   auto const project = google::cloud::Project(argv[1]);
   for (auto c : client.ListCompanies(project.FullName())) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/tasks/README.md
+++ b/google/cloud/tasks/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/tasks/cloud_tasks_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -46,13 +45,14 @@ int main(int argc, char* argv[]) try {
   auto client = tasks::CloudTasksClient(tasks::MakeCloudTasksConnection());
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
-  for (auto const& queue : client.ListQueues(parent)) {
-    std::cout << queue.value().DebugString() << "\n";
+  for (auto queue : client.ListQueues(parent)) {
+    if (!queue) throw std::move(queue).status();
+    std::cout << queue->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/tasks/quickstart/quickstart.cc
+++ b/google/cloud/tasks/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/tasks/cloud_tasks_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -26,12 +25,13 @@ int main(int argc, char* argv[]) try {
   auto client = tasks::CloudTasksClient(tasks::MakeCloudTasksConnection());
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
-  for (auto const& queue : client.ListQueues(parent)) {
-    std::cout << queue.value().DebugString() << "\n";
+  for (auto queue : client.ListQueues(parent)) {
+    if (!queue) throw std::move(queue).status();
+    std::cout << queue->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/texttospeech/README.md
+++ b/google/cloud/texttospeech/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/texttospeech/text_to_speech_client.h"
 #include <iostream>
-#include <stdexcept>
 
 auto constexpr kText = R"""(
 Four score and seven years ago our fathers brought forth on this
@@ -59,7 +58,7 @@ int main(int argc, char* argv[]) try {
   audio.set_audio_encoding(google::cloud::texttospeech::v1::LINEAR16);
 
   auto response = client.SynthesizeSpeech(input, voice, audio);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   // Normally one would play the results (response->audio_content()) over some
   // audio device. For this quickstart, we just print some information.
   auto constexpr kWavHeaderSize = 48;
@@ -69,8 +68,8 @@ int main(int argc, char* argv[]) try {
   std::cout << "The audio has " << sample_count << " samples\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/texttospeech/quickstart/quickstart.cc
+++ b/google/cloud/texttospeech/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/texttospeech/text_to_speech_client.h"
 #include <iostream>
-#include <stdexcept>
 
 auto constexpr kText = R"""(
 Four score and seven years ago our fathers brought forth on this
@@ -39,7 +38,7 @@ int main(int argc, char* argv[]) try {
   audio.set_audio_encoding(google::cloud::texttospeech::v1::LINEAR16);
 
   auto response = client.SynthesizeSpeech(input, voice, audio);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   // Normally one would play the results (response->audio_content()) over some
   // audio device. For this quickstart, we just print some information.
   auto constexpr kWavHeaderSize = 48;
@@ -49,7 +48,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "The audio has " << sample_count << " samples\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/tpu/README.md
+++ b/google/cloud/tpu/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/tpu/tpu_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -47,13 +46,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto n : client.ListNodes(parent)) {
-    if (!n) throw std::runtime_error(n.status().message());
+    if (!n) throw std::move(n).status();
     std::cout << n->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/tpu/quickstart/quickstart.cc
+++ b/google/cloud/tpu/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/tpu/tpu_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -27,12 +26,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto n : client.ListNodes(parent)) {
-    if (!n) throw std::runtime_error(n.status().message());
+    if (!n) throw std::move(n).status();
     std::cout << n->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/trace/README.md
+++ b/google/cloud/trace/README.md
@@ -40,7 +40,6 @@ this library.
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
 #include <random>
-#include <stdexcept>
 #include <thread>
 
 std::string RandomHexDigits(std::mt19937_64& gen, int count) {
@@ -78,12 +77,12 @@ int main(int argc, char* argv[]) try {
   *span.mutable_end_time() = TimeUtil::GetCurrentTime();
 
   auto response = client.CreateSpan(span);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/trace/quickstart/quickstart.cc
+++ b/google/cloud/trace/quickstart/quickstart.cc
@@ -17,7 +17,6 @@
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
 #include <random>
-#include <stdexcept>
 #include <thread>
 
 std::string RandomHexDigits(std::mt19937_64& gen, int count) {
@@ -55,11 +54,11 @@ int main(int argc, char* argv[]) try {
   *span.mutable_end_time() = TimeUtil::GetCurrentTime();
 
   auto response = client.CreateSpan(span);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/translate/README.md
+++ b/google/cloud/translate/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/translate/translation_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 auto constexpr kText = R"""(
 Four score and seven years ago our fathers brought forth on this
@@ -57,15 +56,15 @@ int main(int argc, char* argv[]) try {
   auto const target = std::string{argc >= 3 ? argv[2] : "es-419"};
   auto response =
       client.TranslateText(project.FullName(), target, {std::string{kText}});
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
 
   for (auto const& translation : response->translations()) {
     std::cout << translation.translated_text() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/translate/quickstart/quickstart.cc
+++ b/google/cloud/translate/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/translate/translation_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 auto constexpr kText = R"""(
 Four score and seven years ago our fathers brought forth on this
@@ -37,14 +36,14 @@ int main(int argc, char* argv[]) try {
   auto const target = std::string{argc >= 3 ? argv[2] : "es-419"};
   auto response =
       client.TranslateText(project.FullName(), target, {std::string{kText}});
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
 
   for (auto const& translation : response->translations()) {
     std::cout << translation.translated_text() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/video/README.md
+++ b/google/cloud/video/README.md
@@ -43,7 +43,6 @@ this library.
 ```cc
 #include "google/cloud/video/transcoder_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -58,13 +57,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListJobs(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/video/quickstart/quickstart.cc
+++ b/google/cloud/video/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/video/transcoder_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListJobs(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/videointelligence/README.md
+++ b/google/cloud/videointelligence/README.md
@@ -36,7 +36,6 @@ this library.
 #include "google/cloud/videointelligence/video_intelligence_client.h"
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/video/animals.mp4";
@@ -71,7 +70,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "DONE\n";
 
   auto response = future.get();
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
 
   for (auto const& result : response->annotation_results()) {
     using ::google::protobuf::util::TimeUtil;
@@ -86,8 +85,8 @@ int main(int argc, char* argv[]) try {
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/videointelligence/quickstart/quickstart.cc
+++ b/google/cloud/videointelligence/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/videointelligence/video_intelligence_client.h"
 #include <google/protobuf/util/time_util.h>
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri = "gs://cloud-samples-data/video/animals.mp4";
@@ -50,7 +49,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "DONE\n";
 
   auto response = future.get();
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
 
   for (auto const& result : response->annotation_results()) {
     using ::google::protobuf::util::TimeUtil;
@@ -65,7 +64,7 @@ int main(int argc, char* argv[]) try {
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/vision/README.md
+++ b/google/cloud/vision/README.md
@@ -36,7 +36,6 @@ this library.
 ```cc
 #include "google/cloud/vision/image_annotator_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri =
@@ -66,7 +65,7 @@ int main(int argc, char* argv[]) try {
   google::cloud::vision::v1::BatchAnnotateImagesRequest batch_request;
   *batch_request.add_requests() = std::move(request);
   auto batch = client.BatchAnnotateImages(batch_request);
-  if (!batch) throw std::runtime_error(batch.status().message());
+  if (!batch) throw std::move(batch).status();
 
   // Find the longest annotation and print it
   auto result = std::string{};
@@ -80,8 +79,8 @@ int main(int argc, char* argv[]) try {
   std::cout << "The image contains this text: " << result << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/vision/quickstart/quickstart.cc
+++ b/google/cloud/vision/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/vision/image_annotator_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   auto constexpr kDefaultUri =
@@ -44,7 +43,7 @@ int main(int argc, char* argv[]) try {
   google::cloud::vision::v1::BatchAnnotateImagesRequest batch_request;
   *batch_request.add_requests() = std::move(request);
   auto batch = client.BatchAnnotateImages(batch_request);
-  if (!batch) throw std::runtime_error(batch.status().message());
+  if (!batch) throw std::move(batch).status();
 
   // Find the longest annotation and print it
   auto result = std::string{};
@@ -58,7 +57,7 @@ int main(int argc, char* argv[]) try {
   std::cout << "The image contains this text: " << result << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/vmmigration/README.md
+++ b/google/cloud/vmmigration/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/vmmigration/vm_migration_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -48,13 +47,13 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto s : client.ListSources(parent)) {
-    if (!s) throw std::runtime_error(s.status().message());
+    if (!s) throw std::move(s).status();
     std::cout << s->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/vmmigration/quickstart/quickstart.cc
+++ b/google/cloud/vmmigration/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/vmmigration/vm_migration_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -28,12 +27,12 @@ int main(int argc, char* argv[]) try {
 
   auto const parent = std::string{"projects/"} + argv[1] + "/locations/-";
   for (auto s : client.ListSources(parent)) {
-    if (!s) throw std::runtime_error(s.status().message());
+    if (!s) throw std::move(s).status();
     std::cout << s->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/vpcaccess/README.md
+++ b/google/cloud/vpcaccess/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/vpcaccess/vpc_access_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -49,13 +48,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListConnectors(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/vpcaccess/quickstart/quickstart.cc
+++ b/google/cloud/vpcaccess/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/vpcaccess/vpc_access_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -29,12 +28,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string("projects/") + argv[1] + "/locations/" + argv[2];
   for (auto r : client.ListConnectors(parent)) {
-    if (!r) throw std::runtime_error(r.status().message());
+    if (!r) throw std::move(r).status();
     std::cout << r->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/webrisk/README.md
+++ b/google/cloud/webrisk/README.md
@@ -34,7 +34,6 @@ this library.
 ```cc
 #include "google/cloud/webrisk/web_risk_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc > 2) {
@@ -51,12 +50,12 @@ int main(int argc, char* argv[]) try {
   auto const threat_types = std::vector<webrisk::v1::ThreatType>{
       webrisk::v1::MALWARE, webrisk::v1::UNWANTED_SOFTWARE};
   auto response = client.SearchUris("https://www.google.com/", threat_types);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/webrisk/quickstart/quickstart.cc
+++ b/google/cloud/webrisk/quickstart/quickstart.cc
@@ -14,7 +14,6 @@
 
 #include "google/cloud/webrisk/web_risk_client.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc > 2) {
@@ -31,11 +30,11 @@ int main(int argc, char* argv[]) try {
   auto const threat_types = std::vector<webrisk::v1::ThreatType>{
       webrisk::v1::MALWARE, webrisk::v1::UNWANTED_SOFTWARE};
   auto response = client.SearchUris("https://www.google.com/", threat_types);
-  if (!response) throw std::runtime_error(response.status().message());
+  if (!response) throw std::move(response).status();
   std::cout << response->DebugString() << "\n";
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/websecurityscanner/README.md
+++ b/google/cloud/websecurityscanner/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/websecurityscanner/web_security_scanner_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   google::cloud::websecurityscanner::v1::ListScanConfigsRequest request;
   request.set_parent(project.FullName());
   for (auto c : client.ListScanConfigs(request)) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/websecurityscanner/quickstart/quickstart.cc
+++ b/google/cloud/websecurityscanner/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/websecurityscanner/web_security_scanner_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 2) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
   google::cloud::websecurityscanner::v1::ListScanConfigsRequest request;
   request.set_parent(project.FullName());
   for (auto c : client.ListScanConfigs(request)) {
-    if (!c) throw std::runtime_error(c.status().message());
+    if (!c) throw std::move(c).status();
     std::cout << c->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }

--- a/google/cloud/workflows/README.md
+++ b/google/cloud/workflows/README.md
@@ -35,7 +35,6 @@ this library.
 #include "google/cloud/workflows/workflows_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -50,13 +49,13 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto w : client.ListWorkflows(parent)) {
-    if (!w) throw std::runtime_error(w.status().message());
+    if (!w) throw std::move(w).status();
     std::cout << w->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }
 ```

--- a/google/cloud/workflows/quickstart/quickstart.cc
+++ b/google/cloud/workflows/quickstart/quickstart.cc
@@ -15,7 +15,6 @@
 #include "google/cloud/workflows/workflows_client.h"
 #include "google/cloud/project.h"
 #include <iostream>
-#include <stdexcept>
 
 int main(int argc, char* argv[]) try {
   if (argc != 3) {
@@ -30,12 +29,12 @@ int main(int argc, char* argv[]) try {
   auto const parent =
       std::string{"projects/"} + argv[1] + "/locations/" + argv[2];
   for (auto w : client.ListWorkflows(parent)) {
-    if (!w) throw std::runtime_error(w.status().message());
+    if (!w) throw std::move(w).status();
     std::cout << w->DebugString() << "\n";
   }
 
   return 0;
-} catch (std::exception const& ex) {
-  std::cerr << "Standard exception raised: " << ex.what() << "\n";
+} catch (google::cloud::Status const& status) {
+  std::cerr << "google::cloud::Status thrown: " << status << "\n";
   return 1;
 }


### PR DESCRIPTION
Instead throw/catch `google::cloud::Status` values, so that all the error information can be reported.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10053)
<!-- Reviewable:end -->
