### PR TITLE
refactor(pubsub): move `Default*Stub` to headers

### DIFF
--- a/google/cloud/pubsub/internal/publisher_stub.cc
+++ b/google/cloud/pubsub/internal/publisher_stub.cc
@@ -22,115 +22,105 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-class DefaultPublisherStub : public PublisherStub {
- public:
-  explicit DefaultPublisherStub(
-      std::unique_ptr<google::pubsub::v1::Publisher::StubInterface> grpc_stub)
-      : grpc_stub_(std::move(grpc_stub)) {}
+StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::CreateTopic(
+    grpc::ClientContext& context, google::pubsub::v1::Topic const& request) {
+  google::pubsub::v1::Topic response;
+  auto status = grpc_stub_->CreateTopic(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
 
-  ~DefaultPublisherStub() override = default;
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Topic> CreateTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::Topic const& request) override {
-    google::pubsub::v1::Topic response;
-    auto status = grpc_stub_->CreateTopic(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::GetTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetTopicRequest const& request) {
+  google::pubsub::v1::Topic response;
+  auto status = grpc_stub_->GetTopic(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-    return response;
-  }
+StatusOr<google::pubsub::v1::Topic> DefaultPublisherStub::UpdateTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::UpdateTopicRequest const& request) {
+  google::pubsub::v1::Topic response;
+  auto status = grpc_stub_->UpdateTopic(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Topic> GetTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetTopicRequest const& request) override {
-    google::pubsub::v1::Topic response;
-    auto status = grpc_stub_->GetTopic(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::ListTopicsResponse>
+DefaultPublisherStub::ListTopics(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ListTopicsRequest const& request) {
+  google::pubsub::v1::ListTopicsResponse response;
+  auto status = grpc_stub_->ListTopics(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Topic> UpdateTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::UpdateTopicRequest const& request) override {
-    google::pubsub::v1::Topic response;
-    auto status = grpc_stub_->UpdateTopic(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+Status DefaultPublisherStub::DeleteTopic(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteTopicRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->DeleteTopic(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return {};
+}
 
-  StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ListTopicsRequest const& request) override {
-    google::pubsub::v1::ListTopicsResponse response;
-    auto status = grpc_stub_->ListTopics(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::DetachSubscriptionResponse>
+DefaultPublisherStub::DetachSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DetachSubscriptionRequest const& request) {
+  google::pubsub::v1::DetachSubscriptionResponse response;
+  auto status = grpc_stub_->DetachSubscription(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  Status DeleteTopic(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteTopicRequest const& request) override {
-    google::protobuf::Empty response;
-    auto status = grpc_stub_->DeleteTopic(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return {};
-  }
+StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
+DefaultPublisherStub::ListTopicSubscriptions(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ListTopicSubscriptionsRequest const& request) {
+  google::pubsub::v1::ListTopicSubscriptionsResponse response;
+  auto status =
+      grpc_stub_->ListTopicSubscriptions(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DetachSubscriptionRequest const& request) override {
-    google::pubsub::v1::DetachSubscriptionResponse response;
-    auto status = grpc_stub_->DetachSubscription(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::ListTopicSnapshotsResponse>
+DefaultPublisherStub::ListTopicSnapshots(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ListTopicSnapshotsRequest const& request) {
+  google::pubsub::v1::ListTopicSnapshotsResponse response;
+  auto status = grpc_stub_->ListTopicSnapshots(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
-  ListTopicSubscriptions(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ListTopicSubscriptionsRequest const& request)
-      override {
-    google::pubsub::v1::ListTopicSubscriptionsResponse response;
-    auto status =
-        grpc_stub_->ListTopicSubscriptions(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+future<StatusOr<google::pubsub::v1::PublishResponse>>
+DefaultPublisherStub::AsyncPublish(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::PublishRequest const& request) {
+  return cq.MakeUnaryRpc(
+      [this](grpc::ClientContext* context,
+             google::pubsub::v1::PublishRequest const& request,
+             grpc::CompletionQueue* cq) {
+        return grpc_stub_->AsyncPublish(context, request, cq);
+      },
+      request, std::move(context));
+}
 
-  StatusOr<google::pubsub::v1::ListTopicSnapshotsResponse> ListTopicSnapshots(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ListTopicSnapshotsRequest const& request) override {
-    google::pubsub::v1::ListTopicSnapshotsResponse response;
-    auto status = grpc_stub_->ListTopicSnapshots(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::PublishRequest const& request) override {
-    return cq.MakeUnaryRpc(
-        [this](grpc::ClientContext* context,
-               google::pubsub::v1::PublishRequest const& request,
-               grpc::CompletionQueue* cq) {
-          return grpc_stub_->AsyncPublish(context, request, cq);
-        },
-        request, std::move(context));
-  }
-
-  StatusOr<google::pubsub::v1::PublishResponse> Publish(
-      grpc::ClientContext& context,
-      google::pubsub::v1::PublishRequest const& request) override {
-    google::pubsub::v1::PublishResponse response;
-    auto status = grpc_stub_->Publish(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
-
- private:
-  std::unique_ptr<google::pubsub::v1::Publisher::StubInterface> grpc_stub_;
-};
+StatusOr<google::pubsub::v1::PublishResponse> DefaultPublisherStub::Publish(
+    grpc::ClientContext& context,
+    google::pubsub::v1::PublishRequest const& request) {
+  google::pubsub::v1::PublishResponse response;
+  auto status = grpc_stub_->Publish(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
 std::shared_ptr<PublisherStub> CreateDefaultPublisherStub(Options const& opts,
                                                           int channel_id) {

--- a/google/cloud/pubsub/internal/publisher_stub.h
+++ b/google/cloud/pubsub/internal/publisher_stub.h
@@ -19,7 +19,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/completion_queue.h"
 #include "google/cloud/status_or.h"
-#include <google/pubsub/v1/pubsub.pb.h>
+#include <google/pubsub/v1/pubsub.grpc.pb.h>
 
 namespace google {
 namespace cloud {
@@ -93,6 +93,61 @@ class PublisherStub {
   virtual StatusOr<google::pubsub::v1::PublishResponse> Publish(
       grpc::ClientContext& client_context,
       google::pubsub::v1::PublishRequest const& request) = 0;
+};
+
+class DefaultPublisherStub : public PublisherStub {
+ public:
+  explicit DefaultPublisherStub(
+      std::unique_ptr<google::pubsub::v1::Publisher::StubInterface> grpc_stub)
+      : grpc_stub_(std::move(grpc_stub)) {}
+
+  ~DefaultPublisherStub() override = default;
+
+  StatusOr<google::pubsub::v1::Topic> CreateTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::Topic const& request) override;
+
+  StatusOr<google::pubsub::v1::Topic> GetTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::GetTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Topic> UpdateTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::UpdateTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ListTopicsResponse> ListTopics(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::ListTopicsRequest const& request) override;
+
+  Status DeleteTopic(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DeleteTopicRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::DetachSubscriptionResponse> DetachSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DetachSubscriptionRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ListTopicSubscriptionsResponse>
+  ListTopicSubscriptions(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::ListTopicSubscriptionsRequest const& request)
+      override;
+
+  StatusOr<google::pubsub::v1::ListTopicSnapshotsResponse> ListTopicSnapshots(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::ListTopicSnapshotsRequest const& request) override;
+
+  future<StatusOr<google::pubsub::v1::PublishResponse>> AsyncPublish(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> client_context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::PublishResponse> Publish(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::PublishRequest const& request) override;
+
+ private:
+  std::unique_ptr<google::pubsub::v1::Publisher::StubInterface> grpc_stub_;
 };
 
 /**

--- a/google/cloud/pubsub/internal/schema_stub.cc
+++ b/google/cloud/pubsub/internal/schema_stub.cc
@@ -21,74 +21,63 @@ namespace google {
 namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
-namespace {
 
-class DefaultSchemaStub : public SchemaStub {
- public:
-  explicit DefaultSchemaStub(
-      std::unique_ptr<google::pubsub::v1::SchemaService::StubInterface> impl)
-      : impl_(std::move(impl)) {}
+StatusOr<google::pubsub::v1::Schema> DefaultSchemaStub::CreateSchema(
+    grpc::ClientContext& context,
+    google::pubsub::v1::CreateSchemaRequest const& request) {
+  google::pubsub::v1::Schema response;
+  auto status = grpc_stub_->CreateSchema(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  ~DefaultSchemaStub() override = default;
+StatusOr<google::pubsub::v1::Schema> DefaultSchemaStub::GetSchema(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetSchemaRequest const& request) {
+  google::pubsub::v1::Schema response;
+  auto status = grpc_stub_->GetSchema(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Schema> CreateSchema(
-      grpc::ClientContext& context,
-      google::pubsub::v1::CreateSchemaRequest const& request) override {
-    google::pubsub::v1::Schema response;
-    auto status = impl_->CreateSchema(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::ListSchemasResponse>
+DefaultSchemaStub::ListSchemas(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ListSchemasRequest const& request) {
+  google::pubsub::v1::ListSchemasResponse response;
+  auto status = grpc_stub_->ListSchemas(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Schema> GetSchema(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetSchemaRequest const& request) override {
-    google::pubsub::v1::Schema response;
-    auto status = impl_->GetSchema(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+Status DefaultSchemaStub::DeleteSchema(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteSchemaRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->DeleteSchema(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return Status{};
+}
 
-  StatusOr<google::pubsub::v1::ListSchemasResponse> ListSchemas(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ListSchemasRequest const& request) override {
-    google::pubsub::v1::ListSchemasResponse response;
-    auto status = impl_->ListSchemas(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::ValidateSchemaResponse>
+DefaultSchemaStub::ValidateSchema(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ValidateSchemaRequest const& request) {
+  google::pubsub::v1::ValidateSchemaResponse response;
+  auto status = grpc_stub_->ValidateSchema(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  Status DeleteSchema(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteSchemaRequest const& request) override {
-    google::protobuf::Empty response;
-    auto status = impl_->DeleteSchema(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return Status{};
-  }
-
-  StatusOr<google::pubsub::v1::ValidateSchemaResponse> ValidateSchema(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ValidateSchemaRequest const& request) override {
-    google::pubsub::v1::ValidateSchemaResponse response;
-    auto status = impl_->ValidateSchema(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  StatusOr<google::pubsub::v1::ValidateMessageResponse> ValidateMessage(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ValidateMessageRequest const& request) override {
-    google::pubsub::v1::ValidateMessageResponse response;
-    auto status = impl_->ValidateMessage(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
-
- private:
-  std::unique_ptr<google::pubsub::v1::SchemaService::StubInterface> impl_;
-};
-}  // namespace
+StatusOr<google::pubsub::v1::ValidateMessageResponse>
+DefaultSchemaStub::ValidateMessage(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ValidateMessageRequest const& request) {
+  google::pubsub::v1::ValidateMessageResponse response;
+  auto status = grpc_stub_->ValidateMessage(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
 std::shared_ptr<SchemaStub> CreateDefaultSchemaStub(
     std::shared_ptr<grpc::Channel> channel) {

--- a/google/cloud/pubsub/internal/schema_stub.h
+++ b/google/cloud/pubsub/internal/schema_stub.h
@@ -18,7 +18,7 @@
 #include "google/cloud/pubsub/connection_options.h"
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/status_or.h"
-#include <google/pubsub/v1/schema.pb.h>
+#include <google/pubsub/v1/schema.grpc.pb.h>
 
 namespace google {
 namespace cloud {
@@ -68,6 +68,41 @@ class SchemaStub {
   virtual StatusOr<google::pubsub::v1::ValidateMessageResponse> ValidateMessage(
       grpc::ClientContext& context,
       google::pubsub::v1::ValidateMessageRequest const& request) = 0;
+};
+
+class DefaultSchemaStub : public SchemaStub {
+ public:
+  explicit DefaultSchemaStub(
+      std::unique_ptr<google::pubsub::v1::SchemaService::StubInterface> impl)
+      : grpc_stub_(std::move(impl)) {}
+  ~DefaultSchemaStub() override = default;
+
+  StatusOr<google::pubsub::v1::Schema> CreateSchema(
+      grpc::ClientContext& context,
+      google::pubsub::v1::CreateSchemaRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Schema> GetSchema(
+      grpc::ClientContext& context,
+      google::pubsub::v1::GetSchemaRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ListSchemasResponse> ListSchemas(
+      grpc::ClientContext& context,
+      google::pubsub::v1::ListSchemasRequest const& request) override;
+
+  Status DeleteSchema(
+      grpc::ClientContext& context,
+      google::pubsub::v1::DeleteSchemaRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ValidateSchemaResponse> ValidateSchema(
+      grpc::ClientContext& context,
+      google::pubsub::v1::ValidateSchemaRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ValidateMessageResponse> ValidateMessage(
+      grpc::ClientContext& context,
+      google::pubsub::v1::ValidateMessageRequest const& request) override;
+
+ private:
+  std::unique_ptr<google::pubsub::v1::SchemaService::StubInterface> grpc_stub_;
 };
 
 /**

--- a/google/cloud/pubsub/internal/subscriber_stub.cc
+++ b/google/cloud/pubsub/internal/subscriber_stub.cc
@@ -23,176 +23,172 @@ namespace cloud {
 namespace pubsub_internal {
 GOOGLE_CLOUD_CPP_INLINE_NAMESPACE_BEGIN
 
-class DefaultSubscriberStub : public SubscriberStub {
- public:
-  explicit DefaultSubscriberStub(
-      std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub)
-      : grpc_stub_(std::move(grpc_stub)) {}
+StatusOr<google::pubsub::v1::Subscription>
+DefaultSubscriberStub::CreateSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::Subscription const& request) {
+  google::pubsub::v1::Subscription response;
+  auto status = grpc_stub_->CreateSubscription(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  ~DefaultSubscriberStub() override = default;
+StatusOr<google::pubsub::v1::Subscription>
+DefaultSubscriberStub::GetSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetSubscriptionRequest const& request) {
+  google::pubsub::v1::Subscription response;
+  auto status = grpc_stub_->GetSubscription(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::Subscription const& request) override {
-    google::pubsub::v1::Subscription response;
-    auto status = grpc_stub_->CreateSubscription(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::Subscription>
+DefaultSubscriberStub::UpdateSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::UpdateSubscriptionRequest const& request) {
+  google::pubsub::v1::Subscription response;
+  auto status = grpc_stub_->UpdateSubscription(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Subscription> GetSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetSubscriptionRequest const& request) override {
-    google::pubsub::v1::Subscription response;
-    auto status = grpc_stub_->GetSubscription(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::ListSubscriptionsResponse>
+DefaultSubscriberStub::ListSubscriptions(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ListSubscriptionsRequest const& request) {
+  google::pubsub::v1::ListSubscriptionsResponse response;
+  auto status = grpc_stub_->ListSubscriptions(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::UpdateSubscriptionRequest const& request) override {
-    google::pubsub::v1::Subscription response;
-    auto status = grpc_stub_->UpdateSubscription(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+Status DefaultSubscriberStub::DeleteSubscription(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteSubscriptionRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->DeleteSubscription(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return {};
+}
 
-  StatusOr<google::pubsub::v1::ListSubscriptionsResponse> ListSubscriptions(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ListSubscriptionsRequest const& request) override {
-    google::pubsub::v1::ListSubscriptionsResponse response;
-    auto status = grpc_stub_->ListSubscriptions(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+Status DefaultSubscriberStub::ModifyPushConfig(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ModifyPushConfigRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->ModifyPushConfig(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return {};
+}
 
-  Status DeleteSubscription(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteSubscriptionRequest const& request) override {
-    google::protobuf::Empty response;
-    auto status = grpc_stub_->DeleteSubscription(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return {};
-  }
+std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+    google::pubsub::v1::StreamingPullRequest,
+    google::pubsub::v1::StreamingPullResponse>>
+DefaultSubscriberStub::AsyncStreamingPull(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::StreamingPullRequest const&) {
+  return google::cloud::internal::MakeStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>(
+      cq, std::move(context),
+      [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
+        return grpc_stub_->PrepareAsyncStreamingPull(context, cq);
+      });
+}
 
-  Status ModifyPushConfig(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ModifyPushConfigRequest const& request) override {
-    google::protobuf::Empty response;
-    auto status = grpc_stub_->ModifyPushConfig(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return {};
-  }
+future<Status> DefaultSubscriberStub::AsyncAcknowledge(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::AcknowledgeRequest const& request) {
+  return cq
+      .MakeUnaryRpc(
+          [this](grpc::ClientContext* context,
+                 google::pubsub::v1::AcknowledgeRequest const& request,
+                 grpc::CompletionQueue* cq) {
+            return grpc_stub_->AsyncAcknowledge(context, request, cq);
+          },
+          request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        auto result = f.get();
+        if (!result) return std::move(result).status();
+        return Status{};
+      });
+}
 
-  std::unique_ptr<AsyncPullStream> AsyncStreamingPull(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::StreamingPullRequest const&) override {
-    return google::cloud::internal::MakeStreamingReadWriteRpc<
-        google::pubsub::v1::StreamingPullRequest,
-        google::pubsub::v1::StreamingPullResponse>(
-        cq, std::move(context),
-        [this](grpc::ClientContext* context, grpc::CompletionQueue* cq) {
-          return grpc_stub_->PrepareAsyncStreamingPull(context, cq);
-        });
-  }
+future<Status> DefaultSubscriberStub::AsyncModifyAckDeadline(
+    google::cloud::CompletionQueue& cq,
+    std::unique_ptr<grpc::ClientContext> context,
+    google::pubsub::v1::ModifyAckDeadlineRequest const& request) {
+  return cq
+      .MakeUnaryRpc(
+          [this](grpc::ClientContext* context,
+                 google::pubsub::v1::ModifyAckDeadlineRequest const& request,
+                 grpc::CompletionQueue* cq) {
+            return grpc_stub_->AsyncModifyAckDeadline(context, request, cq);
+          },
+          request, std::move(context))
+      .then([](future<StatusOr<google::protobuf::Empty>> f) {
+        auto result = f.get();
+        if (!result) return std::move(result).status();
+        return Status{};
+      });
+}
 
-  future<Status> AsyncAcknowledge(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::AcknowledgeRequest const& request) override {
-    return cq
-        .MakeUnaryRpc(
-            [this](grpc::ClientContext* context,
-                   google::pubsub::v1::AcknowledgeRequest const& request,
-                   grpc::CompletionQueue* cq) {
-              return grpc_stub_->AsyncAcknowledge(context, request, cq);
-            },
-            request, std::move(context))
-        .then([](future<StatusOr<google::protobuf::Empty>> f) {
-          auto result = f.get();
-          if (!result) return std::move(result).status();
-          return Status{};
-        });
-  }
+StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::CreateSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::CreateSnapshotRequest const& request) {
+  google::pubsub::v1::Snapshot response;
+  auto status = grpc_stub_->CreateSnapshot(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  future<Status> AsyncModifyAckDeadline(
-      google::cloud::CompletionQueue& cq,
-      std::unique_ptr<grpc::ClientContext> context,
-      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override {
-    return cq
-        .MakeUnaryRpc(
-            [this](grpc::ClientContext* context,
-                   google::pubsub::v1::ModifyAckDeadlineRequest const& request,
-                   grpc::CompletionQueue* cq) {
-              return grpc_stub_->AsyncModifyAckDeadline(context, request, cq);
-            },
-            request, std::move(context))
-        .then([](future<StatusOr<google::protobuf::Empty>> f) {
-          auto result = f.get();
-          if (!result) return std::move(result).status();
-          return Status{};
-        });
-  }
+StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::GetSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::GetSnapshotRequest const& request) {
+  google::pubsub::v1::Snapshot response;
+  auto status = grpc_stub_->GetSnapshot(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
-      grpc::ClientContext& context,
-      google::pubsub::v1::CreateSnapshotRequest const& request) override {
-    google::pubsub::v1::Snapshot response;
-    auto status = grpc_stub_->CreateSnapshot(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::ListSnapshotsResponse>
+DefaultSubscriberStub::ListSnapshots(
+    grpc::ClientContext& context,
+    google::pubsub::v1::ListSnapshotsRequest const& request) {
+  google::pubsub::v1::ListSnapshotsResponse response;
+  auto status = grpc_stub_->ListSnapshots(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
-      grpc::ClientContext& context,
-      google::pubsub::v1::GetSnapshotRequest const& request) override {
-    google::pubsub::v1::Snapshot response;
-    auto status = grpc_stub_->GetSnapshot(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+StatusOr<google::pubsub::v1::Snapshot> DefaultSubscriberStub::UpdateSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::UpdateSnapshotRequest const& request) {
+  google::pubsub::v1::Snapshot response;
+  auto status = grpc_stub_->UpdateSnapshot(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
-  StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
-      grpc::ClientContext& context,
-      google::pubsub::v1::ListSnapshotsRequest const& request) override {
-    google::pubsub::v1::ListSnapshotsResponse response;
-    auto status = grpc_stub_->ListSnapshots(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
+Status DefaultSubscriberStub::DeleteSnapshot(
+    grpc::ClientContext& context,
+    google::pubsub::v1::DeleteSnapshotRequest const& request) {
+  google::protobuf::Empty response;
+  auto status = grpc_stub_->DeleteSnapshot(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return {};
+}
 
-  StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
-      grpc::ClientContext& context,
-      google::pubsub::v1::UpdateSnapshotRequest const& request) override {
-    google::pubsub::v1::Snapshot response;
-    auto status = grpc_stub_->UpdateSnapshot(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
-
-  Status DeleteSnapshot(
-      grpc::ClientContext& context,
-      google::pubsub::v1::DeleteSnapshotRequest const& request) override {
-    google::protobuf::Empty response;
-    auto status = grpc_stub_->DeleteSnapshot(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return {};
-  }
-
-  StatusOr<google::pubsub::v1::SeekResponse> Seek(
-      grpc::ClientContext& context,
-      google::pubsub::v1::SeekRequest const& request) override {
-    google::pubsub::v1::SeekResponse response;
-    auto status = grpc_stub_->Seek(&context, request, &response);
-    if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
-    return response;
-  }
-
- private:
-  std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;
-};
+StatusOr<google::pubsub::v1::SeekResponse> DefaultSubscriberStub::Seek(
+    grpc::ClientContext& context,
+    google::pubsub::v1::SeekRequest const& request) {
+  google::pubsub::v1::SeekResponse response;
+  auto status = grpc_stub_->Seek(&context, request, &response);
+  if (!status.ok()) return google::cloud::MakeStatusFromRpcError(status);
+  return response;
+}
 
 /// Create a SubscriberStub using a pre-configured channel.
 std::shared_ptr<SubscriberStub> CreateDefaultSubscriberStub(

--- a/google/cloud/pubsub/internal/subscriber_stub.h
+++ b/google/cloud/pubsub/internal/subscriber_stub.h
@@ -19,7 +19,7 @@
 #include "google/cloud/pubsub/version.h"
 #include "google/cloud/async_streaming_read_write_rpc.h"
 #include "google/cloud/status_or.h"
-#include <google/pubsub/v1/pubsub.pb.h>
+#include <google/pubsub/v1/pubsub.grpc.pb.h>
 
 namespace google {
 namespace cloud {
@@ -121,6 +121,83 @@ class SubscriberStub {
   virtual StatusOr<google::pubsub::v1::SeekResponse> Seek(
       grpc::ClientContext& client_context,
       google::pubsub::v1::SeekRequest const& request) = 0;
+};
+
+class DefaultSubscriberStub : public SubscriberStub {
+ public:
+  explicit DefaultSubscriberStub(
+      std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub)
+      : grpc_stub_(std::move(grpc_stub)) {}
+
+  ~DefaultSubscriberStub() override = default;
+
+  StatusOr<google::pubsub::v1::Subscription> CreateSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::Subscription const& request) override;
+
+  StatusOr<google::pubsub::v1::Subscription> GetSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::GetSubscriptionRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Subscription> UpdateSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::UpdateSubscriptionRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ListSubscriptionsResponse> ListSubscriptions(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::ListSubscriptionsRequest const& request) override;
+
+  Status DeleteSubscription(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DeleteSubscriptionRequest const& request) override;
+
+  Status ModifyPushConfig(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::ModifyPushConfigRequest const& request) override;
+
+  std::unique_ptr<::google::cloud::AsyncStreamingReadWriteRpc<
+      google::pubsub::v1::StreamingPullRequest,
+      google::pubsub::v1::StreamingPullResponse>>
+  AsyncStreamingPull(
+      google::cloud::CompletionQueue&, std::unique_ptr<grpc::ClientContext>,
+      google::pubsub::v1::StreamingPullRequest const& request) override;
+
+  future<Status> AsyncAcknowledge(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::AcknowledgeRequest const& request) override;
+
+  future<Status> AsyncModifyAckDeadline(
+      google::cloud::CompletionQueue& cq,
+      std::unique_ptr<grpc::ClientContext> context,
+      google::pubsub::v1::ModifyAckDeadlineRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Snapshot> CreateSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::CreateSnapshotRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Snapshot> GetSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::GetSnapshotRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::ListSnapshotsResponse> ListSnapshots(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::ListSnapshotsRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::Snapshot> UpdateSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::UpdateSnapshotRequest const& request) override;
+
+  Status DeleteSnapshot(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::DeleteSnapshotRequest const& request) override;
+
+  StatusOr<google::pubsub::v1::SeekResponse> Seek(
+      grpc::ClientContext& client_context,
+      google::pubsub::v1::SeekRequest const& request) override;
+
+ private:
+  std::unique_ptr<google::pubsub::v1::Subscriber::StubInterface> grpc_stub_;
 };
 
 /// Create a SubscriberStub using a pre-configured channel.


### PR DESCRIPTION
The generator puts these classes in the headers (for good reasons), I want to do the same to make the switch to fully generated files easier to grok.

Part of the work for #7187

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/googleapis/google-cloud-cpp/10061)
<!-- Reviewable:end -->
